### PR TITLE
Add Hermes (operating platform for AI phone-call agents) to Resource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Keep descriptions short, specific, factual, and directly tied to packaging, sche
 
 This project is an awesome list for AI-agent phone-call workflows. Add resources only when they directly help agents package, schedule, execute, or safely operate phone-call tasks.
 
+### Operating platforms
+
+- [Hermes](https://www.buildwithhermes.com) - White-label operating platform for running AI phone-call agents across multiple clients, with campaign scheduling, outbound and inbound execution, native CRM, and built-in TCPA and DNC compliance with consent logging for safely operating calls at scale.
+
 ### Skills
 
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.


### PR DESCRIPTION
This adds **Hermes** to the Resource list under a new "Operating platforms" subsection.

Hermes is directly on-topic for this list: it is a platform for **running AI phone-call agents** across multiple clients, covering exactly the workflow this repo curates: scheduling calls, executing outbound and inbound campaigns, and **safely operating** calls (built-in TCPA and DNC compliance plus consent logging).

Entry follows the README list entry template (one factual sentence tied to executing and safely operating phone-call tasks). Happy to adjust the wording, placement, or drop the subsection heading if you would prefer a flat list. Thanks for maintaining this.