### PR TITLE
docs(n8n-calle-api): improve IVR workflow setup

### DIFF
--- a/plugins/n8n-calle-api/README.md
+++ b/plugins/n8n-calle-api/README.md
@@ -7,7 +7,7 @@ The sample runs two call tasks one by one, waits for each call to reach a termin
 - metadata sent to CALL-E and metadata returned by CALL-E
 - answered, no answer, busy, and failed status signals
 - summary, transcript turns, and structured result
-- raw CALL-E call result for debugging
+- redacted raw CALL-E call result for debugging
 - API error details when a request fails
 
 ## Files
@@ -17,33 +17,36 @@ The sample runs two call tasks one by one, waits for each call to reach a termin
 
 ## What The Workflow Does
 
-The workflow is intentionally small and visible:
+The workflow keeps configuration, validation, dialing, parsing, and output handling visible:
 
 1. `Manual Trigger` starts the sample.
 2. `CALL-E Config` stores `apiKey`, `baseUrl`, polling interval, and timeout.
 3. `Validate CALL-E Config` fails fast if the API key is missing or still set to the placeholder.
-4. `2 Phone/Task List` defines two sample IVR quality tasks and metadata payloads.
+4. `Phone/Task List` defines two fictional IVR quality rows, validates E.164 numbers, and blocks the shipped placeholders.
 5. `Loop Over Calls` runs with batch size `1`, so calls are created and waited on one at a time.
-6. `Build CALL-E API Input` creates the CALL-E request body, result schema, recipient schema, metadata, and idempotency key.
-7. `CALL-E API createAndWait` calls `POST /v1/calls`, polls `GET /v1/calls/{id}`, and waits for a terminal status.
+6. `Build CALL-E Request Payload` creates the request body, result schema, recipient schema, metadata, and idempotency key.
+7. `Create CALL-E Call and Wait` calls `POST /v1/calls`, polls `GET /v1/calls/{id}`, and waits for a terminal status.
 8. `Parse CALL-E Result` extracts status, transcript, summary, structured result, metadata, and failure signals.
-9. `Demo Result View` and `Execution Summary` produce easy-to-inspect n8n outputs.
+9. `Demo Result View` masks phone numbers, including phone fields inside the displayed raw result.
+10. `Execution Summary` reports counts and compact per-call results after the loop finishes.
 
 ## Setup
 
-1. Open n8n and import `examples/calle-ivr-quality-create-and-wait.workflow.json`.
-2. Open the `CALL-E Config` node.
-3. Replace `replace_with_calle_api_key` with your CALL-E API key.
-4. Keep `baseUrl` as `https://api.heycall-e.com` for production, or replace it with your test API base URL.
-5. Review the two rows in `2 Phone/Task List`.
-6. Replace the default phone numbers with owned or authorized test IVR numbers before a live run.
-7. Execute the workflow manually.
+1. Create or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys).
+2. Open n8n and import `examples/calle-ivr-quality-create-and-wait.workflow.json`.
+3. Open `CALL-E Config` and replace `replace_with_calle_api_key` with your API key.
+4. Use the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.
+5. Keep `baseUrl` as `https://api.heycall-e.com` for production, or replace it with your test API base URL.
+6. In `Phone/Task List`, replace the blocked placeholders with owned or explicitly authorized E.164 test numbers.
+7. Review the IVR task, locale, and metadata for both rows before allowing a live call.
+8. Keep the imported workflow inactive until its configuration and destinations have been reviewed.
+9. Execute the workflow manually.
 
 Do not commit real API keys or private lead data into this template.
 
 ## Sample Data
 
-The default rows are desensitized IVR quality checks. They do not contain real leads, private Notion page IDs, customer properties, or campaign data.
+The default rows are desensitized IVR quality checks. They do not contain real leads, private Notion page IDs, customer properties, or campaign data. Their shipped E.164 values are fictional placeholders and are explicitly blocked by `Phone/Task List`, so the workflow cannot dial them.
 
 Each row still demonstrates metadata round-trip behavior with keys similar to a lead workflow:
 
@@ -54,9 +57,9 @@ Each row still demonstrates metadata round-trip behavior with keys similar to a 
 - `campaign`
 - `source_url`
 
-The included task text is in English and instructs the agent to listen to the public IVR opening only. The task tells the agent not to enter personal data, authenticate, make purchases, open a case, or request a human agent.
+The included task text is in English and instructs the agent to listen to an owned or explicitly authorized test IVR opening only. The task tells the agent not to enter personal data, authenticate, make purchases, open a case, or request a human agent.
 
-The default IVR/contact-center numbers are public business numbers from official pages. They may still trigger real outbound calls, so replace them with your own test numbers unless you explicitly intend to call those public IVRs.
+Replace both placeholders with phone numbers you own or are explicitly authorized to call. A valid replacement can create a real outbound call.
 
 ## Inputs
 
@@ -64,19 +67,20 @@ Configure these fields in `CALL-E Config`:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `apiKey` | Yes | CALL-E API key. The workflow fails before dialing if this is missing or still set to the placeholder. |
+| `apiKey` | Yes | CALL-E API key created or copied from the [CALL-E API Keys page](https://dashboard.heycall-e.com/account/api-keys). The workflow fails before dialing if the key is missing or still set to the placeholder. |
 | `baseUrl` | Yes | CALL-E API base URL. Defaults to `https://api.heycall-e.com`. |
 | `pollIntervalSeconds` | Yes | Seconds between call status polls. Defaults to `5`. |
 | `waitTimeoutMinutes` | Yes | Maximum wait time for each call. Defaults to `30`. |
 
-Configure each call row in `2 Phone/Task List`:
+Configure each call row in `Phone/Task List`:
 
 | Field | Required | Description |
 | --- | --- | --- |
 | `callItemId` | Yes | Stable sample row ID. Used in the idempotency key. |
-| `phone` | Yes | Destination phone number. Replace with an authorized test number before live execution. |
-| `region` | Yes | Region hint, for example `BR`. |
-| `locale` | Yes | Locale hint, for example `pt-BR`. |
+| `ivrName` | Yes | Human-readable label for the authorized test IVR. |
+| `phone` | Yes | E.164 destination phone number. The shipped placeholders are blocked and must be replaced with an authorized test number before live execution. |
+| `region` | Yes | Region hint, for example `US`. |
+| `locale` | Yes | Locale hint, for example `en-US`. |
 | `task` | Yes | English instruction for the CALL-E agent. |
 | `metadata` | Yes | Metadata sent to CALL-E and compared with metadata returned by CALL-E. |
 
@@ -86,6 +90,9 @@ Configure each call row in `2 Phone/Task List`:
 
 | Field | Description |
 | --- | --- |
+| `callItemId` | Stable identifier for the input row. |
+| `maskedPhone` | Masked destination phone number. |
+| `task` | IVR quality-check instruction sent to CALL-E. |
 | `metadataSent` | Metadata included in the CALL-E create request. |
 | `metadataReturned` | Metadata from the CALL-E call result. |
 | `metadataRoundTrip` | Comparison for `lead_id`, `notion_page_id`, `company`, `property`, and `campaign`. |
@@ -93,12 +100,12 @@ Configure each call row in `2 Phone/Task List`:
 | `returnedData.summary` | Summary from structured result or call-level summary fields. |
 | `returnedData.transcript` | Transcript turns if returned by CALL-E. |
 | `returnedData.structuredResult` | Structured IVR quality result following the configured schema. |
-| `rawCallResult` | Full raw CALL-E call result. |
+| `redactedRawCallResult` | Raw CALL-E call result with phone-number fields masked for safer inspection. |
 | `apiError` | API error message and name when the create or poll request fails. |
 
 ## Side Effects
 
-This workflow creates outbound calls when a valid API key and reachable phone numbers are configured. It has no dry-run mode beyond the required API-key placeholder check.
+This workflow creates outbound calls when a valid API key and reachable phone numbers are configured. It has no dry-run mode beyond the required API-key and phone-placeholder checks.
 
 To disable or roll back the sample:
 

--- a/plugins/n8n-calle-api/README.md
+++ b/plugins/n8n-calle-api/README.md
@@ -4,16 +4,17 @@ This plugin contains an importable n8n workflow template that uses the CALL-E AP
 
 The sample runs two call tasks one by one, waits for each call to reach a terminal state, and returns a compact result view with:
 
-- metadata sent to CALL-E and metadata returned by CALL-E
+- metadata sent to CALL-E and metadata returned by CALL-E, with phone-bearing values masked
 - answered, no answer, busy, and failed status signals
 - summary, transcript turns, and structured result
 - redacted raw CALL-E call result for debugging
-- API error details when a request fails
+- sanitized API error details when a request fails
 
 ## Files
 
 - `examples/calle-ivr-quality-create-and-wait.workflow.json` - n8n workflow import file.
 - `manifest.json` - plugin metadata for this repository.
+- `test/workflow-safety.test.mjs` - regression tests for masking, timeout bounds, and manifest safety claims.
 
 ## What The Workflow Does
 
@@ -21,13 +22,13 @@ The workflow keeps configuration, validation, dialing, parsing, and output handl
 
 1. `Manual Trigger` starts the sample.
 2. `CALL-E Config` stores `apiKey`, `baseUrl`, polling interval, and timeout.
-3. `Validate CALL-E Config` fails fast if the API key is missing or still set to the placeholder.
+3. `Validate CALL-E Config` fails fast if the API key is missing, still set to the placeholder, or the Code-node wait timeout exceeds four minutes.
 4. `Phone/Task List` defines two fictional IVR quality rows, validates E.164 numbers, and blocks the shipped placeholders.
 5. `Loop Over Calls` runs with batch size `1`, so calls are created and waited on one at a time.
 6. `Build CALL-E Request Payload` creates the request body, result schema, recipient schema, metadata, and idempotency key.
-7. `Create CALL-E Call and Wait` calls `POST /v1/calls`, polls `GET /v1/calls/{id}`, and waits for a terminal status.
+7. `Create CALL-E Call and Wait` calls `POST /v1/calls`, polls `GET /v1/calls/{id}`, and waits for a terminal status for up to four minutes.
 8. `Parse CALL-E Result` extracts status, transcript, summary, structured result, metadata, and failure signals.
-9. `Demo Result View` masks phone numbers, including phone fields inside the displayed raw result.
+9. `Demo Result View` masks phone numbers across the complete displayed result, including metadata, raw call data, status messages, and API errors.
 10. `Execution Summary` reports counts and compact per-call results after the loop finishes.
 
 ## Setup
@@ -69,8 +70,10 @@ Configure these fields in `CALL-E Config`:
 | --- | --- | --- |
 | `apiKey` | Yes | CALL-E API key created or copied from the [CALL-E API Keys page](https://dashboard.heycall-e.com/account/api-keys). The workflow fails before dialing if the key is missing or still set to the placeholder. |
 | `baseUrl` | Yes | CALL-E API base URL. Defaults to `https://api.heycall-e.com`. |
-| `pollIntervalSeconds` | Yes | Seconds between call status polls. Defaults to `5`. |
-| `waitTimeoutMinutes` | Yes | Maximum wait time for each call. Defaults to `30`. |
+| `pollIntervalSeconds` | Yes | Seconds between call status polls. Defaults to `5` and must be between `1` and `30`. |
+| `waitTimeoutMinutes` | Yes | Maximum Code-node polling time for each call. Defaults to `4` and cannot exceed `4`, leaving a one-minute buffer below n8n's default 300-second task-runner limit. |
+
+The workflow performs polling inside one Code-node task. n8n's [`N8N_RUNNERS_TASK_TIMEOUT`](https://docs.n8n.io/hosting/configuration/environment-variables/task-runners/) defaults to 300 seconds, so `Validate CALL-E Config` rejects waits above four minutes rather than advertising an unsupported 30-minute wait. Poll intervals are limited to 30 seconds, the final sleep is shortened to the remaining deadline, and each HTTP request is limited to 30 seconds. For longer-running calls, replace the Code-node polling loop with n8n Wait and HTTP Request nodes before raising this guard.
 
 Configure each call row in `Phone/Task List`:
 
@@ -93,15 +96,15 @@ Configure each call row in `Phone/Task List`:
 | `callItemId` | Stable identifier for the input row. |
 | `maskedPhone` | Masked destination phone number. |
 | `task` | IVR quality-check instruction sent to CALL-E. |
-| `metadataSent` | Metadata included in the CALL-E create request. |
-| `metadataReturned` | Metadata from the CALL-E call result. |
+| `metadataSent` | Metadata included in the CALL-E create request, with phone-bearing values masked in the displayed output. |
+| `metadataReturned` | Metadata from the CALL-E call result, with phone-bearing values masked in the displayed output. |
 | `metadataRoundTrip` | Comparison for `lead_id`, `notion_page_id`, `company`, `property`, and `campaign`. |
 | `callStatus` | `ok`, call ID, raw status values, failure code/message, and answered/no answer/busy/failed booleans. |
 | `returnedData.summary` | Summary from structured result or call-level summary fields. |
 | `returnedData.transcript` | Transcript turns if returned by CALL-E. |
 | `returnedData.structuredResult` | Structured IVR quality result following the configured schema. |
 | `redactedRawCallResult` | Raw CALL-E call result with phone-number fields masked for safer inspection. |
-| `apiError` | API error message and name when the create or poll request fails. |
+| `apiError` | Sanitized API error message and name when the create or poll request fails. Response bodies are omitted, and phone-like E.164 values are masked. |
 
 ## Side Effects
 
@@ -122,9 +125,12 @@ To disable or roll back the sample:
 4. Set a valid API key and replace the phone numbers with authorized test IVRs.
 5. Run the workflow again.
 6. Confirm the loop processes one item at a time and `Execution Summary` contains two result objects.
+7. Set `waitTimeoutMinutes` above `4` and confirm `Validate CALL-E Config` rejects the unsupported Code-node wait before dialing.
 
 ## Notes
 
 - The workflow uses n8n `helpers.httpRequest` inside a Code node because n8n Code nodes may not expose global `fetch`.
+- The four-minute wait cap, deadline-aware sleeps, and 30-second HTTP request limit keep the polling Code node below the stock 300-second runner task timeout with a one-minute execution buffer.
 - The request uses an `Idempotency-Key` header built from sample metadata and `callItemId`.
 - The workflow intentionally avoids Notion and webhooks so it can be imported and tested as a standalone CALL-E API example.
+- Run `node --test plugins/n8n-calle-api/test/workflow-safety.test.mjs` from the repository root to execute the focused safety regression tests.

--- a/plugins/n8n-calle-api/examples/calle-ivr-quality-create-and-wait.workflow.json
+++ b/plugins/n8n-calle-api/examples/calle-ivr-quality-create-and-wait.workflow.json
@@ -1,185 +1,232 @@
 {
-  "id": "calleApiIvrQualityCreateAndWaitSample",
-  "name": "CALL-E API createAndWait - IVR quality sample",
+  "name": "Run IVR call quality checks with CALL-E phone calls in n8n",
   "nodes": [
     {
       "parameters": {
-        "content": "## CALL-E API IVR quality sample\nManual trigger sample with two public Brazil IVR/contact-center rows. Each row has `phone`, `task`, and `metadata`. `Loop Over Calls` runs with batch size 1, so CALL-E createAndWait is executed one phone at a time before the loop advances to the next row.",
-        "height": 200,
-        "width": 620,
+        "content": "## Run IVR call quality checks with CALL-E phone calls in n8n\n\n### How it works\n\nThis workflow runs manually, loads and validates CALL-E API settings, builds a small list of IVR quality-check tasks, loops through the tasks one at a time, creates each CALL-E call with `POST /v1/calls`, polls `GET /v1/calls/{id}` until a terminal status, parses the call result, and returns a demo-friendly result view plus an execution summary.\n\n### Setup steps\n\n- Create or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys).\n- Open `CALL-E Config` and replace `replace_with_calle_api_key` with that API key.\n- Review the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n- Open `Phone/Task List` and replace the blocked placeholder E.164 phone numbers with numbers you own or are explicitly authorized to call.\n- Update the IVR task text, locale, region, and metadata for your quality-check scenario.\n- Keep the workflow inactive until the API key and authorized test numbers are configured.\n- Run from `Manual Trigger` and inspect `Demo Result View` and `Execution Summary`.\n\n### Safety\n\nThis template can create real outbound calls after a valid API key and authorized phone numbers are configured. By default, placeholder numbers fail validation so the sample cannot dial accidentally. The output masks phone numbers and redacts phone fields from the raw call result view.\n\n### Customization\n\nAdjust the task list, CALL-E payload construction, result schema, parsing logic, and summary formatting to match different IVR quality checks, scoring criteria, or reporting needs.",
+        "height": 900,
+        "width": 520,
         "color": 4
       },
-      "id": "sticky-overview",
-      "name": "Overview",
+      "id": "7696cbad-cded-463e-9db1-89e397e016e9",
+      "name": "Template overview",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -760,
-        -360
+        0,
+        0
       ]
     },
     {
       "parameters": {
-        "content": "## Configure before running\n1. Fill `apiKey` in CALL-E Config. The workflow fails fast if it is missing.\n2. The default rows use public Brazil IVR/contact-center numbers from official pages and may trigger real calls. Replace them with owned or authorized test numbers for live runs.\n3. Edit each IVR QA task and metadata as needed.\n\nNo Form Trigger, Notion node, npm SDK, Execute Command, or external dependency is used. The visible loop node controls one-by-one dialing.",
-        "height": 220,
-        "width": 520,
-        "color": 5
+        "content": "## Start and configure\n\nCreate or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys), then open `CALL-E Config` and replace `replace_with_calle_api_key`.\n\nUse the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n\n`Manual Trigger` starts the workflow. `CALL-E Config` stores the API key, base URL, polling interval, and timeout. `Validate CALL-E Config` fails fast before any call task is built if the API key is missing or still set to the placeholder.",
+        "height": 416,
+        "width": 736,
+        "color": 7
       },
-      "id": "sticky-config",
-      "name": "Config note",
+      "id": "98c1784e-67d7-4a7c-970d-6d7d7ad475f7",
+      "name": "Start and configure note",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -80,
-        -360
+        560,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Prepare call batches\n\n`Phone/Task List` defines the IVR quality-check rows, validates E.164 numbers, blocks the default placeholder numbers, and passes one item at a time into `Loop Over Calls` with batch size 1.",
+        "height": 352,
+        "width": 484,
+        "color": 7
+      },
+      "id": "aef54dae-9062-4408-b3ba-0ffb4af6371e",
+      "name": "Prepare call batches note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1376,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Create API request\n\n`Build CALL-E Request Payload` constructs the per-call request body, result schema, recipient schema, metadata, and idempotency key. `Create CALL-E Call and Wait` sends `POST /v1/calls`, then polls `GET /v1/calls/{id}` until the call reaches `completed`, `failed`, or `canceled`, or until timeout.",
+        "height": 368,
+        "width": 552,
+        "color": 7
+      },
+      "id": "14397733-8b48-4ce6-b310-e11047b17806",
+      "name": "Create request note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1920,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Parse call results\n\n`Parse CALL-E Result` extracts call status, recipient status, attempt status, summary, transcript turns, structured result, metadata, failure code, and status signals. `Demo Result View` masks phone numbers and redacts raw phone fields before displaying per-call output.",
+        "height": 368,
+        "width": 520,
+        "color": 7
+      },
+      "id": "a23c35b7-41dc-43ae-bd1b-48a60f5564af",
+      "name": "Parse results note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2560,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Summarize execution\n\nThe upper branch from `Loop Over Calls` produces `Execution Summary` after all items have been processed. The summary includes counts, masked phone values, metadata round-trip data, call status, and returned summary/structured result fields.",
+        "height": 424,
+        "width": 300,
+        "color": 7
+      },
+      "id": "0bc44e59-312e-4942-8560-98d66f255645",
+      "name": "Summarize execution note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1920,
+        -48
       ]
     },
     {
       "parameters": {},
-      "id": "manual-trigger",
+      "id": "d463f632-8ba7-474a-9e21-16ba016c72fb",
       "name": "Manual Trigger",
       "type": "n8n-nodes-base.manualTrigger",
       "typeVersion": 1,
       "position": [
-        -760,
-        40
+        608,
+        496
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
         "jsCode": "return [\n  {\n    json: {\n      calleConfig: {\n        apiKey: \"replace_with_calle_api_key\",\n        baseUrl: \"https://api.heycall-e.com\",\n        pollIntervalSeconds: 5,\n        waitTimeoutMinutes: 30\n      }\n    }\n  }\n];"
       },
-      "id": "calle-config",
+      "id": "56fb6781-18dc-4293-a1ca-54df15c2365c",
       "name": "CALL-E Config",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -500,
-        40
+        864,
+        496
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
         "jsCode": "const items = $input.all();\nconst config = items[0]?.json?.calleConfig || {};\n\nif (!config.apiKey || config.apiKey === \"replace_with_calle_api_key\") {\n  throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n}\n\nif (!config.baseUrl) {\n  throw new Error(\"CALL-E baseUrl is missing. Open the CALL-E Config node and set baseUrl.\");\n}\n\nreturn items;"
       },
-      "id": "validate-config",
+      "id": "19166449-3e98-4f9f-9c61-017b9c571335",
       "name": "Validate CALL-E Config",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -220,
-        40
+        1152,
+        496
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
-        "jsCode": "const config = $input.first().json.calleConfig;\n\nconst callTasks = [\n  {\n    callItemId: \"ivr_azul_001\",\n    ivrName: \"Azul customer service IVR\",\n    phone: \"+551140031118\",\n    region: \"BR\",\n    locale: \"pt-BR\",\n    task: \"Call the public Azul customer service IVR in Brazil. This is an IVR quality recording sample. Do not enter personal data, do not attempt authentication, do not make purchases, and do not request a human agent. Listen to the opening IVR/menu for up to 90 seconds. Record whether the IVR connected, detected language, menu clarity, audio quality, latency, interruptions, DTMF or speech prompts, and any transfer or retry prompts. Return a concise summary and structured IVR quality result.\",\n    metadata: {\n      lead_id: \"ivr_azul_001\",\n      notion_page_id: \"ivr_demo_azul\",\n      company: \"Azul\",\n      property: \"Public customer service IVR\",\n      campaign: \"Brazil IVR QA\",\n      source_url: \"https://www.voeazul.com.br/br/pt/ajuda/acompanhamento-de-solicitacao\"\n    }\n  },\n  {\n    callItemId: \"ivr_correios_002\",\n    ivrName: \"Correios customer service IVR\",\n    phone: \"40038212\",\n    region: \"BR\",\n    locale: \"pt-BR\",\n    task: \"Call the public Correios customer service IVR in Brazil. This is an IVR quality recording sample. Do not enter personal data, do not attempt authentication, do not open a customer case, and do not request a human agent. Listen to the opening IVR/menu for up to 90 seconds. Record whether the IVR connected, detected language, menu clarity, audio quality, latency, interruptions, DTMF or speech prompts, and any transfer or retry prompts. Return a concise summary and structured IVR quality result.\",\n    metadata: {\n      lead_id: \"ivr_correios_002\",\n      notion_page_id: \"ivr_demo_correios\",\n      company: \"Correios\",\n      property: \"Public customer service IVR\",\n      campaign: \"Brazil IVR QA\",\n      source_url: \"https://www.correios.com.br/falecomoscorreios\"\n    }\n  }\n];\n\nreturn callTasks.map((callTask) => ({\n  json: {\n    ...callTask,\n    metadataSent: callTask.metadata,\n    calleConfig: config\n  }\n}));"
+        "jsCode": "const config = $input.first().json.calleConfig;\n\nconst callTasks = [\n  {\n    callItemId: \"ivr_sample_001\",\n    ivrName: \"Authorized test IVR sample 1\",\n    phone: \"+15555550101\",\n    region: \"US\",\n    locale: \"en-US\",\n    task: \"Call an owned or explicitly authorized test IVR number. This is an IVR quality recording sample. Do not enter personal data, do not attempt authentication, do not make purchases, and do not request a human agent. Listen to the opening IVR/menu for up to 90 seconds. Record whether the IVR connected, detected language, menu clarity, audio quality, latency, interruptions, DTMF or speech prompts, and any transfer or retry prompts. Return a concise summary and structured IVR quality result.\",\n    metadata: {\n      lead_id: \"ivr_sample_001\",\n      notion_page_id: \"ivr_demo_sample_001\",\n      company: \"Sample IVR 1\",\n      property: \"Authorized test IVR\",\n      campaign: \"IVR QA sample\",\n      source_url: \"https://example.com/authorized-test-ivr-1\"\n    }\n  },\n  {\n    callItemId: \"ivr_sample_002\",\n    ivrName: \"Authorized test IVR sample 2\",\n    phone: \"+15555550102\",\n    region: \"US\",\n    locale: \"en-US\",\n    task: \"Call an owned or explicitly authorized test IVR number. This is an IVR quality recording sample. Do not enter personal data, do not attempt authentication, do not open a customer case, and do not request a human agent. Listen to the opening IVR/menu for up to 90 seconds. Record whether the IVR connected, detected language, menu clarity, audio quality, latency, interruptions, DTMF or speech prompts, and any transfer or retry prompts. Return a concise summary and structured IVR quality result.\",\n    metadata: {\n      lead_id: \"ivr_sample_002\",\n      notion_page_id: \"ivr_demo_sample_002\",\n      company: \"Sample IVR 2\",\n      property: \"Authorized test IVR\",\n      campaign: \"IVR QA sample\",\n      source_url: \"https://example.com/authorized-test-ivr-2\"\n    }\n  }\n];\n\nconst placeholderPhones = new Set([\"+15555550101\", \"+15555550102\"]);\nconst e164Pattern = /^\\+[1-9]\\d{7,14}$/;\n\nfor (const callTask of callTasks) {\n  if (!e164Pattern.test(callTask.phone)) {\n    throw new Error(\"Phone number for \" + callTask.callItemId + \" must be in E.164 format, for example +15555550123.\");\n  }\n\n  if (placeholderPhones.has(callTask.phone)) {\n    throw new Error(\"Replace the placeholder phone number for \" + callTask.callItemId + \" with a number you own or are explicitly authorized to call before running live calls.\");\n  }\n}\n\nreturn callTasks.map((callTask) => ({\n  json: {\n    ...callTask,\n    metadataSent: callTask.metadata,\n    calleConfig: config\n  }\n}));"
       },
-      "id": "phone-task-list",
-      "name": "2 Phone/Task List",
+      "id": "a42f8132-fc52-4960-ba1b-a9b46667a48e",
+      "name": "Phone/Task List",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        60,
-        40
+        1424,
+        496
       ]
     },
     {
       "parameters": {
-        "batchSize": 1,
         "options": {}
       },
-      "id": "loop-over-calls",
+      "id": "b93bbcb6-6f7a-48f6-b009-889c186c6fcc",
       "name": "Loop Over Calls",
       "type": "n8n-nodes-base.splitInBatches",
       "typeVersion": 3,
       "position": [
-        340,
-        40
+        1712,
+        496
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
         "jsCode": "const resultSchema = {\n  type: \"object\",\n  required: [\"ivr_reachable\", \"call_quality\", \"summary\", \"next_action\"],\n  properties: {\n    ivr_reachable: {\n      type: \"string\",\n      enum: [\"yes\", \"no\", \"unknown\"]\n    },\n    call_quality: {\n      type: \"string\",\n      enum: [\"good\", \"fair\", \"poor\", \"unknown\"]\n    },\n    summary: { type: \"string\" },\n    next_action: {\n      type: \"string\",\n      enum: [\"pass\", \"retry_later\", \"manual_review\"]\n    },\n    language_detected: { type: \"string\" },\n    menu_summary: { type: \"string\" },\n    audio_issues: { type: \"string\" },\n    latency_or_interruption_notes: { type: \"string\" },\n    dtmf_or_speech_prompt_notes: { type: \"string\" }\n  }\n};\n\nconst recipientResultSchema = {\n  type: \"object\",\n  required: [\"ivr_reachable\", \"call_quality\", \"summary\", \"next_action\"],\n  properties: resultSchema.properties\n};\n\nreturn $input.all().map((item) => {\n  const { calleConfig, metadata, metadataSent, ...callTask } = item.json;\n  const metadataPayload = metadataSent || metadata || {};\n  const createInput = {\n    task: callTask.task,\n    recipients: [\n      {\n        phones: [callTask.phone],\n        region: callTask.region || \"BR\",\n        locale: callTask.locale || \"pt-BR\"\n      }\n    ],\n    result_schema: resultSchema,\n    recipient_result_schema: recipientResultSchema,\n    metadata: {\n      ...metadataPayload,\n      source: \"n8n_two_call_task_list_sample\"\n    }\n  };\n\n  const idempotencyKey = [\n    \"n8n_list\",\n    metadataPayload.campaign || \"campaign\",\n    metadataPayload.lead_id || callTask.phone,\n    callTask.callItemId\n  ].join(\"_\").replace(/[^a-zA-Z0-9_-]/g, \"_\");\n\n  return {\n    json: {\n      ...callTask,\n      calleConfig,\n      metadataSent: createInput.metadata,\n      createInput,\n      idempotencyKey\n    }\n  };\n});"
       },
-      "id": "build-api-input",
-      "name": "Build CALL-E API Input",
+      "id": "d28ea12c-d539-4207-9713-a96ae8082fbf",
+      "name": "Build CALL-E Request Payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        640,
-        140
+        2000,
+        608
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
         "jsCode": "const terminalStatuses = new Set([\"completed\", \"failed\", \"canceled\"]);\n\nfunction sleep(ms) {\n  return new Promise((resolve) => setTimeout(resolve, ms));\n}\n\nasync function requestJson(url, options) {\n  const response = await helpers.httpRequest({\n    url,\n    method: options.method,\n    headers: options.headers,\n    body: options.body,\n    json: true,\n    returnFullResponse: true,\n    ignoreHttpStatusErrors: true\n  });\n\n  const statusCode = response.statusCode;\n  const body = response.body;\n\n  if (statusCode < 200 || statusCode >= 300) {\n    throw new Error(`CALL-E API request failed: ${statusCode} ${response.statusMessage || \"\"} ${JSON.stringify(body)}`);\n  }\n\n  return body;\n}\n\nasync function createAndWaitForCurrentItem(item) {\n  const { calleConfig, createInput, idempotencyKey, ...callTask } = item.json;\n  const apiKey = calleConfig?.apiKey;\n\n  if (!apiKey || apiKey === \"replace_with_calle_api_key\") {\n    throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n  }\n\n  const baseUrl = (calleConfig?.baseUrl || \"https://api.heycall-e.com\").replace(/\\/$/, \"\");\n  const pollIntervalMs = Math.max(1, Number(calleConfig?.pollIntervalSeconds || 5)) * 1000;\n  const timeoutMs = Math.max(1, Number(calleConfig?.waitTimeoutMinutes || 30)) * 60 * 1000;\n  const startedAtMs = Date.now();\n  let pollCount = 0;\n\n  const headers = {\n    \"Accept\": \"application/json\",\n    \"Authorization\": `Bearer ${apiKey}`,\n    \"Content-Type\": \"application/json\"\n  };\n\n  if (idempotencyKey) {\n    headers[\"Idempotency-Key\"] = idempotencyKey;\n  }\n\n  try {\n    let call = await requestJson(`${baseUrl}/v1/calls`, {\n      method: \"POST\",\n      headers,\n      body: createInput\n    });\n\n    while (!terminalStatuses.has(call.status)) {\n      if (Date.now() - startedAtMs >= timeoutMs) {\n        throw new Error(`Timed out waiting for CALL-E call ${call.id} after ${timeoutMs}ms.`);\n      }\n\n      await sleep(pollIntervalMs);\n      pollCount += 1;\n      call = await requestJson(`${baseUrl}/v1/calls/${call.id}`, {\n        method: \"GET\",\n        headers\n      });\n    }\n\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: true,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: call,\n        apiError: null\n      }\n    };\n  } catch (error) {\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: false,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: null,\n        apiError: {\n          message: error.message,\n          name: error.name || \"Error\"\n        }\n      }\n    };\n  }\n}\n\nreturn await Promise.all($input.all().map((item) => createAndWaitForCurrentItem(item)));"
       },
-      "id": "api-create-and-wait",
-      "name": "CALL-E API createAndWait",
+      "id": "ed4b9e80-93c2-41be-9c3d-093a249f0cec",
+      "name": "Create CALL-E Call and Wait",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        940,
-        140
+        2304,
+        608
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
         "jsCode": "function asArray(value) {\n  return Array.isArray(value) ? value : [];\n}\n\nfunction asObject(value) {\n  return value && typeof value === \"object\" && !Array.isArray(value) ? value : null;\n}\n\nfunction normalizeCode(value) {\n  return String(value || \"\").trim().toLowerCase().replace(/[\\s-]+/g, \"_\");\n}\n\nfunction latest(values) {\n  return values.length > 0 ? values[values.length - 1] : null;\n}\n\nreturn $input.all().map((item) => {\n  const call = asObject(item.json.rawCallResult);\n  const recipient = latest(asArray(call?.recipients));\n  const attempts = asArray(recipient?.attempts);\n  const latestAttempt = latest(attempts);\n  const transcriptTurns = attempts.flatMap((attempt) => asArray(attempt.transcript_turns));\n  const structuredResult = asObject(recipient?.structured_result) || asObject(call?.structured_result) || null;\n  const rawFailureCode = latestAttempt?.failure_code || call?.failure_code || null;\n  const failureCode = normalizeCode(rawFailureCode);\n  const callStatus = call?.status || null;\n  const recipientStatus = recipient?.status || null;\n  const latestAttemptStatus = latestAttempt?.status || null;\n  const answered = latestAttemptStatus === \"completed\" || recipientStatus === \"completed\";\n  const noAnswer = failureCode === \"no_answer\";\n  const busy = failureCode === \"busy\";\n  const failed = Boolean(item.json.apiError) || callStatus === \"failed\" || recipientStatus === \"failed\" || latestAttemptStatus === \"failed\";\n\n  return {\n    json: {\n      ...item.json,\n      callId: call?.id || null,\n      callStatus,\n      recipientStatus,\n      latestAttemptStatus,\n      failureCode: rawFailureCode,\n      failureMessage: latestAttempt?.failure_message || call?.failure_message || null,\n      metadataReturned: asObject(call?.metadata) || {},\n      summary: structuredResult?.summary || recipient?.summary || call?.summary || latestAttempt?.summary || null,\n      transcriptTurns,\n      structuredResult,\n      statusSignals: {\n        answered,\n        no_answer: noAnswer,\n        busy,\n        failed\n      },\n      taskCompleted: call?.task_completed ?? null,\n      completionConfidence: call?.completion_confidence ?? null,\n      evidence: asArray(call?.evidence)\n    }\n  };\n});"
       },
-      "id": "parse-api-result",
+      "id": "82a6a2ee-1053-418c-8773-2c514cc58207",
       "name": "Parse CALL-E Result",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1240,
-        140
+        2608,
+        608
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
-        "jsCode": "const metadataKeys = [\"lead_id\", \"notion_page_id\", \"company\", \"property\", \"campaign\"];\n\nreturn $input.all().map((item) => {\n  const result = item.json;\n  const metadataSent = result.metadataSent || {};\n  const metadataReturned = result.metadataReturned || {};\n  const missingReturnedMetadata = metadataKeys.filter((key) => metadataSent[key] !== metadataReturned[key]);\n\n  return {\n    json: {\n      callItemId: result.callItemId,\n      phone: result.phone,\n      task: result.task,\n      metadataSent,\n      metadataReturned,\n      metadataRoundTrip: {\n        requestedKeys: metadataKeys,\n        allRequestedKeysReturned: missingReturnedMetadata.length === 0,\n        missingOrDifferentKeys: missingReturnedMetadata\n      },\n      callStatus: {\n        ok: result.ok,\n        callId: result.callId,\n        call_status: result.callStatus,\n        recipient_status: result.recipientStatus,\n        latest_attempt_status: result.latestAttemptStatus,\n        failure_code: result.failureCode,\n        failure_message: result.failureMessage,\n        answered: result.statusSignals?.answered || false,\n        no_answer: result.statusSignals?.no_answer || false,\n        busy: result.statusSignals?.busy || false,\n        failed: result.statusSignals?.failed || false\n      },\n      returnedData: {\n        summary: result.summary,\n        transcript: result.transcriptTurns,\n        structuredResult: result.structuredResult\n      },\n      rawCallResult: result.rawCallResult,\n      apiError: result.apiError\n    }\n  };\n});"
+        "jsCode": "const metadataKeys = [\"lead_id\", \"notion_page_id\", \"company\", \"property\", \"campaign\"];\n\nfunction maskPhone(phone) {\n  const value = String(phone || \"\").trim();\n  if (!value) return null;\n  if (value.length <= 5) return \"****\";\n  return value.slice(0, 3) + \"****\" + value.slice(-2);\n}\n\nfunction redactPhoneFields(value, parentKey = \"\") {\n  if (Array.isArray(value)) {\n    return value.map((entry) => redactPhoneFields(entry, parentKey));\n  }\n\n  if (value && typeof value === \"object\") {\n    return Object.fromEntries(\n      Object.entries(value).map(([key, entry]) => {\n        const lowerKey = key.toLowerCase();\n        if (lowerKey === \"phone\" || lowerKey === \"phones\" || lowerKey.includes(\"phone_number\")) {\n          if (Array.isArray(entry)) return [key, entry.map(maskPhone)];\n          return [key, maskPhone(entry)];\n        }\n        return [key, redactPhoneFields(entry, key)];\n      })\n    );\n  }\n\n  if (typeof value === \"string\" && /phone/i.test(parentKey)) {\n    return maskPhone(value);\n  }\n\n  return value;\n}\n\nreturn $input.all().map((item) => {\n  const result = item.json;\n  const metadataSent = result.metadataSent || {};\n  const metadataReturned = result.metadataReturned || {};\n  const missingReturnedMetadata = metadataKeys.filter((key) => metadataSent[key] !== metadataReturned[key]);\n\n  return {\n    json: {\n      callItemId: result.callItemId,\n      maskedPhone: maskPhone(result.phone),\n      task: result.task,\n      metadataSent,\n      metadataReturned,\n      metadataRoundTrip: {\n        requestedKeys: metadataKeys,\n        allRequestedKeysReturned: missingReturnedMetadata.length === 0,\n        missingOrDifferentKeys: missingReturnedMetadata\n      },\n      callStatus: {\n        ok: result.ok,\n        callId: result.callId,\n        call_status: result.callStatus,\n        recipient_status: result.recipientStatus,\n        latest_attempt_status: result.latestAttemptStatus,\n        failure_code: result.failureCode,\n        failure_message: result.failureMessage,\n        answered: result.statusSignals?.answered || false,\n        no_answer: result.statusSignals?.no_answer || false,\n        busy: result.statusSignals?.busy || false,\n        failed: result.statusSignals?.failed || false\n      },\n      returnedData: {\n        summary: result.summary,\n        transcript: result.transcriptTurns,\n        structuredResult: result.structuredResult\n      },\n      redactedRawCallResult: redactPhoneFields(result.rawCallResult),\n      apiError: result.apiError\n    }\n  };\n});"
       },
-      "id": "demo-result-view",
+      "id": "1cf5d320-aecf-4d68-997e-b515c8a6555c",
       "name": "Demo Result View",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1540,
-        140
+        2912,
+        608
       ]
     },
     {
       "parameters": {
-        "mode": "runOnceForAllItems",
-        "language": "javaScript",
-        "jsCode": "const items = $input.all();\n\nreturn [\n  {\n    json: {\n      processedCount: items.length,\n      successfulCount: items.filter((item) => item.json.callStatus?.ok).length,\n      failedCount: items.filter((item) => !item.json.callStatus?.ok).length,\n      results: items.map((item) => ({\n        callItemId: item.json.callItemId,\n        phone: item.json.phone,\n        task: item.json.task,\n        metadataSent: item.json.metadataSent,\n        metadataReturned: item.json.metadataReturned,\n        metadataRoundTrip: item.json.metadataRoundTrip,\n        callStatus: item.json.callStatus,\n        returnedData: item.json.returnedData\n      }))\n    }\n  }\n];"
+        "jsCode": "const items = $input.all();\n\nfunction maskPhone(phone) {\n  const value = String(phone || \"\").trim();\n  if (!value) return null;\n  if (value.length <= 5) return \"****\";\n  return value.slice(0, 3) + \"****\" + value.slice(-2);\n}\n\nreturn [\n  {\n    json: {\n      processedCount: items.length,\n      successfulCount: items.filter((item) => item.json.callStatus?.ok).length,\n      failedCount: items.filter((item) => !item.json.callStatus?.ok).length,\n      results: items.map((item) => ({\n        callItemId: item.json.callItemId,\n        maskedPhone: item.json.maskedPhone || maskPhone(item.json.phone),\n        task: item.json.task,\n        metadataSent: item.json.metadataSent,\n        metadataReturned: item.json.metadataReturned,\n        metadataRoundTrip: item.json.metadataRoundTrip,\n        callStatus: item.json.callStatus,\n        returnedData: item.json.returnedData\n      }))\n    }\n  }\n];"
       },
-      "id": "execution-summary",
+      "id": "771d3c58-fe9f-49a1-a57e-42f7cff8749f",
       "name": "Execution Summary",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        640,
-        -120
+        2000,
+        240
       ]
     }
   ],
+  "pinData": {},
   "connections": {
     "Manual Trigger": {
       "main": [
@@ -207,18 +254,7 @@
       "main": [
         [
           {
-            "node": "2 Phone/Task List",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "2 Phone/Task List": {
-      "main": [
-        [
-          {
-            "node": "Loop Over Calls",
+            "node": "Phone/Task List",
             "type": "main",
             "index": 0
           }
@@ -236,29 +272,7 @@
         ],
         [
           {
-            "node": "Build CALL-E API Input",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Build CALL-E API Input": {
-      "main": [
-        [
-          {
-            "node": "CALL-E API createAndWait",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "CALL-E API createAndWait": {
-      "main": [
-        [
-          {
-            "node": "Parse CALL-E Result",
+            "node": "Build CALL-E Request Payload",
             "type": "main",
             "index": 0
           }
@@ -286,17 +300,45 @@
           }
         ]
       ]
+    },
+    "Phone/Task List": {
+      "main": [
+        [
+          {
+            "node": "Loop Over Calls",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build CALL-E Request Payload": {
+      "main": [
+        [
+          {
+            "node": "Create CALL-E Call and Wait",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create CALL-E Call and Wait": {
+      "main": [
+        [
+          {
+            "node": "Parse CALL-E Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
-  "pinData": {},
-  "settings": {
-    "executionOrder": "v1"
-  },
-  "staticData": null,
   "active": false,
-  "versionId": "calle-api-two-call-list-sample-v1",
-  "meta": {
-    "templateCredsSetupCompleted": false
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
   },
   "tags": []
 }

--- a/plugins/n8n-calle-api/examples/calle-ivr-quality-create-and-wait.workflow.json
+++ b/plugins/n8n-calle-api/examples/calle-ivr-quality-create-and-wait.workflow.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Run IVR call quality checks with CALL-E phone calls in n8n\n\n### How it works\n\nThis workflow runs manually, loads and validates CALL-E API settings, builds a small list of IVR quality-check tasks, loops through the tasks one at a time, creates each CALL-E call with `POST /v1/calls`, polls `GET /v1/calls/{id}` until a terminal status, parses the call result, and returns a demo-friendly result view plus an execution summary.\n\n### Setup steps\n\n- Create or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys).\n- Open `CALL-E Config` and replace `replace_with_calle_api_key` with that API key.\n- Review the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n- Open `Phone/Task List` and replace the blocked placeholder E.164 phone numbers with numbers you own or are explicitly authorized to call.\n- Update the IVR task text, locale, region, and metadata for your quality-check scenario.\n- Keep the workflow inactive until the API key and authorized test numbers are configured.\n- Run from `Manual Trigger` and inspect `Demo Result View` and `Execution Summary`.\n\n### Safety\n\nThis template can create real outbound calls after a valid API key and authorized phone numbers are configured. By default, placeholder numbers fail validation so the sample cannot dial accidentally. The output masks phone numbers and redacts phone fields from the raw call result view.\n\n### Customization\n\nAdjust the task list, CALL-E payload construction, result schema, parsing logic, and summary formatting to match different IVR quality checks, scoring criteria, or reporting needs.",
+        "content": "## Run IVR call quality checks with CALL-E phone calls in n8n\n\n### How it works\n\nThis workflow runs manually, loads and validates CALL-E API settings, builds a small list of IVR quality-check tasks, loops through the tasks one at a time, creates each CALL-E call with `POST /v1/calls`, polls `GET /v1/calls/{id}` until a terminal status, parses the call result, and returns a demo-friendly result view plus an execution summary.\n\n### Setup steps\n\n- Create or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys).\n- Open `CALL-E Config` and replace `replace_with_calle_api_key` with that API key.\n- Review the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n- Open `Phone/Task List` and replace the blocked placeholder E.164 phone numbers with numbers you own or are explicitly authorized to call.\n- Update the IVR task text, locale, region, and metadata for your quality-check scenario.\n- Keep the workflow inactive until the API key and authorized test numbers are configured.\n- Run from `Manual Trigger` and inspect `Demo Result View` and `Execution Summary`.\n\n### Safety\n\nThis template can create real outbound calls after a valid API key and authorized phone numbers are configured. By default, placeholder numbers fail validation so the sample cannot dial accidentally. The output masks phone numbers across the complete displayed result, including metadata, raw call data, status messages, and API errors. Code-node polling is capped at four minutes so it remains below n8n's default runner task timeout.\n\n### Customization\n\nAdjust the task list, CALL-E payload construction, result schema, parsing logic, and summary formatting to match different IVR quality checks, scoring criteria, or reporting needs.",
         "height": 900,
         "width": 520,
         "color": 4
@@ -19,8 +19,8 @@
     },
     {
       "parameters": {
-        "content": "## Start and configure\n\nCreate or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys), then open `CALL-E Config` and replace `replace_with_calle_api_key`.\n\nUse the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n\n`Manual Trigger` starts the workflow. `CALL-E Config` stores the API key, base URL, polling interval, and timeout. `Validate CALL-E Config` fails fast before any call task is built if the API key is missing or still set to the placeholder.",
-        "height": 416,
+        "content": "## Start and configure\n\nCreate or copy an API key from [CALL-E API Keys](https://dashboard.heycall-e.com/account/api-keys), then open `CALL-E Config` and replace `replace_with_calle_api_key`.\n\nUse the [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) for endpoint, request, and response details.\n\n`Manual Trigger` starts the workflow. `CALL-E Config` stores the API key, base URL, polling interval, and timeout. `Validate CALL-E Config` fails fast before any call task is built if the API key is missing, still set to the placeholder, or the Code-node wait timeout exceeds four minutes.",
+        "height": 480,
         "width": 736,
         "color": 7
       },
@@ -36,7 +36,7 @@
     {
       "parameters": {
         "content": "## Prepare call batches\n\n`Phone/Task List` defines the IVR quality-check rows, validates E.164 numbers, blocks the default placeholder numbers, and passes one item at a time into `Loop Over Calls` with batch size 1.",
-        "height": 352,
+        "height": 480,
         "width": 484,
         "color": 7
       },
@@ -46,13 +46,13 @@
       "typeVersion": 1,
       "position": [
         1376,
-        304
+        320
       ]
     },
     {
       "parameters": {
-        "content": "## Create API request\n\n`Build CALL-E Request Payload` constructs the per-call request body, result schema, recipient schema, metadata, and idempotency key. `Create CALL-E Call and Wait` sends `POST /v1/calls`, then polls `GET /v1/calls/{id}` until the call reaches `completed`, `failed`, or `canceled`, or until timeout.",
-        "height": 368,
+        "content": "## Create API request\n\n`Build CALL-E Request Payload` builds the request body, schemas, metadata, and idempotency key. `Create CALL-E Call and Wait` creates the call and polls until a terminal status or the four-minute deadline. Poll intervals and HTTP requests are bounded to stay within the n8n runner limit.",
+        "height": 480,
         "width": 552,
         "color": 7
       },
@@ -62,13 +62,13 @@
       "typeVersion": 1,
       "position": [
         1920,
-        400
+        432
       ]
     },
     {
       "parameters": {
-        "content": "## Parse call results\n\n`Parse CALL-E Result` extracts call status, recipient status, attempt status, summary, transcript turns, structured result, metadata, failure code, and status signals. `Demo Result View` masks phone numbers and redacts raw phone fields before displaying per-call output.",
-        "height": 368,
+        "content": "## Parse call results\n\n`Parse CALL-E Result` extracts call status, recipient status, attempt status, summary, transcript turns, structured result, metadata, failure code, and status signals. `Demo Result View` applies phone masking to the complete displayed result, including metadata, raw call data, status messages, and API errors.",
+        "height": 480,
         "width": 520,
         "color": 7
       },
@@ -78,13 +78,13 @@
       "typeVersion": 1,
       "position": [
         2560,
-        400
+        432
       ]
     },
     {
       "parameters": {
         "content": "## Summarize execution\n\nThe upper branch from `Loop Over Calls` produces `Execution Summary` after all items have been processed. The summary includes counts, masked phone values, metadata round-trip data, call status, and returned summary/structured result fields.",
-        "height": 424,
+        "height": 448,
         "width": 300,
         "color": 7
       },
@@ -105,12 +105,12 @@
       "typeVersion": 1,
       "position": [
         608,
-        496
+        640
       ]
     },
     {
       "parameters": {
-        "jsCode": "return [\n  {\n    json: {\n      calleConfig: {\n        apiKey: \"replace_with_calle_api_key\",\n        baseUrl: \"https://api.heycall-e.com\",\n        pollIntervalSeconds: 5,\n        waitTimeoutMinutes: 30\n      }\n    }\n  }\n];"
+        "jsCode": "return [\n  {\n    json: {\n      calleConfig: {\n        apiKey: \"replace_with_calle_api_key\",\n        baseUrl: \"https://api.heycall-e.com\",\n        pollIntervalSeconds: 5,\n        waitTimeoutMinutes: 4\n      }\n    }\n  }\n];"
       },
       "id": "56fb6781-18dc-4293-a1ca-54df15c2365c",
       "name": "CALL-E Config",
@@ -118,12 +118,12 @@
       "typeVersion": 2,
       "position": [
         864,
-        496
+        640
       ]
     },
     {
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst config = items[0]?.json?.calleConfig || {};\n\nif (!config.apiKey || config.apiKey === \"replace_with_calle_api_key\") {\n  throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n}\n\nif (!config.baseUrl) {\n  throw new Error(\"CALL-E baseUrl is missing. Open the CALL-E Config node and set baseUrl.\");\n}\n\nreturn items;"
+        "jsCode": "const items = $input.all();\nconst config = items[0]?.json?.calleConfig || {};\n\nif (!config.apiKey || config.apiKey === \"replace_with_calle_api_key\") {\n  throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n}\n\nif (!config.baseUrl) {\n  throw new Error(\"CALL-E baseUrl is missing. Open the CALL-E Config node and set baseUrl.\");\n}\n\nconst pollIntervalSeconds = Number(config.pollIntervalSeconds);\nif (!Number.isFinite(pollIntervalSeconds) || pollIntervalSeconds < 1 || pollIntervalSeconds > 30) {\n  throw new Error(\"CALL-E pollIntervalSeconds must be between 1 and 30 seconds.\");\n}\n\nconst waitTimeoutMinutes = Number(config.waitTimeoutMinutes);\nif (!Number.isFinite(waitTimeoutMinutes) || waitTimeoutMinutes <= 0 || waitTimeoutMinutes > 4) {\n  throw new Error(\"CALL-E waitTimeoutMinutes must be greater than 0 and cannot exceed 4 minutes. This keeps the Code-node polling loop below n8n\\'s default 300-second N8N_RUNNERS_TASK_TIMEOUT.\");\n}\n\nreturn items;"
       },
       "id": "19166449-3e98-4f9f-9c61-017b9c571335",
       "name": "Validate CALL-E Config",
@@ -131,7 +131,7 @@
       "typeVersion": 2,
       "position": [
         1152,
-        496
+        640
       ]
     },
     {
@@ -144,7 +144,7 @@
       "typeVersion": 2,
       "position": [
         1424,
-        496
+        640
       ]
     },
     {
@@ -157,7 +157,7 @@
       "typeVersion": 3,
       "position": [
         1712,
-        496
+        640
       ]
     },
     {
@@ -170,12 +170,12 @@
       "typeVersion": 2,
       "position": [
         2000,
-        608
+        752
       ]
     },
     {
       "parameters": {
-        "jsCode": "const terminalStatuses = new Set([\"completed\", \"failed\", \"canceled\"]);\n\nfunction sleep(ms) {\n  return new Promise((resolve) => setTimeout(resolve, ms));\n}\n\nasync function requestJson(url, options) {\n  const response = await helpers.httpRequest({\n    url,\n    method: options.method,\n    headers: options.headers,\n    body: options.body,\n    json: true,\n    returnFullResponse: true,\n    ignoreHttpStatusErrors: true\n  });\n\n  const statusCode = response.statusCode;\n  const body = response.body;\n\n  if (statusCode < 200 || statusCode >= 300) {\n    throw new Error(`CALL-E API request failed: ${statusCode} ${response.statusMessage || \"\"} ${JSON.stringify(body)}`);\n  }\n\n  return body;\n}\n\nasync function createAndWaitForCurrentItem(item) {\n  const { calleConfig, createInput, idempotencyKey, ...callTask } = item.json;\n  const apiKey = calleConfig?.apiKey;\n\n  if (!apiKey || apiKey === \"replace_with_calle_api_key\") {\n    throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n  }\n\n  const baseUrl = (calleConfig?.baseUrl || \"https://api.heycall-e.com\").replace(/\\/$/, \"\");\n  const pollIntervalMs = Math.max(1, Number(calleConfig?.pollIntervalSeconds || 5)) * 1000;\n  const timeoutMs = Math.max(1, Number(calleConfig?.waitTimeoutMinutes || 30)) * 60 * 1000;\n  const startedAtMs = Date.now();\n  let pollCount = 0;\n\n  const headers = {\n    \"Accept\": \"application/json\",\n    \"Authorization\": `Bearer ${apiKey}`,\n    \"Content-Type\": \"application/json\"\n  };\n\n  if (idempotencyKey) {\n    headers[\"Idempotency-Key\"] = idempotencyKey;\n  }\n\n  try {\n    let call = await requestJson(`${baseUrl}/v1/calls`, {\n      method: \"POST\",\n      headers,\n      body: createInput\n    });\n\n    while (!terminalStatuses.has(call.status)) {\n      if (Date.now() - startedAtMs >= timeoutMs) {\n        throw new Error(`Timed out waiting for CALL-E call ${call.id} after ${timeoutMs}ms.`);\n      }\n\n      await sleep(pollIntervalMs);\n      pollCount += 1;\n      call = await requestJson(`${baseUrl}/v1/calls/${call.id}`, {\n        method: \"GET\",\n        headers\n      });\n    }\n\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: true,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: call,\n        apiError: null\n      }\n    };\n  } catch (error) {\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: false,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: null,\n        apiError: {\n          message: error.message,\n          name: error.name || \"Error\"\n        }\n      }\n    };\n  }\n}\n\nreturn await Promise.all($input.all().map((item) => createAndWaitForCurrentItem(item)));"
+        "jsCode": "const terminalStatuses = new Set([\"completed\", \"failed\", \"canceled\"]);\n\nfunction sleep(ms) {\n  return new Promise((resolve) => setTimeout(resolve, ms));\n}\n\nasync function requestJson(url, options) {\n  const response = await helpers.httpRequest({\n    url,\n    method: options.method,\n    headers: options.headers,\n    body: options.body,\n    json: true,\n    returnFullResponse: true,\n    ignoreHttpStatusErrors: true,\n    timeout: options.timeoutMs\n  });\n\n  const statusCode = response.statusCode;\n  const body = response.body;\n\n  if (statusCode < 200 || statusCode >= 300) {\n    const statusMessage = String(response.statusMessage || \"\").replace(/[\\r\\n]+/g, \" \").trim();\n    throw new Error(\"CALL-E API request failed: \" + statusCode + (statusMessage ? \" \" + statusMessage : \"\") + \". Response body omitted from workflow output.\");\n  }\n\n  return body;\n}\n\nasync function createAndWaitForCurrentItem(item) {\n  const { calleConfig, createInput, idempotencyKey, ...callTask } = item.json;\n  const apiKey = calleConfig?.apiKey;\n\n  if (!apiKey || apiKey === \"replace_with_calle_api_key\") {\n    throw new Error(\"CALL-E API key is missing. Open the CALL-E Config node and replace apiKey before running this workflow.\");\n  }\n\n  const baseUrl = (calleConfig?.baseUrl || \"https://api.heycall-e.com\").replace(/\\/$/, \"\");\n  const pollIntervalMs = Math.min(30, Math.max(1, Number(calleConfig?.pollIntervalSeconds || 5))) * 1000;\n  const timeoutMs = Math.max(1, Number(calleConfig?.waitTimeoutMinutes || 4)) * 60 * 1000;\n  const startedAtMs = Date.now();\n  let pollCount = 0;\n\n  const headers = {\n    \"Accept\": \"application/json\",\n    \"Authorization\": `Bearer ${apiKey}`,\n    \"Content-Type\": \"application/json\"\n  };\n\n  if (idempotencyKey) {\n    headers[\"Idempotency-Key\"] = idempotencyKey;\n  }\n\n  try {\n    let call = await requestJson(`${baseUrl}/v1/calls`, {\n      method: \"POST\",\n      headers,\n      body: createInput,\n      timeoutMs: 30 * 1000\n    });\n\n    while (!terminalStatuses.has(call.status)) {\n      const remainingBeforeSleepMs = timeoutMs - (Date.now() - startedAtMs);\n      if (remainingBeforeSleepMs <= 0) {\n        throw new Error(`Timed out waiting for CALL-E call ${call.id} after ${timeoutMs}ms.`);\n      }\n\n      await sleep(Math.min(pollIntervalMs, remainingBeforeSleepMs));\n      const remainingBeforePollMs = timeoutMs - (Date.now() - startedAtMs);\n      if (remainingBeforePollMs <= 0) {\n        throw new Error(`Timed out waiting for CALL-E call ${call.id} after ${timeoutMs}ms.`);\n      }\n\n      pollCount += 1;\n      call = await requestJson(`${baseUrl}/v1/calls/${call.id}`, {\n        method: \"GET\",\n        headers,\n        timeoutMs: Math.min(30 * 1000, remainingBeforePollMs)\n      });\n    }\n\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: true,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: call,\n        apiError: null\n      }\n    };\n  } catch (error) {\n    return {\n      json: {\n        ...callTask,\n        createInput,\n        ok: false,\n        idempotencyKey,\n        pollCount,\n        rawCallResult: null,\n        apiError: {\n          message: error.message,\n          name: error.name || \"Error\"\n        }\n      }\n    };\n  }\n}\n\nreturn await Promise.all($input.all().map((item) => createAndWaitForCurrentItem(item)));"
       },
       "id": "ed4b9e80-93c2-41be-9c3d-093a249f0cec",
       "name": "Create CALL-E Call and Wait",
@@ -183,7 +183,7 @@
       "typeVersion": 2,
       "position": [
         2304,
-        608
+        752
       ]
     },
     {
@@ -196,12 +196,12 @@
       "typeVersion": 2,
       "position": [
         2608,
-        608
+        752
       ]
     },
     {
       "parameters": {
-        "jsCode": "const metadataKeys = [\"lead_id\", \"notion_page_id\", \"company\", \"property\", \"campaign\"];\n\nfunction maskPhone(phone) {\n  const value = String(phone || \"\").trim();\n  if (!value) return null;\n  if (value.length <= 5) return \"****\";\n  return value.slice(0, 3) + \"****\" + value.slice(-2);\n}\n\nfunction redactPhoneFields(value, parentKey = \"\") {\n  if (Array.isArray(value)) {\n    return value.map((entry) => redactPhoneFields(entry, parentKey));\n  }\n\n  if (value && typeof value === \"object\") {\n    return Object.fromEntries(\n      Object.entries(value).map(([key, entry]) => {\n        const lowerKey = key.toLowerCase();\n        if (lowerKey === \"phone\" || lowerKey === \"phones\" || lowerKey.includes(\"phone_number\")) {\n          if (Array.isArray(entry)) return [key, entry.map(maskPhone)];\n          return [key, maskPhone(entry)];\n        }\n        return [key, redactPhoneFields(entry, key)];\n      })\n    );\n  }\n\n  if (typeof value === \"string\" && /phone/i.test(parentKey)) {\n    return maskPhone(value);\n  }\n\n  return value;\n}\n\nreturn $input.all().map((item) => {\n  const result = item.json;\n  const metadataSent = result.metadataSent || {};\n  const metadataReturned = result.metadataReturned || {};\n  const missingReturnedMetadata = metadataKeys.filter((key) => metadataSent[key] !== metadataReturned[key]);\n\n  return {\n    json: {\n      callItemId: result.callItemId,\n      maskedPhone: maskPhone(result.phone),\n      task: result.task,\n      metadataSent,\n      metadataReturned,\n      metadataRoundTrip: {\n        requestedKeys: metadataKeys,\n        allRequestedKeysReturned: missingReturnedMetadata.length === 0,\n        missingOrDifferentKeys: missingReturnedMetadata\n      },\n      callStatus: {\n        ok: result.ok,\n        callId: result.callId,\n        call_status: result.callStatus,\n        recipient_status: result.recipientStatus,\n        latest_attempt_status: result.latestAttemptStatus,\n        failure_code: result.failureCode,\n        failure_message: result.failureMessage,\n        answered: result.statusSignals?.answered || false,\n        no_answer: result.statusSignals?.no_answer || false,\n        busy: result.statusSignals?.busy || false,\n        failed: result.statusSignals?.failed || false\n      },\n      returnedData: {\n        summary: result.summary,\n        transcript: result.transcriptTurns,\n        structuredResult: result.structuredResult\n      },\n      redactedRawCallResult: redactPhoneFields(result.rawCallResult),\n      apiError: result.apiError\n    }\n  };\n});"
+        "jsCode": "const metadataKeys = [\"lead_id\", \"notion_page_id\", \"company\", \"property\", \"campaign\"];\n\nfunction maskPhone(phone) {\n  const value = String(phone || \"\").trim();\n  if (!value) return null;\n  if (value.length <= 5) return \"****\";\n  return value.slice(0, 3) + \"****\" + value.slice(-2);\n}\n\nfunction redactPhoneData(value, parentKey = \"\", phoneContext = false) {\n  const hasPhoneContext = phoneContext || /phone/i.test(parentKey);\n\n  if (Array.isArray(value)) {\n    return value.map((entry) => redactPhoneData(entry, parentKey, hasPhoneContext));\n  }\n\n  if (value && typeof value === \"object\") {\n    return Object.fromEntries(\n      Object.entries(value).map(([key, entry]) => [key, redactPhoneData(entry, key, hasPhoneContext)])\n    );\n  }\n\n  if (typeof value === \"string\") {\n    const maskedE164 = value.replace(/\\+[1-9]\\d{7,14}/g, (phone) => maskPhone(phone));\n    if (hasPhoneContext && maskedE164 === value) return maskPhone(value);\n    return maskedE164;\n  }\n\n  if (hasPhoneContext && value !== null && (typeof value === \"number\" || typeof value === \"boolean\")) {\n    return \"****\";\n  }\n\n  return value;\n}\n\nreturn $input.all().map((item) => {\n  const result = item.json;\n  const metadataSent = result.metadataSent || {};\n  const metadataReturned = result.metadataReturned || {};\n  const missingReturnedMetadata = metadataKeys.filter((key) => metadataSent[key] !== metadataReturned[key]);\n\n  return {\n    json: redactPhoneData({\n      callItemId: result.callItemId,\n      maskedPhone: maskPhone(result.phone),\n      task: result.task,\n      metadataSent,\n      metadataReturned,\n      metadataRoundTrip: {\n        requestedKeys: metadataKeys,\n        allRequestedKeysReturned: missingReturnedMetadata.length === 0,\n        missingOrDifferentKeys: missingReturnedMetadata\n      },\n      callStatus: {\n        ok: result.ok,\n        callId: result.callId,\n        call_status: result.callStatus,\n        recipient_status: result.recipientStatus,\n        latest_attempt_status: result.latestAttemptStatus,\n        failure_code: result.failureCode,\n        failure_message: result.failureMessage,\n        answered: result.statusSignals?.answered || false,\n        no_answer: result.statusSignals?.no_answer || false,\n        busy: result.statusSignals?.busy || false,\n        failed: result.statusSignals?.failed || false\n      },\n      returnedData: {\n        summary: result.summary,\n        transcript: result.transcriptTurns,\n        structuredResult: result.structuredResult\n      },\n      redactedRawCallResult: result.rawCallResult,\n      apiError: result.apiError\n    })\n  };\n});"
       },
       "id": "1cf5d320-aecf-4d68-997e-b515c8a6555c",
       "name": "Demo Result View",
@@ -209,12 +209,12 @@
       "typeVersion": 2,
       "position": [
         2912,
-        608
+        752
       ]
     },
     {
       "parameters": {
-        "jsCode": "const items = $input.all();\n\nfunction maskPhone(phone) {\n  const value = String(phone || \"\").trim();\n  if (!value) return null;\n  if (value.length <= 5) return \"****\";\n  return value.slice(0, 3) + \"****\" + value.slice(-2);\n}\n\nreturn [\n  {\n    json: {\n      processedCount: items.length,\n      successfulCount: items.filter((item) => item.json.callStatus?.ok).length,\n      failedCount: items.filter((item) => !item.json.callStatus?.ok).length,\n      results: items.map((item) => ({\n        callItemId: item.json.callItemId,\n        maskedPhone: item.json.maskedPhone || maskPhone(item.json.phone),\n        task: item.json.task,\n        metadataSent: item.json.metadataSent,\n        metadataReturned: item.json.metadataReturned,\n        metadataRoundTrip: item.json.metadataRoundTrip,\n        callStatus: item.json.callStatus,\n        returnedData: item.json.returnedData\n      }))\n    }\n  }\n];"
+        "jsCode": "const items = $input.all();\n\nreturn [\n  {\n    json: {\n      processedCount: items.length,\n      successfulCount: items.filter((item) => item.json.callStatus?.ok).length,\n      failedCount: items.filter((item) => !item.json.callStatus?.ok).length,\n      results: items.map((item) => ({\n        callItemId: item.json.callItemId,\n        maskedPhone: item.json.maskedPhone,\n        task: item.json.task,\n        metadataSent: item.json.metadataSent,\n        metadataReturned: item.json.metadataReturned,\n        metadataRoundTrip: item.json.metadataRoundTrip,\n        callStatus: item.json.callStatus,\n        returnedData: item.json.returnedData\n      }))\n    }\n  }\n];"
       },
       "id": "771d3c58-fe9f-49a1-a57e-42f7cff8749f",
       "name": "Execution Summary",

--- a/plugins/n8n-calle-api/manifest.json
+++ b/plugins/n8n-calle-api/manifest.json
@@ -3,7 +3,7 @@
   "title": "n8n CALL-E API workflow template",
   "platform": "n8n",
   "type": "workflow-template",
-  "description": "Importable n8n workflow that calls the CALL-E API directly, waits for completion, and returns metadata, status, transcript, summary, and structured results.",
+  "description": "Inactive-by-default n8n workflow that manually calls the CALL-E API, waits for completion, and returns masked metadata, status, transcript, summary, and structured results.",
   "entrypoints": [
     {
       "name": "Run IVR call quality checks with CALL-E phone calls in n8n",
@@ -11,7 +11,14 @@
     }
   ],
   "side_effects": [
-    "Creates outbound phone calls when a valid CALL-E API key and reachable phone numbers are configured."
+    "Creates outbound phone calls only after a valid CALL-E API key and non-placeholder destination numbers are configured and the workflow is run manually."
+  ],
+  "safety": [
+    "Imports inactive and runs only from its Manual Trigger.",
+    "Validates E.164 destination numbers and blocks the shipped placeholder numbers.",
+    "Use only phone numbers you own or are explicitly authorized to call.",
+    "Masks phone numbers across displayed outputs, including metadata, raw results, status messages, and API errors.",
+    "Caps polling at four minutes, limits poll intervals and HTTP requests to 30 seconds, and shortens the final sleep so the Code-node task stays below n8n's default 300-second runner timeout."
   ],
   "credentials": [
     "CALL-E API key stored in the n8n CALL-E Config code node before execution."

--- a/plugins/n8n-calle-api/manifest.json
+++ b/plugins/n8n-calle-api/manifest.json
@@ -6,7 +6,7 @@
   "description": "Importable n8n workflow that calls the CALL-E API directly, waits for completion, and returns metadata, status, transcript, summary, and structured results.",
   "entrypoints": [
     {
-      "name": "CALL-E API createAndWait - IVR quality sample",
+      "name": "Run IVR call quality checks with CALL-E phone calls in n8n",
       "path": "examples/calle-ivr-quality-create-and-wait.workflow.json"
     }
   ],

--- a/plugins/n8n-calle-api/test/workflow-safety.test.mjs
+++ b/plugins/n8n-calle-api/test/workflow-safety.test.mjs
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowPath = new URL(
+  "../examples/calle-ivr-quality-create-and-wait.workflow.json",
+  import.meta.url,
+);
+const manifestPath = new URL("../manifest.json", import.meta.url);
+const workflow = JSON.parse(await readFile(workflowPath, "utf8"));
+const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function codeFor(nodeName) {
+  const node = workflow.nodes.find((candidate) => candidate.name === nodeName);
+  assert.ok(node, `Missing workflow node: ${nodeName}`);
+  assert.equal(node.type, "n8n-nodes-base.code");
+  return node.parameters.jsCode;
+}
+
+async function runCodeNode(nodeName, inputItems = [], helpers = {}, globals = {}) {
+  const input = {
+    all: () => structuredClone(inputItems),
+    first: () => structuredClone(inputItems[0]),
+  };
+  const execute = new AsyncFunction(
+    "$input",
+    "helpers",
+    "Date",
+    "setTimeout",
+    codeFor(nodeName),
+  );
+  return execute(
+    input,
+    helpers,
+    globals.Date ?? Date,
+    globals.setTimeout ?? setTimeout,
+  );
+}
+
+test("Demo Result View redacts phone numbers from every displayed field", async () => {
+  const primaryPhone = "+14155550100";
+  const returnedPhone = "+442071838750";
+  const errorPhone = "+61293744000";
+  const [output] = await runCodeNode("Demo Result View", [
+    {
+      json: {
+        callItemId: "ivr_sample_001",
+        phone: primaryPhone,
+        task: "Inspect the authorized IVR.",
+        metadataSent: { contact_phone: primaryPhone },
+        metadataReturned: {
+          callback_phone: returnedPhone,
+          numeric_phone: 14155550100,
+          phone: { countryCode: 1, nationalNumber: 4155550100 },
+        },
+        ok: false,
+        callId: "call_123",
+        callStatus: "failed",
+        recipientStatus: "failed",
+        latestAttemptStatus: "failed",
+        failureCode: "provider_error",
+        failureMessage: `Provider rejected ${returnedPhone}`,
+        statusSignals: { failed: true },
+        summary: null,
+        transcriptTurns: [],
+        structuredResult: null,
+        rawCallResult: {
+          metadata: { contact_phone: primaryPhone },
+          recipients: [{ phones: [returnedPhone] }],
+        },
+        apiError: {
+          name: "Error",
+          message: `CALL-E API request failed for ${errorPhone}`,
+        },
+      },
+    },
+  ]);
+
+  const serialized = JSON.stringify(output.json);
+  for (const phone of [primaryPhone, returnedPhone, errorPhone]) {
+    assert.equal(serialized.includes(phone), false, `Leaked phone number: ${phone}`);
+  }
+  assert.equal(output.json.maskedPhone, "+14****00");
+  assert.equal(output.json.metadataSent.contact_phone, "+14****00");
+  assert.equal(output.json.metadataReturned.callback_phone, "+44****50");
+  assert.equal(output.json.metadataReturned.numeric_phone, "****");
+  assert.deepEqual(output.json.metadataReturned.phone, {
+    countryCode: "****",
+    nationalNumber: "****",
+  });
+  assert.match(output.json.apiError.message, /\+61\*{4}00/);
+});
+
+test("API failure messages do not stringify unredacted response bodies", async () => {
+  const responsePhone = "+14155550100";
+  assert.doesNotMatch(
+    codeFor("Create CALL-E Call and Wait"),
+    /JSON\.stringify\(body\)/,
+  );
+  const [output] = await runCodeNode(
+    "Create CALL-E Call and Wait",
+    [
+      {
+        json: {
+          calleConfig: {
+            apiKey: "test_api_key",
+            baseUrl: "https://api.heycall-e.com",
+            pollIntervalSeconds: 5,
+            waitTimeoutMinutes: 4,
+          },
+          createInput: { recipients: [{ phones: [responsePhone] }] },
+          idempotencyKey: "test-key",
+          callItemId: "ivr_sample_001",
+        },
+      },
+    ],
+    {
+      httpRequest: async () => ({
+        statusCode: 400,
+        statusMessage: "Bad Request",
+        body: { error: `Invalid phone ${responsePhone}` },
+      }),
+    },
+  );
+  assert.equal(output.json.ok, false);
+  assert.equal(output.json.apiError.message.includes(responsePhone), false);
+  assert.match(output.json.apiError.message, /Response body omitted/);
+});
+
+test("the Code-node polling timeout stays below the stock runner task limit", async () => {
+  const [configured] = await runCodeNode("CALL-E Config");
+  assert.equal(configured.json.calleConfig.waitTimeoutMinutes, 4);
+
+  const validConfig = {
+    apiKey: "test_api_key",
+    baseUrl: "https://api.heycall-e.com",
+    pollIntervalSeconds: 5,
+    waitTimeoutMinutes: 4,
+  };
+  await assert.doesNotReject(() =>
+    runCodeNode("Validate CALL-E Config", [{ json: { calleConfig: validConfig } }]),
+  );
+  await assert.rejects(
+    () =>
+      runCodeNode("Validate CALL-E Config", [
+        {
+          json: {
+            calleConfig: { ...validConfig, waitTimeoutMinutes: 5 },
+          },
+        },
+      ]),
+    /cannot exceed 4 minutes/,
+  );
+  await assert.rejects(
+    () =>
+      runCodeNode("Validate CALL-E Config", [
+        {
+          json: {
+            calleConfig: { ...validConfig, pollIntervalSeconds: 31 },
+          },
+        },
+      ]),
+    /between 1 and 30 seconds/,
+  );
+});
+
+test("polling stays within its deadline when the final interval is partial", async () => {
+  let now = 0;
+  const sleepDurations = [];
+  const requestTimeouts = [];
+  const [output] = await runCodeNode(
+    "Create CALL-E Call and Wait",
+    [
+      {
+        json: {
+          calleConfig: {
+            apiKey: "test_api_key",
+            baseUrl: "https://api.heycall-e.com",
+            pollIntervalSeconds: 29,
+            waitTimeoutMinutes: 4,
+          },
+          createInput: { recipients: [{ phones: ["+14155550100"] }] },
+          idempotencyKey: "test-key",
+          callItemId: "ivr_sample_001",
+        },
+      },
+    ],
+    {
+      httpRequest: async (options) => {
+        requestTimeouts.push(options.timeout);
+        return {
+          statusCode: 200,
+          statusMessage: "OK",
+          body: { id: "call_123", status: "running" },
+        };
+      },
+    },
+    {
+      Date: { now: () => now },
+      setTimeout: (resolve, milliseconds) => {
+        sleepDurations.push(milliseconds);
+        now += milliseconds;
+        resolve();
+      },
+    },
+  );
+
+  assert.equal(output.json.ok, false);
+  assert.match(output.json.apiError.message, /Timed out waiting/);
+  assert.equal(now, 4 * 60 * 1000);
+  assert.ok(sleepDurations.at(-1) < 29 * 1000);
+  assert.ok(
+    requestTimeouts.every(
+      (timeout) => Number.isFinite(timeout) && timeout > 0 && timeout <= 30 * 1000,
+    ),
+  );
+});
+
+test("manifest describes the workflow safety gates and masked output", () => {
+  const safety = manifest.safety.join(" ");
+  assert.match(safety, /inactive.*Manual Trigger/i);
+  assert.match(safety, /E\.164.*placeholder/i);
+  assert.match(safety, /own or are explicitly authorized/i);
+  assert.match(safety, /mask.*metadata.*API errors/i);
+});
+
+test("Execution Summary trusts the already masked result contract", () => {
+  const summaryCode = codeFor("Execution Summary");
+  assert.doesNotMatch(summaryCode, /function maskPhone/);
+  assert.match(summaryCode, /maskedPhone:\s*item\.json\.maskedPhone/);
+});
+
+test("sticky notes wrap their assigned nodes below the text area", () => {
+  const groupSpecs = [
+    {
+      note: "Start and configure note",
+      contentHeight: 288,
+      nodes: ["Manual Trigger", "CALL-E Config", "Validate CALL-E Config"],
+    },
+    {
+      note: "Prepare call batches note",
+      contentHeight: 288,
+      nodes: ["Phone/Task List", "Loop Over Calls"],
+    },
+    {
+      note: "Create request note",
+      contentHeight: 288,
+      nodes: ["Build CALL-E Request Payload", "Create CALL-E Call and Wait"],
+    },
+    {
+      note: "Parse results note",
+      contentHeight: 288,
+      nodes: ["Parse CALL-E Result", "Demo Result View"],
+    },
+    {
+      note: "Summarize execution note",
+      contentHeight: 256,
+      nodes: ["Execution Summary"],
+    },
+  ];
+  const nodesByName = new Map(workflow.nodes.map((node) => [node.name, node]));
+  const stickyNotes = workflow.nodes.filter(
+    (node) => node.type === "n8n-nodes-base.stickyNote",
+  );
+  const executableNodes = workflow.nodes.filter(
+    (node) => node.type !== "n8n-nodes-base.stickyNote",
+  );
+  const nodeWidth = 120;
+  const nodeHeight = 120;
+  const outerPadding = 24;
+  const textGap = 32;
+  const assignedNodes = new Set();
+  const violations = [];
+
+  const rectanglesOverlap = (left, right) =>
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y;
+
+  for (const spec of groupSpecs) {
+    const note = nodesByName.get(spec.note);
+    assert.ok(note, `Missing sticky note: ${spec.note}`);
+    const [noteX, noteY] = note.position;
+    const noteRight = noteX + note.parameters.width;
+    const noteBottom = noteY + note.parameters.height;
+
+    for (const nodeName of spec.nodes) {
+      const node = nodesByName.get(nodeName);
+      assert.ok(node, `Missing executable node: ${nodeName}`);
+      assignedNodes.add(nodeName);
+      const [nodeX, nodeY] = node.position;
+
+      if (nodeX < noteX + outerPadding) {
+        violations.push(`${nodeName} lacks left padding in ${spec.note}`);
+      }
+      if (nodeX + nodeWidth > noteRight - outerPadding) {
+        violations.push(`${nodeName} lacks right padding in ${spec.note}`);
+      }
+      if (nodeY < noteY + spec.contentHeight + textGap) {
+        violations.push(`${nodeName} overlaps the text area in ${spec.note}`);
+      }
+      if (nodeY + nodeHeight > noteBottom - outerPadding) {
+        violations.push(`${nodeName} lacks bottom padding in ${spec.note}`);
+      }
+    }
+  }
+
+  for (const node of executableNodes) {
+    if (!assignedNodes.has(node.name)) {
+      violations.push(`Executable node is not assigned to a sticky note: ${node.name}`);
+    }
+  }
+
+  for (let index = 0; index < stickyNotes.length; index += 1) {
+    const note = stickyNotes[index];
+    const [noteX, noteY] = note.position;
+    const noteRect = {
+      x: noteX,
+      y: noteY,
+      width: note.parameters.width,
+      height: note.parameters.height,
+    };
+
+    for (const otherNote of stickyNotes.slice(index + 1)) {
+      const [otherX, otherY] = otherNote.position;
+      const otherRect = {
+        x: otherX,
+        y: otherY,
+        width: otherNote.parameters.width,
+        height: otherNote.parameters.height,
+      };
+      if (rectanglesOverlap(noteRect, otherRect)) {
+        violations.push(`Sticky notes overlap: ${note.name} -> ${otherNote.name}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

- Replace the n8n API workflow example with the supplied 16-node `Run IVR call quality checks with CALL-E phone calls in n8n` template, remove exported instance metadata, and keep the workflow inactive by default.
- Show the [CALL-E API Keys page](https://dashboard.heycall-e.com/account/api-keys) and [CALL-E API Reference](https://docs.heycall-e.com/#/api-reference) in the workflow README and both setup sticky-note cards.
- Ship only fictional E.164 phone placeholders, block those placeholders before dialing, require owned or explicitly authorized replacements, and mask phone fields in displayed results.
- Align the workflow README and manifest with the imported node names, inputs, outputs, and safety behavior.

This PR is limited to `plugins/n8n-calle-api`. The separately maintained `plugins/n8n-nodes-calle` community-node package is unchanged.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior (not applicable: this workflow is manual and non-recurring).
- [x] Runnable code has a dry-run, fake-server, or no-call path by default (the workflow is inactive and blocks its API-key and phone placeholders).
- [x] `python3 scripts/validate_repository.py` passes.

## Validation

- `python3 scripts/validate_repository.py`
- Confirmed the workflow is inactive and contains one 10-node executable flow plus six sticky-note cards.
- Confirmed the sanitized workflow matches the supplied n8n export except for the two intentionally updated setup cards and removed export-instance metadata.
- Confirmed both CALL-E links return HTTP 200.
