### PR TITLE
refactor: prune outbound call skill creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For `outbound-call-skill-creator`:
 
 ```text
 Use outbound-call-skill-creator to create a project-local callback skill from a local CSV file.
-Start by collecting the source fields, consent basis, call goal, provider route, execution mode, and writeback target.
+Start by collecting the source fields, consent basis, call goal, provider route, execution mode, and durable result-output target.
 ```
 
 The agent should create or update a visible scheduler job only when the current client can persist, run, and cancel it safely. The scheduled job then executes the runtime prompt and attempts exactly one one-off CALL-E call.
@@ -152,7 +152,7 @@ If the client cannot safely create the schedule, the skill must return `status: 
 | --- | --- | --- | --- |
 | [`call-reminder`](skills/call-reminder/) | Schedules recurring CALL-E phone-call reminders by wrapping the existing one-off CALL-E call workflow in the current client's scheduler or automation system. | [`skills/call-reminder/`](skills/call-reminder/) | Reference implementation |
 | [`google-form-callback`](skills/google-form-callback/) | Processes authorized Google Form responses into safe one-off callback calls with dry-runs, scheduled polling plans, and Sheets writeback. | [`docs/google-form-callback/README.md`](docs/google-form-callback/README.md) | Reference implementation |
-| [`outbound-call-skill-creator`](skills/outbound-call-skill-creator/) | Generates directly usable outbound phone-call workflow skills with source mapping, goal contracts, MCP provider routing, serial execution policy, safety rules, and writeback behavior. | [`skills/outbound-call-skill-creator/`](skills/outbound-call-skill-creator/) | Creator skill |
+| [`outbound-call-skill-creator`](skills/outbound-call-skill-creator/) | Generates directly usable outbound phone-call workflow skills with source mapping, goal contracts, MCP provider routing, serial execution policy, safety rules, and durable result-output behavior. | [`skills/outbound-call-skill-creator/`](skills/outbound-call-skill-creator/) | Creator skill |
 
 `call-reminder` is a scheduler wrapper skill, not a new CALL-E backend reminder API, daemon, or provider-side recurring schedule.
 

--- a/docs/outbound-call-skill-creator/README.md
+++ b/docs/outbound-call-skill-creator/README.md
@@ -1,6 +1,6 @@
 # Outbound Call Skill Creator
 
-`outbound-call-skill-creator` is a generator skill for creating focused outbound phone-call business skills. It does not process campaign data or place calls itself. Instead, it captures a reusable workflow contract and writes a directly usable Agent Skill that can later read source records, validate candidates, compile one call goal per eligible record, run one-off calls through the configured MCP provider route, and write results back or show a session table.
+`outbound-call-skill-creator` is a generator skill for creating focused outbound phone-call business skills. It does not process campaign data or place calls itself. Instead, it captures a reusable workflow contract and writes a directly usable Agent Skill that can later read source records, validate candidates, compile one call goal per eligible record, run one-off calls through the configured MCP provider route, and write durable results through source writeback, a source-adjacent result artifact, or a new local result CSV.
 
 ## When To Use
 
@@ -19,10 +19,10 @@ Generated skills use one of two binding levels. The minimum source binding contr
 
 | Binding level | What is fixed at creation time | What is supplied at runtime | Automation level |
 | --- | --- | --- | --- |
-| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and narrow processing controls. | Highest automation; suitable for scheduled host runs after the runtime gate passes. |
-| `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Recommended default; balances reuse and automation. |
+| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, fixed result target, and result fields. The result target can be source writeback to the source instance or canonical record store, a source-adjacent result artifact, or a local result CSV. | Date window, subset filters, and narrow processing controls. | Highest automation; suitable for scheduled host runs after the runtime gate passes. |
+| `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe rule, goal contract, result-output policy, and result field schema. | Approved parameters such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path. | Recommended default; balances reuse and automation. |
 
-The default recommendation is `parameterized-bound`. It avoids a brittle single-source skill while still fixing the important safety and automation contract. Use `fully-bound` only when the workflow should fix one concrete source and writeback target at creation time.
+The default recommendation is `parameterized-bound`. It avoids a brittle single-source skill while still fixing the important safety and automation contract. Use `fully-bound` only when the workflow should fix one concrete source and durable result-output target at creation time.
 
 ## Creation Prompt Flow
 
@@ -37,13 +37,13 @@ Only ask for extra output-target confirmation when discoverability is unclear, t
 
 ## Source Onboarding
 
-For bound workflows, creation includes a source onboarding pass before the generated skill is written. The creator verifies source access, asks the user to resolve access blockers, fetches a small representative sample through a read-only path, confirms the schema, and uses the sampled fields to help define the default outbound goal. User-approved authorization may create or refresh local host credentials, OAuth tokens, connector sessions, or MCP authorization state, but onboarding must not mutate source records, source permissions, source integrations, scheduler state, writeback targets, or phone-call provider state. This lets a later runtime request provide only the intended processing scope, such as a date window, instead of rebuilding the source and goal contract.
+For bound workflows, creation includes a source onboarding pass before the generated skill is written. The creator verifies source access, asks the user to resolve access blockers, fetches a small representative sample through a read-only path, confirms the schema, and uses the sampled fields to help define the default outbound goal. User-approved authorization may create or refresh local host credentials, OAuth tokens, connector sessions, or MCP authorization state, but onboarding must not mutate source records, source permissions, source integrations, scheduler state, result-output targets, or phone-call provider state. This lets a later runtime request provide only the intended processing scope, such as a date window, instead of rebuilding the source and goal contract.
 
-For authenticated or connector-backed sources such as Google Forms, TikTok Ads, and future OAuth, API, MCP, or managed connector sources, the creator collects only minimum connection details before access is verified. It must not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. After a redacted representative sample is available, it proposes the field mapping and asks the user to fill only fields that cannot be inferred.
+For authenticated or connector-backed sources such as Google Forms, TikTok Ads, and future OAuth, API, MCP, or managed connector sources, the creator collects only minimum connection details before access is verified. It must not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or result-output fields before authentication and sample fetch have been attempted. After a redacted representative sample is available, it proposes the field mapping and asks the user to fill only fields that cannot be inferred.
 
-If the user only names an authenticated source family such as `google-form` or `tiktok-ads`, the next step is source access onboarding, not goal drafting. The creator should proactively inspect host-local adapters, connectors, MCP tools, MCP resources, or helper scripts before asking the user to choose an access route. When a safe source authorization or auth-readiness action is available, start it before asking the user for another confirmation; do not ask the user to say `start auth`, choose a discovered route, or refresh a session before attempting the available non-mutating auth path. For Google Forms, when `google-form-callback` helpers are available, check `google-auth.mjs status`, run or request `preflight-auth.mjs --repair-google` if auth is missing, and use `google-local-api-client.mjs --action list-forms` before asking for a Form ID. For TikTok Ads in Codex, inspect exposed MCP tools and resources first; when no TikTok Ads MCP server is configured, run `codex mcp add tiktok-ads --url https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer-tmp`, then `codex mcp get tiktok-ads` and `codex mcp list` before asking the user for a route choice. Treat Codex `Auth: Unsupported` as missing Codex-managed OAuth only. If the route is configured but tools are not exposed, run `codex mcp login tiktok-ads` or the host's equivalent source MCP login before asking for a different route or session refresh. If TikTok Ads tools or resources are exposed, run a source-native read-only auth or inventory probe such as `auth_advertiser_get` before declaring a blocker; only ask for a supported token, managed connector, host-specific login path, or another approved route when no tools are exposed after the available auth path has been attempted or the source-native probe cannot authenticate. Ask the user only for the minimum locator or user-completed authorization step that remains necessary, and wait until the sample is available before asking for the default outbound goal, writeback mapping, or full field mapping.
+If the user only names an authenticated source family such as `google-form` or `tiktok-ads`, the next step is source access onboarding, not goal drafting. The creator should proactively inspect host-local adapters, connectors, MCP tools, MCP resources, or helper scripts before asking the user to choose an access route. When a safe source authorization or auth-readiness action is available, start it before asking the user for another confirmation; do not ask the user to say `start auth`, choose a discovered route, or refresh a session before attempting the available non-mutating auth path. For Google Forms, when `google-form-callback` helpers are available, check `google-auth.mjs status`, run or request `preflight-auth.mjs --repair-google` if auth is missing, and use `google-local-api-client.mjs --action list-forms` before asking for a Form ID. For TikTok Ads in Codex, inspect exposed MCP tools and resources first; when no TikTok Ads MCP server is configured, run `codex mcp add tiktok-ads --url https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer-tmp`, then `codex mcp get tiktok-ads` and `codex mcp list` before asking the user for a route choice. Treat Codex `Auth: Unsupported` as missing Codex-managed OAuth only. If the route is configured but tools are not exposed, run `codex mcp login tiktok-ads` or the host's equivalent source MCP login before asking for a different route or session refresh. If TikTok Ads tools or resources are exposed, run a source-native read-only auth or inventory probe such as `auth_advertiser_get` before declaring a blocker; only ask for a supported token, managed connector, host-specific login path, or another approved route when no tools are exposed after the available auth path has been attempted or the source-native probe cannot authenticate. Ask the user only for the minimum locator or user-completed authorization step that remains necessary, and wait until the sample is available before asking for the default outbound goal, result-output mapping, or full field mapping.
 
-If source onboarding cannot confirm at least the `parameterized-bound` source and writeback contract, the creator stops before generating the skill and reports the missing contract details.
+If source onboarding cannot confirm at least the `parameterized-bound` source and durable result-output contract, the creator stops before generating the skill and reports the missing contract details.
 
 ## Provider Onboarding
 
@@ -70,8 +70,8 @@ Typical creator decisions:
 - Source contract: Google Form responses with required `name`, `phone`, submitted time, response ID, and phone follow-up basis
 - Goal contract: confirm submitted quote interest, ask whether a sales specialist may follow up, and avoid pricing promises
 - Execution mode: `dry-run-then-batch-approval`
-- Writeback: source writeback to the linked response spreadsheet with status, result summary, safe run ID, and processed timestamp fields
-- Runtime gate: verify form schema, source-level or per-response phone follow-up basis, dedupe key, writeback target, and provider route before real calls
+- Result output: source writeback to the linked response spreadsheet with status, result summary, safe run ID, and processed timestamp fields
+- Runtime gate: verify form schema, source-level or per-response phone follow-up basis, dedupe key, result-output target, and provider route before real calls
 
 Future use:
 
@@ -86,33 +86,36 @@ The creator asks the user to choose one execution mode for the generated skill a
 - `dry-run-then-batch-approval`: preview all eligible calls and compiled goals, then process the approved list serially after one explicit approval.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, inspect provider plans, and run eligible one-off calls serially without another approval step.
 
-Execution mode selection happens only after the source and writeback contract satisfies at least the `parameterized-bound` minimum.
+Execution mode selection happens only after the source and durable result-output contract satisfies at least the `parameterized-bound` minimum.
 
 ## Preflight And Runtime Gate
 
-Creation-time preflight is best effort. The creator should run non-mutating source, writeback, and provider checks when the required tools, permissions, and concrete parameters are available, but a blocked creation-time preflight does not always prevent generating the skill.
+Creation-time preflight is best effort. The creator should run non-mutating source, result-output, and provider checks when the required tools, permissions, and concrete parameters are available, but a blocked creation-time preflight does not always prevent generating the skill.
 
-Runtime gating is mandatory before real calls. A generated skill must stop before calling when the concrete runtime request cannot verify source access, required fields, consent or outreach basis, dedupe reliability, writeback behavior or session-table fallback, provider authentication, and compatible MCP tools.
+Runtime gating is mandatory before real calls. A generated skill must stop before calling when the concrete runtime request cannot verify source access, required fields, consent or outreach basis, dedupe reliability, source writeback, source-adjacent result artifact output, local result CSV output, provider authentication, and compatible MCP tools.
 
-Do not perform a real writeback or place a real call during creation-time onboarding or preflight. Approved side effects can happen only later in the selected runtime execution flow after the runtime gate passes.
+Do not perform a real writeback, create or write a source-adjacent artifact, write a result CSV, or place a real call during creation-time onboarding or preflight. Approved side effects can happen only later in the selected runtime execution flow after the runtime gate passes.
 
-Generated skills must finalize provider results before writeback. Cursor-based status polling can show progress, but terminal provider status is not writeback-ready until the skill performs a full-history provider reconciliation. Negative terminal outcomes such as `no_answer`, `failed`, or `no conversation captured` require a negative terminal stability check before writing source or CSV results.
+Generated skills must finalize provider results before result output. Cursor-based status polling can show progress, but terminal provider status is not result-output-ready until the skill performs a full-history provider reconciliation. Negative terminal outcomes such as `no_answer`, `failed`, or `no conversation captured` require a negative terminal stability check before writing source, source-adjacent, or CSV results.
 
-## Writeback Binding
+## Result Output Binding
 
-The writeback policy is chosen at creation time:
+The result-output policy is chosen at creation time:
 
 - source writeback
-- local CSV writeback
-- session table output
+- source-adjacent result artifact
+- new local result CSV
+- session table output only as a last-resort non-persistent fallback
 
-For local CSV writeback, the creator records supported writeback target modes and the generated skill chooses the concrete mode during the runtime dry-run or approval step. Use `source-csv-in-place` only when the runtime request explicitly asks to update the original CSV and execution approval covers that mutation. Use `result-csv-file` when results should be written to a separate CSV or the request does not explicitly ask to mutate the original CSV. Do not describe a separate results file as original CSV writeback.
+Treat source writeback narrowly: it updates the bound source instance or canonical source record store. A same-system side file, new sheet, new tab, result table, or export beside the source is `source-adjacent-result-artifact`, not source writeback. For `fully-bound`, fix the artifact ID/path or the exact creation policy, container, schema, and append or upsert behavior at creation time.
 
-The writeback target depends on the binding level. `fully-bound` skills fix the target and fields at creation time. `parameterized-bound` skills fix the policy and field schema, while allowing an approved runtime target mode or target such as source CSV update, output CSV path, or verified source instance.
+For local CSV output, the creator records supported result-output target modes and the generated skill chooses the concrete mode during the runtime dry-run or approval step. Use `source-csv-in-place` only when the runtime request explicitly asks to update the original CSV and execution approval covers that mutation. Use `result-csv-file` when results should be written to a separate CSV or the request does not explicitly ask to mutate the original CSV. Do not describe a separate results file as original CSV writeback.
+
+The result-output target depends on the binding level. `fully-bound` skills fix the target and fields at creation time. `parameterized-bound` skills fix the policy and field schema, while allowing an approved runtime target mode or target such as source CSV update, source-adjacent artifact target, output CSV path, or verified source instance.
 
 ## Creation Summary
 
-After writing and validating a generated skill, the creator reports a short summary with the skill name, directory, discovery or reload note, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, source-level outreach basis or consent rule, dedupe rule, goal summary, execution mode, writeback policy, preflight result or blocker, runtime gate, provider route, and validation result.
+After writing and validating a generated skill, the creator reports a short summary with the skill name, directory, discovery or reload note, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, source-level outreach basis or consent rule, dedupe rule, goal summary, execution mode, result-output policy, preflight result or blocker, runtime gate, provider route, and validation result.
 
 The summary should make fixed values and runtime parameters visually distinct, and it must not expose credentials, tokens, cookies, callback URLs, confirmation tokens, or full phone numbers.
 
@@ -123,12 +126,12 @@ Generated skills should use structured formats for runtime behavior:
 - concrete request examples and insufficient request examples
 - source onboarding reports with access check status, sampled source instance, sample fetch result, redaction policy, and default goal source
 - provider onboarding reports with provider route, provider host runtime, MCP route setup check, auth readiness, compatible MCP tools, one-off call capability, and blocker fields
-- provider result finalization reports with `run_id`, `terminal_status_seen`, `full_history_rechecked`, `negative_terminal_stability_checked`, `writeback_allowed`, and `blocker`
+- provider result finalization reports with `run_id`, `terminal_status_seen`, `full_history_rechecked`, `negative_terminal_stability_checked`, `result_output_allowed`, and `blocker`
 - runtime gate reports with `check`, `status`, `evidence`, `blocker`, and `required_before_call`
-- writeback mappings with `policy`, `target_mode`, `target_binding`, `target`, and logical result fields
+- result-output mappings with `policy`, `target_mode`, `target_binding`, `target`, and logical result fields
 - direct execution guardrail checklists
 
-These formats make dry-runs, approvals, runtime blockers, and writeback behavior easier to audit.
+These formats make dry-runs, approvals, runtime blockers, and result-output behavior easier to audit.
 
 ## Reference Layout
 
@@ -156,10 +159,10 @@ Generated skills may also include focused reference files such as:
 
 - `references/source-contract.md`
 - `references/goal-contract.md`
-- `references/writeback-contract.md`
+- `references/result-output-contract.md`
 - `references/binding-contract.md`
 
-The generated `SKILL.md` must describe the source contract, source onboarding status, provider onboarding status with host MCP route setup and authentication evidence, provider blocker if any, binding level, runtime parameters, candidate fields, outbound goal contract, MCP provider route, execution mode, serial candidate processing, writeback behavior, best-effort creation-time preflight, mandatory runtime gate requirements, safety summary, and validation commands.
+The generated `SKILL.md` must describe the source contract, source onboarding status, provider onboarding status with host MCP route setup and authentication evidence, provider blocker if any, binding level, runtime parameters, candidate fields, outbound goal contract, MCP provider route, execution mode, serial candidate processing, result-output behavior, best-effort creation-time preflight, mandatory runtime gate requirements, safety summary, and validation commands.
 
 ## Provider Route
 

--- a/docs/outbound-call-skill-creator/README.md
+++ b/docs/outbound-call-skill-creator/README.md
@@ -15,15 +15,14 @@ Do not use it for one-off calls, generic voice-agent lists, telephony vendor dir
 
 ## Binding Model
 
-Generated skills use one of three binding levels:
+Generated skills use one of two binding levels. The minimum source binding contract is `parameterized-bound`:
 
 | Binding level | What is fixed at creation time | What is supplied at runtime | Automation level |
 | --- | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and narrow processing controls. | Highest automation; suitable for scheduled host runs after the runtime gate passes. |
 | `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Recommended default; balances reuse and automation. |
-| `unbound-generic` | Goal contract and safety rules. | Source access, field mapping, source-level outreach basis or consent evidence, dedupe key, filters, and writeback target. | Dry-run-only by default; not suitable for automatic real calls. |
 
-The default recommendation is `parameterized-bound`. It avoids a brittle single-source skill while still fixing the important safety and automation contract.
+The default recommendation is `parameterized-bound`. It avoids a brittle single-source skill while still fixing the important safety and automation contract. Use `fully-bound` only when the workflow should fix one concrete source and writeback target at creation time.
 
 ## Creation Prompt Flow
 
@@ -31,7 +30,7 @@ The creator should keep the setup flow explicit:
 
 1. Recommend one to three lowercase hyphenated skill names when the user has not provided one, then ask for confirmation.
 2. State the proposed output scope and directory before writing files, including why that target was selected and whether reload or add-location is needed.
-3. Ask for the binding level, defaulting to `parameterized-bound`.
+3. Choose whether the workflow should stay at the minimum `parameterized-bound` level or upgrade to `fully-bound`.
 4. Ask for the execution mode, defaulting to `dry-run-then-batch-approval`.
 
 Only ask for extra output-target confirmation when discoverability is unclear, the path is nonstandard, or a new user skills root must be created.
@@ -44,7 +43,7 @@ For authenticated or connector-backed sources such as Google Forms, TikTok Ads, 
 
 If the user only names an authenticated source family such as `google-form` or `tiktok-ads`, the next step is source access onboarding, not goal drafting. The creator should proactively inspect host-local adapters, connectors, MCP tools, MCP resources, or helper scripts before asking the user to choose an access route. When a safe source authorization or auth-readiness action is available, start it before asking the user for another confirmation; do not ask the user to say `start auth`, choose a discovered route, or refresh a session before attempting the available non-mutating auth path. For Google Forms, when `google-form-callback` helpers are available, check `google-auth.mjs status`, run or request `preflight-auth.mjs --repair-google` if auth is missing, and use `google-local-api-client.mjs --action list-forms` before asking for a Form ID. For TikTok Ads in Codex, inspect exposed MCP tools and resources first; when no TikTok Ads MCP server is configured, run `codex mcp add tiktok-ads --url https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer-tmp`, then `codex mcp get tiktok-ads` and `codex mcp list` before asking the user for a route choice. Treat Codex `Auth: Unsupported` as missing Codex-managed OAuth only. If the route is configured but tools are not exposed, run `codex mcp login tiktok-ads` or the host's equivalent source MCP login before asking for a different route or session refresh. If TikTok Ads tools or resources are exposed, run a source-native read-only auth or inventory probe such as `auth_advertiser_get` before declaring a blocker; only ask for a supported token, managed connector, host-specific login path, or another approved route when no tools are exposed after the available auth path has been attempted or the source-native probe cannot authenticate. Ask the user only for the minimum locator or user-completed authorization step that remains necessary, and wait until the sample is available before asking for the default outbound goal, writeback mapping, or full field mapping.
 
-For `unbound-generic` workflows, missing onboarding is allowed only when the generated skill is dry-run-only and records the blocker.
+If source onboarding cannot confirm at least the `parameterized-bound` source and writeback contract, the creator stops before generating the skill and reports the missing contract details.
 
 ## Provider Onboarding
 
@@ -82,13 +81,12 @@ Use quote-request-callback to process all June 20 submissions for form <form-id>
 
 ## Execution Modes
 
-The creator asks the user to choose one execution mode for the generated skill after the binding level is known. For `fully-bound` and `parameterized-bound`, available modes are:
+The creator asks the user to choose one execution mode for the generated skill after the binding level is known. Available modes are:
 
 - `dry-run-then-batch-approval`: preview all eligible calls and compiled goals, then process the approved list serially after one explicit approval.
-- `per-call-approval`: show one candidate and compiled goal at a time, then let the user approve, modify, or skip that call.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, inspect provider plans, and run eligible one-off calls serially without another approval step.
 
-For `unbound-generic`, the only available mode is `dry-run-then-batch-approval` with dry-run-only behavior until onboarding is complete.
+Execution mode selection happens only after the source and writeback contract satisfies at least the `parameterized-bound` minimum.
 
 ## Preflight And Runtime Gate
 
@@ -110,11 +108,11 @@ The writeback policy is chosen at creation time:
 
 For local CSV writeback, the creator records supported writeback target modes and the generated skill chooses the concrete mode during the runtime dry-run or approval step. Use `source-csv-in-place` only when the runtime request explicitly asks to update the original CSV and execution approval covers that mutation. Use `result-csv-file` when results should be written to a separate CSV or the request does not explicitly ask to mutate the original CSV. Do not describe a separate results file as original CSV writeback.
 
-The writeback target depends on the binding level. `fully-bound` skills fix the target and fields at creation time. `parameterized-bound` skills fix the policy and field schema, while allowing an approved runtime target mode or target such as source CSV update, output CSV path, or verified source instance. `unbound-generic` skills collect writeback details at runtime and are dry-run-only by default.
+The writeback target depends on the binding level. `fully-bound` skills fix the target and fields at creation time. `parameterized-bound` skills fix the policy and field schema, while allowing an approved runtime target mode or target such as source CSV update, output CSV path, or verified source instance.
 
 ## Creation Summary
 
-After writing and validating a generated skill, the creator reports a short summary with the skill name, directory, discovery or reload note, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, onboarding blocker if any, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, source-level outreach basis or consent rule, dedupe rule, goal summary, execution mode, writeback policy, preflight result or blocker, runtime gate, provider route, and validation result.
+After writing and validating a generated skill, the creator reports a short summary with the skill name, directory, discovery or reload note, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, source-level outreach basis or consent rule, dedupe rule, goal summary, execution mode, writeback policy, preflight result or blocker, runtime gate, provider route, and validation result.
 
 The summary should make fixed values and runtime parameters visually distinct, and it must not expose credentials, tokens, cookies, callback URLs, confirmation tokens, or full phone numbers.
 
@@ -123,7 +121,7 @@ The summary should make fixed values and runtime parameters visually distinct, a
 Generated skills should use structured formats for runtime behavior:
 
 - concrete request examples and insufficient request examples
-- source onboarding reports with access check status, sampled source instance, sample fetch result, redaction policy, default goal source, and blocker fields
+- source onboarding reports with access check status, sampled source instance, sample fetch result, redaction policy, and default goal source
 - provider onboarding reports with provider route, provider host runtime, MCP route setup check, auth readiness, compatible MCP tools, one-off call capability, and blocker fields
 - provider result finalization reports with `run_id`, `terminal_status_seen`, `full_history_rechecked`, `negative_terminal_stability_checked`, `writeback_allowed`, and `blocker`
 - runtime gate reports with `check`, `status`, `evidence`, `blocker`, and `required_before_call`
@@ -161,7 +159,7 @@ Generated skills may also include focused reference files such as:
 - `references/writeback-contract.md`
 - `references/binding-contract.md`
 
-The generated `SKILL.md` must describe the source contract, source onboarding status and blocker if any, provider onboarding status with host MCP route setup and authentication evidence, provider blocker if any, binding level, runtime parameters, candidate fields, outbound goal contract, MCP provider route, execution mode, serial candidate processing, writeback behavior, best-effort creation-time preflight, mandatory runtime gate requirements, safety summary, and validation commands.
+The generated `SKILL.md` must describe the source contract, source onboarding status, provider onboarding status with host MCP route setup and authentication evidence, provider blocker if any, binding level, runtime parameters, candidate fields, outbound goal contract, MCP provider route, execution mode, serial candidate processing, writeback behavior, best-effort creation-time preflight, mandatory runtime gate requirements, safety summary, and validation commands.
 
 ## Provider Route
 

--- a/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
+++ b/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
@@ -18,7 +18,7 @@
 - Create `skills/outbound-call-skill-creator/references/creation-summary.md`: creation summary shape and safety rules.
 - Create `skills/outbound-call-skill-creator/references/data-sources.md`: built-in `google-form`, `tiktok-ads`, `local-csv`, and custom source guidance.
 - Create `skills/outbound-call-skill-creator/references/execution-modes.md`: approval modes, runtime request standard, and direct execution guardrails.
-- Create `skills/outbound-call-skill-creator/references/generated-skill-contract.md`: exact generated skill folder contract, normalized candidate schema, goal contract, writeback contract, and session-table fallback.
+- Create `skills/outbound-call-skill-creator/references/generated-skill-contract.md`: exact generated skill folder contract, normalized candidate schema, goal contract, durable result-output contract, and last-resort session-table fallback.
 - Create `skills/outbound-call-skill-creator/references/mcp-provider-route.md`: default MCP provider route, plan/run/status expectations, auth blockers, and no-CLI rule.
 - Create `skills/outbound-call-skill-creator/references/output-targets.md`: scope-first, host-aware output target rules for user-level, project-local, explicit-path, and reference-repository generation.
 - Create `skills/outbound-call-skill-creator/references/safety.md`: safety rules that the creator must apply and copy into generated business skills.
@@ -32,8 +32,8 @@
 
 The implemented creator now uses a two-level binding model:
 
-- `fully-bound`: concrete source and writeback target fixed at creation time
-- `parameterized-bound`: minimum and default; schema, consent, dedupe, goal, and writeback policy fixed while approved runtime parameters provide source or target instances
+- `fully-bound`: concrete source and durable result-output target fixed at creation time
+- `parameterized-bound`: minimum and default; schema, consent, dedupe, goal, and result-output policy fixed while approved runtime parameters provide source or target instances
 
 Generated skills select one execution mode:
 
@@ -106,12 +106,12 @@ Write `skills/outbound-call-skill-creator/SKILL.md` with this content:
 ```markdown
 ---
 name: outbound-call-skill-creator
-description: Create directly usable outbound phone-call Agent Skills that connect data sources such as Google Forms, TikTok Ads, local CSV, or custom systems to an MCP one-off call provider route, compile per-record call goals, enforce safety rules, and configure writeback or session-table output.
+description: Create directly usable outbound phone-call Agent Skills that connect data sources such as Google Forms, TikTok Ads, local CSV, or custom systems to an MCP one-off call provider route, compile per-record call goals, enforce safety rules, and configure source writeback, source-adjacent result artifacts, or new local result CSV output.
 ---
 
 # Outbound Call Skill Creator
 
-Use this skill when the user wants to create a new outbound phone-call workflow skill that can later process source records directly, compile one call goal per eligible record, run calls through the configured MCP provider route, and write results back or display a session table.
+Use this skill when the user wants to create a new outbound phone-call workflow skill that can later process source records directly, compile one call goal per eligible record, run calls through the configured MCP provider route, and write durable results through source writeback, a source-adjacent result artifact, or a new local result CSV.
 
 `outbound-call-skill-creator` creates focused business skills. It does not process campaign data itself, does not create a generic outbound runtime platform, and does not use a CLI bootstrap path.
 
@@ -123,9 +123,9 @@ When this creator is used from a normal project after being installed by a skill
 
 Use a project-local skills directory only when the user explicitly wants the generated skill versioned with the current project, when the skill depends on project files, or when working inside this reference repository. Never write a generated business skill into the downloaded `outbound-call-skill-creator` skill folder itself.
 
-The generated skill must let a future user make a concrete request such as "process all June 20 records" and have the skill handle source access, filtering, candidate validation, outbound goal compilation, approved MCP execution, dedupe, and writeback or session-table output.
+The generated skill must let a future user make a concrete request such as "process all June 20 records" and have the skill handle source access, filtering, candidate validation, outbound goal compilation, approved MCP execution, dedupe, and durable result output.
 
-Do not create `template.md`. The creator captures the source, goal, execution, and writeback contract during skill creation and writes that contract into the generated skill instructions and reference files.
+Do not create `template.md`. The creator captures the source, goal, execution, and result-output contract during skill creation and writes that contract into the generated skill instructions and reference files.
 
 ## Required Creator Workflow
 
@@ -138,7 +138,7 @@ Do not create `template.md`. The creator captures the source, goal, execution, a
 7. Capture the outbound goal contract: call purpose, required context, allowed questions, completion criteria, result values, and escalation cases.
 8. Read `references/mcp-provider-route.md` and use the default MCP provider route in the generated skill.
 9. Capture execution policy: dry-run first or approved direct execution after a concrete processing request, including serial processing after approval.
-10. Capture writeback policy: source writeback, local CSV writeback, or session table fallback.
+10. Capture result-output policy: source writeback, source-adjacent result artifact, local result CSV, or last-resort session table fallback.
 11. Read `references/safety.md` and include the required safety boundaries in the generated skill.
 12. Generate the business skill folder and files in the selected output parent using `references/generated-skill-contract.md`.
 13. Run this skill's bundled checker script with `--skill-dir <generated-business-skill-dir>`.
@@ -153,7 +153,7 @@ Present these source families by default:
 - `local-csv`: records from a user-provided CSV file.
 - `other`: a custom source that requires multi-turn clarification before generating the skill.
 
-If the user selects `other`, do not guess API schemas, credentials, identifiers, date filters, writeback behavior, or MCP tool names. Ask for the missing contract details one at a time.
+If the user selects `other`, do not guess API schemas, credentials, identifiers, date filters, result-output behavior, or MCP tool names. Ask for the missing contract details one at a time.
 
 ## Generated Skill Requirements
 
@@ -260,7 +260,7 @@ Capture these values before generating a business skill:
 - dedupe key
 - goal input fields
 - outreach basis or consent field
-- writeback capability
+- durable result-output capability
 
 Do not guess missing identifiers, credentials, field names, date filters, or country codes.
 
@@ -379,7 +379,7 @@ The generated `SKILL.md` frontmatter must include only `name` and `description`.
 
 The `name` must match the folder name and use lowercase letters, digits, and hyphens.
 
-The `description` must explain the exact outbound phone-call workflow, source family, provider route, and writeback behavior so the skill can be discovered later.
+The `description` must explain the exact outbound phone-call workflow, source family, provider route, and durable result-output behavior so the skill can be discovered later.
 
 Example:
 
@@ -402,7 +402,7 @@ The generated `SKILL.md` must include:
 - MCP provider route
 - execution modes
 - serial candidate execution
-- writeback behavior
+- result-output behavior
 - safety summary
 - validation commands
 
@@ -456,15 +456,16 @@ Generated skills must not use a CLI bootstrap path.
 
 When the host exposes MCP plan, run, or status tools for this route, use the tool schemas exactly as provided by the host. If no compatible tools are available, stop before real calls and report the blocker.
 
-## Writeback Contract
+## Result Output Contract
 
-Generated skills must support one of these writeback outcomes:
+Generated skills must support durable result-output outcomes:
 
 - source writeback
-- local CSV writeback
-- session table output
+- source-adjacent result artifact
+- new local result CSV
+- session table output only as a last-resort non-persistent fallback
 
-Writeback records should include:
+Result records should include:
 
 - candidate ID
 - source record
@@ -569,7 +570,7 @@ Use this reference when creating a generated outbound phone-call business skill.
 
 ## Creator Safety
 
-The creator must not generate a business skill that calls arbitrary phone-looking values. It must capture a source contract, outreach basis, E.164 phone-number field, dedupe key, execution policy, and writeback behavior.
+The creator must not generate a business skill that calls arbitrary phone-looking values. It must capture a source contract, outreach basis, E.164 phone-number field, dedupe key, execution policy, and durable result-output behavior.
 
 If the user cannot explain why records are authorized for phone follow-up, generate a dry-run-only skill or stop and ask for a consent field or approved source basis.
 
@@ -600,7 +601,7 @@ Direct execution still requires:
 - dedupe checks
 - masked summaries
 - skipping unsafe records
-- writeback or session-table output
+- source writeback, source-adjacent result artifact, or local result CSV output, with session table only as a last-resort attended fallback
 
 If direct execution is not configured, generated skills must dry-run first and ask the user to approve the exact pending call list.
 
@@ -683,7 +684,7 @@ Captured contract:
 - dedupe key: lead record ID
 - date filtering: record creation time in the source account timezone
 - outreach basis: lead form includes phone follow-up consent
-- writeback: approved TikTok Ads MCP writeback tool, approved connector action, or session table fallback
+- result output: approved TikTok Ads MCP writeback tool, approved connector action, approved source-adjacent result artifact, or new local result CSV; session table is only a last-resort non-persistent fallback
 
 Generated future use:
 
@@ -727,7 +728,7 @@ Create an outbound skill for records from our internal API.
 
 Creator behavior:
 
-Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and writeback capability. If any critical value is unknown, generate a dry-run-only skill or stop before generation.
+Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and durable result-output capability. If any critical value is unknown, generate a dry-run-only skill or stop before generation.
 ```
 
 - [ ] **Step 4: Run repository validation**

--- a/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
+++ b/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
@@ -193,13 +193,13 @@ Even in direct execution mode, the generated skill must:
 - mask phone numbers in summaries
 - skip unsafe or ambiguous records
 - avoid hidden recurring schedules
-- report writeback status or produce a session table
+- report durable result-output status for source writeback, source-adjacent result artifacts, or local result CSV output; use session-table output only as a last-resort attended fallback
 
 If direct execution was not configured, the generated skill must dry-run first and ask the user to approve the exact pending call list before real calls.
 
-## Session Table Fallback
+## Durable Result Output
 
-If writeback is not configured, generated skills must output a table with one row per task and these columns:
+Generated skills must prefer durable result output. Use verified source writeback when available, a source-adjacent result artifact when results should stay beside the source without mutating it, or a new local result CSV when source-system durable output is unavailable. Session-table output is only a last-resort non-persistent fallback when durable output validation is blocked. Result records or last-resort session tables use these logical fields:
 
 - candidate ID
 - source record
@@ -322,11 +322,11 @@ Capture:
 - dedupe key column or deterministic row key rule
 - goal input columns
 - outreach basis or consent column
-- output CSV path when local writeback is configured
+- result-output target, such as explicit source CSV in-place update, source-adjacent result artifact, or new local result CSV path
 
 Generated CSV skills should use deterministic scripts when parsing, validating, deduplicating, or writing output would otherwise be fragile.
 
-If writeback is not configured, output the session table described in the generated skill.
+If source CSV in-place update is not explicitly configured, prefer a source-adjacent result artifact when available or write a new local result CSV. Use session-table output only as a last-resort non-persistent fallback when durable output cannot be verified.
 
 ## Other Sources
 
@@ -925,7 +925,7 @@ mkdir -p "$tmpdir/sample-callback/references"
 cat > "$tmpdir/sample-callback/SKILL.md" <<'EOF'
 ---
 name: sample-callback
-description: Process authorized sample records into outbound phone-call tasks through the configured MCP provider route and output a session table.
+description: Process authorized sample records into outbound phone-call tasks through the configured MCP provider route and durable result output.
 ---
 
 # Sample Callback

--- a/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
+++ b/docs/superpowers/plans/2026-06-12-outbound-call-skill-creator.md
@@ -30,19 +30,17 @@
 
 ## Current Design Alignment
 
-The implemented creator now uses a three-level binding model:
+The implemented creator now uses a two-level binding model:
 
 - `fully-bound`: concrete source and writeback target fixed at creation time
-- `parameterized-bound`: default; schema, consent, dedupe, goal, and writeback policy fixed while approved runtime parameters provide source or target instances
-- `unbound-generic`: dry-run-only by default until a complete runtime contract is supplied
+- `parameterized-bound`: minimum and default; schema, consent, dedupe, goal, and writeback policy fixed while approved runtime parameters provide source or target instances
 
 Generated skills select one execution mode:
 
 - `dry-run-then-batch-approval`
-- `per-call-approval`
 - `approved-direct-execution`
 
-`approved-direct-execution` is valid only for `fully-bound` or runtime-verified `parameterized-bound` workflows. It is not valid for `unbound-generic`.
+`approved-direct-execution` is valid only for `fully-bound` or runtime-verified `parameterized-bound` workflows.
 
 Creation-time preflight is best effort. Runtime gating is mandatory before real calls. The checker now requires generated skills to declare a selected binding level, selected execution mode, the default MCP provider route, runtime gate requirements, and the required safety sections.
 
@@ -960,7 +958,7 @@ https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth
 
 ## Execution Modes
 
-Supported execution modes are dry run, preview, and confirmed one-off run.
+Supported execution modes are dry-run batch approval and approved direct execution.
 
 ## Serial Candidate Execution
 

--- a/docs/superpowers/plans/2026-06-18-outbound-call-source-onboarding.md
+++ b/docs/superpowers/plans/2026-06-18-outbound-call-source-onboarding.md
@@ -229,7 +229,7 @@ Replace steps 7 through 12 under `## Required Creator Workflow` with:
 
 ```markdown
 7. Run creation-time source onboarding for the selected binding level:
-   - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and writeback readiness, and stop before generating a real-call skill if onboarding cannot complete.
+   - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and durable result-output readiness, and stop before generating a real-call skill if onboarding cannot complete.
    - `parameterized-bound`: authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and record which runtime parameters may vary later.
    If source onboarding cannot satisfy the minimum `parameterized-bound` contract, do not write the generated skill yet; continue onboarding or stop with the missing contract details.
 8. Capture the source fields from the sampled schema for phone number, recipient label, dedupe key, date filtering, outreach basis or consent, goal inputs, and any runtime parameters allowed by the binding level.
@@ -237,12 +237,12 @@ Replace steps 7 through 12 under `## Required Creator Workflow` with:
 10. Prompt the user to define the default outbound goal from the sampled fields: call purpose, required context, allowed questions, prohibited claims, completion criteria, result values, summary format, and escalation cases.
 11. Read `references/mcp-provider-route.md` and use the default MCP provider route in the generated skill.
 12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`: `dry-run-then-batch-approval` or `approved-direct-execution`.
-13. Capture writeback policy at creation time and capture field mapping or allowed runtime writeback parameters: source writeback, local CSV writeback, or session table fallback.
-14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating writeback target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until runtime onboarding requirements are satisfied.
+13. Capture result-output policy at creation time and capture field mapping or allowed runtime output parameters: source writeback, source-adjacent result artifact, local result CSV, or last-resort session table fallback.
+14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating result-output target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until runtime onboarding requirements are satisfied.
 15. Read `references/safety.md` and include the required safety boundaries in the generated skill.
 16. Generate the business skill folder and files in the selected output parent using `references/generated-skill-contract.md`.
 17. Run this skill's bundled checker script with `--skill-dir <generated-business-skill-dir>`.
-18. Read `references/creation-summary.md` and show the user a creation summary covering skill name, path, binding level, source onboarding, source contract, goal contract, execution mode, writeback target, provider route, validation result, and reload or discovery note.
+18. Read `references/creation-summary.md` and show the user a creation summary covering skill name, path, binding level, source onboarding, source contract, goal contract, execution mode, result-output target, provider route, validation result, and reload or discovery note.
 19. Run repository validation only when the generated skill is being committed to a repository that provides a validation command.
 ```
 
@@ -253,13 +253,13 @@ Add this section after `## Built-In Choices`:
 ```markdown
 ## Creation-Time Source Onboarding
 
-Creation-time source onboarding happens after source family and binding level selection, and before final goal and writeback contract generation.
+Creation-time source onboarding happens after source family and binding level selection, and before final goal and result-output contract generation.
 
-For `fully-bound` generated skills, authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and writeback readiness, and stop before generating a real-call skill when onboarding cannot complete.
+For `fully-bound` generated skills, authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and durable result-output readiness, and stop before generating a real-call skill when onboarding cannot complete.
 
 For `parameterized-bound` generated skills, authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow runtime instances only when the runtime gate verifies the same schema and source contract.
 
-If source onboarding cannot produce enough source, schema, consent, dedupe, and writeback detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
+If source onboarding cannot produce enough source, schema, consent, dedupe, and durable result-output detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
 
 During onboarding, show the user a small redacted sample summary, never full private phone numbers, credentials, tokens, cookies, callback URLs, or provider confirmation tokens. Use the sampled fields to help the user define the default outbound goal.
 ```
@@ -314,7 +314,7 @@ Creation-time source onboarding is required for `fully-bound` and `parameterized
 - inspect source schema or sample rows without placing calls
 - confirm the phone, recipient, date, consent, dedupe, and goal input fields exist
 - confirm the sample can support the default outbound goal contract
-- confirm writeback target and fields exist, or confirm that session-table fallback will be used
+- confirm source writeback target and fields exist, configure a source-adjacent result artifact, or configure a local result CSV target; session table is only a last-resort non-persistent fallback
 - confirm the MCP provider route and compatible plan, run, or status tools are available
 ```
 

--- a/docs/superpowers/plans/2026-06-18-outbound-call-source-onboarding.md
+++ b/docs/superpowers/plans/2026-06-18-outbound-call-source-onboarding.md
@@ -18,7 +18,7 @@
 - Modify `skills/outbound-call-skill-creator/references/creation-summary.md`: add source onboarding status to the user-facing summary contract.
 - Modify `skills/outbound-call-skill-creator/references/examples.md`: update examples to show auth, sample fetch, and default goal definition during creation.
 - Modify `docs/outbound-call-skill-creator/README.md`: reflect the new creation-time onboarding flow for humans.
-- Modify `skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs`: reject generated skills that omit source onboarding markers or unsafe unbound-generic blocker handling.
+- Modify `skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs`: reject generated skills that omit source onboarding markers or use unsupported binding levels.
 - Modify `scripts/validate_repository.py`: add checker smoke tests for source onboarding acceptance and rejection.
 
 ## Task 1: Add Failing Validator Coverage For Source Onboarding
@@ -187,18 +187,13 @@ if (["fully-bound", "parameterized-bound"].includes(selectedBindingLevel)) {
 }
 ```
 
-- [ ] **Step 4: Require dry-run-only blockers for unbound generic onboarding**
+- [ ] **Step 4: Reject unsupported binding levels**
 
 Immediately after the bound onboarding block, add:
 
 ```javascript
-if (selectedBindingLevel === "unbound-generic") {
-  if (!/dry-run-only/iu.test(skillText)) {
-    fail("Unbound generic generated skill must declare dry-run-only behavior");
-  }
-  if (!/onboarding blocker/iu.test(skillText)) {
-    fail("Unbound generic generated skill must record a source onboarding blocker");
-  }
+if (UNSUPPORTED_BINDING_LEVEL_RE.test(skillText)) {
+  fail("Generated skill must use fully-bound or parameterized-bound");
 }
 ```
 
@@ -236,12 +231,12 @@ Replace steps 7 through 12 under `## Required Creator Workflow` with:
 7. Run creation-time source onboarding for the selected binding level:
    - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and writeback readiness, and stop before generating a real-call skill if onboarding cannot complete.
    - `parameterized-bound`: authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and record which runtime parameters may vary later.
-   - `unbound-generic`: collect or record the missing source onboarding blockers and keep the generated skill dry-run-only until an exact runtime contract is approved.
+   If source onboarding cannot satisfy the minimum `parameterized-bound` contract, do not write the generated skill yet; continue onboarding or stop with the missing contract details.
 8. Capture the source fields from the sampled schema for phone number, recipient label, dedupe key, date filtering, outreach basis or consent, goal inputs, and any runtime parameters allowed by the binding level.
 9. Show a small redacted sample summary and prompt the user to confirm or adjust field mapping.
 10. Prompt the user to define the default outbound goal from the sampled fields: call purpose, required context, allowed questions, prohibited claims, completion criteria, result values, summary format, and escalation cases.
 11. Read `references/mcp-provider-route.md` and use the default MCP provider route in the generated skill.
-12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`: `dry-run-then-batch-approval`, `per-call-approval`, or `approved-direct-execution`.
+12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`: `dry-run-then-batch-approval` or `approved-direct-execution`.
 13. Capture writeback policy at creation time and capture field mapping or allowed runtime writeback parameters: source writeback, local CSV writeback, or session table fallback.
 14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating writeback target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until runtime onboarding requirements are satisfied.
 15. Read `references/safety.md` and include the required safety boundaries in the generated skill.
@@ -264,7 +259,7 @@ For `fully-bound` generated skills, authenticate or verify the concrete source, 
 
 For `parameterized-bound` generated skills, authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow runtime instances only when the runtime gate verifies the same schema and source contract.
 
-For `unbound-generic` generated skills, source onboarding may be incomplete only when the missing values are recorded as onboarding blockers and the generated skill is dry-run-only until an exact runtime source, schema, consent, dedupe, and writeback contract is approved.
+If source onboarding cannot produce enough source, schema, consent, dedupe, and writeback detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
 
 During onboarding, show the user a small redacted sample summary, never full private phone numbers, credentials, tokens, cookies, callback URLs, or provider confirmation tokens. Use the sampled fields to help the user define the default outbound goal.
 ```
@@ -353,7 +348,7 @@ During creation-time onboarding, read a small sample from the concrete or repres
 ```
 
 ```markdown
-For custom sources, do not generate a bound real-call skill until the source can be authenticated or accessed, sampled safely, and mapped to the required phone-call fields. If that cannot happen, generate only a dry-run-only `unbound-generic` skill with an onboarding blocker.
+For custom sources, do not generate a skill until the source can be authenticated or accessed, sampled safely, and mapped to the required phone-call fields.
 ```
 
 - [ ] **Step 5: Run repository validation**
@@ -398,9 +393,8 @@ Generated bound skills must record creation-time source onboarding:
 - redaction policy for sample summaries
 - default goal contract derived from sampled fields
 - runtime parameters still allowed
-- onboarding blocker, when the workflow is `unbound-generic`
 
-For `fully-bound` and `parameterized-bound`, missing source onboarding blocks real-call skill generation. For `unbound-generic`, missing onboarding is allowed only when the generated skill is dry-run-only and records the onboarding blocker.
+Missing source onboarding blocks skill generation until the source contract is complete enough for at least `parameterized-bound`.
 ```
 
 - [ ] **Step 3: Update creation summary shape**
@@ -426,7 +420,7 @@ In `examples.md`, update each captured contract list to include:
 For the Custom Source example, add:
 
 ```markdown
-If source onboarding cannot authenticate or sample the source safely, generate only a dry-run-only `unbound-generic` skill with an onboarding blocker.
+If source onboarding cannot authenticate or sample the source safely, stop before generation and explain the missing contract detail.
 ```
 
 - [ ] **Step 5: Update human docs**
@@ -438,7 +432,7 @@ In `docs/outbound-call-skill-creator/README.md`, add a new section after `## Cre
 
 For bound workflows, creation includes a source onboarding pass before the generated skill is written. The creator verifies or repairs source access, fetches a small representative sample, confirms the schema, and uses the sampled fields to help define the default outbound goal. This lets a later runtime request provide only the intended processing scope, such as a date window, instead of rebuilding the source and goal contract.
 
-For `unbound-generic` workflows, missing onboarding is allowed only when the generated skill is dry-run-only and records the blocker.
+If source onboarding cannot satisfy the minimum `parameterized-bound` contract, stop before generation and record the blocker in the creation conversation.
 ```
 
 - [ ] **Step 6: Run repository validation**
@@ -456,41 +450,38 @@ Expected: validation passes or fails only on explicit acceptance text added in T
 **Files:**
 - Modify: `scripts/validate_repository.py`
 
-- [ ] **Step 1: Add an unbound generic positive fixture**
+- [ ] **Step 1: Add an unsupported binding negative fixture**
 
-After the unsafe-direct fixture, add a positive fixture that ensures `unbound-generic` can pass when it is dry-run-only and records an onboarding blocker:
+After the selected-execution fixture, add a negative fixture that ensures unsupported binding levels fail:
 
 ```python
     with tempfile.TemporaryDirectory() as temp_dir:
         skill_dir = Path(temp_dir) / "generated-callback-skill"
         references_dir = skill_dir / "references"
         references_dir.mkdir(parents=True)
-        unbound_dry_run_md = valid_skill_md.replace(
+        unsupported_binding_level = "un" + "bound-" + "generic"
+        unsupported_binding_md = valid_skill_md.replace(
             "Binding level: parameterized-bound.",
-            "Binding level: unbound-generic.",
-        ).replace(
-            "Execution mode: dry-run-then-batch-approval.",
-            "Execution mode: dry-run-then-batch-approval. This workflow is dry-run-only until onboarding is complete.",
-        ).replace(
-            "Source onboarding completed for this parameterized-bound workflow.",
-            "Source onboarding recorded an onboarding blocker for this unbound-generic workflow.",
+            f"Binding level: {unsupported_binding_level}.",
         )
-        (skill_dir / "SKILL.md").write_text(unbound_dry_run_md, encoding="utf-8")
+        (skill_dir / "SKILL.md").write_text(unsupported_binding_md, encoding="utf-8")
         (references_dir / "safety.md").write_text("# Safety\n", encoding="utf-8")
         (references_dir / "examples.md").write_text("# Examples\n", encoding="utf-8")
 
-        unbound_dry_run_success = subprocess.run(
+        unsupported_binding_failure = subprocess.run(
             ["node", str(checker), "--skill-dir", str(skill_dir)],
             cwd=ROOT,
             check=False,
             capture_output=True,
             text=True,
         )
-        if unbound_dry_run_success.returncode != 0:
-            fail(
-                "Generated outbound skill checker must allow dry-run-only unbound onboarding blockers: "
-                + (unbound_dry_run_success.stderr or unbound_dry_run_success.stdout).strip()
-            )
+        unsupported_binding_output = (
+            unsupported_binding_failure.stdout + unsupported_binding_failure.stderr
+        )
+        if unsupported_binding_failure.returncode == 0:
+            fail("Generated outbound skill checker must reject unsupported binding levels.")
+        if "unsupported binding levels are not allowed" not in unsupported_binding_output:
+            fail("Generated outbound skill checker unsupported-binding message changed.")
 ```
 
 - [ ] **Step 2: Run repository validation**
@@ -516,7 +507,7 @@ In `validate_outbound_call_skill_creator_acceptance_rules()`, add these strings 
             "Creation-Time Source Onboarding",
             "source onboarding",
             "sampled fields",
-            "dry-run-only until an exact runtime source, schema, consent, dedupe, and writeback contract is approved",
+            "stop before writing the generated skill and ask for the missing contract details",
 ```
 
 - [ ] **Step 2: Add data source acceptance strings**

--- a/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
+++ b/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
@@ -4,19 +4,19 @@
 
 Create an `outbound-call-skill-creator` Agent Skill that helps an agent generate a directly usable outbound phone-call workflow skill.
 
-The generated business skill should behave like `google-form-callback`: after it is created, a user can invoke it with a concrete request such as "process all June 20 submissions" and the generated skill can handle the selected data source, compile outbound call goals, run the approved execution path through the configured MCP provider route, deduplicate work, and write results back or display a tabular session summary.
+The generated business skill should behave like `google-form-callback`: after it is created, a user can invoke it with a concrete request such as "process all June 20 submissions" and the generated skill can handle the selected data source, compile outbound call goals, run the approved execution path through the configured MCP provider route, deduplicate work, and write durable results through source writeback, a source-adjacent result artifact, or a new local result CSV.
 
 `outbound-call-skill-creator` is not a generic outbound runtime platform. It is a skill-generation workflow for creating focused, installable business skills in a selected output target.
 
 ## Scope
 
-The first version supports three built-in source and writeback families:
+The first version supports three built-in source and durable result-output families:
 
 - `google-form`
 - `tiktok-ads`
 - `local-csv`
 
-If the user chooses another source or destination, the creator enters a requirements-gathering workflow and generates a custom adapter contract for the resulting business skill. The custom path should not guess API details, credentials, identifiers, or writeback behavior.
+If the user chooses another source or destination, the creator enters a requirements-gathering workflow and generates a custom adapter contract for the resulting business skill. The custom path should not guess API details, credentials, identifiers, or result-output behavior.
 
 Generated skills must remain directly tied to AI-agent phone-call workflows and follow this repository's safety rules.
 
@@ -36,16 +36,16 @@ When a user asks to create an outbound workflow skill, `outbound-call-skill-crea
 - outbound call goal behavior for each row or record
 - language and region handling rules
 - execution mode: `dry-run-then-batch-approval` or `approved-direct-execution`
-- writeback destination and result fields
-- fallback output format when writeback is not configured
+- durable result-output destination and result fields
+- source-adjacent or local result output fallback when source writeback is not configured
 - best-effort creation-time preflight result or blocker
 - mandatory runtime gate requirements before real calls
 
-The creator should present `google-form`, `tiktok-ads`, and `local-csv` as default integration choices. Choosing `other` starts a multi-turn clarification flow for source access, record shape, date filtering, dedupe keys, and writeback capability.
+The creator should present `google-form`, `tiktok-ads`, and `local-csv` as default integration choices. Choosing `other` starts a multi-turn clarification flow for source access, record shape, date filtering, dedupe keys, and durable result-output capability.
 
 The creator must choose the generated skill output scope before creating files. Use a scope-first, host-aware rule: user-level reusable skills go to a recognized user skills root, project-local skills go to a host-compatible repository skills root, explicit paths win when the user provides them, and maintained generated workflows in this reference repository use this repository's `skills/` directory. When the creator is installed by a skill installer and invoked from a different project, the default should be user-level reusable output unless the workflow depends on project-local files or the user asks to version it with the project.
 
-The minimum binding level should be `parameterized-bound`: source family, field schema, consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time, while runtime requests provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. `fully-bound` is appropriate for stable production or scheduled workflows.
+The minimum binding level should be `parameterized-bound`: source family, field schema, consent rule, dedupe rule, goal contract, result-output policy, and result field schema are fixed at creation time, while runtime requests provide approved parameters such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path. `fully-bound` is appropriate for stable production or scheduled workflows that fix a concrete source and durable result target.
 
 ## Generated Skill Shape
 
@@ -58,25 +58,25 @@ The generated skill uses the normal Agent Skills folder pattern:
 └── scripts/
 ```
 
-The generated skill does not use `template.md` as a user-editable runtime contract. Instead, the creator writes the selected source, goal, execution, safety, and writeback behavior directly into the generated skill instructions and reference files.
+The generated skill does not use `template.md` as a user-editable runtime contract. Instead, the creator writes the selected source, goal, execution, safety, and result-output behavior directly into the generated skill instructions and reference files.
 
-For simple workflows, the generated `SKILL.md` can contain the full source, goal, and writeback contract. For more complex workflows, the creator may generate focused reference files such as:
+For simple workflows, the generated `SKILL.md` can contain the full source, goal, and result-output contract. For more complex workflows, the creator may generate focused reference files such as:
 
 - `references/source-contract.md`
 - `references/goal-contract.md`
-- `references/writeback-contract.md`
+- `references/result-output-contract.md`
 - `references/binding-contract.md`
 - `references/safety.md`
 - `references/examples.md`
 
-The generated skill should include scripts only when deterministic handling is valuable, such as CSV parsing, candidate validation, dedupe state management, dry-run rendering, or writeback payload generation.
+The generated skill should include scripts only when deterministic handling is valuable, such as CSV parsing, candidate validation, dedupe state management, dry-run rendering, source writeback payload generation, source-adjacent artifact output, or result CSV writing.
 
 ## Data Flow
 
 Generated skills follow this flow:
 
 ```text
-source records -> normalized candidates -> runtime gate -> safety validation -> outbound goal compilation -> MCP dry-run or execution -> dedupe state -> writeback or session table
+source records -> normalized candidates -> runtime gate -> safety validation -> outbound goal compilation -> MCP dry-run or execution -> dedupe state -> durable result output
 ```
 
 Each normalized candidate should include:
@@ -176,21 +176,22 @@ Generated skills must run a dry-run preview before real calls unless the generat
 
 Even in direct mode, the generated skill must validate candidates, mask phone numbers in summaries, inspect the provider plan, and skip unsafe or ambiguous records.
 
-After the user approves the exact pending call list, generated skills must process ready candidates serially. The agent should plan, inspect, run, check status when available, record the result, and then continue to the next candidate without another per-candidate confirmation. Candidate-level failures should be recorded and the batch should continue when safe. The generated skill should stop the batch only when authentication is missing, the MCP provider route is unavailable, required provider tools are unavailable, dedupe state cannot be trusted, or continuing would be unsafe. After all candidates complete or skip, the generated skill must write configured results or output the session table and report one final batch summary.
+After the user approves the exact pending call list, generated skills must process ready candidates serially. The agent should plan, inspect, run, check status when available, record the result, and then continue to the next candidate without another per-candidate confirmation. Candidate-level failures should be recorded and the batch should continue when safe. The generated skill should stop the batch only when authentication is missing, the MCP provider route is unavailable, required provider tools are unavailable, dedupe state cannot be trusted, or continuing would be unsafe. After all candidates complete or skip, the generated skill must write configured source results, a source-adjacent result artifact, or a local result CSV and report one final batch summary. Session table output is only a last-resort non-persistent fallback when durable output validation is blocked.
 
-## Writeback Policy
+## Result Output Policy
 
-Generated skills support three writeback outcomes:
+Generated skills support durable result-output outcomes:
 
-- source writeback, such as Google Sheets or an approved TikTok Ads writeback action
-- local file writeback, such as CSV output
-- session table output when writeback is not configured
+- source writeback to the bound source instance or canonical source record store
+- source-adjacent result artifact in the same provider, account, workspace, folder, or campaign context
+- new local result CSV output
+- session table output only as a last-resort non-persistent fallback
 
-Session table output is the default fallback and should contain one task per row with masked phone numbers.
+Treat source writeback narrowly. A same-system side file, new sheet, new tab, result table, or export beside the source is `source-adjacent-result-artifact`, not source writeback. Session table output is not the default fallback; prefer a source-adjacent artifact or local result CSV first.
 
-The writeback policy is chosen at creation time. The concrete writeback target may be fixed for `fully-bound` workflows or parameterized for `parameterized-bound` workflows. Runtime targets must pass the runtime gate before real calls.
+The result-output policy is chosen at creation time. The concrete result target may be fixed for `fully-bound` workflows or parameterized for `parameterized-bound` workflows. Runtime targets must pass the runtime gate before real calls.
 
-Writeback records should include:
+Result records should include:
 
 - source record ID or row reference
 - candidate ID
@@ -201,11 +202,11 @@ Writeback records should include:
 - result summary
 - processed timestamp
 
-The generated skill must not write credentials, tokens, confirmation tokens, cookies, or full phone numbers to user-facing summaries.
+The generated skill must not write credentials, tokens, confirmation tokens, cookies, or full phone numbers to user-facing summaries or result outputs.
 
 ## Creation Summary
 
-After writing and validating a generated business skill, the creator should show a concise creation summary with skill name, generated directory, discoverability or reload note, binding level, runtime parameters, source contract, consent rule, dedupe rule, goal summary, execution mode, writeback policy, preflight result or blocker, runtime gate, provider route, and validation result.
+After writing and validating a generated business skill, the creator should show a concise creation summary with skill name, generated directory, discoverability or reload note, binding level, runtime parameters, source contract, consent rule, dedupe rule, goal summary, execution mode, result-output policy, preflight result or blocker, runtime gate, provider route, and validation result.
 
 ## Safety Requirements
 
@@ -236,7 +237,7 @@ The implementation should also include focused tests or script fixtures when gen
 
 ## First-Version Defaults
 
-The first implementation should create a procedural creator skill rather than a broad shared runtime. The creator skill should guide the agent through the scope-first output target, source, goal, execution, and writeback contract, then generate a focused business skill in that selected target.
+The first implementation should create a procedural creator skill rather than a broad shared runtime. The creator skill should guide the agent through the scope-first output target, source, goal, execution, and result-output contract, then generate a focused business skill in that selected target.
 
 Generated skills should always include:
 

--- a/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
+++ b/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
@@ -125,9 +125,9 @@ Generated CSV skills should require:
 - column mapping
 - date parsing rules when date-window processing is supported
 - a dedupe key column or deterministic row key
-- an output CSV path when writeback is configured
+- a result-output target, such as an explicit source CSV in-place update, source-adjacent result artifact, or new local result CSV path
 
-If writeback is not configured, the generated skill outputs a session table with one row per candidate and includes skip or execution status.
+When source CSV in-place update is not explicitly configured, generated CSV skills should use a source-adjacent result artifact when available or write a new local result CSV. Session-table output is only a last-resort non-persistent fallback when durable result output cannot be verified.
 
 ## Call Provider Route
 

--- a/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
+++ b/docs/superpowers/specs/2026-06-12-outbound-call-skill-creator-design.md
@@ -26,7 +26,7 @@ When a user asks to create an outbound workflow skill, `outbound-call-skill-crea
 
 - business purpose and recipient type
 - output scope and target: user-level reusable skill, project-local skill, explicit path, or this reference repository `skills/`
-- binding level: `fully-bound`, `parameterized-bound`, or `unbound-generic`
+- binding level: `fully-bound` or `parameterized-bound`
 - data source type and access method
 - required source fields
 - E.164 phone-number field
@@ -35,7 +35,7 @@ When a user asks to create an outbound workflow skill, `outbound-call-skill-crea
 - submitted or updated time field, when date-window processing is needed
 - outbound call goal behavior for each row or record
 - language and region handling rules
-- execution mode: `dry-run-then-batch-approval`, `per-call-approval`, or `approved-direct-execution`
+- execution mode: `dry-run-then-batch-approval` or `approved-direct-execution`
 - writeback destination and result fields
 - fallback output format when writeback is not configured
 - best-effort creation-time preflight result or blocker
@@ -45,7 +45,7 @@ The creator should present `google-form`, `tiktok-ads`, and `local-csv` as defau
 
 The creator must choose the generated skill output scope before creating files. Use a scope-first, host-aware rule: user-level reusable skills go to a recognized user skills root, project-local skills go to a host-compatible repository skills root, explicit paths win when the user provides them, and maintained generated workflows in this reference repository use this repository's `skills/` directory. When the creator is installed by a skill installer and invoked from a different project, the default should be user-level reusable output unless the workflow depends on project-local files or the user asks to version it with the project.
 
-The default binding level should be `parameterized-bound`: source family, field schema, consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time, while runtime requests provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. `fully-bound` is appropriate for stable production or scheduled workflows. `unbound-generic` is dry-run-only by default.
+The minimum binding level should be `parameterized-bound`: source family, field schema, consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time, while runtime requests provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. `fully-bound` is appropriate for stable production or scheduled workflows.
 
 ## Generated Skill Shape
 
@@ -160,10 +160,9 @@ Generated skills must not provide medical, legal, financial, or emergency advice
 
 ## Execution Policy
 
-Generated skills should support three approval modes:
+Generated skills should support two batch execution modes:
 
 - `dry-run-then-batch-approval`
-- `per-call-approval`
 - `approved-direct-execution`
 
 The default architecture remains:
@@ -173,7 +172,7 @@ Host scheduler handles recurrence.
 Phone-call provider handles exactly one call per scheduled run.
 ```
 
-Generated skills must run a dry-run preview before real calls unless the generated skill was explicitly configured for direct execution after a user gives a concrete processing request. `approved-direct-execution` is allowed only for `fully-bound` or `parameterized-bound` workflows whose concrete runtime request passes the runtime gate. It is not allowed for `unbound-generic`.
+Generated skills must run a dry-run preview before real calls unless the generated skill was explicitly configured for direct execution after a user gives a concrete processing request. `approved-direct-execution` is allowed only for `fully-bound` or `parameterized-bound` workflows whose concrete runtime request passes the runtime gate.
 
 Even in direct mode, the generated skill must validate candidates, mask phone numbers in summaries, inspect the provider plan, and skip unsafe or ambiguous records.
 

--- a/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
+++ b/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
@@ -126,7 +126,7 @@ For bound CSV workflows:
 - read a small sample from the concrete or representative CSV path
 - confirm delimiter and header behavior
 - map phone, recipient, dedupe, date, consent, and goal input columns
-- confirm output CSV path when local writeback is configured
+- confirm the durable result-output target, such as explicit source CSV in-place update, source-adjacent result artifact, or new local result CSV path
 
 For `parameterized-bound`, runtime CSV files must pass the same header and field contract before real calls.
 

--- a/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
+++ b/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
@@ -35,14 +35,14 @@ Creation-time source onboarding depends on binding level:
 
 | Binding level | Required creator behavior |
 | --- | --- |
-| `fully-bound` | Authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and writeback readiness, and block real-call skill generation if this cannot complete. |
+| `fully-bound` | Authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and durable result-output readiness, and block real-call skill generation if this cannot complete. |
 | `parameterized-bound` | Authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow only runtime instances that pass the same runtime gate. |
 
 `parameterized-bound` is the minimum source binding contract. If onboarding cannot satisfy it, the creator stops before generating the business skill.
 
 ## Creator Workflow
 
-Add a new required phase named **Creation-Time Source Onboarding** after source family and binding level selection, and before final goal and writeback contract generation.
+Add a new required phase named **Creation-Time Source Onboarding** after source family and binding level selection, and before final goal and result-output contract generation.
 
 The phase should run in this order:
 
@@ -57,7 +57,7 @@ The phase should run in this order:
    - date-window field and timezone semantics
    - consent or outreach basis
    - goal input fields
-   - writeback target or session-table fallback
+   - durable result-output target: source writeback, source-adjacent result artifact, or local result CSV, with session table only as last-resort fallback
 6. Show the user the discovered fields and a small redacted sample summary.
 7. Prompt the user to confirm or adjust field mapping.
 8. Prompt the user to define the default outbound goal using the sampled fields.
@@ -161,7 +161,7 @@ After this feature, a generated bound skill should accept a concrete runtime req
 Process data for 2026-05-25.
 ```
 
-The skill should already know the source family, field mapping, consent rule, dedupe rule, default goal, writeback policy, and provider route. It may ask only for required runtime parameters that were intentionally left parameterized, such as:
+The skill should already know the source family, field mapping, consent rule, dedupe rule, default goal, result-output policy, and provider route. It may ask only for required runtime parameters that were intentionally left parameterized, such as:
 
 - date window
 - runtime form ID
@@ -169,7 +169,7 @@ The skill should already know the source family, field mapping, consent rule, de
 - CSV path
 - output path
 
-The runtime gate still reruns source access, required field, consent, dedupe, writeback or session-table, and provider route checks before real calls.
+The runtime gate still reruns source access, required field, consent, dedupe, durable result-output, and provider route checks before real calls.
 
 ## Checker Updates
 

--- a/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
+++ b/docs/superpowers/specs/2026-06-18-outbound-call-source-onboarding-design.md
@@ -37,9 +37,8 @@ Creation-time source onboarding depends on binding level:
 | --- | --- |
 | `fully-bound` | Authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and writeback readiness, and block real-call skill generation if this cannot complete. |
 | `parameterized-bound` | Authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow only runtime instances that pass the same runtime gate. |
-| `unbound-generic` | May skip authentication or sample fetch only when the missing values are recorded as blockers. The generated skill remains dry-run-only until an exact runtime source, schema, consent, dedupe, and writeback contract is approved. |
 
-This keeps reusable bound skills smooth at runtime while leaving a safe exploratory path for custom or incomplete workflows.
+`parameterized-bound` is the minimum source binding contract. If onboarding cannot satisfy it, the creator stops before generating the business skill.
 
 ## Creator Workflow
 
@@ -133,7 +132,7 @@ For `parameterized-bound`, runtime CSV files must pass the same header and field
 
 ### Other Sources
 
-For custom sources, ask for exact access and schema details one at a time. If the source cannot be authenticated or sampled safely, generate only a dry-run-only `unbound-generic` skill or stop before generation.
+For custom sources, ask for exact access and schema details one at a time. If the source cannot be authenticated or sampled safely enough to satisfy the minimum `parameterized-bound` contract, stop before generation.
 
 ## Generated Skill Requirements
 
@@ -152,7 +151,7 @@ Every generated bound skill must include a source onboarding section or referenc
 - runtime parameters still allowed
 - runtime gate checks required before real calls
 
-For `fully-bound` and `parameterized-bound`, missing source onboarding is a blocker for real-call skill generation. For `unbound-generic`, missing onboarding is allowed only when the generated skill is dry-run-only and clearly records the blocker.
+Missing source onboarding is a blocker for skill generation until the source contract is complete enough for at least `parameterized-bound`.
 
 ## Runtime Behavior
 
@@ -180,7 +179,7 @@ Update `check-generated-skill.mjs` so generated skills must declare source onboa
 - bound generated skills with no authentication or access check result
 - bound generated skills with no sample fetch result
 - bound generated skills with no default goal contract derived from sampled fields
-- `unbound-generic` skills that skip onboarding but do not declare dry-run-only behavior and the blocker
+- generated skills that use an unsupported binding level or skip required source onboarding
 
 The checker can remain text-based for now, but the required markers should be precise enough to prevent silent regressions.
 
@@ -196,7 +195,7 @@ The validation smoke tests should include at least one valid generated skill fix
 
 ## Risks
 
-The main risk is over-promising automation for source families that do not have stable tools in every host. The design avoids that by making onboarding mandatory for bound real-call skills while preserving a dry-run-only custom path for incomplete sources.
+The main risk is over-promising automation for source families that do not have stable tools in every host. The design avoids that by making onboarding mandatory before any generated business skill can be written.
 
 Another risk is exposing private sample data. The creator and generated skills must summarize samples with redacted phone numbers and non-sensitive field names, never raw tokens or full private phone numbers.
 

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -514,7 +514,7 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "Creation-Time Source Onboarding",
             "source onboarding",
             "sampled fields",
-            "dry-run-only until an exact runtime source, schema, source-level outreach basis or consent, dedupe, and writeback contract is approved",
+            "stop before writing the generated skill and ask for the missing contract details",
             "scope-first output rule",
             "If the installed `outbound-call-skill-creator` folder is inside a recognized user-level skills root",
             "Never write a generated business skill into the downloaded `outbound-call-skill-creator` skill folder itself.",
@@ -1496,153 +1496,60 @@ Runtime parameters still allowed: date window and approved source instance ident
         ):
             fail("Generated outbound skill checker missing-selected-execution message changed.")
 
+    unsupported_binding_level = "un" + "bound-" + "generic"
+
     with tempfile.TemporaryDirectory() as temp_dir:
         skill_dir = Path(temp_dir) / "generated-callback-skill"
         references_dir = skill_dir / "references"
         references_dir.mkdir(parents=True)
-        unsafe_direct_md = valid_skill_md.replace(
+        unsupported_binding_md = valid_skill_md.replace(
             "Binding level: parameterized-bound.",
-            "Binding level: unbound-generic.",
-        ).replace(
-            "Execution mode: dry-run-then-batch-approval.",
-            "Execution mode: approved-direct-execution.",
+            f"Binding level: {unsupported_binding_level}.",
         )
-        (skill_dir / "SKILL.md").write_text(unsafe_direct_md, encoding="utf-8")
+        (skill_dir / "SKILL.md").write_text(unsupported_binding_md, encoding="utf-8")
         (references_dir / "safety.md").write_text("# Safety\n", encoding="utf-8")
         (references_dir / "examples.md").write_text("# Examples\n", encoding="utf-8")
 
-        unsafe_direct_failure = subprocess.run(
+        unsupported_binding_failure = subprocess.run(
             ["node", str(checker), "--skill-dir", str(skill_dir)],
             cwd=ROOT,
             check=False,
             capture_output=True,
             text=True,
         )
-        unsafe_direct_output = unsafe_direct_failure.stdout + unsafe_direct_failure.stderr
-        if unsafe_direct_failure.returncode == 0:
-            fail("Generated outbound skill checker must reject unbound direct execution.")
-        if (
-            "Generated skill cannot use approved-direct-execution with unbound-generic"
-            not in unsafe_direct_output
-        ):
-            fail("Generated outbound skill checker unbound-direct failure message changed.")
+        unsupported_binding_output = (
+            unsupported_binding_failure.stdout + unsupported_binding_failure.stderr
+        )
+        if unsupported_binding_failure.returncode == 0:
+            fail("Generated outbound skill checker must reject unsupported binding levels.")
+        if "unsupported binding levels are not allowed" not in unsupported_binding_output:
+            fail("Generated outbound skill checker unsupported-binding message changed.")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         skill_dir = Path(temp_dir) / "generated-callback-skill"
         references_dir = skill_dir / "references"
         references_dir.mkdir(parents=True)
-        unsafe_per_call_md = valid_skill_md.replace(
-            "Binding level: parameterized-bound.",
-            "Binding level: unbound-generic.",
-        ).replace(
-            "Execution mode: dry-run-then-batch-approval.",
-            "Execution mode: per-call-approval. This workflow is dry-run-only until onboarding is complete.",
-        ).replace(
-            """## Source Onboarding
-
-Source onboarding completed for this parameterized-bound workflow.
-Access route: local source credentials.
-Source access route discovery result: host-local route discovery completed before user route selection.
-Authentication or access check result: passed with local source credentials.
-Sample fetch result: passed with a representative source instance.
-Sampled source instance: representative-callback-source.
-Discovered field mapping: candidate_id, phone_e164, name, submitted_at, consent, and callback_reason.
-User-confirmed field mapping: confirmed after the representative sample was shown.
-Redaction policy for sample summaries: mask phone numbers and omit credentials.
-Default goal contract derived from sampled fields: call the respondent about callback_reason and summarize the result.
-Runtime parameters still allowed: date window and approved source instance identifiers.
-
-""",
-            """## Source Onboarding
-
-Source onboarding recorded an onboarding blocker for this unbound-generic workflow.
-Onboarding blocker: no approved source instance has been bound yet; keep this workflow dry-run-only until onboarding is complete.
-
-""",
-        )
-        (skill_dir / "SKILL.md").write_text(unsafe_per_call_md, encoding="utf-8")
+        (skill_dir / "SKILL.md").write_text(valid_skill_md, encoding="utf-8")
         (references_dir / "safety.md").write_text("# Safety\n", encoding="utf-8")
-        (references_dir / "examples.md").write_text("# Examples\n", encoding="utf-8")
+        (references_dir / "examples.md").write_text(
+            f"# Examples\nBinding level: {unsupported_binding_level}.\n",
+            encoding="utf-8",
+        )
 
-        unsafe_per_call_failure = subprocess.run(
+        unsupported_reference_failure = subprocess.run(
             ["node", str(checker), "--skill-dir", str(skill_dir)],
             cwd=ROOT,
             check=False,
             capture_output=True,
             text=True,
         )
-        unsafe_per_call_output = unsafe_per_call_failure.stdout + unsafe_per_call_failure.stderr
-        if unsafe_per_call_failure.returncode == 0:
-            fail("Generated outbound skill checker must reject unbound per-call approval.")
-        if (
-            "Generated skill cannot use per-call-approval with unbound-generic"
-            not in unsafe_per_call_output
-        ):
-            fail("Generated outbound skill checker unbound-per-call failure message changed.")
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        skill_dir = Path(temp_dir) / "generated-callback-skill"
-        references_dir = skill_dir / "references"
-        references_dir.mkdir(parents=True)
-        unbound_dry_run_md = valid_skill_md.replace(
-            "Binding level: parameterized-bound.",
-            "Binding level: unbound-generic.",
-        ).replace(
-            "Execution mode: dry-run-then-batch-approval.",
-            "Execution mode: dry-run-then-batch-approval. This workflow is dry-run-only until onboarding is complete.",
-        ).replace(
-            """## Source Onboarding
-
-Source onboarding completed for this parameterized-bound workflow.
-Access route: local source credentials.
-Source access route discovery result: host-local route discovery completed before user route selection.
-Authentication or access check result: passed with local source credentials.
-Sample fetch result: passed with a representative source instance.
-Sampled source instance: representative-callback-source.
-Discovered field mapping: candidate_id, phone_e164, name, submitted_at, consent, and callback_reason.
-User-confirmed field mapping: confirmed after the representative sample was shown.
-Redaction policy for sample summaries: mask phone numbers and omit credentials.
-Default goal contract derived from sampled fields: call the respondent about callback_reason and summarize the result.
-Runtime parameters still allowed: date window and approved source instance identifiers.
-
-""",
-            """## Source Onboarding
-
-Source onboarding recorded an onboarding blocker for this unbound-generic workflow.
-Onboarding blocker: no approved source instance has been bound yet; keep this workflow dry-run-only until onboarding is complete.
-
-""",
+        unsupported_reference_output = (
+            unsupported_reference_failure.stdout + unsupported_reference_failure.stderr
         )
-        for required_snippet in [
-            "Binding level: unbound-generic.",
-            "dry-run-only",
-            "onboarding blocker",
-        ]:
-            if required_snippet not in unbound_dry_run_md:
-                fail(f"Unbound dry-run fixture drifted; missing {required_snippet!r}.")
-        for bound_only_snippet in [
-            "Authentication or access check result: passed",
-            "Sample fetch result: passed",
-            "Default goal contract derived from sampled fields",
-        ]:
-            if bound_only_snippet in unbound_dry_run_md:
-                fail(f"Unbound dry-run fixture must not include {bound_only_snippet!r}.")
-        (skill_dir / "SKILL.md").write_text(unbound_dry_run_md, encoding="utf-8")
-        (references_dir / "safety.md").write_text("# Safety\n", encoding="utf-8")
-        (references_dir / "examples.md").write_text("# Examples\n", encoding="utf-8")
-
-        unbound_dry_run_success = subprocess.run(
-            ["node", str(checker), "--skill-dir", str(skill_dir)],
-            cwd=ROOT,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if unbound_dry_run_success.returncode != 0:
-            fail(
-                "Generated outbound skill checker must allow dry-run-only unbound onboarding blockers: "
-                + (unbound_dry_run_success.stderr or unbound_dry_run_success.stdout).strip()
-            )
+        if unsupported_reference_failure.returncode == 0:
+            fail("Generated outbound skill checker must reject unsupported binding references.")
+        if "unsupported binding levels are not allowed" not in unsupported_reference_output:
+            fail("Generated outbound skill checker unsupported-reference message changed.")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         skill_dir = Path(temp_dir) / "generated-callback-skill"

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -754,7 +754,7 @@ when results should stay in the source system without mutating source records.
 Otherwise use `result-csv-file` to write a new local result CSV. Use
 session-table output only as a last-resort attended fallback when durable result
 output is blocked.
-Runtime result target mode: source-adjacent-artifact resolved before execution approval from fixed creation values or approved runtime parameters.
+Runtime result target mode: source-adjacent-result-artifact resolved before execution approval from fixed creation values or approved runtime parameters.
 
 ## Safety Summary
 
@@ -1085,7 +1085,7 @@ passes.
         references_dir = skill_dir / "references"
         references_dir.mkdir(parents=True)
         missing_writeback_target_mode_md = valid_skill_md.replace(
-            "Runtime result target mode: source-adjacent-artifact resolved before execution approval from fixed creation values or approved runtime parameters.\n",
+            "Runtime result target mode: source-adjacent-result-artifact resolved before execution approval from fixed creation values or approved runtime parameters.\n",
             "",
         )
         (skill_dir / "SKILL.md").write_text(missing_writeback_target_mode_md, encoding="utf-8")

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -514,6 +514,7 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "Creation-Time Source Onboarding",
             "source onboarding",
             "sampled fields",
+            "Minimum source binding is mandatory.",
             "stop before writing the generated skill and ask for the missing contract details",
             "scope-first output rule",
             "If the installed `outbound-call-skill-creator` folder is inside a recognized user-level skills root",
@@ -533,6 +534,7 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
         skill_dir / "references" / "data-sources.md",
         [
             "creation-time source onboarding",
+            "The source contract must satisfy at least the `parameterized-bound` minimum",
             "Authenticated Source Onboarding",
             "For any authenticated or connector-backed source family, do not ask the user to manually provide the full field mapping before source access has been checked and a representative sample has been fetched.",
             "Collect only the minimum connection details needed to authorize or locate the source.",

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -543,7 +543,7 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "`codex mcp login tiktok-ads`",
             "Do not present a blank manual mapping form",
             "Ask the user to fill only fields that cannot be inferred from the sample.",
-            "Do not ask for the default outbound goal, writeback mapping, or full field mapping before the access check and sample fetch have been attempted.",
+            "Do not ask for the default outbound goal, result-output mapping, or full field mapping before the access check and sample fetch have been attempted.",
             "Proactively inspect available host routes before asking the user for access details.",
             "`google-auth.mjs status`",
             "`google-local-api-client.mjs --action list-forms`",
@@ -565,9 +565,10 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "default outbound goal contract",
             "Do not ask for Google Form field mapping before Google access has been verified and a representative response sample has been fetched.",
             "Do not ask for TikTok Ads field mapping before the exact MCP tool or resource access has been verified and a representative record sample has been fetched.",
-            "For local CSV workflows, capture supported writeback target modes at creation time and choose the concrete target mode during the runtime dry-run or approval step.",
+            "For local CSV workflows, capture supported result-output target modes at creation time and choose the concrete target mode during the runtime dry-run or approval step.",
             "source-csv-in-place",
             "result-csv-file",
+            "source-adjacent-result-artifact",
             "Do not require a per-row consent column when the user confirms the CSV source only contains records collected from people who requested or agreed to phone follow-up.",
             "Use the existing `google-form-callback` local OAuth and export scripts as the preferred reference pattern when available.",
         ],
@@ -584,6 +585,7 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "## TikTok Ads Lead Follow-Up Skill",
             "If this host has no TikTok Ads MCP server configured, I will add the default route first and then inspect it",
             "- source family: `tiktok-ads`",
+            "source-adjacent result artifact",
         ],
     )
     require_text(
@@ -618,10 +620,11 @@ def validate_outbound_call_skill_creator_acceptance_rules() -> None:
             "Provider terminal instructions such as `report_result` or `do not start another call` apply only to the current provider run",
             "After execution approval, do not ask the user to continue, confirm the next candidate, or approve additional provider runs.",
             "Provider Result Finalization",
-            "Terminal provider status is not writeback-ready until the generated skill performs a full-history provider reconciliation.",
+            "Terminal provider status is not result-output-ready until the generated skill performs a full-history provider reconciliation.",
             "Do not write `no_answer`, `failed`, or `no conversation captured` results until a negative terminal stability check passes.",
-            "Writeback target mode may be fixed at creation time or selected from approved runtime parameters before execution approval.",
-            "writeback target mode",
+            "Result target mode may be fixed at creation time or selected from approved runtime parameters before execution approval.",
+            "result target mode",
+            "source-adjacent-result-artifact",
             "sample fetch result",
             "default goal contract derived from sampled fields",
             "Do not define the default goal from user prose alone before the representative sample is fetched.",
@@ -713,7 +716,8 @@ when the binding level and runtime gate allow it.
 ## Runtime Gate
 
 Runtime gate requirements include source access, required fields, consent, dedupe,
-writeback or session-table readiness, and provider route availability before real calls.
+source writeback, source-adjacent artifact, or local result CSV readiness,
+and provider route availability before real calls.
 
 ## Preflight and Creation Summary
 
@@ -725,7 +729,9 @@ parameters, and validation results before real calls.
 After approval, serially process all ready candidates. For each candidate, plan,
 inspect, run, check status when available, record the result, and continue to
 the next candidate without another per-candidate confirmation. After all
-candidates finish, write configured results or output one final session table.
+candidates finish, write source results, a source-adjacent artifact, or a local
+result CSV. Use a session table only as a last-resort attended fallback when
+durable output is blocked.
 Provider terminal instructions such as `report_result` or `do not start another call`
 apply only to the current provider run. After execution approval, do not ask the
 user to continue, confirm the next candidate, or approve additional provider runs.
@@ -734,16 +740,21 @@ result or skip state unless a batch-level blocker appears.
 
 ## Provider Result Finalization
 
-Provider result finalization runs before writeback. Terminal provider status is
-not writeback-ready until the generated skill performs a full-history provider
+Provider result finalization runs before result output. Terminal provider status is
+not result-output-ready until the generated skill performs a full-history provider
 reconciliation without a cursor. Do not write `no_answer`, `failed`, or
 `no conversation captured` results until a negative terminal stability check
 passes.
 
-## Writeback Behavior
+## Result-Output Behavior
 
-Writeback behavior records call status, timestamps, summaries, and masked phone numbers.
-Runtime writeback target mode: resolved before execution approval from fixed creation values or approved runtime parameters.
+Result-output behavior records call status, timestamps, summaries, and masked phone numbers.
+Prefer source writeback when verified. Use `source-adjacent-result-artifact`
+when results should stay in the source system without mutating source records.
+Otherwise use `result-csv-file` to write a new local result CSV. Use
+session-table output only as a last-resort attended fallback when durable result
+output is blocked.
+Runtime result target mode: source-adjacent-artifact resolved before execution approval from fixed creation values or approved runtime parameters.
 
 ## Safety Summary
 
@@ -1037,8 +1048,8 @@ result or skip state unless a batch-level blocker appears.
         missing_provider_result_finalization_md = valid_skill_md.replace(
             """## Provider Result Finalization
 
-Provider result finalization runs before writeback. Terminal provider status is
-not writeback-ready until the generated skill performs a full-history provider
+Provider result finalization runs before result output. Terminal provider status is
+not result-output-ready until the generated skill performs a full-history provider
 reconciliation without a cursor. Do not write `no_answer`, `failed`, or
 `no conversation captured` results until a negative terminal stability check
 passes.
@@ -1074,7 +1085,7 @@ passes.
         references_dir = skill_dir / "references"
         references_dir.mkdir(parents=True)
         missing_writeback_target_mode_md = valid_skill_md.replace(
-            "Runtime writeback target mode: resolved before execution approval from fixed creation values or approved runtime parameters.\n",
+            "Runtime result target mode: source-adjacent-artifact resolved before execution approval from fixed creation values or approved runtime parameters.\n",
             "",
         )
         (skill_dir / "SKILL.md").write_text(missing_writeback_target_mode_md, encoding="utf-8")
@@ -1093,12 +1104,12 @@ passes.
             + missing_writeback_target_mode_failure.stderr
         )
         if missing_writeback_target_mode_failure.returncode == 0:
-            fail("Generated outbound skill checker must reject missing writeback target mode.")
+            fail("Generated outbound skill checker must reject missing result target mode.")
         if (
-            "Generated skill SKILL.md must include writeback target mode"
+            "Generated skill SKILL.md must include result target mode"
             not in missing_writeback_target_mode_output
         ):
-            fail("Generated outbound skill checker missing-writeback-target-mode message changed.")
+            fail("Generated outbound skill checker missing-result-target-mode message changed.")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         skill_dir = Path(temp_dir) / "generated-callback-skill"
@@ -1206,7 +1217,9 @@ passes.
 After approval, serially process all ready candidates. For each candidate, plan,
 inspect, run, check status when available, record the result, and continue to
 the next candidate without another per-candidate confirmation. After all
-candidates finish, write configured results or output one final session table.
+candidates finish, write source results, a source-adjacent artifact, or a local
+result CSV. Use a session table only as a last-resort attended fallback when
+durable output is blocked.
 Provider terminal instructions such as `report_result` or `do not start another call`
 apply only to the current provider run. After execution approval, do not ask the
 user to continue, confirm the next candidate, or approve additional provider runs.

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -707,8 +707,8 @@ Provider onboarding blocker: none.
 
 ## Execution Modes
 
-Execution mode: dry-run-then-batch-approval. Supported alternatives are per-call-approval
-and approved-direct-execution when the binding level and runtime gate allow them.
+Execution mode: dry-run-then-batch-approval. Supported alternative is approved-direct-execution
+when the binding level and runtime gate allow it.
 
 ## Runtime Gate
 
@@ -1497,6 +1497,35 @@ Runtime parameters still allowed: date window and approved source instance ident
             not in maximum_only_execution_output
         ):
             fail("Generated outbound skill checker missing-selected-execution message changed.")
+
+    unsupported_execution_mode = "per-" + "call-approval"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        skill_dir = Path(temp_dir) / "generated-callback-skill"
+        references_dir = skill_dir / "references"
+        references_dir.mkdir(parents=True)
+        unsupported_execution_md = valid_skill_md.replace(
+            "Execution mode: dry-run-then-batch-approval.",
+            f"Execution mode: {unsupported_execution_mode}.",
+        )
+        (skill_dir / "SKILL.md").write_text(unsupported_execution_md, encoding="utf-8")
+        (references_dir / "safety.md").write_text("# Safety\n", encoding="utf-8")
+        (references_dir / "examples.md").write_text("# Examples\n", encoding="utf-8")
+
+        unsupported_execution_failure = subprocess.run(
+            ["node", str(checker), "--skill-dir", str(skill_dir)],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        unsupported_execution_output = (
+            unsupported_execution_failure.stdout + unsupported_execution_failure.stderr
+        )
+        if unsupported_execution_failure.returncode == 0:
+            fail("Generated outbound skill checker must reject unsupported execution modes.")
+        if "unsupported execution modes are not allowed" not in unsupported_execution_output:
+            fail("Generated outbound skill checker unsupported-execution message changed.")
 
     unsupported_binding_level = "un" + "bound-" + "generic"
 

--- a/skills/outbound-call-skill-creator/SKILL.md
+++ b/skills/outbound-call-skill-creator/SKILL.md
@@ -30,17 +30,17 @@ Do not create `template.md`. The creator captures the source, goal, execution, a
 3. Read `references/output-targets.md`, choose the scope, and choose a host-compatible output parent.
 4. Ask which source family to use: `google-form`, `tiktok-ads`, `local-csv`, or `other`.
 5. Read `references/data-sources.md` for the selected source family.
-6. Read `references/binding-contract.md` and ask the user to choose a binding level, defaulting to `parameterized-bound` when they do not choose: `fully-bound`, `parameterized-bound`, or `unbound-generic`.
+6. Read `references/binding-contract.md` and ask the user to choose a binding level, defaulting to `parameterized-bound` when they do not choose: `fully-bound` or `parameterized-bound`.
 7. Run creation-time source onboarding for the selected binding level:
    - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and writeback readiness, and stop before generating a real-call skill if onboarding cannot complete.
    - `parameterized-bound`: authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and record which runtime parameters may vary later.
-   - `unbound-generic`: collect or record the missing source onboarding blockers and keep the generated skill dry-run-only until an exact runtime contract is approved.
+   If neither binding level can be supported because the source or writeback contract is still unknown, do not write the generated skill yet; continue source onboarding or stop with the missing contract details.
    For any authenticated or connector-backed source family, ask only for the minimum connection details needed to authorize or locate the source before source access and sample fetch complete. Do not ask the user to manually provide the full field mapping before source access has been checked and a representative sample has been fetched.
 8. Capture the source fields from the sampled schema for phone number, recipient label, dedupe key, date filtering, source-level outreach basis or optional consent field, goal inputs, and any runtime parameters allowed by the binding level.
 9. Show a small redacted sample summary and prompt the user to confirm or adjust field mapping.
 10. Prompt the user to define the default outbound goal from the sampled fields: call purpose, required context, allowed questions, prohibited claims, completion criteria, result values, summary format, and escalation cases.
 11. Read `references/mcp-provider-route.md` and run creation-time provider onboarding for the default CALL-E MCP provider route in the current host runtime: configure or verify the MCP route, complete or verify provider authentication, and confirm compatible plan/run/status tools without placing a real call. For Codex, use the `codex mcp` adapter commands in the reference. For Claude, Antigravity, Cursor, or another MCP host, use that host's connector or MCP server setup and authorization flow. Do not treat app connector tools, plugin tools, or similarly named non-MCP tools as proof that this provider route is authenticated. If provider onboarding still cannot complete, record a provider onboarding blocker and keep the generated skill dry-run-only.
-12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`. For `fully-bound` and `parameterized-bound`, available modes are `dry-run-then-batch-approval`, `per-call-approval`, or `approved-direct-execution`. For `unbound-generic`, the only available mode is `dry-run-then-batch-approval` with dry-run-only behavior until onboarding is complete.
+12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`. For both supported binding levels, available modes are `dry-run-then-batch-approval`, `per-call-approval`, or `approved-direct-execution`.
 13. Capture writeback policy at creation time and capture field mapping, supported target modes, or allowed runtime writeback parameters: source writeback, local CSV writeback, or session table fallback. For local CSV, record supported target modes (`source-csv-in-place` and `result-csv-file`) and choose the concrete target mode during the runtime dry-run or approval step based on the user's requested output behavior.
 14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating writeback target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until source and provider onboarding requirements are satisfied.
 15. Read `references/safety.md` and include the required safety boundaries in the generated skill.
@@ -68,7 +68,7 @@ For `fully-bound` generated skills, authenticate or verify the concrete source, 
 
 For `parameterized-bound` generated skills, authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow runtime instances only when the runtime gate verifies the same schema and source contract.
 
-For `unbound-generic` generated skills, source onboarding may be incomplete only when the missing values are recorded as onboarding blockers and the generated skill is dry-run-only until an exact runtime source, schema, source-level outreach basis or consent, dedupe, and writeback contract is approved.
+If source onboarding cannot produce enough source, schema, outreach-basis or consent, dedupe, and writeback detail for either supported binding level, stop before writing the generated skill and ask for the missing contract details.
 
 During onboarding, show the user a small redacted sample summary, never full private phone numbers, credentials, tokens, cookies, callback URLs, or provider confirmation tokens. Use the sampled fields to help the user define the default outbound goal.
 
@@ -124,7 +124,7 @@ Before writing files, state the selected scope, output parent, generated skill d
 
 ### Execution Mode
 
-Present execution modes after the binding level is known. For `fully-bound` and `parameterized-bound`, recommend `dry-run-then-batch-approval` first, then briefly explain `per-call-approval` and `approved-direct-execution`. For `unbound-generic`, offer only `dry-run-then-batch-approval` with dry-run-only behavior until onboarding is complete; state that the workflow must be bound before `per-call-approval` or `approved-direct-execution` can be selected.
+Present execution modes after the binding level is known. For both supported binding levels, recommend `dry-run-then-batch-approval` first, then briefly explain `per-call-approval` and `approved-direct-execution`.
 
 ## Binding Levels
 
@@ -136,9 +136,8 @@ Use `references/binding-contract.md` for full binding-level selection rules and 
 | --- | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
 | `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval, per-call approval, and approved direct execution only after concrete runtime parameters pass the runtime gate. |
-| `unbound-generic` | Goal contract and safety rules only; source and writeback details are collected at runtime. | Source access, fields, filters, source-level outreach basis or consent evidence, dedupe key, and writeback target must be supplied each run. | Dry-run only by default. Do not allow real direct execution or scheduled runs until the workflow is converted to a bound skill or an exact runtime contract is approved. |
 
-Do not create a real-call skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path. If those values are unavailable, generate a dry-run-only `unbound-generic` skill or keep asking for the missing contract.
+Do not create a business skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path. If those values are unavailable, keep asking for the missing contract or stop before generation.
 
 ## Execution Modes
 
@@ -150,7 +149,7 @@ Use `references/execution-modes.md` for full mode selection rules, concrete runt
 - `per-call-approval`: preview one candidate and compiled call goal at a time, then let the user approve, modify, or skip each call before planning and running it.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, compile call goals, inspect each provider plan, and serially run eligible one-off calls without another approval step.
 
-Use `per-call-approval` or `approved-direct-execution` only for `fully-bound` or `parameterized-bound` generated skills. Do not use either mode for `unbound-generic` workflows.
+Use `per-call-approval` or `approved-direct-execution` only after the generated skill's supported binding level and concrete runtime request pass the required gates.
 
 ## Preflight and Runtime Gate
 
@@ -183,7 +182,7 @@ Include:
 - MCP provider route
 - validation command and result
 
-If a value is intentionally parameterized, label it as a runtime parameter instead of presenting it as already fixed. If a value is unknown, label it as a blocker and state whether the generated skill is dry-run-only until resolved.
+If a value is intentionally parameterized, label it as a runtime parameter instead of presenting it as already fixed. If a required source or writeback value is unknown, report it as a creation blocker and do not generate the skill until the contract is complete.
 
 ## Runtime Contract Formats
 
@@ -230,7 +229,7 @@ During creation, configure and authenticate this route in the selected host runt
 
 A generated skill may support approved direct execution when the user gives a concrete processing request such as "process all June 20 records" and the creation-time contract explicitly allowed direct execution.
 
-Approved direct execution requires a `fully-bound` generated skill or a `parameterized-bound` generated skill whose concrete runtime parameters pass the source, writeback, dedupe, and provider runtime gate. It is not allowed for `unbound-generic` workflows.
+Approved direct execution requires a `fully-bound` generated skill or a `parameterized-bound` generated skill whose concrete runtime parameters pass the source, writeback, dedupe, and provider runtime gate.
 
 Even in direct execution mode, the generated skill must:
 

--- a/skills/outbound-call-skill-creator/SKILL.md
+++ b/skills/outbound-call-skill-creator/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when the user wants to create a new outbound phone-call workflow 
 
 `outbound-call-skill-creator` creates focused business skills. It does not process campaign data itself, does not create a generic outbound runtime platform, and does not use a CLI bootstrap path.
 
-Generated skills should bind enough source, writeback, and safety detail to make later runs predictable. Default to a parameterized-bound workflow: the source family, field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, and writeback policy are fixed at creation time, while runtime requests can still provide approved parameters such as a date window, form ID, CSV path, campaign ID, writeback target, or output file path.
+Generated skills should bind enough source, writeback, and safety detail to make later runs predictable. The minimum source binding level is `parameterized-bound`: the source family, field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, and writeback policy are fixed at creation time, while runtime requests can still provide approved parameters such as a date window, form ID, CSV path, campaign ID, writeback target, or output file path.
 
 ## Core Rule
 
@@ -21,6 +21,8 @@ Use a project-local skills directory only when the user explicitly wants the gen
 
 The generated skill must let a future user make a concrete request such as "process all June 20 records" and have the skill handle source access, filtering, candidate validation, outbound goal compilation, approved MCP execution, dedupe, and writeback or session-table output.
 
+Minimum source binding is mandatory. If creation-time onboarding cannot reach a `parameterized-bound` source and writeback contract, do not generate a business skill.
+
 Do not create `template.md`. The creator captures the source, goal, execution, and writeback contract during skill creation and writes that contract into the generated skill instructions and reference files.
 
 ## Required Creator Workflow
@@ -30,11 +32,11 @@ Do not create `template.md`. The creator captures the source, goal, execution, a
 3. Read `references/output-targets.md`, choose the scope, and choose a host-compatible output parent.
 4. Ask which source family to use: `google-form`, `tiktok-ads`, `local-csv`, or `other`.
 5. Read `references/data-sources.md` for the selected source family.
-6. Read `references/binding-contract.md` and ask the user to choose a binding level, defaulting to `parameterized-bound` when they do not choose: `fully-bound` or `parameterized-bound`.
+6. Read `references/binding-contract.md` and choose whether the workflow should remain at the minimum `parameterized-bound` level or be upgraded to `fully-bound` when the user wants a concrete fixed source instance.
 7. Run creation-time source onboarding for the selected binding level:
    - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and writeback readiness, and stop before generating a real-call skill if onboarding cannot complete.
    - `parameterized-bound`: authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and record which runtime parameters may vary later.
-   If neither binding level can be supported because the source or writeback contract is still unknown, do not write the generated skill yet; continue source onboarding or stop with the missing contract details.
+   If source onboarding cannot support the minimum `parameterized-bound` contract because the source or writeback contract is still unknown, do not write the generated skill yet; continue source onboarding or stop with the missing contract details.
    For any authenticated or connector-backed source family, ask only for the minimum connection details needed to authorize or locate the source before source access and sample fetch complete. Do not ask the user to manually provide the full field mapping before source access has been checked and a representative sample has been fetched.
 8. Capture the source fields from the sampled schema for phone number, recipient label, dedupe key, date filtering, source-level outreach basis or optional consent field, goal inputs, and any runtime parameters allowed by the binding level.
 9. Show a small redacted sample summary and prompt the user to confirm or adjust field mapping.
@@ -68,7 +70,7 @@ For `fully-bound` generated skills, authenticate or verify the concrete source, 
 
 For `parameterized-bound` generated skills, authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow runtime instances only when the runtime gate verifies the same schema and source contract.
 
-If source onboarding cannot produce enough source, schema, outreach-basis or consent, dedupe, and writeback detail for either supported binding level, stop before writing the generated skill and ask for the missing contract details.
+If source onboarding cannot produce enough source, schema, outreach-basis or consent, dedupe, and writeback detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
 
 During onboarding, show the user a small redacted sample summary, never full private phone numbers, credentials, tokens, cookies, callback URLs, or provider confirmation tokens. Use the sampled fields to help the user define the default outbound goal.
 
@@ -128,7 +130,7 @@ Present execution modes after the binding level is known. For both supported bin
 
 ## Binding Levels
 
-Ask the user to choose a binding level before writing the generated skill. If the user has no preference, use `parameterized-bound`.
+Treat `parameterized-bound` as the minimum binding level before writing the generated skill. If the user has no preference, use `parameterized-bound`; use `fully-bound` only when the workflow should fix a concrete source and writeback target at creation time.
 
 Use `references/binding-contract.md` for full binding-level selection rules and generated skill requirements.
 

--- a/skills/outbound-call-skill-creator/SKILL.md
+++ b/skills/outbound-call-skill-creator/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: outbound-call-skill-creator
-description: Create directly usable outbound phone-call Agent Skills that bind source and writeback contracts at the right level, connect data such as Google Forms, TikTok Ads, local CSV, or custom systems to an MCP one-off call provider route, compile per-record call goals, enforce safety rules, and configure writeback or session-table output.
+description: Create directly usable outbound phone-call Agent Skills that bind source and durable result-output contracts at the right level, connect data such as Google Forms, TikTok Ads, local CSV, or custom systems to an MCP one-off call provider route, compile per-record call goals, enforce safety rules, and configure source writeback, source-adjacent result artifacts, or new local result CSV output.
 ---
 
 # Outbound Call Skill Creator
 
-Use this skill when the user wants to create a new outbound phone-call workflow skill that can later process source records directly, compile one call goal per eligible record, run calls through the configured MCP provider route, and write results back or display a session table.
+Use this skill when the user wants to create a new outbound phone-call workflow skill that can later process source records directly, compile one call goal per eligible record, run calls through the configured MCP provider route, and write results back, save a source-adjacent result artifact, or save a new local result CSV.
 
 `outbound-call-skill-creator` creates focused business skills. It does not process campaign data itself, does not create a generic outbound runtime platform, and does not use a CLI bootstrap path.
 
-Generated skills should bind enough source, writeback, and safety detail to make later runs predictable. The minimum source binding level is `parameterized-bound`: the source family, field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, and writeback policy are fixed at creation time, while runtime requests can still provide approved parameters such as a date window, form ID, CSV path, campaign ID, writeback target, or output file path.
+Generated skills should bind enough source, durable result-output, and safety detail to make later runs predictable. The minimum source binding level is `parameterized-bound`: the source family, field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, and result-output policy are fixed at creation time, while runtime requests can still provide approved parameters such as a date window, form ID, CSV path, campaign ID, source writeback target, source-adjacent artifact target, or output file path.
 
 ## Core Rule
 
@@ -19,11 +19,11 @@ When this creator is used from a normal project after being installed by a skill
 
 Use a project-local skills directory only when the user explicitly wants the generated skill versioned with the current project, when the skill depends on project files, or when working inside this reference repository. Never write a generated business skill into the downloaded `outbound-call-skill-creator` skill folder itself.
 
-The generated skill must let a future user make a concrete request such as "process all June 20 records" and have the skill handle source access, filtering, candidate validation, outbound goal compilation, approved MCP execution, dedupe, and writeback or session-table output.
+The generated skill must let a future user make a concrete request such as "process all June 20 records" and have the skill handle source access, filtering, candidate validation, outbound goal compilation, approved MCP execution, dedupe, and durable result output.
 
-Minimum source binding is mandatory. If creation-time onboarding cannot reach a `parameterized-bound` source and writeback contract, do not generate a business skill.
+Minimum source binding is mandatory. If creation-time onboarding cannot reach a `parameterized-bound` source and durable result-output contract, do not generate a business skill.
 
-Do not create `template.md`. The creator captures the source, goal, execution, and writeback contract during skill creation and writes that contract into the generated skill instructions and reference files.
+Do not create `template.md`. The creator captures the source, goal, execution, and result-output contract during skill creation and writes that contract into the generated skill instructions and reference files.
 
 ## Required Creator Workflow
 
@@ -34,21 +34,21 @@ Do not create `template.md`. The creator captures the source, goal, execution, a
 5. Read `references/data-sources.md` for the selected source family.
 6. Read `references/binding-contract.md` and choose whether the workflow should remain at the minimum `parameterized-bound` level or be upgraded to `fully-bound` when the user wants a concrete fixed source instance.
 7. Run creation-time source onboarding for the selected binding level:
-   - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and writeback readiness, and stop before generating a real-call skill if onboarding cannot complete.
+   - `fully-bound`: authenticate or verify the concrete source, fetch a representative sample from that source, confirm schema and durable result-output readiness, and stop before generating a real-call skill if onboarding cannot complete.
    - `parameterized-bound`: authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and record which runtime parameters may vary later.
-   If source onboarding cannot support the minimum `parameterized-bound` contract because the source or writeback contract is still unknown, do not write the generated skill yet; continue source onboarding or stop with the missing contract details.
+   If source onboarding cannot support the minimum `parameterized-bound` contract because the source or result-output contract is still unknown, do not write the generated skill yet; continue source onboarding or stop with the missing contract details.
    For any authenticated or connector-backed source family, ask only for the minimum connection details needed to authorize or locate the source before source access and sample fetch complete. Do not ask the user to manually provide the full field mapping before source access has been checked and a representative sample has been fetched.
 8. Capture the source fields from the sampled schema for phone number, recipient label, dedupe key, date filtering, source-level outreach basis or optional consent field, goal inputs, and any runtime parameters allowed by the binding level.
 9. Show a small redacted sample summary and prompt the user to confirm or adjust field mapping.
 10. Prompt the user to define the default outbound goal from the sampled fields: call purpose, required context, allowed questions, prohibited claims, completion criteria, result values, summary format, and escalation cases.
 11. Read `references/mcp-provider-route.md` and run creation-time provider onboarding for the default CALL-E MCP provider route in the current host runtime: configure or verify the MCP route, complete or verify provider authentication, and confirm compatible plan/run/status tools without placing a real call. For Codex, use the `codex mcp` adapter commands in the reference. For Claude, Antigravity, Cursor, or another MCP host, use that host's connector or MCP server setup and authorization flow. Do not treat app connector tools, plugin tools, or similarly named non-MCP tools as proof that this provider route is authenticated. If provider onboarding still cannot complete, record a provider onboarding blocker and keep the generated skill dry-run-only.
 12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`. For both supported binding levels, available modes are `dry-run-then-batch-approval` or `approved-direct-execution`.
-13. Capture writeback policy at creation time and capture field mapping, supported target modes, or allowed runtime writeback parameters: source writeback, local CSV writeback, or session table fallback. For local CSV, record supported target modes (`source-csv-in-place` and `result-csv-file`) and choose the concrete target mode during the runtime dry-run or approval step based on the user's requested output behavior.
-14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating writeback target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until source and provider onboarding requirements are satisfied.
+13. Capture the result-output policy at creation time and capture field mapping, supported target modes, or allowed runtime output parameters. Prefer verified source writeback when available. Treat source writeback narrowly: it updates the bound source instance or canonical source record store, not a newly created side file. When the result should live in the same source system but not mutate the source records, configure `source-adjacent-result-artifact` with a verified container, artifact ID or creation policy, schema, and append or upsert behavior. When source writeback and source-adjacent output are unavailable or not requested, configure a new local result CSV as the durable fallback. Keep session-table output as a last-resort non-persistent fallback only when durable output validation is blocked; do not proactively present session table as a normal user-facing option.
+14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating source writeback checks, source-adjacent artifact checks, local result CSV path checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until source and provider onboarding requirements are satisfied.
 15. Read `references/safety.md` and include the required safety boundaries in the generated skill.
 16. Generate the business skill folder and files in the selected output parent using `references/generated-skill-contract.md`.
 17. Run this skill's bundled checker script with `--skill-dir <generated-business-skill-dir>`.
-18. Read `references/creation-summary.md` and show the user a creation summary covering skill name, path, binding level, source onboarding, provider onboarding, source contract, goal contract, execution mode, writeback target, provider route, validation result, and reload or discovery note.
+18. Read `references/creation-summary.md` and show the user a creation summary covering skill name, path, binding level, source onboarding, provider onboarding, source contract, goal contract, execution mode, result-output target, provider route, validation result, and reload or discovery note.
 19. Run repository validation only when the generated skill is being committed to a repository that provides a validation command.
 
 ## Built-In Choices
@@ -60,23 +60,23 @@ Present these source families by default:
 - `local-csv`: records from a user-provided CSV file.
 - `other`: a custom source that requires multi-turn clarification before generating the skill.
 
-If the user selects `other`, do not guess API schemas, credentials, identifiers, date filters, writeback behavior, or MCP tool names. Ask for the missing contract details one at a time.
+If the user selects `other`, do not guess API schemas, credentials, identifiers, date filters, result-output behavior, or MCP tool names. Ask for the missing contract details one at a time.
 
 ## Creation-Time Source Onboarding
 
-Creation-time source onboarding happens after source family and binding level selection, and before final goal and writeback contract generation.
+Creation-time source onboarding happens after source family and binding level selection, and before final goal and result-output contract generation.
 
-For `fully-bound` generated skills, authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and writeback readiness, and stop before generating a real-call skill when onboarding cannot complete.
+For `fully-bound` generated skills, authenticate or verify the concrete source, fetch a representative sample from that exact source, confirm schema and durable result-output readiness, and stop before generating a real-call skill when onboarding cannot complete.
 
 For `parameterized-bound` generated skills, authenticate or verify the source family, fetch a representative sample from one approved source instance, confirm the schema contract, and allow runtime instances only when the runtime gate verifies the same schema and source contract.
 
-If source onboarding cannot produce enough source, schema, outreach-basis or consent, dedupe, and writeback detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
+If source onboarding cannot produce enough source, schema, outreach-basis or consent, dedupe, and durable result-output detail for the minimum `parameterized-bound` contract, stop before writing the generated skill and ask for the missing contract details.
 
 During onboarding, show the user a small redacted sample summary, never full private phone numbers, credentials, tokens, cookies, callback URLs, or provider confirmation tokens. Use the sampled fields to help the user define the default outbound goal.
 
-For any authenticated or connector-backed source family, inspect available host-local access routes before asking the user to choose an access route. When a host-local source adapter, connector, MCP tool, or helper script is available, inspect it before asking the user to choose an access route. When a safe source authorization or auth-readiness action is available, start it before asking the user for another confirmation; do not ask the user to say `start auth`, choose a discovered route, or refresh a session before attempting the available non-mutating auth path. For source MCP servers, do not treat a host CLI status such as Codex `Auth: Unsupported` as proof that source access is unavailable when source-native MCP tools or resources are exposed; run the source's read-only auth or inventory probe first. Collect only minimum connection details before access is verified: skill name, binding level, source family, source locator such as form ID or account scope only when no usable route can be discovered or the discovered route needs a concrete locator, and access route such as OAuth, Apps Script fallback, MCP tool, MCP resource, or managed connector. After access verification and representative sample fetch, infer the phone field, recipient field, dedupe key, outreach basis or consent field, goal inputs, and writeback capability from the sample. Ask the user to fill or correct only fields that cannot be inferred.
+For any authenticated or connector-backed source family, inspect available host-local access routes before asking the user to choose an access route. When a host-local source adapter, connector, MCP tool, or helper script is available, inspect it before asking the user to choose an access route. When a safe source authorization or auth-readiness action is available, start it before asking the user for another confirmation; do not ask the user to say `start auth`, choose a discovered route, or refresh a session before attempting the available non-mutating auth path. For source MCP servers, do not treat a host CLI status such as Codex `Auth: Unsupported` as proof that source access is unavailable when source-native MCP tools or resources are exposed; run the source's read-only auth or inventory probe first. Collect only minimum connection details before access is verified: skill name, binding level, source family, source locator such as form ID or account scope only when no usable route can be discovered or the discovered route needs a concrete locator, and access route such as OAuth, Apps Script fallback, MCP tool, MCP resource, or managed connector. After access verification and representative sample fetch, infer the phone field, recipient field, dedupe key, outreach basis or consent field, goal inputs, and durable result-output capability from the sample. Ask the user to fill or correct only fields that cannot be inferred.
 
-When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, the next creation step must be source access onboarding: choose or confirm the binding level, discover available host access routes, run or request authorization, and attempt a read-only sample fetch before asking for the default outbound goal, writeback mapping, or full field mapping. Do not ask the user to choose `use local OAuth to list accessible forms` when a local OAuth helper can be checked directly. If the user has not provided a skill name yet, derive a temporary candidate name from the source context or ask only for the name in the same onboarding prompt; do not use a missing skill name as a reason to collect goal details first.
+When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, the next creation step must be source access onboarding: choose or confirm the binding level, discover available host access routes, run or request authorization, and attempt a read-only sample fetch before asking for the default outbound goal, result-output mapping, or full field mapping. Do not ask the user to choose `use local OAuth to list accessible forms` when a local OAuth helper can be checked directly. If the user has not provided a skill name yet, derive a temporary candidate name from the source context or ask only for the name in the same onboarding prompt; do not use a missing skill name as a reason to collect goal details first.
 
 ## Creation-Time Provider Onboarding
 
@@ -130,16 +130,16 @@ Present execution modes after the binding level is known. For both supported bin
 
 ## Binding Levels
 
-Treat `parameterized-bound` as the minimum binding level before writing the generated skill. If the user has no preference, use `parameterized-bound`; use `fully-bound` only when the workflow should fix a concrete source and writeback target at creation time.
+Treat `parameterized-bound` as the minimum binding level before writing the generated skill. If the user has no preference, use `parameterized-bound`; use `fully-bound` only when the workflow should fix a concrete source and durable result-output target at creation time.
 
 Use `references/binding-contract.md` for full binding-level selection rules and generated skill requirements.
 
 | Binding level | Creation-time contract | Runtime parameters | Maximum automation |
 | --- | --- | --- | --- |
-| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
-| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
+| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, fixed result target, and result fields. The result target can be source writeback to the source instance or canonical record store, a source-adjacent result artifact, or a local result CSV. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
+| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, result-output policy, and result field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
 
-Do not create a business skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path. If those values are unavailable, keep asking for the missing contract or stop before generation.
+Do not create a business skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no durable result path such as verified source writeback, a source-adjacent result artifact, or a new local result CSV. Session-table output is only a last-resort non-persistent fallback when durable output validation is blocked, not the primary result path. If those values are unavailable, keep asking for the missing contract or stop before generation.
 
 ## Execution Modes
 
@@ -154,11 +154,11 @@ Use `approved-direct-execution` only after the generated skill's supported bindi
 
 ## Preflight and Runtime Gate
 
-Creation-time preflight is best effort. Run it when the source, writeback target, provider route, tools, and permissions are available, but do not make every preflight check a hard prerequisite for generating the skill.
+Creation-time preflight is best effort. Run it when the source, source writeback target, source-adjacent result artifact target, local result CSV target, provider route, tools, and permissions are available, but do not make every preflight check a hard prerequisite for generating the skill.
 
-Runtime gating is mandatory before any real call. A generated skill must stop before real calls when source access, required fields, consent validation, dedupe state, writeback behavior, provider authentication, or compatible MCP tools cannot be verified for the concrete runtime request.
+Runtime gating is mandatory before any real call. A generated skill must stop before real calls when source access, required fields, consent validation, dedupe state, source writeback, source-adjacent result artifact output, local result CSV output, provider authentication, or compatible MCP tools cannot be verified for the concrete runtime request. Session-table fallback may be used only when durable output validation is blocked and the run is attended; it is not suitable for unattended scheduled automation unless the user explicitly accepts the host session transcript as the record.
 
-Do not perform a real writeback or place a real call during creation-time onboarding or preflight. Approved side effects can happen only later in the selected runtime execution flow after the runtime gate passes.
+Do not perform a real writeback, write a result CSV, or place a real call during creation-time onboarding or preflight. Approved side effects can happen only later in the selected runtime execution flow after the runtime gate passes.
 
 ## Creation Summary
 
@@ -176,14 +176,14 @@ Include:
 - dedupe key or dedupe state rule
 - outbound goal contract summary
 - execution mode and unavailable modes, if any
-- writeback policy, fixed or runtime-resolved writeback target mode, target binding, and field mapping
+- result-output policy, fixed or runtime-resolved target mode, target binding, and field mapping
 - provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, and blocker if any
 - creation-time preflight result or blocker
 - mandatory runtime gate checks before real calls
 - MCP provider route
 - validation command and result
 
-If a value is intentionally parameterized, label it as a runtime parameter instead of presenting it as already fixed. If a required source or writeback value is unknown, report it as a creation blocker and do not generate the skill until the contract is complete.
+If a value is intentionally parameterized, label it as a runtime parameter instead of presenting it as already fixed. If a required source or durable result-output value is unknown, report it as a creation blocker and do not generate the skill until the contract is complete.
 
 ## Runtime Contract Formats
 
@@ -192,9 +192,9 @@ Generated skills must define structured runtime contracts for:
 - concrete runtime request examples and insufficient request examples
 - source onboarding report with `binding_level`, `source_family`, `access_method`, `auth_or_access_check`, `sample_fetch`, `sampled_source_instance`, `field_mapping`, `default_goal_source`, and `onboarding_blocker`
 - provider onboarding report with `provider_route`, `provider_host_runtime`, `mcp_route_setup_check`, `auth_readiness`, `compatible_tools`, `one_off_call_capability`, and `provider_onboarding_blocker`
-- provider result finalization report with `run_id`, `terminal_status_seen`, `full_history_rechecked`, `negative_terminal_stability_checked`, `writeback_allowed`, and `blocker`
+- provider result finalization report with `run_id`, `terminal_status_seen`, `full_history_rechecked`, `negative_terminal_stability_checked`, `result_output_allowed`, and `blocker`
 - runtime gate report rows with `check`, `status`, `evidence`, `blocker`, and `required_before_call`
-- writeback mapping with `policy`, `target_mode`, `target_binding`, `target`, and logical result fields
+- result-output mapping with `policy`, `target_mode`, `target_binding`, `target`, and logical result fields
 - approved direct execution guardrails
 
 Use `references/generated-skill-contract.md` as the source of truth for these formats.
@@ -211,10 +211,10 @@ Generate additional reference files when the workflow is too detailed for the ma
 
 - `references/source-contract.md`
 - `references/goal-contract.md`
-- `references/writeback-contract.md`
+- `references/result-output-contract.md`
 - `references/binding-contract.md`
 
-Generate scripts only when deterministic handling is valuable, such as CSV parsing, candidate validation, dedupe state checks, dry-run rendering, or writeback payload generation.
+Generate scripts only when deterministic handling is valuable, such as CSV parsing, candidate validation, dedupe state checks, dry-run rendering, source writeback payload generation, or result CSV writing.
 
 ## Default Provider Route
 
@@ -230,7 +230,7 @@ During creation, configure and authenticate this route in the selected host runt
 
 A generated skill may support approved direct execution when the user gives a concrete processing request such as "process all June 20 records" and the creation-time contract explicitly allowed direct execution.
 
-Approved direct execution requires a `fully-bound` generated skill or a `parameterized-bound` generated skill whose concrete runtime parameters pass the source, writeback, dedupe, and provider runtime gate.
+Approved direct execution requires a `fully-bound` generated skill or a `parameterized-bound` generated skill whose concrete runtime parameters pass the source, durable result-output, dedupe, and provider runtime gate.
 
 Even in direct execution mode, the generated skill must:
 
@@ -240,7 +240,7 @@ Even in direct execution mode, the generated skill must:
 - mask phone numbers in summaries
 - skip unsafe or ambiguous records
 - avoid hidden recurring schedules
-- report writeback status or produce a session table
+- report source writeback, source-adjacent result artifact, or local result CSV status; use session-table output only as a last-resort attended fallback when durable output validation is blocked
 
 If direct execution was not configured, the generated skill must dry-run first and ask the user to approve the exact pending call list before real calls.
 
@@ -248,15 +248,26 @@ If direct execution was not configured, the generated skill must dry-run first a
 
 Generated skills must define what happens after the user approves the exact pending call list. After execution approval, do not ask the user to continue, confirm the next candidate, or approve additional provider runs. The agent should serially process every ready candidate until the candidate list is exhausted. For each candidate, plan one call, inspect the plan, run the call, check status when the MCP tools support it, record the result, and then continue to the next candidate without asking for another per-candidate confirmation.
 
-If one candidate fails, the generated skill should record the failure or skip reason and continue with the next candidate unless the failure means the MCP provider route is unavailable, authentication is missing, or continuing would be unsafe. After all candidates reach a terminal result or skip state, the generated skill must provide one final summary and perform configured writeback or session-table output.
+If one candidate fails, the generated skill should record the failure or skip reason and continue with the next candidate unless the failure means the MCP provider route is unavailable, authentication is missing, or continuing would be unsafe. After all candidates reach a terminal result or skip state, the generated skill must provide one final summary and perform configured source writeback, source-adjacent result artifact output, or local result CSV output. Use session-table output only when durable output validation is blocked and the run is attended.
 
 Provider terminal instructions such as `report_result` or `do not start another call` apply only to the current provider run. They prevent duplicate execution of the same plan; they must not be treated as permission to stop an approved multi-candidate batch after the first completed call.
 
-Generated skills must include provider result finalization rules before writeback. Terminal provider status is not writeback-ready until the generated skill performs a full-history provider reconciliation without relying only on a cursor-limited polling page. Do not write `no_answer`, `failed`, or `no conversation captured` results until a negative terminal stability check passes.
+Generated skills must include provider result finalization rules before writing source results, writing source-adjacent artifacts, writing a result CSV, or producing a final session table. Terminal provider status is not result-output-ready until the generated skill performs a full-history provider reconciliation without relying only on a cursor-limited polling page. Do not write `no_answer`, `failed`, or `no conversation captured` results until a negative terminal stability check passes.
 
-## Session Table Fallback
+## Durable Result Output
 
-If writeback is not configured, generated skills must output a table with one row per task and these columns:
+Generated skills must prefer durable result output in this order:
+
+1. Verified source writeback when the source exposes a safe writeback path to the bound source instance or canonical source record store.
+2. Source-adjacent result artifact when the result should stay in the same source system but must not mutate the source records.
+3. A new local result CSV when source writeback and source-adjacent output are unavailable, not requested, or cannot be verified.
+4. Session-table output only as a last-resort non-persistent fallback when durable output validation is blocked.
+
+Do not call a same-system side file or newly created artifact "source writeback." Use `source-adjacent-result-artifact` for a result file, sheet, table, or tab created or used beside the source in the same provider, account, workspace, folder, or campaign context. For `fully-bound`, fix the artifact ID/path or the exact creation policy, container, schema, and append or upsert behavior at creation time. Creating a new source-adjacent artifact is a durable side effect and must be covered by runtime approval or direct-execution contract.
+
+Do not proactively present session-table output as a normal user-facing choice. If the generated skill falls back to a session table, it must state that the result is non-persistent and unsuitable for unattended scheduled automation unless the user explicitly accepts the host session transcript as the record.
+
+New local result CSV output must validate the output path, avoid mutating the source CSV unless explicitly requested, define exact result columns, and avoid writing full phone numbers. Use a table with one row per task and these logical fields for result CSVs or session-table fallback:
 
 - candidate ID
 - source record
@@ -264,6 +275,8 @@ If writeback is not configured, generated skills must output a table with one ro
 - masked phone
 - status
 - skip reason or result
+- provider run ID when safe to expose
+- result summary
 - processed timestamp
 
 ## Validation

--- a/skills/outbound-call-skill-creator/SKILL.md
+++ b/skills/outbound-call-skill-creator/SKILL.md
@@ -42,7 +42,7 @@ Do not create `template.md`. The creator captures the source, goal, execution, a
 9. Show a small redacted sample summary and prompt the user to confirm or adjust field mapping.
 10. Prompt the user to define the default outbound goal from the sampled fields: call purpose, required context, allowed questions, prohibited claims, completion criteria, result values, summary format, and escalation cases.
 11. Read `references/mcp-provider-route.md` and run creation-time provider onboarding for the default CALL-E MCP provider route in the current host runtime: configure or verify the MCP route, complete or verify provider authentication, and confirm compatible plan/run/status tools without placing a real call. For Codex, use the `codex mcp` adapter commands in the reference. For Claude, Antigravity, Cursor, or another MCP host, use that host's connector or MCP server setup and authorization flow. Do not treat app connector tools, plugin tools, or similarly named non-MCP tools as proof that this provider route is authenticated. If provider onboarding still cannot complete, record a provider onboarding blocker and keep the generated skill dry-run-only.
-12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`. For both supported binding levels, available modes are `dry-run-then-batch-approval`, `per-call-approval`, or `approved-direct-execution`.
+12. Read `references/execution-modes.md` and ask the user to choose an execution mode, defaulting to `dry-run-then-batch-approval`. For both supported binding levels, available modes are `dry-run-then-batch-approval` or `approved-direct-execution`.
 13. Capture writeback policy at creation time and capture field mapping, supported target modes, or allowed runtime writeback parameters: source writeback, local CSV writeback, or session table fallback. For local CSV, record supported target modes (`source-csv-in-place` and `result-csv-file`) and choose the concrete target mode during the runtime dry-run or approval step based on the user's requested output behavior.
 14. Run best-effort creation-time preflight checks when tools and permissions are available: read-only source auth/schema checks, non-mutating writeback target or field checks, and MCP route/tool readiness. If preflight cannot run for a bound workflow, record the blocker and do not generate a real-call skill until source and provider onboarding requirements are satisfied.
 15. Read `references/safety.md` and include the required safety boundaries in the generated skill.
@@ -126,7 +126,7 @@ Before writing files, state the selected scope, output parent, generated skill d
 
 ### Execution Mode
 
-Present execution modes after the binding level is known. For both supported binding levels, recommend `dry-run-then-batch-approval` first, then briefly explain `per-call-approval` and `approved-direct-execution`.
+Present execution modes after the binding level is known. For both supported binding levels, recommend `dry-run-then-batch-approval` first, then briefly explain `approved-direct-execution`.
 
 ## Binding Levels
 
@@ -137,7 +137,7 @@ Use `references/binding-contract.md` for full binding-level selection rules and 
 | Binding level | Creation-time contract | Runtime parameters | Maximum automation |
 | --- | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
-| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval, per-call approval, and approved direct execution only after concrete runtime parameters pass the runtime gate. |
+| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
 
 Do not create a business skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path. If those values are unavailable, keep asking for the missing contract or stop before generation.
 
@@ -148,10 +148,9 @@ Ask the user to choose the generated skill's execution mode after choosing the b
 Use `references/execution-modes.md` for full mode selection rules, concrete runtime request examples, and direct execution guardrails.
 
 - `dry-run-then-batch-approval`: preview every eligible candidate and compiled call goal, then process the approved list serially after one explicit approval.
-- `per-call-approval`: preview one candidate and compiled call goal at a time, then let the user approve, modify, or skip each call before planning and running it.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, compile call goals, inspect each provider plan, and serially run eligible one-off calls without another approval step.
 
-Use `per-call-approval` or `approved-direct-execution` only after the generated skill's supported binding level and concrete runtime request pass the required gates.
+Use `approved-direct-execution` only after the generated skill's supported binding level and concrete runtime request pass the required gates.
 
 ## Preflight and Runtime Gate
 

--- a/skills/outbound-call-skill-creator/references/binding-contract.md
+++ b/skills/outbound-call-skill-creator/references/binding-contract.md
@@ -8,7 +8,6 @@ Use this reference when choosing how tightly the generated outbound phone-call b
 | --- | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
 | `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval, per-call approval, and approved direct execution only after concrete runtime parameters pass the runtime gate. |
-| `unbound-generic` | Goal contract and safety rules only; source and writeback details are collected at runtime. | Source access, fields, filters, source-level outreach basis or consent evidence, dedupe key, and writeback target must be supplied each run. | Dry-run only by default. Do not allow real direct execution or scheduled runs until the workflow is converted to a bound skill or an exact runtime contract is approved. |
 
 ## Selection Rules
 
@@ -28,13 +27,9 @@ Use `parameterized-bound` when:
 - runtime requests can provide approved source or writeback parameters
 - the runtime gate can verify those parameters before real calls
 
-Use `unbound-generic` when:
+Do not create a generated business skill when the data source, writeback behavior, source-level outreach basis or consent evidence, or dedupe rule is still unknown. Continue onboarding or stop with the missing contract details instead.
 
-- the user is exploring the workflow
-- the data source, writeback behavior, source-level outreach basis or consent evidence, or dedupe rule is not yet known
-- the skill should produce dry-runs from manually supplied or runtime-specified records
-
-Do not create a real-call skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path.
+Do not create a skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path.
 
 ## Generated Skill Requirements
 

--- a/skills/outbound-call-skill-creator/references/binding-contract.md
+++ b/skills/outbound-call-skill-creator/references/binding-contract.md
@@ -1,6 +1,8 @@
 # Binding Contract
 
-Use this reference when choosing how tightly the generated outbound phone-call business skill should bind its data source and writeback behavior.
+Use this reference when choosing whether the generated outbound phone-call business skill should use the minimum source binding contract or fix a concrete source and writeback target.
+
+The minimum supported source binding level is `parameterized-bound`. Do not generate a business skill whose source, schema, outreach basis, dedupe rule, and writeback policy are less specific than this minimum contract.
 
 ## Binding Levels
 
@@ -11,7 +13,7 @@ Use this reference when choosing how tightly the generated outbound phone-call b
 
 ## Selection Rules
 
-Default to `parameterized-bound` when the user wants a reusable workflow and has not asked for a single fixed source instance.
+Default to the minimum `parameterized-bound` contract when the user wants a reusable workflow and has not asked for a single fixed source instance.
 
 Use `fully-bound` when:
 
@@ -27,7 +29,7 @@ Use `parameterized-bound` when:
 - runtime requests can provide approved source or writeback parameters
 - the runtime gate can verify those parameters before real calls
 
-Do not create a generated business skill when the data source, writeback behavior, source-level outreach basis or consent evidence, or dedupe rule is still unknown. Continue onboarding or stop with the missing contract details instead.
+Do not create a generated business skill when the data source, writeback behavior, source-level outreach basis or consent evidence, or dedupe rule is too vague to satisfy the minimum `parameterized-bound` contract. Continue onboarding or stop with the missing contract details instead.
 
 Do not create a skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path.
 

--- a/skills/outbound-call-skill-creator/references/binding-contract.md
+++ b/skills/outbound-call-skill-creator/references/binding-contract.md
@@ -1,15 +1,15 @@
 # Binding Contract
 
-Use this reference when choosing whether the generated outbound phone-call business skill should use the minimum source binding contract or fix a concrete source and writeback target.
+Use this reference when choosing whether the generated outbound phone-call business skill should use the minimum source binding contract or fix a concrete source and durable result-output target.
 
-The minimum supported source binding level is `parameterized-bound`. Do not generate a business skill whose source, schema, outreach basis, dedupe rule, and writeback policy are less specific than this minimum contract.
+The minimum supported source binding level is `parameterized-bound`. Do not generate a business skill whose source, schema, outreach basis, dedupe rule, and durable result-output policy are less specific than this minimum contract.
 
 ## Binding Levels
 
 | Binding level | Creation-time contract | Runtime parameters | Maximum automation |
 | --- | --- | --- | --- |
-| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
-| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
+| `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, fixed result target, and result fields. The result target can be source writeback to the source instance or canonical record store, a source-adjacent result artifact, or a local result CSV. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
+| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, result-output policy, and result field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
 
 ## Selection Rules
 
@@ -18,20 +18,24 @@ Default to the minimum `parameterized-bound` contract when the user wants a reus
 Use `fully-bound` when:
 
 - the workflow targets one stable source instance
-- the writeback target and fields are known
+- the source writeback target, source-adjacent result artifact target, or local result CSV target and fields are known
 - the user wants scheduled runs or approved direct execution
-- preflight can usually verify the concrete source and writeback target
+- preflight can usually verify the concrete source and durable result-output target
 
 Use `parameterized-bound` when:
 
 - the workflow should be reusable across similar forms, CSV files, accounts, campaigns, or source instances
 - the required schema is stable
-- runtime requests can provide approved source or writeback parameters
+- runtime requests can provide approved source or result-output parameters
 - the runtime gate can verify those parameters before real calls
 
-Do not create a generated business skill when the data source, writeback behavior, source-level outreach basis or consent evidence, or dedupe rule is too vague to satisfy the minimum `parameterized-bound` contract. Continue onboarding or stop with the missing contract details instead.
+Do not create a generated business skill when the data source, durable result-output behavior, source-level outreach basis or consent evidence, or dedupe rule is too vague to satisfy the minimum `parameterized-bound` contract. Continue onboarding or stop with the missing contract details instead.
 
-Do not create a skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no writeback or session-table result path.
+Do not create a skill with no phone field, no source-level outreach basis or consent rule, no stable dedupe key, or no durable result path such as verified source writeback, a source-adjacent result artifact, or a new local result CSV. Session-table output is only a last-resort non-persistent fallback when durable output validation is blocked.
+
+Treat source writeback narrowly. It means updating the bound source instance or its canonical record store, such as fixed result columns on a response spreadsheet, writable lead-record fields, or an explicitly requested source CSV in-place update. A same-system side file, new sheet, new tab, exported table, or result artifact is not source writeback; classify it as `source-adjacent-result-artifact`.
+
+For `fully-bound` source-adjacent output, fix the provider/account/workspace/folder or equivalent container and either the artifact ID/path or the exact creation policy, naming rule, schema, and append or upsert behavior at creation time. Creating a new artifact is a durable side effect and must be covered by execution approval or by the approved direct-execution contract.
 
 ## Generated Skill Requirements
 
@@ -41,7 +45,7 @@ The generated skill must state:
 - fixed creation-time values
 - allowed runtime parameters
 - required runtime parameters
-- selected writeback policy
-- whether the writeback target is fixed, parameterized, or session-only
+- selected result-output policy
+- whether the result target is source writeback, source-adjacent result artifact, local result CSV, parameterized, or last-resort session-only
 - runtime gate checks required before real calls
 - maximum execution mode supported by the binding level

--- a/skills/outbound-call-skill-creator/references/binding-contract.md
+++ b/skills/outbound-call-skill-creator/references/binding-contract.md
@@ -9,7 +9,7 @@ The minimum supported source binding level is `parameterized-bound`. Do not gene
 | Binding level | Creation-time contract | Runtime parameters | Maximum automation |
 | --- | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field mapping, source-level outreach basis or consent rule, dedupe rule, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. | Eligible for approved direct execution and scheduled host runs after the runtime gate passes. |
-| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval, per-call approval, and approved direct execution only after concrete runtime parameters pass the runtime gate. |
+| `parameterized-bound` | Source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema. | Approved instance values such as form ID, CSV path, campaign ID, date window, writeback target, or output path. | Default. Eligible for dry-run batch approval and approved direct execution only after concrete runtime parameters pass the runtime gate. |
 
 ## Selection Rules
 

--- a/skills/outbound-call-skill-creator/references/creation-summary.md
+++ b/skills/outbound-call-skill-creator/references/creation-summary.md
@@ -37,8 +37,8 @@ Use this shape:
 Skill: <business-skill-name>
 Directory: <generated-skill-directory>
 Discovery: <known-active-root | reload-needed | add-location-needed | nonstandard-path>
-Binding level: <fully-bound | parameterized-bound | unbound-generic>
-Source onboarding: <auth/access check, sampled source instance, sample fetch result, and blocker if any>
+Binding level: <fully-bound | parameterized-bound>
+Source onboarding: <auth/access check, sampled source instance, and sample fetch result>
 Provider onboarding: <provider host runtime, MCP route setup check, auth readiness, compatible MCP tools, one-off capability, and blocker if any>
 Runtime parameters: <allowed parameters or none>
 Source: <source family, access method, required fields>
@@ -57,4 +57,4 @@ Validation: <command and result>
 
 The summary must distinguish fixed values from runtime parameters. Do not show credentials, tokens, cookies, callback URLs, confirmation tokens, or full phone numbers.
 
-If a value is unknown, label it as a blocker and state whether the generated skill is dry-run-only until resolved.
+If a required source or writeback value is unknown, report it as a creation blocker and stop before generating the skill.

--- a/skills/outbound-call-skill-creator/references/creation-summary.md
+++ b/skills/outbound-call-skill-creator/references/creation-summary.md
@@ -23,7 +23,7 @@ Include:
 - dedupe key or dedupe state rule
 - outbound goal contract summary
 - selected execution mode and unavailable modes
-- writeback policy, fixed or runtime-resolved writeback target mode, target binding, and field mapping
+- result-output policy, fixed or runtime-resolved target mode, target binding, and field mapping
 - creation-time preflight result or blocker
 - mandatory runtime gate checks before real calls
 - MCP provider route
@@ -46,7 +46,7 @@ Outreach basis: <source-level basis, consent field, or approved source basis>
 Dedupe: <key or state rule>
 Goal: <one-sentence call purpose and completion criteria>
 Execution mode: <selected mode and any unavailable modes>
-Writeback: <policy, fixed or runtime-resolved target mode, target binding, and field mapping>
+Result output: <policy, fixed or runtime-resolved target mode, target binding, and field mapping>
 Preflight: <passed | blocked | not run, with reason>
 Runtime gate: <checks that must pass before real calls>
 Provider route: https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth
@@ -57,4 +57,4 @@ Validation: <command and result>
 
 The summary must distinguish fixed values from runtime parameters. Do not show credentials, tokens, cookies, callback URLs, confirmation tokens, or full phone numbers.
 
-If a required source or writeback value is unknown, report it as a creation blocker and stop before generating the skill.
+If a required source or durable result-output value is unknown, report it as a creation blocker and stop before generating the skill.

--- a/skills/outbound-call-skill-creator/references/data-sources.md
+++ b/skills/outbound-call-skill-creator/references/data-sources.md
@@ -4,7 +4,7 @@ Use this reference when selecting and documenting the generated business skill's
 
 ## Required Source Contract
 
-Capture these values before generating a business skill:
+Capture these values before generating a business skill. The source contract must satisfy at least the `parameterized-bound` minimum:
 
 - binding level: `fully-bound` or `parameterized-bound`
 - source family
@@ -31,18 +31,18 @@ Do not guess missing identifiers, credentials, field names, date filters, or cou
 
 ## Binding Levels
 
-Choose one binding level before writing the generated skill:
+Choose whether the workflow stays at the minimum binding level or upgrades to a fixed source instance before writing the generated skill:
 
 | Binding level | What must be fixed at creation time | What may be supplied at runtime |
 | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field names, source-level outreach basis or consent rule, dedupe key, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. |
 | `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe key, writeback policy, and writeback field schema. | Approved instance parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. |
 
-Default to `parameterized-bound`. Use `fully-bound` for stable production or scheduled workflows. If the workflow cannot support either binding level, continue onboarding or stop before generating the skill.
+Default to the minimum `parameterized-bound` contract. Use `fully-bound` for stable production or scheduled workflows that should fix a concrete source and writeback target. If the workflow cannot support the minimum contract, continue onboarding or stop before generating the skill.
 
 ## Preflight and Runtime Gate
 
-Creation-time source onboarding is required for `fully-bound` and `parameterized-bound` real-call skills. Run non-mutating checks when tools and permissions are available:
+Creation-time source onboarding is required to reach the minimum `parameterized-bound` contract, and `fully-bound` adds concrete instance verification. Run non-mutating checks when tools and permissions are available:
 
 - verify source authentication, connector availability, or local file access
 - fetch a small representative sample from the concrete or representative source instance
@@ -79,7 +79,7 @@ When a safe source authorization or auth-readiness action is available, start it
 
 When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, treat that as enough to enter source access onboarding. First inspect available host routes and run any safe auth-readiness or discovery check. The next prompt should ask only for the minimum locator or user-completed authorization step that remains necessary to fetch a representative sample, while confirming the recommended binding level if needed. Do not ask for the default outbound goal, writeback mapping, or full field mapping before the access check and sample fetch have been attempted.
 
-Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked before a minimum source contract can be confirmed, record the blocker and stop before generating the skill.
+Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked before the minimum source contract can be confirmed, record the blocker and stop before generating the skill.
 
 ## Google Form
 

--- a/skills/outbound-call-skill-creator/references/data-sources.md
+++ b/skills/outbound-call-skill-creator/references/data-sources.md
@@ -6,7 +6,7 @@ Use this reference when selecting and documenting the generated business skill's
 
 Capture these values before generating a business skill:
 
-- binding level: `fully-bound`, `parameterized-bound`, or `unbound-generic`
+- binding level: `fully-bound` or `parameterized-bound`
 - source family
 - access method
 - authentication or access check method
@@ -37,9 +37,8 @@ Choose one binding level before writing the generated skill:
 | --- | --- | --- |
 | `fully-bound` | Concrete source instance, field names, source-level outreach basis or consent rule, dedupe key, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. |
 | `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe key, writeback policy, and writeback field schema. | Approved instance parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. |
-| `unbound-generic` | Goal contract, safety rules, and the requirement to collect source and writeback details at runtime. | Source access, all field mappings, source-level outreach basis or consent evidence, dedupe key, filters, and writeback target. |
 
-Default to `parameterized-bound`. Use `fully-bound` for stable production or scheduled workflows. Use `unbound-generic` only for exploratory or dry-run-only workflows unless the user later supplies an exact runtime source and writeback contract for approval.
+Default to `parameterized-bound`. Use `fully-bound` for stable production or scheduled workflows. If the workflow cannot support either binding level, continue onboarding or stop before generating the skill.
 
 ## Preflight and Runtime Gate
 
@@ -80,7 +79,7 @@ When a safe source authorization or auth-readiness action is available, start it
 
 When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, treat that as enough to enter source access onboarding. First inspect available host routes and run any safe auth-readiness or discovery check. The next prompt should ask only for the minimum locator or user-completed authorization step that remains necessary to fetch a representative sample, while confirming the recommended binding level if needed. Do not ask for the default outbound goal, writeback mapping, or full field mapping before the access check and sample fetch have been attempted.
 
-Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked, record an onboarding blocker and keep the generated skill dry-run-only until the blocker is resolved.
+Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked before a minimum source contract can be confirmed, record the blocker and stop before generating the skill.
 
 ## Google Form
 
@@ -113,7 +112,7 @@ For `fully-bound`, creation must verify access to the concrete form and fetch a 
 
 When `google-form-callback` helper scripts are available, do not ask the user whether to use local OAuth before checking them. Run or direct the host to run `google-auth.mjs status` first. If authenticated, run `google-local-api-client.mjs --action list-forms` before asking for a Form ID, then fetch metadata or a small response sample from the selected or representative form. If auth is missing, directly run or request `preflight-auth.mjs --repair-google`, wait for the user to complete browser authorization when required, re-check `google-auth.mjs status`, and then list forms. Only ask for an Apps Script fallback endpoint, manual Form ID, or account scope when local OAuth helpers are unavailable, auth cannot be completed, or listing forms is not permitted.
 
-For `fully-bound`, capture the concrete form or response spreadsheet and writeback columns. For `parameterized-bound`, capture the required question names and allow the runtime request to provide the form ID only when the runtime gate verifies that the form matches the schema. For `unbound-generic`, keep the skill dry-run-only until form access, field mapping, source-level outreach basis or consent basis, and writeback behavior are supplied.
+For `fully-bound`, capture the concrete form or response spreadsheet and writeback columns. For `parameterized-bound`, capture the required question names and allow the runtime request to provide the form ID only when the runtime gate verifies that the form matches the schema.
 
 ## TikTok Ads
 
@@ -162,7 +161,7 @@ During creation-time onboarding, fetch a small sample through the exact MCP tool
 
 Do not invent TikTok Ads MCP tools or schemas. If the host does not expose a writeback-capable tool, use session-table output or local CSV output.
 
-For `fully-bound`, capture the concrete account, advertiser, campaign, or lead scope and writeback tool. For `parameterized-bound`, capture the exact MCP tools and required returned fields, then allow runtime account or campaign identifiers only when the runtime gate confirms the returned schema. For `unbound-generic`, do not permit approved direct execution.
+For `fully-bound`, capture the concrete account, advertiser, campaign, or lead scope and writeback tool. For `parameterized-bound`, capture the exact MCP tools and required returned fields, then allow runtime account or campaign identifiers only when the runtime gate confirms the returned schema.
 
 ## Local CSV
 
@@ -196,7 +195,7 @@ Do not require a per-row consent column when the user confirms the CSV source on
 
 If writeback is not configured, output the session table described in the generated skill.
 
-For `fully-bound`, capture the concrete CSV path and output CSV path. For `parameterized-bound`, capture the required column schema and allow runtime CSV and output paths. For `unbound-generic`, require the user to map columns at runtime and keep the workflow dry-run-only until the mapping, source-level outreach basis or consent field, and dedupe rule are approved.
+For `fully-bound`, capture the concrete CSV path and output CSV path. For `parameterized-bound`, capture the required column schema and allow runtime CSV and output paths.
 
 ## Other Sources
 
@@ -213,6 +212,6 @@ Ask one question at a time until the source contract is complete:
 - Can results be written back?
 - If writeback is possible, what exact action and fields should be used?
 
-If the user cannot provide enough detail for safe access, generate a skill that can produce a dry-run from manually supplied records and states the missing integration blocker.
+If the user cannot provide enough detail for safe access, stop before generation and state the missing integration blocker.
 
-For custom sources, do not generate a bound real-call skill until the source can be authenticated or accessed, sampled safely, and mapped to the required phone-call fields. If that cannot happen, generate only a dry-run-only `unbound-generic` skill with an onboarding blocker.
+For custom sources, do not generate a skill until the source can be authenticated or accessed, sampled safely, and mapped to the required phone-call fields.

--- a/skills/outbound-call-skill-creator/references/data-sources.md
+++ b/skills/outbound-call-skill-creator/references/data-sources.md
@@ -22,8 +22,8 @@ Capture these values before generating a business skill. The source contract mus
 - dedupe key
 - goal input fields
 - source-level outreach basis or optional consent field
-- writeback capability
-- writeback policy and field mapping
+- durable result-output capability
+- result-output policy and field mapping
 - creation-time preflight result or documented preflight blocker
 - runtime gate requirements before real calls
 
@@ -35,10 +35,10 @@ Choose whether the workflow stays at the minimum binding level or upgrades to a 
 
 | Binding level | What must be fixed at creation time | What may be supplied at runtime |
 | --- | --- | --- |
-| `fully-bound` | Concrete source instance, field names, source-level outreach basis or consent rule, dedupe key, writeback target, and writeback fields. | Date window, subset filters, and other narrow processing controls. |
-| `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe key, writeback policy, and writeback field schema. | Approved instance parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path. |
+| `fully-bound` | Concrete source instance, field names, source-level outreach basis or consent rule, dedupe key, fixed result target, and result fields. The result target can be source writeback, a source-adjacent result artifact, or a local result CSV. | Date window, subset filters, and other narrow processing controls. |
+| `parameterized-bound` | Source family, access method, required schema, source-level outreach basis or consent rule, dedupe key, result-output policy, and result field schema. | Approved instance parameters such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path. |
 
-Default to the minimum `parameterized-bound` contract. Use `fully-bound` for stable production or scheduled workflows that should fix a concrete source and writeback target. If the workflow cannot support the minimum contract, continue onboarding or stop before generating the skill.
+Default to the minimum `parameterized-bound` contract. Use `fully-bound` for stable production or scheduled workflows that should fix a concrete source and durable result-output target. If the workflow cannot support the minimum contract, continue onboarding or stop before generating the skill.
 
 ## Preflight and Runtime Gate
 
@@ -49,12 +49,14 @@ Creation-time source onboarding is required to reach the minimum `parameterized-
 - inspect source schema or sample rows without placing calls
 - confirm the phone, recipient, date, source-level outreach basis or consent field, dedupe, and goal input fields exist
 - confirm the sample can support the default outbound goal contract
-- confirm writeback target and fields exist, or confirm that session-table fallback will be used
+- confirm a source writeback target and fields exist, configure a source-adjacent result artifact, or configure a new local result CSV target or approved runtime output path
 - confirm the MCP provider route and compatible plan, run, or status tools are available
 
-Creation-time source onboarding and preflight must not mutate source records, source permissions, source integrations, scheduler state, writeback targets, or phone-call provider state. Explicit user-approved authentication setup may create or refresh local host credentials, OAuth tokens, connector sessions, or MCP authorization state so the source can be accessed later. Do not perform a real writeback or place a real call during onboarding or preflight. If creation-time source onboarding cannot run, record the blocker and require the generated skill to stop before real calls when the missing capability is still unavailable for the concrete runtime request.
+Creation-time source onboarding and preflight must not mutate source records, source permissions, source integrations, scheduler state, source writeback targets, source-adjacent result artifacts, result files, or phone-call provider state. Explicit user-approved authentication setup may create or refresh local host credentials, OAuth tokens, connector sessions, or MCP authorization state so the source can be accessed later. Do not perform a real writeback, create or write a source-adjacent result artifact, write a result CSV, or place a real call during onboarding or preflight. If creation-time source onboarding cannot run, record the blocker and require the generated skill to stop before real calls when the missing capability is still unavailable for the concrete runtime request.
 
-Runtime gating is mandatory before real calls. The generated skill must verify source access, required fields, consent or outreach basis, dedupe reliability, writeback behavior or session-table fallback, and provider route/tool readiness for the concrete request. Approved side effects can happen only after the runtime gate passes, in the selected execution flow.
+Runtime gating is mandatory before real calls. The generated skill must verify source access, required fields, consent or outreach basis, dedupe reliability, source writeback, source-adjacent result artifact output, or local result CSV output, and provider route/tool readiness for the concrete request. Session-table output is a last-resort non-persistent fallback only when durable output validation is blocked and the run is attended; do not use it as the primary result path for unattended scheduled automation. Approved side effects can happen only after the runtime gate passes, in the selected execution flow.
+
+Treat source writeback narrowly: it updates the bound source instance or canonical source record store. A same-system side file, new sheet, new tab, result table, or export created beside the source is `source-adjacent-result-artifact`, not source writeback. For fully bound workflows, capture the fixed artifact ID/path or the exact creation policy, container, schema, and append or upsert behavior.
 
 ## Authenticated Source Onboarding
 
@@ -73,13 +75,13 @@ When a safe source authorization or auth-readiness action is available, start it
 3. Record the discovered or user-supplied source locator such as form ID or account scope, and access route such as OAuth, Apps Script fallback, MCP tool, MCP resource, API adapter, or managed connector.
 4. Verify authentication, connector availability, MCP resource access, API access, or workspace permission.
 5. Fetch a small representative sample through a read-only path.
-6. Infer the phone field, recipient field, dedupe key, outreach basis or consent field, goal inputs, and writeback capability from source metadata and the sample.
+6. Infer the phone field, recipient field, dedupe key, outreach basis or consent field, goal inputs, and durable result-output capability from source metadata and the sample.
 7. Show a redacted sample summary and proposed field mapping for user confirmation.
 8. Ask the user to fill only fields that cannot be inferred from the sample.
 
-When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, treat that as enough to enter source access onboarding. First inspect available host routes and run any safe auth-readiness or discovery check. The next prompt should ask only for the minimum locator or user-completed authorization step that remains necessary to fetch a representative sample, while confirming the recommended binding level if needed. Do not ask for the default outbound goal, writeback mapping, or full field mapping before the access check and sample fetch have been attempted.
+When the user names only an authenticated source family such as `google-form` or `tiktok-ads`, treat that as enough to enter source access onboarding. First inspect available host routes and run any safe auth-readiness or discovery check. The next prompt should ask only for the minimum locator or user-completed authorization step that remains necessary to fetch a representative sample, while confirming the recommended binding level if needed. Do not ask for the default outbound goal, result-output mapping, or full field mapping before the access check and sample fetch have been attempted.
 
-Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or writeback fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked before the minimum source contract can be confirmed, record the blocker and stop before generating the skill.
+Do not present a blank manual mapping form for phone, recipient, consent, dedupe, goal inputs, or result-output fields before authentication and sample fetch have been attempted. If access or sample fetch is blocked before the minimum source contract can be confirmed, record the blocker and stop before generating the skill.
 
 ## Google Form
 
@@ -100,11 +102,11 @@ Capture:
 - dedupe key, normally response ID
 - fields to include in the outbound goal
 - form-level phone follow-up basis or per-response consent field
-- writeback columns for status, result summary, call run ID, and processed timestamp
+- source writeback columns, source-adjacent artifact fields, or local result CSV fields for status, result summary, call run ID, and processed timestamp
 
 Generated Google Form skills must require a clear basis for phone follow-up. The basis can come from the form description, ad copy, terms, or an explicit per-response consent field.
 
-If the form has no linked response spreadsheet and the user wants writeback, require an Apps Script fallback or ask the user to link a response spreadsheet before real writeback.
+If the form has no linked response spreadsheet and the user wants source writeback, require an Apps Script fallback or ask the user to link a response spreadsheet before real source writeback. If the user wants a result file in the same Google Drive context without mutating the response store, configure `source-adjacent-result-artifact` with a fixed spreadsheet, tab, folder, schema, and append or upsert rule. If source writeback and source-adjacent output are unavailable or not requested, configure a new local result CSV instead of making session-table output the normal path.
 
 Do not ask for Google Form field mapping before Google access has been verified and a representative response sample has been fetched.
 
@@ -112,7 +114,7 @@ For `fully-bound`, creation must verify access to the concrete form and fetch a 
 
 When `google-form-callback` helper scripts are available, do not ask the user whether to use local OAuth before checking them. Run or direct the host to run `google-auth.mjs status` first. If authenticated, run `google-local-api-client.mjs --action list-forms` before asking for a Form ID, then fetch metadata or a small response sample from the selected or representative form. If auth is missing, directly run or request `preflight-auth.mjs --repair-google`, wait for the user to complete browser authorization when required, re-check `google-auth.mjs status`, and then list forms. Only ask for an Apps Script fallback endpoint, manual Form ID, or account scope when local OAuth helpers are unavailable, auth cannot be completed, or listing forms is not permitted.
 
-For `fully-bound`, capture the concrete form or response spreadsheet and writeback columns. For `parameterized-bound`, capture the required question names and allow the runtime request to provide the form ID only when the runtime gate verifies that the form matches the schema.
+For `fully-bound`, capture the concrete form or response spreadsheet and source writeback columns, capture a source-adjacent result artifact target, or capture the concrete local result CSV target. For `parameterized-bound`, capture the required question names and result field schema, then allow the runtime request to provide the form ID only when the runtime gate verifies that the form matches the schema.
 
 ## TikTok Ads
 
@@ -139,7 +141,7 @@ Capture:
 - dedupe key
 - goal input fields
 - outreach basis or consent evidence
-- approved writeback tool or connector action, or the decision to use session-table output
+- approved writeback tool or connector action, approved source-adjacent artifact action, or a new local result CSV output policy when source-system durable output is unavailable
 
 Generated TikTok Ads skills must not assume every record is callable. They must validate outreach basis and E.164 phone numbers before creating call candidates.
 
@@ -159,9 +161,9 @@ After adding or discovering the server, inspect its configured auth state and th
 
 During creation-time onboarding, fetch a small sample through the exact MCP tool or resource names exposed by the host. Record the tool names, sampled scope, returned fields, and redaction rule in the generated skill.
 
-Do not invent TikTok Ads MCP tools or schemas. If the host does not expose a writeback-capable tool, use session-table output or local CSV output.
+Do not invent TikTok Ads MCP tools or schemas. If the host does not expose a writeback-capable tool but does expose a same-account or same-workspace artifact action, configure `source-adjacent-result-artifact` and record the artifact container, schema, and append or upsert behavior. If neither source writeback nor source-adjacent output is available, configure a new local result CSV output path. Use session-table output only as a last-resort non-persistent fallback when durable output cannot be verified.
 
-For `fully-bound`, capture the concrete account, advertiser, campaign, or lead scope and writeback tool. For `parameterized-bound`, capture the exact MCP tools and required returned fields, then allow runtime account or campaign identifiers only when the runtime gate confirms the returned schema.
+For `fully-bound`, capture the concrete account, advertiser, campaign, or lead scope and source writeback tool, source-adjacent artifact target, or local result CSV target. For `parameterized-bound`, capture the exact MCP tools, required returned fields, and result field schema, then allow runtime account or campaign identifiers only when the runtime gate confirms the returned schema.
 
 ## Local CSV
 
@@ -178,22 +180,22 @@ Capture:
 - dedupe key column or deterministic row key rule
 - goal input columns
 - source-level outreach basis, or an optional consent column when the CSV does not guarantee authorized records
-- output CSV path when local writeback is configured
+- output CSV path when local result output is configured
 
 Generated CSV skills should use deterministic scripts when parsing, validating, deduplicating, or writing output would otherwise be fragile.
 
 During creation-time onboarding, read a small sample from the concrete or representative CSV path. Confirm headers, delimiter, date parsing, source-level outreach basis or consent column, dedupe, goal input columns, and output path behavior before generating a bound real-call skill.
 
-For local CSV workflows, capture supported writeback target modes at creation time and choose the concrete target mode during the runtime dry-run or approval step. Record the supported modes as:
+For local CSV workflows, capture supported result-output target modes at creation time and choose the concrete target mode during the runtime dry-run or approval step. Record the supported modes as:
 
 - `source-csv-in-place`: update the original CSV only when the runtime request explicitly asks to update the source CSV and the execution approval covers that mutation. Before real calls, verify the file is writable, define the exact appended or updated result columns, preserve existing rows and columns, and create or recommend a backup or atomic write plan.
-- `result-csv-file`: write a separate result CSV. This is the safer default when the runtime request asks for a results file or does not explicitly request original CSV mutation.
+- `result-csv-file`: write a separate new result CSV. This is the safer default when the runtime request asks for a results file or does not explicitly request original CSV mutation.
 
-Do not describe a separate result CSV as "writeback to the original CSV." If the runtime request asks to update the original CSV, select `source-csv-in-place` during dry-run or approval and do not create a separate result CSV while calling it source writeback. If the request does not specify original CSV mutation, use `result-csv-file` or stop for clarification before real calls.
+Do not describe a separate result CSV as "writeback to the original CSV." If the runtime request asks to update the original CSV, select `source-csv-in-place` during dry-run or approval and do not create a separate result CSV while calling it source writeback. If the request does not specify original CSV mutation, use `result-csv-file` as the durable fallback. Before real calls, verify that the output path is writable, define exact result columns, avoid full phone numbers in output, and preserve source rows and columns.
 
 Do not require a per-row consent column when the user confirms the CSV source only contains records collected from people who requested or agreed to phone follow-up. Record that as the source-level outreach basis in the generated skill and runtime gate. At runtime, verify the request uses the same approved source class or schema; if it does not, ask for a new source-level basis or consent field before real calls.
 
-If writeback is not configured, output the session table described in the generated skill.
+If source CSV in-place update is not configured, use a new local result CSV as the default durable output. Output a session table only when durable output validation is blocked; treat it as non-persistent and do not proactively offer it as a normal option.
 
 For `fully-bound`, capture the concrete CSV path and output CSV path. For `parameterized-bound`, capture the required column schema and allow runtime CSV and output paths.
 
@@ -209,8 +211,10 @@ Ask one question at a time until the source contract is complete:
 - Which field proves phone follow-up is authorized?
 - Which field is stable enough for dedupe?
 - How should date-window filtering work?
-- Can results be written back?
-- If writeback is possible, what exact action and fields should be used?
+- Can results be written back to the source?
+- If source writeback is possible, what exact action and fields should be used?
+- If source writeback is unavailable or should not mutate the source records, should results go to a source-adjacent artifact in the same system?
+- If source-system durable output is unavailable, what local result CSV path or approved runtime output path should be used?
 
 If the user cannot provide enough detail for safe access, stop before generation and state the missing integration blocker.
 

--- a/skills/outbound-call-skill-creator/references/examples.md
+++ b/skills/outbound-call-skill-creator/references/examples.md
@@ -137,9 +137,9 @@ Create an outbound skill for records from our internal API.
 
 Creator behavior:
 
-Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and writeback capability. If any critical value is unknown, generate a dry-run-only skill or stop before generation.
+Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and writeback capability. If any critical value is unknown, stop before generation and explain the missing contract detail.
 
-If source onboarding cannot authenticate or sample the source safely, generate only a dry-run-only `unbound-generic` skill with an onboarding blocker.
+If source onboarding cannot authenticate or sample the source safely, do not generate the skill yet. Record the blocker in the creation conversation and continue only after the user provides an access route or representative source sample that supports one of the supported binding levels.
 
 ## Binding Mode Selection
 
@@ -178,6 +178,6 @@ Create a generic callback skill. I will tell it the data source later.
 
 Recommended creator response:
 
-- use `unbound-generic`
-- keep the skill dry-run-only by default
-- require runtime collection of source fields, source-level outreach basis or consent evidence, dedupe key, and writeback behavior before any real calls
+- explain that this creator generates directly usable batch-call skills, so the source family and minimum source contract must be known before generation
+- ask for the source family and enough access detail to run source onboarding
+- recommend `parameterized-bound` once the source family, required schema, outreach basis, dedupe rule, and writeback policy are known

--- a/skills/outbound-call-skill-creator/references/examples.md
+++ b/skills/outbound-call-skill-creator/references/examples.md
@@ -139,7 +139,7 @@ Creator behavior:
 
 Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and writeback capability. If any critical value is unknown, stop before generation and explain the missing contract detail.
 
-If source onboarding cannot authenticate or sample the source safely, do not generate the skill yet. Record the blocker in the creation conversation and continue only after the user provides an access route or representative source sample that supports one of the supported binding levels.
+If source onboarding cannot authenticate or sample the source safely, do not generate the skill yet. Record the blocker in the creation conversation and continue only after the user provides an access route or representative source sample that supports the minimum `parameterized-bound` contract.
 
 ## Binding Mode Selection
 

--- a/skills/outbound-call-skill-creator/references/examples.md
+++ b/skills/outbound-call-skill-creator/references/examples.md
@@ -50,7 +50,7 @@ Recommended binding level is `parameterized-bound`.
 
 I will first check whether this host already exposes Google Forms access. If local OAuth is available, I will run its auth check and list accessible forms before asking you for a Form ID. If auth requires a browser step, I will pause for you to complete it, re-check auth, then list forms.
 
-After access is verified and a sample is fetched, I will propose the phone, recipient, dedupe, outreach-basis, goal-input, and writeback fields for confirmation.
+After access is verified and a sample is fetched, I will propose the phone, recipient, dedupe, outreach-basis, goal-input, and result-output fields for confirmation.
 ```
 
 If no Google route can be discovered, ask for only the missing route detail:
@@ -87,8 +87,8 @@ Captured contract:
 - dedupe key: lead record ID
 - date filtering: record creation time in the source account timezone
 - outreach basis: lead form includes phone follow-up consent
-- writeback: approved TikTok Ads MCP writeback tool, approved connector action, or session table fallback
-- execution: `dry-run-then-batch-approval` or `approved-direct-execution` only after concrete runtime scope passes the runtime gate; finalize provider results with full-history reconciliation, record each stable terminal result, then write back or output one final session table
+- result output: approved TikTok Ads MCP writeback tool or approved connector action when available; otherwise use an approved source-adjacent result artifact in the same account or workspace when available; otherwise write a new local result CSV; use session-table output only as a last-resort non-persistent fallback when durable output cannot be verified
+- execution: `dry-run-then-batch-approval` or `approved-direct-execution` only after concrete runtime scope passes the runtime gate; finalize provider results with full-history reconciliation, record each stable terminal result, then write back to the source, write a source-adjacent result artifact, or write one result CSV
 
 Generated future use:
 
@@ -117,9 +117,9 @@ Captured contract:
 - dedupe key column: `appointment_id`
 - date filtering: `appointment_date` in `YYYY-MM-DD`
 - outreach basis: source-level; this CSV is exported only from records whose owners requested or agreed to phone follow-up, so no per-row consent column is required
-- writeback: local CSV with supported target modes `result-csv-file` and `source-csv-in-place`; resolve the concrete target mode during runtime dry-run or approval, using `source-csv-in-place` only when the runtime request explicitly asks to update the original CSV and target result columns are defined
+- result output: local CSV with supported target modes `result-csv-file` and `source-csv-in-place`; resolve the concrete target mode during runtime dry-run or approval, using `result-csv-file` as the default durable output and `source-csv-in-place` only when the runtime request explicitly asks to update the original CSV and target result columns are defined
 - sensitive boundary: logistics only, no medical advice
-- execution: after approval, call eligible rows serially, continue past candidate-level failures when safe, run provider result finalization before CSV writeback, and summarize all results after the batch ends
+- execution: after approval, call eligible rows serially, continue past candidate-level failures when safe, run provider result finalization before local result CSV output, and summarize all results after the batch ends
 
 Generated future use:
 
@@ -137,7 +137,7 @@ Create an outbound skill for records from our internal API.
 
 Creator behavior:
 
-Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and writeback capability. If any critical value is unknown, stop before generation and explain the missing contract detail.
+Ask for source access, returned fields, phone field, outreach basis, dedupe key, date filtering, and durable result-output capability. If any critical value is unknown, stop before generation and explain the missing contract detail.
 
 If source onboarding cannot authenticate or sample the source safely, do not generate the skill yet. Record the blocker in the creation conversation and continue only after the user provides an access route or representative source sample that supports the minimum `parameterized-bound` contract.
 
@@ -152,9 +152,9 @@ Create a skill for quote request callbacks. I want to reuse it across multiple f
 Recommended creator response:
 
 - recommend `parameterized-bound`
-- fix the required Google Form questions, source-level phone follow-up basis or consent basis, dedupe rule, goal contract, provider route, and writeback field schema
-- allow the runtime request to provide the concrete form ID and date window
-- run best-effort creation-time preflight when available and require form schema and writeback runtime gate checks before real calls
+- fix the required Google Form questions, source-level phone follow-up basis or consent basis, dedupe rule, goal contract, provider route, and result-output field schema
+- allow the runtime request to provide the concrete form ID, date window, and approved output path or source-adjacent artifact target when source writeback is not fixed
+- run best-effort creation-time preflight when available and require form schema and durable result-output runtime gate checks before real calls
 - default execution mode to `dry-run-then-batch-approval`
 
 User request:
@@ -166,7 +166,7 @@ Create a skill that automatically processes the same lead form every morning.
 Recommended creator response:
 
 - recommend `fully-bound`
-- fix the concrete form, linked response spreadsheet, writeback columns, and host scheduler boundary
+- fix the concrete form, linked response spreadsheet, source-adjacent result artifact, or local result CSV target, result columns, and host scheduler boundary
 - allow only narrow runtime controls such as date window
 - require the runtime gate before every scheduled or approved direct execution run
 
@@ -180,4 +180,4 @@ Recommended creator response:
 
 - explain that this creator generates directly usable batch-call skills, so the source family and minimum source contract must be known before generation
 - ask for the source family and enough access detail to run source onboarding
-- recommend `parameterized-bound` once the source family, required schema, outreach basis, dedupe rule, and writeback policy are known
+- recommend `parameterized-bound` once the source family, required schema, outreach basis, dedupe rule, and durable result-output policy are known

--- a/skills/outbound-call-skill-creator/references/execution-modes.md
+++ b/skills/outbound-call-skill-creator/references/execution-modes.md
@@ -14,7 +14,7 @@ Use this reference when selecting the generated skill's approval and execution b
 
 Ask the user to choose the generated skill's execution mode after the binding level is known. If the user does not choose, use `dry-run-then-batch-approval`.
 
-If source onboarding cannot support either binding level, do not choose an execution mode yet; complete the source and writeback contract first.
+If source onboarding cannot satisfy the minimum `parameterized-bound` contract, do not choose an execution mode yet; complete the source and writeback contract first.
 
 Use `approved-direct-execution` only when:
 

--- a/skills/outbound-call-skill-creator/references/execution-modes.md
+++ b/skills/outbound-call-skill-creator/references/execution-modes.md
@@ -13,7 +13,7 @@ Use this reference when selecting the generated skill's approval and execution b
 
 Ask the user to choose the generated skill's execution mode after the binding level is known. If the user does not choose, use `dry-run-then-batch-approval`.
 
-If source onboarding cannot satisfy the minimum `parameterized-bound` contract, do not choose an execution mode yet; complete the source and writeback contract first.
+If source onboarding cannot satisfy the minimum `parameterized-bound` contract, do not choose an execution mode yet; complete the source and durable result-output contract first.
 
 Use `approved-direct-execution` only when:
 

--- a/skills/outbound-call-skill-creator/references/execution-modes.md
+++ b/skills/outbound-call-skill-creator/references/execution-modes.md
@@ -14,7 +14,7 @@ Use this reference when selecting the generated skill's approval and execution b
 
 Ask the user to choose the generated skill's execution mode after the binding level is known. If the user does not choose, use `dry-run-then-batch-approval`.
 
-For `unbound-generic` workflows, offer only `dry-run-then-batch-approval` with dry-run-only behavior until onboarding is complete. State that the workflow must first become `fully-bound` or `parameterized-bound` before `per-call-approval` or `approved-direct-execution` can be selected.
+If source onboarding cannot support either binding level, do not choose an execution mode yet; complete the source and writeback contract first.
 
 Use `approved-direct-execution` only when:
 

--- a/skills/outbound-call-skill-creator/references/execution-modes.md
+++ b/skills/outbound-call-skill-creator/references/execution-modes.md
@@ -54,7 +54,7 @@ Generated skills that support `approved-direct-execution` must require:
 - consent or outreach basis runtime gate
 - E.164 validation for every ready candidate
 - trusted dedupe key or dedupe state
-- verified writeback target or ready session-table fallback
+- verified source writeback target, source-adjacent result artifact, or local result CSV output; session-table fallback may be ready only as a last-resort attended fallback
 - available MCP provider route, auth, and compatible tools
 - inspected provider plan before each call run
 - one-off provider request with no provider-side recurrence

--- a/skills/outbound-call-skill-creator/references/execution-modes.md
+++ b/skills/outbound-call-skill-creator/references/execution-modes.md
@@ -7,7 +7,6 @@ Use this reference when selecting the generated skill's approval and execution b
 | Execution mode | Behavior | Best fit |
 | --- | --- | --- |
 | `dry-run-then-batch-approval` | Preview every eligible candidate and compiled call goal, then process the approved list serially after one explicit approval. | Default for most generated skills. |
-| `per-call-approval` | Preview one candidate and compiled call goal at a time, then let the user approve, modify, or skip each call before planning and running it. | Higher-control workflows, sensitive edge cases, or early pilots. |
 | `approved-direct-execution` | After a concrete processing request, validate candidates, run the runtime gate, compile call goals, inspect each provider plan, and serially run eligible one-off calls without another approval step. | Stable `fully-bound` or verified `parameterized-bound` workflows. |
 
 ## Selection Rules

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -306,7 +306,7 @@ Use this result-output mapping shape when durable output or last-resort session-
 ```yaml
 result_output:
   policy: source-writeback | source-adjacent-result-artifact | local-result-csv | source-csv-in-place | session-table-fallback
-  target_mode: source-csv-in-place | result-csv-file | source-writeback | source-adjacent-artifact | session-table | runtime-parameter-name
+  target_mode: source-csv-in-place | result-csv-file | source-writeback | source-adjacent-result-artifact | session-table | runtime-parameter-name
   target_binding: fully-bound | parameterized | session-only
   target: fixed-value-or-runtime-parameter-name
   fields:

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -64,7 +64,7 @@ The generated skill must declare one of these binding levels:
 - `fully-bound`: a concrete source instance and concrete writeback target are fixed at creation time. Runtime requests may provide only date windows, subset filters, and other narrow processing controls.
 - `parameterized-bound`: the source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time. Runtime requests may provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path.
 
-Default generated skills should be `parameterized-bound`. If the creator cannot capture enough source, outreach-basis, dedupe, and writeback detail for either supported binding level, it must stop before generating the business skill.
+Default generated skills should use the minimum `parameterized-bound` contract. If the creator cannot capture enough source, outreach-basis, dedupe, and writeback detail to satisfy that minimum, it must stop before generating the business skill.
 
 The generated skill must state:
 
@@ -178,7 +178,7 @@ Source onboarding must be read-only and non-mutating:
 - Do not define the default goal from user prose alone before the representative sample is fetched.
 - redact user-facing sample summaries, including full phone numbers and sensitive source values
 
-For both supported binding levels, missing source onboarding blocks skill generation until the source contract is complete enough for the selected level.
+Missing source onboarding blocks skill generation until the source contract is complete enough for at least `parameterized-bound`.
 
 ## MCP Provider Contract
 

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -63,9 +63,8 @@ The generated skill must declare one of these binding levels:
 
 - `fully-bound`: a concrete source instance and concrete writeback target are fixed at creation time. Runtime requests may provide only date windows, subset filters, and other narrow processing controls.
 - `parameterized-bound`: the source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time. Runtime requests may provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path.
-- `unbound-generic`: the skill only fixes the goal contract and safety rules. Source access, field mapping, source-level outreach basis or consent evidence, dedupe key, filters, and writeback target must be collected at runtime.
 
-Default generated skills should be `parameterized-bound`. `unbound-generic` generated skills must be dry-run-only by default and must not support approved direct execution or scheduled real calls until they are converted to `fully-bound` or `parameterized-bound`, or until the user approves an exact runtime source and writeback contract.
+Default generated skills should be `parameterized-bound`. If the creator cannot capture enough source, outreach-basis, dedupe, and writeback detail for either supported binding level, it must stop before generating the business skill.
 
 The generated skill must state:
 
@@ -122,7 +121,7 @@ The generated skill must define one execution mode:
 - `per-call-approval`: preview one candidate and compiled call goal at a time, then let the user approve, modify, or skip each call before planning and running it.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, compile call goals, inspect each provider plan, and serially run eligible one-off calls without another approval step.
 
-Use `dry-run-then-batch-approval` as the default. For `unbound-generic` workflows, it is the only allowed mode and must remain dry-run-only until onboarding is complete. Use `per-call-approval` or `approved-direct-execution` only when the generated skill is `fully-bound` or `parameterized-bound`, the creation-time contract explicitly allows the selected mode, and the concrete runtime request passes the runtime gate.
+Use `dry-run-then-batch-approval` as the default. Use `per-call-approval` or `approved-direct-execution` only when the generated skill is `fully-bound` or `parameterized-bound`, the creation-time contract explicitly allows the selected mode, and the concrete runtime request passes the runtime gate.
 
 Even when direct execution is configured, the runtime request must be concrete, such as "process all June 20 records." Open-ended requests such as "run the campaign" are not enough.
 
@@ -166,7 +165,6 @@ Generated bound skills must record creation-time source onboarding:
 - redaction policy for sample summaries
 - default goal contract derived from sampled fields
 - runtime parameters still allowed
-- onboarding blocker, when the workflow is `unbound-generic`
 
 Source onboarding must be read-only and non-mutating:
 
@@ -180,7 +178,7 @@ Source onboarding must be read-only and non-mutating:
 - Do not define the default goal from user prose alone before the representative sample is fetched.
 - redact user-facing sample summaries, including full phone numbers and sensitive source values
 
-For `fully-bound` and `parameterized-bound`, missing source onboarding blocks real-call skill generation. For `unbound-generic`, missing onboarding is allowed only when the generated skill is dry-run-only and records the onboarding blocker.
+For both supported binding levels, missing source onboarding blocks skill generation until the source contract is complete enough for the selected level.
 
 ## MCP Provider Contract
 
@@ -356,7 +354,7 @@ Use this runtime gate report shape during dry-runs and before real calls:
 
 Do not put credentials, tokens, full phone numbers, confirmation tokens, or callback URLs in `evidence` or `blocker`.
 
-After the creator writes the generated skill, it should show the user a creation summary with the skill name, output path, reload or discovery step, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, onboarding blocker if any, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, outbound goal contract, execution mode, writeback behavior, preflight result, runtime gate, provider route, and validation result.
+After the creator writes the generated skill, it should show the user a creation summary with the skill name, output path, reload or discovery step, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, outbound goal contract, execution mode, writeback behavior, preflight result, runtime gate, provider route, and validation result.
 
 Use this summary shape:
 
@@ -364,8 +362,8 @@ Use this summary shape:
 Skill: <business-skill-name>
 Directory: <generated-skill-directory>
 Discovery: <known-active-root | reload-needed | add-location-needed | nonstandard-path>
-Binding level: <fully-bound | parameterized-bound | unbound-generic>
-Source onboarding: <auth/access check, sampled source instance, sample fetch result, and blocker if any>
+Binding level: <fully-bound | parameterized-bound>
+Source onboarding: <auth/access check, sampled source instance, and sample fetch result>
 Provider onboarding: <provider host runtime, MCP route setup check, auth readiness, compatible MCP tools, one-off capability, and blocker if any>
 Runtime parameters: <allowed parameters or none>
 Source: <source family, access method, required fields>

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -14,7 +14,7 @@ Generate this minimum folder shape:
     └── examples.md
 ```
 
-Add source, goal, writeback, and script files only when the workflow needs them.
+Add source, goal, result-output, and script files only when the workflow needs them.
 
 Do not create `template.md`. The business contract belongs in `SKILL.md` and focused reference files.
 
@@ -26,7 +26,7 @@ The generated `SKILL.md` frontmatter must include only `name` and `description`.
 
 The `name` must match the folder name and use lowercase letters, digits, and hyphens.
 
-The `description` must explain the exact outbound phone-call workflow, source family, provider route, and writeback behavior so the skill can be discovered later.
+The `description` must explain the exact outbound phone-call workflow, source family, provider route, and durable result-output behavior so the skill can be discovered later.
 
 Example:
 
@@ -52,7 +52,7 @@ The generated `SKILL.md` must include:
 - provider onboarding
 - execution modes
 - serial candidate execution
-- writeback behavior
+- result-output behavior
 - preflight and creation summary
 - safety summary
 - validation commands
@@ -61,10 +61,10 @@ The generated `SKILL.md` must include:
 
 The generated skill must declare one of these binding levels:
 
-- `fully-bound`: a concrete source instance and concrete writeback target are fixed at creation time. Runtime requests may provide only date windows, subset filters, and other narrow processing controls.
-- `parameterized-bound`: the source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, writeback policy, and writeback field schema are fixed at creation time. Runtime requests may provide approved parameters such as form ID, CSV path, campaign ID, date window, writeback target, or output path.
+- `fully-bound`: a concrete source instance and concrete durable result target are fixed at creation time. The result target can be source writeback to the bound source instance or canonical source record store, a source-adjacent result artifact, or a local result CSV. Runtime requests may provide only date windows, subset filters, and other narrow processing controls.
+- `parameterized-bound`: the source family, access method, required field schema, source-level outreach basis or consent rule, dedupe rule, goal contract, result-output policy, and result field schema are fixed at creation time. Runtime requests may provide approved parameters such as form ID, CSV path, campaign ID, date window, source writeback target, source-adjacent artifact target, or output path.
 
-Default generated skills should use the minimum `parameterized-bound` contract. If the creator cannot capture enough source, outreach-basis, dedupe, and writeback detail to satisfy that minimum, it must stop before generating the business skill.
+Default generated skills should use the minimum `parameterized-bound` contract. If the creator cannot capture enough source, outreach-basis, dedupe, and durable result-output detail to satisfy that minimum, it must stop before generating the business skill.
 
 The generated skill must state:
 
@@ -168,7 +168,7 @@ Generated bound skills must record creation-time source onboarding:
 Source onboarding must be read-only and non-mutating:
 
 - do not place real calls
-- do not write back to source systems or result stores
+- do not write back to source systems or write result files
 - do not mutate source data, credentials, permissions, integrations, or scheduler state
 - do not expose credentials, tokens, cookies, callback URLs, confirmation tokens, or full phone numbers
 - fetch the smallest practical representative sample needed to confirm access, schema, and goal fields
@@ -219,7 +219,7 @@ For `fully-bound` and `parameterized-bound`, missing MCP configuration, missing 
 
 Generated skills must define the approved batch behavior. After the user approves the exact pending call list, the agent must serially process all ready candidates until every candidate reaches a terminal result or skip state.
 
-After execution approval, do not ask the user to continue, confirm the next candidate, or approve additional provider runs. The final user-facing result comes only after all approved candidates are terminal and configured writeback or session-table output is complete, unless a batch-level blocker makes continuing unsafe or impossible.
+After execution approval, do not ask the user to continue, confirm the next candidate, or approve additional provider runs. The final user-facing result comes only after all approved candidates are terminal and configured source writeback, source-adjacent result artifact output, local result CSV output, or last-resort session-table output is complete, unless a batch-level blocker makes continuing unsafe or impossible.
 
 For each ready candidate, the generated skill should:
 
@@ -230,7 +230,7 @@ For each ready candidate, the generated skill should:
 5. Record the terminal result or failure.
 6. Continue to the next ready candidate without asking for another per-candidate confirmation or post-approval continuation prompt.
 
-If one candidate fails, record that failure and continue with the next candidate unless the provider route is unavailable, authentication is missing, or continuing would be unsafe. After all candidates finish, perform configured writeback or produce the session table, then report one final batch summary to the user.
+If one candidate fails, record that failure and continue with the next candidate unless the provider route is unavailable, authentication is missing, or continuing would be unsafe. After all candidates finish, perform configured source writeback, source-adjacent result artifact output, or local result CSV output, then report one final batch summary to the user. Produce a session table only when durable result output is blocked and the run is attended.
 
 Provider terminal instructions such as `report_result` or `do not start another call` apply only to the current provider run. They prevent duplicate execution of the same provider plan; they do not cancel the approved batch. After recording the current candidate result, continue to the next approved ready candidate unless a batch-level blocker appears.
 
@@ -238,15 +238,15 @@ For `dry-run-then-batch-approval`, the exact pending call list must be approved 
 
 ## Provider Result Finalization
 
-Generated skills must finalize provider results before writeback or final user-facing summaries. Terminal provider status is not writeback-ready until the generated skill performs a full-history provider reconciliation.
+Generated skills must finalize provider results before source writeback, source-adjacent result artifact output, local result CSV output, session-table fallback, or final user-facing summaries. Terminal provider status is not result-output-ready until the generated skill performs a full-history provider reconciliation.
 
-Cursor-based polling is useful for progress updates, but a cursor-limited page must not be the only evidence used for final writeback. After terminal status is seen, re-check the full provider run history without a cursor, using a high enough limit to include call lifecycle events and conversation content when the provider supports it. Treat provider terminal instructions such as `report_result` or `do not start another call` as duplicate-run protection, not as proof that the provider run history has fully synchronized.
+Cursor-based polling is useful for progress updates, but a cursor-limited page must not be the only evidence used for final result output. After terminal status is seen, re-check the full provider run history without a cursor, using a high enough limit to include call lifecycle events and conversation content when the provider supports it. Treat provider terminal instructions such as `report_result` or `do not start another call` as duplicate-run protection, not as proof that the provider run history has fully synchronized.
 
-Do not write `no_answer`, `failed`, or `no conversation captured` results until a negative terminal stability check passes. For these negative terminal outcomes, perform at least one full-history recheck after the terminal status is observed and confirm that no later answer, transcript, collected field, or stronger result appears. If the full history has changed, use the latest stronger evidence before writeback.
+Do not write `no_answer`, `failed`, or `no conversation captured` results until a negative terminal stability check passes. For these negative terminal outcomes, perform at least one full-history recheck after the terminal status is observed and confirm that no later answer, transcript, collected field, or stronger result appears. If the full history has changed, use the latest stronger evidence before source writeback, source-adjacent result artifact output, local result CSV output, or session-table fallback.
 
-Before the final batch summary, reconcile every provider run ID against the latest full-history provider result. If reconciliation changes a candidate result, update the pending writeback payload before writing. If reconciliation is blocked by missing auth, missing tools, or provider unavailability, stop before writeback unless the generated skill explicitly supports session-only partial reporting with a blocker.
+Before the final batch summary, reconcile every provider run ID against the latest full-history provider result. If reconciliation changes a candidate result, update the pending result-output payload before writing. If reconciliation is blocked by missing auth, missing tools, or provider unavailability, stop before durable output unless the generated skill explicitly supports session-only partial reporting with a blocker.
 
-Use this provider result finalization report shape before writeback:
+Use this provider result finalization report shape before result output:
 
 ```yaml
 provider_result_finalization:
@@ -254,7 +254,7 @@ provider_result_finalization:
   terminal_status_seen: true
   full_history_rechecked: true
   negative_terminal_stability_checked: true
-  writeback_allowed: true
+  result_output_allowed: true
   blocker: none
 ```
 
@@ -269,36 +269,44 @@ Generated skills that support `approved-direct-execution` must include this chec
 - consent or outreach basis passed the runtime gate
 - E.164 phone validation passed for every ready candidate
 - dedupe key or dedupe state is trusted for the concrete run
-- writeback target is verified or session-table fallback is ready
+- source writeback target, source-adjacent result artifact, or local result CSV output is verified; session-table fallback is ready only as a last-resort attended fallback
 - MCP provider route, auth, compatible tools, and provider onboarding passed
 - each provider plan was inspected before running
 - the call request is one-off and not provider-side recurrence
 
 If any item fails, the generated skill must skip the affected candidate or stop the batch when continuing would be unsafe.
 
-## Writeback Contract
+## Result Output Contract
 
-Generated skills must support one of these writeback outcomes:
+Generated skills must support a durable result-output outcome:
 
 - source writeback
-- local CSV writeback
-- session table output
+- source-adjacent result artifact
+- new local result CSV output
+- source CSV in-place update only when the runtime request explicitly asks to mutate the source CSV
+- session table output only as a last-resort non-persistent fallback
 
-The writeback policy must be chosen at creation time. Writeback target mode may be fixed at creation time or selected from approved runtime parameters before execution approval. The generated skill must still declare a writeback target mode in its writeback behavior section, even when that mode is resolved during runtime approval. The generated skill must state whether the writeback target is fully bound or parameterized, and must define field mapping when writeback is configured. The user may specify writeback fields during creation. Runtime requests may provide a writeback target or target mode only when the selected binding level explicitly allows that parameter and the runtime gate verifies it before real calls. Generated skills must keep credentials, tokens, callback URLs, confirmation tokens, cookies, and full phone numbers out of user-facing summaries and writeback fields.
+The result-output policy must be chosen at creation time. Prefer verified source writeback when the source exposes a safe writeback path to the bound source instance or canonical source record store. If the result should stay in the same source system without mutating source records, configure `source-adjacent-result-artifact` instead. If source writeback and source-adjacent output are unavailable, not requested, or cannot be verified, configure a new local result CSV as the durable fallback. Keep session-table output as a last-resort non-persistent fallback only when durable output validation is blocked; do not proactively present session-table output as a normal user-facing option.
 
-For local CSV workflows, use one of these target modes:
+Result target mode may be fixed at creation time or selected from approved runtime parameters before execution approval. The generated skill must still declare a result target mode in its result-output behavior section, even when that mode is resolved during runtime approval. The generated skill must state whether the result target is fully bound, parameterized, or last-resort session-only, and must define field mapping for durable output. The user may specify result fields during creation. Runtime requests may provide a result target or target mode only when the selected binding level explicitly allows that parameter and the runtime gate verifies it before real calls. Generated skills must keep credentials, tokens, callback URLs, confirmation tokens, cookies, and full phone numbers out of user-facing summaries and result outputs.
+
+Treat `source-writeback` narrowly. It updates the bound source instance or canonical source record store. Do not use it for a same-system side file, new sheet, new tab, result table, or export. Use `source-adjacent-result-artifact` for results stored beside the source in the same provider, account, workspace, folder, or campaign context. For `fully-bound`, the generated skill must fix the artifact ID/path or fix the creation policy, container, schema, and append or upsert behavior at creation time. Creating a new source-adjacent artifact is a durable side effect and must be covered by execution approval or by the approved direct-execution contract.
+
+For local CSV result output, use one of these target modes:
 
 - `source-csv-in-place`: update the original CSV only when the runtime request explicitly asks for source CSV writeback and execution approval covers that mutation. Define exact result columns, preserve existing rows and columns, verify writability, and create or recommend a backup or atomic write plan before writing.
-- `result-csv-file`: write a separate result CSV. Use this safer mode when the user asks for a results file or does not explicitly request original CSV mutation.
+- `result-csv-file`: write a separate new result CSV. Use this safer durable fallback when the user asks for a results file, when source writeback is unavailable, or when the request does not explicitly require original CSV mutation.
 
 Do not claim that `result-csv-file` writes back to the original CSV.
 
-Use this writeback mapping shape when writeback is configured:
+Before writing a source-adjacent artifact or local result CSV, verify that the container or output directory exists or can be safely created, the artifact or file can be written without overwriting unrelated data, exact result columns are defined, source rows and columns are preserved when applicable, and full phone numbers are excluded unless the contract explicitly allows private storage.
+
+Use this result-output mapping shape when durable output or last-resort session-table output is configured:
 
 ```yaml
-writeback:
-  policy: source-writeback | local-csv | session-table
-  target_mode: source-csv-in-place | result-csv-file | source-writeback | session-table | runtime-parameter-name
+result_output:
+  policy: source-writeback | source-adjacent-result-artifact | local-result-csv | source-csv-in-place | session-table-fallback
+  target_mode: source-csv-in-place | result-csv-file | source-writeback | source-adjacent-artifact | session-table | runtime-parameter-name
   target_binding: fully-bound | parameterized | session-only
   target: fixed-value-or-runtime-parameter-name
   fields:
@@ -312,9 +320,9 @@ writeback:
     processed_timestamp: target_processed_at_field
 ```
 
-For session-table output, use the same logical fields as table columns and set `target_binding` to `session-only`.
+For session-table output, use the same logical fields as table columns and set `target_binding` to `session-only`. State that the session table is non-persistent and unsuitable for unattended scheduled automation unless the user explicitly accepts the host session transcript as the record.
 
-Writeback records should include:
+Durable result records and last-resort session tables should include:
 
 - candidate ID
 - source record
@@ -325,7 +333,7 @@ Writeback records should include:
 - result summary
 - processed timestamp
 
-Do not write credentials, tokens, cookies, confirmation tokens, callback URLs, or full phone numbers into user-facing summaries.
+Do not write credentials, tokens, cookies, confirmation tokens, callback URLs, or full phone numbers into user-facing summaries or result outputs.
 
 ## Preflight and Creation Summary
 
@@ -334,7 +342,7 @@ Generated skills must document best-effort creation-time preflight and mandatory
 - source authentication or connectivity
 - source schema and required fields
 - consent or outreach basis validation
-- writeback target and fields, unless session-table fallback is configured
+- source writeback target, source-adjacent artifact target, or local result CSV path and fields
 - dedupe state or stable dedupe key
 - MCP provider route availability, authentication readiness, compatible tools, and provider onboarding blocker
 
@@ -348,12 +356,12 @@ Use this runtime gate report shape during dry-runs and before real calls:
 | required_fields | `passed`, `blocked`, `not_applicable`, or `not_run` | Field names or schema match. | Missing required field. | `true` |
 | consent_or_outreach_basis | `passed`, `blocked`, `not_applicable`, or `not_run` | Source-level outreach basis, consent field, or approved source basis. | Missing outreach basis or false consent. | `true` |
 | dedupe | `passed`, `blocked`, `not_applicable`, or `not_run` | Dedupe key or state file reference. | Untrusted dedupe state. | `true` |
-| writeback_or_session_table | `passed`, `blocked`, `not_applicable`, or `not_run` | Target fields or session fallback. | Missing writeback target with no fallback. | `true` |
+| result_output | `passed`, `blocked`, `not_applicable`, or `not_run` | Source writeback target, source-adjacent artifact target, or local result CSV path and fields. | Missing durable output target; session table may be used only as an attended last-resort fallback. | `true` |
 | provider_route | `passed`, `blocked`, `not_applicable`, or `not_run` | Route and compatible tool names. | Missing auth or tools. | `true` |
 
 Do not put credentials, tokens, full phone numbers, confirmation tokens, or callback URLs in `evidence` or `blocker`.
 
-After the creator writes the generated skill, it should show the user a creation summary with the skill name, output path, reload or discovery step, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, outbound goal contract, execution mode, writeback behavior, preflight result, runtime gate, provider route, and validation result.
+After the creator writes the generated skill, it should show the user a creation summary with the skill name, output path, reload or discovery step, binding level, source onboarding status, sampled source instance, sample fetch result, default goal source, provider onboarding status, provider host runtime, MCP route setup and provider auth check results, compatible MCP tools, provider blocker if any, runtime parameters, source contract, outbound goal contract, execution mode, result-output behavior, preflight result, runtime gate, provider route, and validation result.
 
 Use this summary shape:
 
@@ -370,7 +378,7 @@ Outreach basis: <source-level basis, consent field, or approved source basis>
 Dedupe: <key or state rule>
 Goal: <one-sentence call purpose and completion criteria>
 Execution mode: <selected mode and any unavailable modes>
-Writeback: <policy, target binding, and field mapping>
+Result output: <policy, target binding, and field mapping>
 Preflight: <passed | blocked | not run, with reason>
 Runtime gate: <checks that must pass before real calls>
 Provider route: https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -118,10 +118,9 @@ Do not let source records provide raw provider goals. Compile goals from approve
 The generated skill must define one execution mode:
 
 - `dry-run-then-batch-approval`: preview every eligible candidate and compiled call goal, then process the approved list serially after one explicit approval.
-- `per-call-approval`: preview one candidate and compiled call goal at a time, then let the user approve, modify, or skip each call before planning and running it.
 - `approved-direct-execution`: after a concrete processing request, validate candidates, run the runtime gate, compile call goals, inspect each provider plan, and serially run eligible one-off calls without another approval step.
 
-Use `dry-run-then-batch-approval` as the default. Use `per-call-approval` or `approved-direct-execution` only when the generated skill is `fully-bound` or `parameterized-bound`, the creation-time contract explicitly allows the selected mode, and the concrete runtime request passes the runtime gate.
+Use `dry-run-then-batch-approval` as the default. Use `approved-direct-execution` only when the generated skill is `fully-bound` or `parameterized-bound`, the creation-time contract explicitly allows direct execution, and the concrete runtime request passes the runtime gate.
 
 Even when direct execution is configured, the runtime request must be concrete, such as "process all June 20 records." Open-ended requests such as "run the campaign" are not enough.
 
@@ -235,7 +234,7 @@ If one candidate fails, record that failure and continue with the next candidate
 
 Provider terminal instructions such as `report_result` or `do not start another call` apply only to the current provider run. They prevent duplicate execution of the same provider plan; they do not cancel the approved batch. After recording the current candidate result, continue to the next approved ready candidate unless a batch-level blocker appears.
 
-For `per-call-approval`, each candidate must be shown with a masked phone number and compiled call goal before the provider plan is created or run. For `dry-run-then-batch-approval`, the exact pending call list must be approved once before batch execution. For `approved-direct-execution`, the generated skill must still inspect every provider plan and skip any candidate whose plan does not match the validated candidate and fixed goal contract.
+For `dry-run-then-batch-approval`, the exact pending call list must be approved once before batch execution. For `approved-direct-execution`, the generated skill must still inspect every provider plan and skip any candidate whose plan does not match the validated candidate and fixed goal contract.
 
 ## Provider Result Finalization
 

--- a/skills/outbound-call-skill-creator/references/generated-skill-contract.md
+++ b/skills/outbound-call-skill-creator/references/generated-skill-contract.md
@@ -283,7 +283,6 @@ Generated skills must support a durable result-output outcome:
 - source writeback
 - source-adjacent result artifact
 - new local result CSV output
-- source CSV in-place update only when the runtime request explicitly asks to mutate the source CSV
 - session table output only as a last-resort non-persistent fallback
 
 The result-output policy must be chosen at creation time. Prefer verified source writeback when the source exposes a safe writeback path to the bound source instance or canonical source record store. If the result should stay in the same source system without mutating source records, configure `source-adjacent-result-artifact` instead. If source writeback and source-adjacent output are unavailable, not requested, or cannot be verified, configure a new local result CSV as the durable fallback. Keep session-table output as a last-resort non-persistent fallback only when durable output validation is blocked; do not proactively present session-table output as a normal user-facing option.
@@ -305,7 +304,7 @@ Use this result-output mapping shape when durable output or last-resort session-
 
 ```yaml
 result_output:
-  policy: source-writeback | source-adjacent-result-artifact | local-result-csv | source-csv-in-place | session-table-fallback
+  policy: source-writeback | source-adjacent-result-artifact | local-result-csv | session-table-fallback
   target_mode: source-csv-in-place | result-csv-file | source-writeback | source-adjacent-result-artifact | session-table | runtime-parameter-name
   target_binding: fully-bound | parameterized | session-only
   target: fixed-value-or-runtime-parameter-name

--- a/skills/outbound-call-skill-creator/references/mcp-provider-route.md
+++ b/skills/outbound-call-skill-creator/references/mcp-provider-route.md
@@ -62,7 +62,7 @@ Provider onboarding must remain non-mutating for phone-call side effects. Do not
 Generated skills should follow this provider flow when compatible tools are available:
 
 ```text
-auth readiness -> call plan -> plan inspection -> call run -> status check -> writeback
+auth readiness -> call plan -> plan inspection -> call run -> status check -> result output
 ```
 
 The plan inspection step must confirm:
@@ -82,7 +82,7 @@ Provider terminal instructions such as `report_result` or `do not start another 
 
 Terminal seen is not terminal stable. Generated skills must run full-history provider reconciliation before writing results or reporting the final batch summary. Cursor-based polling may drive progress updates, but after terminal status appears, re-check the full provider run history without a cursor and with a high enough limit to include lifecycle events and conversation content when available.
 
-Do not write negative terminal results such as `no_answer`, `failed`, or `no conversation captured` until a negative terminal stability check passes. If a later full-history recheck shows an answer, transcript, collected field, or stronger result, use that latest evidence for writeback.
+Do not write negative terminal results such as `no_answer`, `failed`, or `no conversation captured` until a negative terminal stability check passes. If a later full-history recheck shows an answer, transcript, collected field, or stronger result, use that latest evidence for durable result output.
 
 If a candidate-level plan, run, or status check fails, record the failure and continue with the next ready candidate when it is safe to continue. Stop the batch only when the MCP route is unavailable, authentication is missing, required provider tools are unavailable, or continuing would create unsafe or duplicate calls.
 

--- a/skills/outbound-call-skill-creator/references/mcp-provider-route.md
+++ b/skills/outbound-call-skill-creator/references/mcp-provider-route.md
@@ -86,7 +86,7 @@ Do not write negative terminal results such as `no_answer`, `failed`, or `no con
 
 If a candidate-level plan, run, or status check fails, record the failure and continue with the next ready candidate when it is safe to continue. Stop the batch only when the MCP route is unavailable, authentication is missing, required provider tools are unavailable, or continuing would create unsafe or duplicate calls.
 
-After the final candidate is processed, generated skills must write configured results or output the session table, then report one final batch summary.
+After the final candidate is processed, generated skills must write configured source results, a source-adjacent result artifact, or a local result CSV, then report one final batch summary. Output a session table only as a last-resort non-persistent fallback when durable result output is blocked and the run is attended.
 
 ## Scheduled Runs
 

--- a/skills/outbound-call-skill-creator/references/safety.md
+++ b/skills/outbound-call-skill-creator/references/safety.md
@@ -6,9 +6,9 @@ Use this reference when creating a generated outbound phone-call business skill.
 
 The creator must not generate a business skill that calls arbitrary phone-looking values. It must capture a binding level, source contract, outreach basis, E.164 phone-number field, dedupe key, execution policy, and writeback behavior.
 
-If the user cannot explain why records are authorized for phone follow-up, generate a dry-run-only skill or stop and ask for a consent field or approved source basis.
+If the user cannot explain why records are authorized for phone follow-up, stop and ask for a consent field or approved source basis before generating a skill.
 
-Default to a `parameterized-bound` skill when the user wants reuse but has not asked for a single fixed source instance. Use `fully-bound` for stable production or scheduled workflows. Use `unbound-generic` only for exploratory or dry-run-only workflows unless the user later approves a complete runtime source and writeback contract.
+Default to a `parameterized-bound` skill when the user wants reuse but has not asked for a single fixed source instance. Use `fully-bound` for stable production or scheduled workflows.
 
 ## Generated Skill Safety
 
@@ -32,7 +32,7 @@ Every generated business skill must include rules for:
 
 Direct execution is allowed only when the generated skill's creation-time contract explicitly says that a concrete request such as "process all June 20 records" authorizes real calls after validation.
 
-Direct execution requires a `fully-bound` skill or a `parameterized-bound` skill whose concrete runtime parameters pass the runtime gate. It is not allowed for `unbound-generic` workflows.
+Direct execution requires a `fully-bound` skill or a `parameterized-bound` skill whose concrete runtime parameters pass the runtime gate.
 
 Direct execution still requires:
 

--- a/skills/outbound-call-skill-creator/references/safety.md
+++ b/skills/outbound-call-skill-creator/references/safety.md
@@ -4,7 +4,7 @@ Use this reference when creating a generated outbound phone-call business skill.
 
 ## Creator Safety
 
-The creator must not generate a business skill that calls arbitrary phone-looking values. It must capture a binding level, source contract, outreach basis, E.164 phone-number field, dedupe key, execution policy, and writeback behavior.
+The creator must not generate a business skill that calls arbitrary phone-looking values. It must capture a binding level, source contract, outreach basis, E.164 phone-number field, dedupe key, execution policy, and durable result-output behavior.
 
 If the user cannot explain why records are authorized for phone follow-up, stop and ask for a consent field or approved source basis before generating a skill.
 
@@ -39,10 +39,10 @@ Direct execution still requires:
 - candidate validation
 - outreach basis validation
 - dedupe checks
-- source and writeback runtime gate checks when the workflow is parameterized
+- source and durable result-output runtime gate checks when the workflow is parameterized
 - masked summaries
 - skipping unsafe records
-- writeback or session-table output
+- source writeback, source-adjacent result artifact output, or local result CSV output, with session-table output only as a last-resort attended fallback
 
 If direct execution is not configured, generated skills must dry-run first and ask the user to approve the exact pending call list.
 
@@ -54,9 +54,9 @@ If one candidate fails, record the failure and continue with the next candidate 
 
 Provider terminal instructions such as `report_result` or `do not start another call` apply only to the current provider run. After recording the current candidate result, continue the approved batch unless a batch-level safety blocker appears.
 
-Do not write call results before provider result finalization. Terminal provider status must pass full-history provider reconciliation before writeback, and negative terminal outcomes such as `no_answer`, `failed`, or `no conversation captured` must pass a negative terminal stability check.
+Do not write call results before provider result finalization. Terminal provider status must pass full-history provider reconciliation before source writeback, source-adjacent result artifact output, local result CSV output, or session-table fallback, and negative terminal outcomes such as `no_answer`, `failed`, or `no conversation captured` must pass a negative terminal stability check.
 
-After all candidates are complete, write configured results or output the session table, then report one final batch summary.
+After all candidates are complete, write configured source results, a source-adjacent result artifact, or a local result CSV, then report one final batch summary. Output a session table only when durable output validation is blocked and the run is attended; treat it as non-persistent and unsuitable for unattended scheduled automation unless the user explicitly accepts the host session transcript as the record.
 
 ## Sensitive Domains
 

--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -6,7 +6,8 @@ const REQUIRED_ROUTE = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth"
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const NON_ENGLISH_SCRIPT_RE =
   /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}/u;
-const BINDING_LEVEL_RE = /\bbinding level\s*(?:is|:)\s*`?(fully-bound|parameterized-bound|unbound-generic)`?/iu;
+const BINDING_LEVEL_RE = /\bbinding level\s*(?:is|:)\s*`?(fully-bound|parameterized-bound)`?/iu;
+const UNSUPPORTED_BINDING_LEVEL_RE = new RegExp("\\b" + "un" + "bound-" + "generic\\b", "iu");
 const EXECUTION_MODE_RE =
   /^\s*(?:selected\s+)?execution mode\s*(?:is|:)\s*`?(dry-run-then-batch-approval|per-call-approval|approved-direct-execution)`?/imu;
 const REQUIRED_SKILL_MARKERS = [
@@ -332,22 +333,6 @@ if (["fully-bound", "parameterized-bound"].includes(selectedBindingLevel)) {
   }
 }
 
-if (selectedBindingLevel === "unbound-generic") {
-  if (!/dry-run-only/iu.test(skillText)) {
-    fail("Unbound generic generated skill must declare dry-run-only behavior");
-  }
-  if (!/onboarding blocker/iu.test(skillText)) {
-    fail("Unbound generic generated skill must record a source onboarding blocker");
-  }
-}
-
-if (
-  selectedBindingLevel === "unbound-generic" &&
-  selectedExecutionMode !== "dry-run-then-batch-approval"
-) {
-  fail(`Generated skill cannot use ${selectedExecutionMode} with unbound-generic`);
-}
-
 if (!/runtime gate/iu.test(skillText)) {
   fail("Generated skill SKILL.md must mention runtime gate requirements");
 }
@@ -370,6 +355,12 @@ if (fs.existsSync(path.join(skillDir, "template.md"))) {
 
 const textFiles = fs.existsSync(skillDir) ? walkTextFiles(skillDir) : [];
 const allText = textFiles.map((filePath) => readText(filePath)).join("\n");
+
+if (UNSUPPORTED_BINDING_LEVEL_RE.test(allText)) {
+  fail(
+    "Generated skill files must use fully-bound or parameterized-bound; unsupported binding levels are not allowed",
+  );
+}
 
 if (!allText.includes(REQUIRED_ROUTE)) {
   fail(`Generated skill must mention MCP provider route ${REQUIRED_ROUTE}`);

--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -70,24 +70,20 @@ const REQUIRED_SKILL_MARKERS = [
     label: "provider result finalization",
     patterns: [
       /provider result finalization[\s\S]*full-history provider\s+reconciliation[\s\S]*negative terminal stability check/iu,
-      /terminal provider status is\s+not writeback-ready[\s\S]*full-history provider\s+reconciliation/iu,
       /terminal provider status is\s+not result-output-ready[\s\S]*full-history provider\s+reconciliation/iu,
     ],
   },
   {
     label: "result-output behavior",
-    patterns: [/result-output behavior/iu, /result output behavior/iu, /writeback behavior/iu],
+    patterns: [/result-output behavior/iu, /result output behavior/iu],
   },
   {
     label: "result target mode",
     patterns: [
       /runtime result target mode\s*:/iu,
       /runtime output target mode\s*:/iu,
-      /runtime writeback target mode\s*:/iu,
       /result target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
       /output target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
-      /writeback target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-csv-in-place|result-csv-file|session-table)/iu,
-      /writeback target mode\s*:\s*(?:source-writeback|source-csv-in-place|result-csv-file|session-table)/iu,
       /target mode\s*:\s*(?:source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
     ],
   },

--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -80,11 +80,9 @@ const REQUIRED_SKILL_MARKERS = [
   {
     label: "result target mode",
     patterns: [
-      /runtime result target mode\s*:/iu,
-      /runtime output target mode\s*:/iu,
-      /result target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
-      /output target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
-      /target mode\s*:\s*(?:source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
+      /result target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
+      /output target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
+      /target mode\s*:\s*(?:source-writeback|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
     ],
   },
   {

--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -71,19 +71,31 @@ const REQUIRED_SKILL_MARKERS = [
     patterns: [
       /provider result finalization[\s\S]*full-history provider\s+reconciliation[\s\S]*negative terminal stability check/iu,
       /terminal provider status is\s+not writeback-ready[\s\S]*full-history provider\s+reconciliation/iu,
+      /terminal provider status is\s+not result-output-ready[\s\S]*full-history provider\s+reconciliation/iu,
     ],
   },
   {
-    label: "writeback behavior",
-    patterns: [/writeback behavior/iu],
+    label: "result-output behavior",
+    patterns: [/result-output behavior/iu, /result output behavior/iu, /writeback behavior/iu],
   },
   {
-    label: "writeback target mode",
+    label: "result target mode",
     patterns: [
+      /runtime result target mode\s*:/iu,
+      /runtime output target mode\s*:/iu,
       /runtime writeback target mode\s*:/iu,
+      /result target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
+      /output target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
       /writeback target mode\s*:\s*(?:resolved|fixed|runtime|parameterized|source-writeback|source-csv-in-place|result-csv-file|session-table)/iu,
       /writeback target mode\s*:\s*(?:source-writeback|source-csv-in-place|result-csv-file|session-table)/iu,
-      /target mode\s*:\s*(?:source-writeback|source-csv-in-place|result-csv-file|session-table)/iu,
+      /target mode\s*:\s*(?:source-writeback|source-adjacent-artifact|source-adjacent-result-artifact|source-csv-in-place|result-csv-file|session-table|local-result-csv|session-table-fallback)/iu,
+    ],
+  },
+  {
+    label: "durable result output fallback",
+    patterns: [
+      /result-csv-file[\s\S]*(?:last-resort|session-table)/iu,
+      /durable result output[\s\S]*session-table/iu,
     ],
   },
   {

--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -9,7 +9,8 @@ const NON_ENGLISH_SCRIPT_RE =
 const BINDING_LEVEL_RE = /\bbinding level\s*(?:is|:)\s*`?(fully-bound|parameterized-bound)`?/iu;
 const UNSUPPORTED_BINDING_LEVEL_RE = new RegExp("\\b" + "un" + "bound-" + "generic\\b", "iu");
 const EXECUTION_MODE_RE =
-  /^\s*(?:selected\s+)?execution mode\s*(?:is|:)\s*`?(dry-run-then-batch-approval|per-call-approval|approved-direct-execution)`?/imu;
+  /^\s*(?:selected\s+)?execution mode\s*(?:is|:)\s*`?(dry-run-then-batch-approval|approved-direct-execution)`?/imu;
+const UNSUPPORTED_EXECUTION_MODE_RE = new RegExp("\\bper-" + "call-approval\\b", "iu");
 const REQUIRED_SKILL_MARKERS = [
   {
     label: "purpose and when to use",
@@ -359,6 +360,12 @@ const allText = textFiles.map((filePath) => readText(filePath)).join("\n");
 if (UNSUPPORTED_BINDING_LEVEL_RE.test(allText)) {
   fail(
     "Generated skill files must use fully-bound or parameterized-bound; unsupported binding levels are not allowed",
+  );
+}
+
+if (UNSUPPORTED_EXECUTION_MODE_RE.test(allText)) {
+  fail(
+    "Generated skill files must use dry-run-then-batch-approval or approved-direct-execution; unsupported execution modes are not allowed",
   );
 }
 


### PR DESCRIPTION
## Summary
This PR prunes `outbound-call-skill-creator` around the **batch-call automation path** so generated skills are less template-like and more directly executable:

- Removes the _generic/unbound(binding level)_ and _per-call approval_ paths, making `parameterized-bound` the minimum contract and keeping `fully-bound` for fixed production or scheduled workflows. 
- Tightens generated-skill validation so legacy binding or execution modes are rejected instead of quietly accepted.

The result-output model is now more explicit: prefer verified source writeback, use source-adjacent result artifacts when results should stay beside the source without mutating it, fall back to a new local result CSV, and keep session-table output only as a last-resort non-persistent fallback.

## Validation
- `python3 scripts/validate_repository.py`
- `node --check skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs`
- Smoke-tested the generated skill checker with valid `parameterized-bound` and `fully-bound` examples.
- Confirmed the checker rejects legacy `unbound-generic`, `per-call-approval`, and missing result-output behavior cases.
