### PR TITLE
Add consent-first callback window coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`apps/python/batch-runner`](apps/python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`apps/python/broker-login-client`](apps/python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`apps/typescript/broker-login-client`](apps/typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`python/callback-window-coordinator`](python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`python/batch-runner`](python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`python/broker-login-client`](python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`typescript/broker-login-client`](typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |

--- a/apps/python/callback-window-coordinator/README.md
+++ b/apps/python/callback-window-coordinator/README.md
@@ -1,0 +1,95 @@
+# Callback Window Coordinator
+
+This focused Python app uses the CALL-E server SDK to call a person who already requested a callback, disclose that the caller is AI, offer a small set of human-callback windows, and return a schema-validated choice.
+
+The default mode is a masked preview. It does not contact CALL-E or place a call. Live mode requires the request file to record prior callback consent, a separate `--confirm-recipient-opt-in` flag, and a server-side API key.
+
+## Why this workflow
+
+Service teams often receive callback requests without a usable time window. Repeated missed calls waste staff time and frustrate customers. This app converts one explicitly requested coordination call into a compact result containing:
+
+- right-person confirmation;
+- consent to continue after AI disclosure;
+- one confirmed offered window;
+- voicemail permission; and
+- a short evidence summary.
+
+It does not book, cancel, purchase, promise, or modify a service.
+
+## Setup
+
+Python 3.11 or later and `uv` are recommended:
+
+```bash
+cd apps/python/callback-window-coordinator
+uv sync --dev
+```
+
+Copy `example_request.json` and replace its fictional reserved phone number with an E.164 number that you own or are authorized to call. Set a future date and keep the IANA timezone explicit.
+
+## Preview without a call
+
+Preview is the default and does not need credentials:
+
+```bash
+uv run python client.py --request example_request.json
+```
+
+The printed plan masks the phone number. Add `--output new-plan.json` to create a private, mode-`0600` file. Existing files are never overwritten.
+
+## Run one live call
+
+API keys are server credentials. Keep them in a secret manager or environment variable, never in request files or source control.
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+export CALLE_BASE_URL="https://api.heycall-e.com"
+
+uv run python client.py \
+  --request your-authorized-request.json \
+  --execute \
+  --confirm-recipient-opt-in \
+  --output call-result.json
+```
+
+Live mode creates exactly one CALL-E call task and waits for its terminal result. A stable `callwindow-<workflow_id>` idempotency key prevents a retry from creating a second call for the same workflow.
+
+## Input contract
+
+The request JSON must contain:
+
+- `workflow_id`: a stable non-secret workflow identifier;
+- `phone`: one E.164 phone number;
+- `recipient_has_requested_callback`: literal `true`;
+- `business_display_name`: the name disclosed during the call;
+- `callback_purpose`: a short, non-sensitive explanation;
+- `callback_date`: `YYYY-MM-DD`, today or later;
+- `timezone`: an IANA timezone such as `America/New_York`;
+- `locale`: a locale such as `en-US`; and
+- `available_windows`: two to six `{ "id", "label" }` options.
+
+Do not put names, account numbers, health details, legal matters, payment data, credentials, or other sensitive information in this file.
+
+## Side effects and safety
+
+- A live run places a real outbound phone call. Use it only after the intended recipient explicitly requests the callback.
+- The agent announces that it is AI before collecting a choice and ends immediately after a wrong-person response or opt-out.
+- The app creates no recurring schedule and processes one recipient per run.
+- Phone numbers are masked in previews and removed from returned evidence text.
+- The output deliberately excludes transcripts and provider evidence that may contain personal data.
+- This workflow is not for medical, legal, financial, emergency, collections, political, or unsolicited marketing calls.
+
+## Cancellation and rollback
+
+Preview mode has no side effect and needs no rollback. Before live execution, stop by omitting `--execute` or `--confirm-recipient-opt-in`. After the provider accepts a live call task, this app cannot guarantee cancellation; use the CALL-E dashboard or provider controls if they expose a cancel action. The call script always lets the recipient decline or hang up, and the app creates no future jobs to remove.
+
+## Validation
+
+Default tests use an injected fake CALL-E client and never place a phone call:
+
+```bash
+uv run pytest -q
+python3 ../../../scripts/validate_repository.py
+```
+
+For opt-in live verification, use a phone you own or are authorized to call, retain only the redacted result, and do not commit the request or result file.

--- a/apps/python/callback-window-coordinator/client.py
+++ b/apps/python/callback-window-coordinator/client.py
@@ -1,0 +1,350 @@
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+from zoneinfo import available_timezones
+
+
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+E164_PATTERN = re.compile(r"^\+[1-9]\d{7,14}$")
+SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{2,63}$")
+WINDOW_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{1,31}$")
+PHONE_LIKE_PATTERN = re.compile(r"(?<!\w)\+?[1-9]\d{7,14}(?!\w)")
+
+
+@dataclass(frozen=True)
+class CallbackWindow:
+    id: str
+    label: str
+
+
+@dataclass(frozen=True)
+class CallbackRequest:
+    workflow_id: str
+    phone: str
+    recipient_has_requested_callback: bool
+    business_display_name: str
+    callback_purpose: str
+    callback_date: str
+    timezone: str
+    locale: str
+    windows: tuple[CallbackWindow, ...]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preview or run one consent-first callback-window call with CALL-E."
+    )
+    parser.add_argument(
+        "--request", required=True, type=Path, help="Path to the request JSON file."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional new JSON result path; existing files are never overwritten.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--preview",
+        action="store_true",
+        help="Validate and print a masked no-call plan. This is the default.",
+    )
+    mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Create exactly one CALL-E call task and wait for its result.",
+    )
+    parser.add_argument(
+        "--confirm-recipient-opt-in",
+        action="store_true",
+        help="Required with --execute; confirms the recipient requested this callback.",
+    )
+    parser.add_argument(
+        "--base-url", default=os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL)
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    return parser.parse_args(argv)
+
+
+def clean_text(value: Any, field: str, *, minimum: int, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = " ".join(value.split())
+    if len(cleaned) < minimum or len(cleaned) > maximum:
+        raise ValueError(f"{field} must contain {minimum}-{maximum} characters")
+    return cleaned
+
+
+def parse_request(raw: Any) -> CallbackRequest:
+    if not isinstance(raw, dict):
+        raise ValueError("request must be a JSON object")
+
+    workflow_id = clean_text(
+        raw.get("workflow_id"), "workflow_id", minimum=3, maximum=64
+    )
+    if not SAFE_ID_PATTERN.fullmatch(workflow_id):
+        raise ValueError(
+            "workflow_id may contain only letters, numbers, dot, underscore, and hyphen"
+        )
+
+    phone = clean_text(raw.get("phone"), "phone", minimum=8, maximum=16)
+    if not E164_PATTERN.fullmatch(phone):
+        raise ValueError("phone must use E.164 format, for example +12025550123")
+
+    opt_in = raw.get("recipient_has_requested_callback")
+    if opt_in is not True:
+        raise ValueError("recipient_has_requested_callback must be true")
+
+    callback_date = clean_text(
+        raw.get("callback_date"), "callback_date", minimum=10, maximum=10
+    )
+    try:
+        parsed_date = date.fromisoformat(callback_date)
+    except ValueError as exc:
+        raise ValueError("callback_date must use YYYY-MM-DD") from exc
+    if parsed_date < date.today():
+        raise ValueError("callback_date must not be in the past")
+
+    timezone_name = clean_text(raw.get("timezone"), "timezone", minimum=3, maximum=64)
+    if timezone_name not in available_timezones() or (
+        "/" not in timezone_name and timezone_name != "UTC"
+    ):
+        raise ValueError("timezone must be a valid IANA timezone name")
+
+    locale = clean_text(raw.get("locale", "en-US"), "locale", minimum=2, maximum=16)
+    if not re.fullmatch(r"[a-z]{2,3}(?:-[A-Z]{2})?", locale):
+        raise ValueError("locale must look like en-US or ko-KR")
+
+    raw_windows = raw.get("available_windows")
+    if not isinstance(raw_windows, list) or not 2 <= len(raw_windows) <= 6:
+        raise ValueError("available_windows must contain 2-6 window objects")
+
+    windows: list[CallbackWindow] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(raw_windows):
+        if not isinstance(item, dict):
+            raise ValueError(f"available_windows[{index}] must be an object")
+        window_id = clean_text(
+            item.get("id"), f"available_windows[{index}].id", minimum=2, maximum=32
+        )
+        if not WINDOW_ID_PATTERN.fullmatch(window_id):
+            raise ValueError(
+                f"available_windows[{index}].id must be lower-case kebab-case"
+            )
+        if window_id in seen_ids or window_id in {"decline", "unknown"}:
+            raise ValueError(
+                f"available_windows[{index}].id must be unique and not reserved"
+            )
+        seen_ids.add(window_id)
+        label = clean_text(
+            item.get("label"),
+            f"available_windows[{index}].label",
+            minimum=3,
+            maximum=80,
+        )
+        windows.append(CallbackWindow(id=window_id, label=label))
+
+    return CallbackRequest(
+        workflow_id=workflow_id,
+        phone=phone,
+        recipient_has_requested_callback=True,
+        business_display_name=clean_text(
+            raw.get("business_display_name"),
+            "business_display_name",
+            minimum=2,
+            maximum=80,
+        ),
+        callback_purpose=clean_text(
+            raw.get("callback_purpose"), "callback_purpose", minimum=10, maximum=180
+        ),
+        callback_date=callback_date,
+        timezone=timezone_name,
+        locale=locale,
+        windows=tuple(windows),
+    )
+
+
+def load_request(path: Path) -> CallbackRequest:
+    with path.expanduser().open(encoding="utf-8") as handle:
+        return parse_request(json.load(handle))
+
+
+def mask_phone(phone: str) -> str:
+    return f"{phone[:3]}{'*' * max(4, len(phone) - 6)}{phone[-3:]}"
+
+
+def build_task(request: CallbackRequest) -> str:
+    choices = "; ".join(f"{window.id}: {window.label}" for window in request.windows)
+    return (
+        f"Place one callback-window coordination call on behalf of {request.business_display_name}. "
+        "At the start, identify yourself as an AI calling assistant and say the recipient previously requested this callback. "
+        "Ask whether this is the intended recipient and whether they want to continue. If either answer is no, apologize, "
+        "do not ask anything else, record the opt-out, and end the call. Do not request sensitive personal, medical, legal, "
+        "or financial information. Do not book, cancel, purchase, promise, or modify any service. "
+        f"The callback purpose is: {request.callback_purpose}. The date is {request.callback_date} in {request.timezone}. "
+        f"Offer only these callback windows: {choices}. Ask which window they prefer and whether a voicemail is acceptable "
+        "if the future human callback is missed. Repeat the selected window once for confirmation, then end politely."
+    )
+
+
+def build_result_schema(request: CallbackRequest) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": [
+            "right_person",
+            "continued_after_ai_disclosure",
+            "preferred_window_id",
+            "voicemail_allowed",
+            "evidence_summary",
+        ],
+        "properties": {
+            "right_person": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+                "description": "Whether the recipient confirmed they are the intended callback recipient.",
+            },
+            "continued_after_ai_disclosure": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+                "description": "Whether the recipient agreed to continue after the AI identity and callback context were disclosed.",
+            },
+            "preferred_window_id": {
+                "type": "string",
+                "enum": [
+                    *[window.id for window in request.windows],
+                    "decline",
+                    "unknown",
+                ],
+                "description": "The confirmed offered window id, decline if no callback is wanted, or unknown when unclear.",
+            },
+            "voicemail_allowed": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+                "description": "Whether the recipient permits a voicemail if the future human callback is missed.",
+            },
+            "evidence_summary": {
+                "type": "string",
+                "description": "One short paraphrase supporting the extracted choices; omit phone numbers and sensitive information.",
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def idempotency_key(request: CallbackRequest) -> str:
+    return f"callwindow-{request.workflow_id}"
+
+
+def build_call_arguments(request: CallbackRequest) -> dict[str, Any]:
+    return {
+        "task": build_task(request),
+        "recipients": [{"phones": [request.phone], "locale": request.locale}],
+        "result_schema": build_result_schema(request),
+        "metadata": {
+            "workflow_id": request.workflow_id,
+            "workflow_type": "callback_window_coordination",
+        },
+        "idempotency_key": idempotency_key(request),
+    }
+
+
+def preview(request: CallbackRequest) -> dict[str, Any]:
+    arguments = build_call_arguments(request)
+    arguments["recipients"] = [
+        {"phones": [mask_phone(request.phone)], "locale": request.locale}
+    ]
+    return {
+        "mode": "preview",
+        "creates_phone_call": False,
+        "workflow_id": request.workflow_id,
+        "recipient_opt_in_recorded": request.recipient_has_requested_callback,
+        "call_arguments": arguments,
+    }
+
+
+def redact_phone_like_text(value: Any) -> Any:
+    if isinstance(value, str):
+        return PHONE_LIKE_PATTERN.sub("[phone-redacted]", value)
+    if isinstance(value, list):
+        return [redact_phone_like_text(item) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_phone_like_text(item) for key, item in value.items()}
+    return value
+
+
+def execute(
+    request: CallbackRequest, client: Any, *, timeout_seconds: int
+) -> dict[str, Any]:
+    arguments = build_call_arguments(request)
+    created = client.calls.create(**arguments)
+    call_id = created.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        raise RuntimeError("CALL-E create response did not contain a call id")
+    completed = client.calls.wait_for_result(
+        call_id, timeout_seconds=timeout_seconds, interval_seconds=2
+    )
+    return {
+        "mode": "execute",
+        "creates_phone_call": True,
+        "workflow_id": request.workflow_id,
+        "idempotency_key": idempotency_key(request),
+        "call_id": call_id,
+        "status": completed.get("status"),
+        "task_completed": completed.get("task_completed"),
+        "completion_confidence": completed.get("completion_confidence"),
+        "structured_result": redact_phone_like_text(completed.get("structured_result")),
+    }
+
+
+def write_output(path: Path | None, payload: dict[str, Any]) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if path is None:
+        sys.stdout.write(rendered)
+        return
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("x", encoding="utf-8") as handle:
+        handle.write(rendered)
+    destination.chmod(0o600)
+    sys.stdout.write(f"Wrote {destination}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        request = load_request(args.request)
+        if not args.execute:
+            write_output(args.output, preview(request))
+            return 0
+        if not args.confirm_recipient_opt_in:
+            raise ValueError("--execute requires --confirm-recipient-opt-in")
+        if args.timeout_seconds <= 0:
+            raise ValueError("--timeout-seconds must be positive")
+        api_key = os.environ.get("CALLE_API_KEY")
+        if not api_key:
+            raise ValueError("CALLE_API_KEY is required for --execute")
+        from calle import CalleClient
+
+        client = CalleClient(api_key=api_key, base_url=args.base_url)
+        write_output(
+            args.output, execute(request, client, timeout_seconds=args.timeout_seconds)
+        )
+        return 0
+    except (
+        FileExistsError,
+        OSError,
+        ValueError,
+        RuntimeError,
+        json.JSONDecodeError,
+    ) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/callback-window-coordinator/example_request.json
+++ b/apps/python/callback-window-coordinator/example_request.json
@@ -1,0 +1,20 @@
+{
+  "workflow_id": "support-demo-2026-001",
+  "phone": "+12025550123",
+  "recipient_has_requested_callback": true,
+  "business_display_name": "Example Service Desk",
+  "callback_purpose": "Choose a convenient time for a requested support callback",
+  "callback_date": "2026-09-01",
+  "timezone": "America/New_York",
+  "locale": "en-US",
+  "available_windows": [
+    {
+      "id": "morning",
+      "label": "09:00-11:00"
+    },
+    {
+      "id": "afternoon",
+      "label": "14:00-16:00"
+    }
+  ]
+}

--- a/apps/python/callback-window-coordinator/pyproject.toml
+++ b/apps/python/callback-window-coordinator/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "calle-callback-window-coordinator-app"
+version = "0.1.0"
+description = "Consent-first callback-window coordination with the CALL-E Python SDK."
+requires-python = ">=3.11"
+dependencies = [
+  "calle-ai==0.2.0",
+]
+
+[dependency-groups]
+dev = [
+  "pytest>=9.0.0",
+]

--- a/apps/python/callback-window-coordinator/test_client.py
+++ b/apps/python/callback-window-coordinator/test_client.py
@@ -1,0 +1,148 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+
+APP_ROOT = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "callback_window_client", APP_ROOT / "client.py"
+)
+assert SPEC and SPEC.loader
+client_module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = client_module
+SPEC.loader.exec_module(client_module)
+
+
+def valid_payload() -> dict:
+    return {
+        "workflow_id": "demo-2026-001",
+        "phone": "+12025550123",
+        "recipient_has_requested_callback": True,
+        "business_display_name": "Example Service Desk",
+        "callback_purpose": "Choose a convenient time for a requested support callback",
+        "callback_date": (date.today() + timedelta(days=2)).isoformat(),
+        "timezone": "America/New_York",
+        "locale": "en-US",
+        "available_windows": [
+            {"id": "morning", "label": "09:00-11:00"},
+            {"id": "afternoon", "label": "14:00-16:00"},
+        ],
+    }
+
+
+def test_preview_masks_phone_and_never_requires_api_key(tmp_path):
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(valid_payload()), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "client.py", "--request", str(request_path)],
+        cwd=APP_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "+12025550123" not in result.stdout
+    assert "+12******123" in result.stdout
+    parsed = json.loads(result.stdout)
+    assert parsed["mode"] == "preview"
+    assert parsed["creates_phone_call"] is False
+
+
+def test_execute_requires_separate_opt_in_confirmation(tmp_path):
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(valid_payload()), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "client.py", "--request", str(request_path), "--execute"],
+        cwd=APP_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "--confirm-recipient-opt-in" in result.stderr
+
+
+def test_request_rejects_missing_consent_and_bad_timezone():
+    payload = valid_payload()
+    payload["recipient_has_requested_callback"] = False
+    try:
+        client_module.parse_request(payload)
+    except ValueError as exc:
+        assert "must be true" in str(exc)
+    else:
+        raise AssertionError("missing opt-in was accepted")
+
+    payload = valid_payload()
+    payload["timezone"] = "EST"
+    try:
+        client_module.parse_request(payload)
+    except ValueError as exc:
+        assert "IANA timezone" in str(exc)
+    else:
+        raise AssertionError("timezone abbreviation was accepted")
+
+
+class FakeCalls:
+    def __init__(self):
+        self.created = None
+
+    def create(self, **kwargs):
+        self.created = kwargs
+        return {"id": "call_demo_123"}
+
+    def wait_for_result(self, call_id, **kwargs):
+        assert call_id == "call_demo_123"
+        assert kwargs == {"timeout_seconds": 30, "interval_seconds": 2}
+        return {
+            "status": "completed",
+            "task_completed": True,
+            "completion_confidence": {"score": 0.91, "label": "high"},
+            "structured_result": {
+                "right_person": "yes",
+                "continued_after_ai_disclosure": "yes",
+                "preferred_window_id": "morning",
+                "voicemail_allowed": "no",
+                "evidence_summary": "Confirmed +12025550123 and selected morning.",
+            },
+        }
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = FakeCalls()
+
+
+def test_execute_uses_stable_idempotency_and_redacts_result_phone():
+    request = client_module.parse_request(valid_payload())
+    fake = FakeClient()
+    result = client_module.execute(request, fake, timeout_seconds=30)
+    assert fake.calls.created["idempotency_key"] == "callwindow-demo-2026-001"
+    assert fake.calls.created["recipients"] == [
+        {"phones": ["+12025550123"], "locale": "en-US"}
+    ]
+    assert (
+        result["structured_result"]["evidence_summary"]
+        == "Confirmed [phone-redacted] and selected morning."
+    )
+    schema = fake.calls.created["result_schema"]
+    assert schema["properties"]["preferred_window_id"]["enum"] == [
+        "morning",
+        "afternoon",
+        "decline",
+        "unknown",
+    ]
+
+
+def test_output_refuses_overwrite(tmp_path):
+    path = tmp_path / "result.json"
+    path.write_text("keep me", encoding="utf-8")
+    try:
+        client_module.write_output(path, {"ok": True})
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError("existing output was overwritten")
+    assert path.read_text(encoding="utf-8") == "keep me"

--- a/apps/python/callback-window-coordinator/uv.lock
+++ b/apps/python/callback-window-coordinator/uv.lock
@@ -1,0 +1,172 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "calle-ai"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/5a/e6f2ca0b377c50c2b01b7b1805473045123c11f51108b5feabc44b1bb57c/calle_ai-0.2.0.tar.gz", hash = "sha256:4bd4260f6915f81de6504f6aa34048a5c9f645bf9b69744878d8cf90bcff7ca9", size = 76310, upload-time = "2026-06-11T07:39:23.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/8e/23ce0e54fc7d97915b792b6a34fc9835a90ca2a5416a8531417605a0025b/calle_ai-0.2.0-py3-none-any.whl", hash = "sha256:e67010516047156d2470817039441723a3d1df6f90947dddfcd34eab297c0436", size = 36546, upload-time = "2026-06-11T07:39:22.919Z" },
+]
+
+[[package]]
+name = "calle-callback-window-coordinator-app"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "calle-ai" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "calle-ai", specifier = "==0.2.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.0" }]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## What changed

- add a focused Python callback-window coordination app using the public CALL-E server SDK;
- make masked, credential-free preview mode the default;
- require both a recorded recipient callback request and a separate live-execution confirmation;
- return a strict structured result for right-person check, AI-disclosure consent, selected window, and voicemail permission;
- add stable idempotency, phone-like text redaction, no-overwrite private outputs, tests, and operator documentation; and
- list the app in both app indexes.

## Why

Service teams often receive an explicit callback request without a usable time window. The app turns one authorized coordination call into a small, inspectable result without booking, purchasing, changing a service, or collecting sensitive information.

## Safety and operator impact

Preview mode never calls CALL-E. Live mode is one recipient and one call task per stable workflow id. The call discloses that it is AI, checks the intended recipient and ongoing consent, ends on wrong-person or opt-out responses, creates no recurring schedule, masks preview numbers, and omits transcripts from returned output.

## Validation

- `python3 scripts/validate_repository.py`
- `ruff check apps/python/callback-window-coordinator/client.py apps/python/callback-window-coordinator/test_client.py`
- `ruff format --check apps/python/callback-window-coordinator/client.py apps/python/callback-window-coordinator/test_client.py`
- `pytest -q apps/python/callback-window-coordinator` (5 passed)
- masked preview JSON parse check

Default tests use an injected fake client and place no real phone call. Live verification remains explicitly opt-in with an authorized E.164 recipient and a server-side API key.
