### PR TITLE
feat: add crisis-lifeline-bridge skill (verify-before-refer crisis routing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
 - [`google-form-callback`](skills/google-form-callback/) - Google Form response workflow for safe one-off callback calls with dry-runs, scheduling plans, and Sheets writeback. See the [workflow guide](docs/google-form-callback/).
 - [`outbound-call-skill-creator`](skills/outbound-call-skill-creator/) - Creator skill for generating focused outbound phone-call workflow skills from Google Forms, TikTok Ads, Notion, Airtable, local CSV files, or custom sources.
+- [`crisis-lifeline-bridge`](skills/crisis-lifeline-bridge/) - Verify-before-refer safety skill: find a real local crisis service and use CALL-E to phone-verify it is real and in service before referring a person in crisis, with a dry-run no-call default.
 
 ### Apps
 

--- a/skills/crisis-lifeline-bridge/SKILL.md
+++ b/skills/crisis-lifeline-bridge/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: crisis-lifeline-bridge
+description: When a person shows acute-crisis signals (housing loss, food insecurity, fraud victimization, domestic violence, deportation fear, medical emergency, self-harm, or severe isolation), find a REAL local human service for their situation and use CALL-E to phone-verify that service is real and in-service BEFORE referring the person to it. Verify-before-refer safety so an agent never hands a vulnerable person a fake, dead, or wrong number.
+license: MIT
+---
+
+# Crisis Lifeline Bridge
+
+Use this skill when an AI agent detects that a person it is talking to is in **acute crisis** and would be better served by a **real human service** than by more conversation. It turns "here's a number, good luck" into "I called them, they're real, they're open, here's who to ask for."
+
+`crisis-lifeline-bridge` is a **verify-before-refer** wrapper. It does not diagnose, triage medical emergencies, or replace emergency services. It finds a candidate local agency for the person's specific need and location, then uses the existing CALL-E one-off call workflow to place **one verification call** to that agency to confirm the line is real, in service, and can actually help — before the agent gives the number to the person.
+
+## The Problem It Solves
+People in crisis get handed generic hotline numbers constantly. Most never call. And when an agent surfaces a number from a web search, that number is often **out of date, disconnected, wrong department, or a national line that can't help locally**. A dead or wrong number given to someone in crisis is worse than none — it burns the one moment they were ready to reach out. This skill closes that gap: **no resource is given to the person until a real call has confirmed it is real and reachable.**
+
+## When To Use
+- An agent has classified a person's messages as acute crisis (severity high) with a concrete need: emergency shelter, food, domestic-violence safety, immigration legal aid, mental-health/self-harm support, utility/eviction help, fraud/exploitation recovery.
+- The agent already has (or can research) a candidate **local** agency + phone number for that need.
+- The operator wants the referral **phone-verified** before it is handed to the person.
+
+## When Not To Use
+- **Imminent danger to life.** If someone is in immediate physical danger or actively attempting self-harm, do NOT run a verification workflow. Direct them to emergency services (e.g. 911 in the US) and the national crisis line (e.g. 988 in the US) immediately. This skill is for *routing to ongoing human services*, not for handling a live emergency.
+- To place a call **to the person in crisis** without their explicit consent and their own number.
+- To guess a phone number, country code, region, or language. Never infer these.
+- To diagnose, counsel, or make medical/legal/financial decisions on the person's behalf.
+- To create recurring calls or a monitoring daemon.
+
+## Core Workflow
+```text
+detect crisis  ->  research local agency  ->  VERIFY by phone (CALL-E)  ->  refer only if verified
+```
+1. **Confirm severity + need.** The host agent classifies the person's situation (see `references/crisis-classification.md`): severity 1-5 and a marker type (housing / food / dv / deportation / medical / self_harm / fraud / isolation). This skill engages at severity >= 4 with a concrete, addressable need.
+2. **Determine location + need.** Infer the person's region/city ONLY from what they or their public profile actually state. Never guess from locale, IP, or phone. If location is unknown, ask, or fall back to a verified national line for the stated country.
+3. **Research a candidate agency.** Use `scripts/find-local-agency.mjs` (or the host's own research tool) to find a real local service for the need + place. Capture name, phone (E.164 when possible), hours, URL, source.
+4. **Verify by phone with CALL-E.** Use `scripts/verify-agency-call.mjs`. It plans a call whose goal is to *confirm the line is real and in service, ask intake hours and current capacity* — the caller represents nobody, it is confirming service details; it runs the call **only** when a real `to_phone` is present (planning alone never calls); then fetches the structured result.
+5. **Refer only if verified.** If the call confirms a real, reachable service, the agent gives the person that number with specifics ("ask for intake, they're open until 8pm, they had space today"). If verification fails (disconnected / wrong / no capacity), the agent does NOT hand out that number — it researches another, or falls back to the best verified national line, and is honest that it could not confirm a local option.
+
+## Honesty Rail (non-negotiable)
+The agent may only tell a person a resource is real if a call verified it **this run**, or it is a well-known standing national line for their country. **Never invent, embellish, or assume** a hotline, address, or capacity. An unverifiable local option becomes: "I couldn't confirm a local service right now, but this national line is real: <line>. I'm here while you call."
+
+## Dry-Run Default (no real calls to try it)
+Everything runs with **no real phone call** by default:
+- `find-local-agency.mjs` ships with bundled sample agencies and only hits a live research endpoint when `RESEARCH_URL` (+ optional `RESEARCH_TOKEN`) are set.
+- `verify-agency-call.mjs` runs in dry-run mode by default: it produces the exact `plan_call` goal and a simulated verified result **without invoking CALL-E**. Add `--live` (and a real, consented, non-sample E.164 number) to place an actual verification call.
+- All sample numbers are fictional reserved samples (`+1 555 01xx`).
+
+## CALL-E Integration
+Host + provider: any Agent-Skills-compatible host (Claude Code, Codex, skills.sh, Cowork-style agents) with the CALL-E CLI/MCP available. See `references/calle-cli-bootstrap.md` for resolving the `calle` command and the `plan_call` -> `run_call` -> `get_call_run` flow, and `references/safety.md` for the full safety contract.
+
+## Side Effects
+This skill can cause a **real outbound phone call** to a service agency (only in `--live` mode with a real number). It never calls the person in crisis. It creates no recurring jobs and no schedules. There is nothing to cancel in dry-run; a live verification call is a single one-off call.

--- a/skills/crisis-lifeline-bridge/references/calle-cli-bootstrap.md
+++ b/skills/crisis-lifeline-bridge/references/calle-cli-bootstrap.md
@@ -1,0 +1,59 @@
+# CALL-E CLI Bootstrap
+
+How to resolve and use the `calle` CLI for the verification call. This skill uses the existing CALL-E one-off call workflow — it does not add any CALL-E backend API or new MCP tools.
+
+## Install (once, per host)
+```bash
+npx -y skills add https://github.com/CALLE-AI/call-e-integrations --skill calle -g
+npm install -g @call-e/cli   # if the calle CLI is not already available
+```
+
+## Required attribution env
+Set these for every invocation:
+```bash
+export CALLE_SOURCE=skills_sh
+export CALLE_INTEGRATION=skills_sh_skill
+export CALLE_INTEGRATION_VERSION=0.1.0
+```
+
+## Auth
+```bash
+calle auth login --start-only --no-browser-open   # prints an authorization URL
+# user completes browser authorization, then:
+calle auth login --no-browser-open                 # finishes the pending login
+calle auth status                                  # { usable: true }
+```
+The token is cached locally (e.g. `~/.calle-mcp/cli/<hash>/token.json`). Never print or embed it.
+
+## The three tools
+```bash
+calle mcp tools     # must include: plan_call, run_call, get_call_run
+```
+
+## Verification-call flow
+The canonical pattern passes the operator's request verbatim through `user_input`, then supplies the agency phone number, then runs:
+```bash
+# 1) PLAN - pass the goal via user_input; do NOT guess the number.
+calle mcp call --args-json '{
+  "user_input":"Verify this homeless-services intake line is real and in service. Ask intake hours and whether beds are available tonight. You are confirming service details only and represent no one."
+}' plan_call --json
+# -> returns { plan_id, ready_to_run:false, questions:[{key:"to_phones",...}], display_goal, ... }
+
+# 2) When (and only when) a real, consented, non-sample number is available, provide it:
+calle call plan --plan-id <plan_id> --to-phone "+1XXXXXXXXXX" --region US --language en \
+  --timezone America/New_York --json
+# -> ready_to_run:true
+
+# 3) RUN the planned call, then fetch status:
+calle call run --plan-id <plan_id> --json         # places ONE outbound call
+calle call status --plan-id <plan_id> --json       # get_call_run: structured result
+```
+
+### Response shape (verified live)
+`plan_call` returns `plan_id`, `ready_to_run`, `display_goal` (the planner expands a terse goal into a full call script with voicemail / disconnected / suspicious-line fallbacks), `questions[]`, `confirm_summary`, and `expires_at`. `ready_to_run` stays `false` until a real `to_phone` is supplied — so **planning alone never places a call**. This skill uses that as its dry-run gate.
+
+### Timeouts
+`tools/call` can be slow to warm on a cold server. Use `--poll-timeout-seconds 120` for plan/run.
+
+## Provider separation
+CALL-E places the call. Any recurrence or scheduling belongs to the host — this skill does neither; it performs exactly one verification call per run in `--live` mode.

--- a/skills/crisis-lifeline-bridge/references/crisis-classification.md
+++ b/skills/crisis-lifeline-bridge/references/crisis-classification.md
@@ -1,0 +1,43 @@
+# Crisis Classification
+
+How the host agent should classify a person's situation before engaging this skill. This is guidance for the calling agent — the skill itself trusts the severity + need the host passes in.
+
+## Severity 1-5
+
+| Severity | Meaning | Action |
+| --- | --- | --- |
+| 1 | Venting / mild stress | Normal supportive reply. Do not engage this skill. |
+| 2 | Ongoing difficulty, coping | Supportive reply, optional gentle resource mention. |
+| 3 | Significant distress, some risk | Supportive reply + offer to find real help. |
+| 4 | Acute crisis, concrete unmet need | **Engage this skill**: research + verify + refer. |
+| 5 | Imminent danger / active self-harm | **Do NOT run verification.** Direct to emergency + national crisis line NOW. |
+
+Severity 5 is an emergency boundary, not a routing case. See `safety-crisis-boundaries.md`.
+
+## Need markers
+Classify the concrete need so research targets the right service:
+
+- `housing` — homelessness, eviction, unsafe housing -> shelters, housing intake, 211.
+- `food` — food insecurity, hunger -> food banks, pantries, meal programs.
+- `dv` — domestic violence, abuse, unsafe partner/home -> DV hotlines, safe shelters, advocates.
+- `deportation` — immigration fear, detention, status -> immigration legal aid, know-your-rights orgs.
+- `medical` — untreated illness, no access to care -> community clinics, medical assistance (non-emergency).
+- `self_harm` — suicidal ideation, self-harm -> national crisis/suicide line first; warmlines.
+- `fraud` — financial exploitation, scam victimization -> consumer protection, legal aid, adult protective services.
+- `isolation` — severe loneliness, no support system -> warmlines, community/peer support.
+
+A person may present several. Address the most acute, addressable need first.
+
+## Inferring location
+Use ONLY location the person or their public profile actually states. If unknown, ask, or fall back to the national line for the stated country. Never infer from locale, IP, timezone, or phone number.
+
+## Output the skill expects
+```json
+{
+  "severity": 4,
+  "need": "housing",
+  "location": { "country": "US", "region": "CO", "city": "Denver" },
+  "person_consented_to_call": false
+}
+```
+`severity >= 4` + a concrete `need` + a resolvable `location` (or a country fallback) is the trigger to research, verify, and refer.

--- a/skills/crisis-lifeline-bridge/references/examples.md
+++ b/skills/crisis-lifeline-bridge/references/examples.md
@@ -1,0 +1,85 @@
+# Examples
+
+All examples run in **dry-run** by default and place **no real call**. Sample numbers are fictional
+reserved samples (`+1 555 01xx`) and are never dialed.
+
+## 1. Find a candidate local agency (dry-run)
+
+```bash
+node scripts/find-local-agency.mjs --need housing --country US --region CO --city Denver
+```
+
+Returns a sample candidate plus the correct real national fallback (211 for housing):
+
+```json
+{
+  "ok": true,
+  "mode": "dry-run",
+  "query": "emergency homeless shelter intake Denver, CO, US",
+  "candidates": [
+    { "name": "Sample City Shelter Intake", "phone_e164": "+15550101",
+      "hours": "Mon-Sun 8:00-20:00", "url": "https://example.org/shelter", "source": "sample-dataset" }
+  ],
+  "national_fallback": { "name": "211 (United Way)", "phone_e164": "+1211", "hours": "24/7",
+      "url": "https://www.211.org", "national": true }
+}
+```
+
+## 2. Verify an agency by phone (dry-run — no call placed)
+
+```bash
+node scripts/verify-agency-call.mjs --need housing \
+  --agency "Denver Rescue Mission Intake" --to-phone "+15550101"
+```
+
+Produces the exact call goal and a simulated verified result, with the number masked:
+
+```json
+{
+  "ok": true,
+  "mode": "dry-run",
+  "would_call": "+15••••01",
+  "plan_goal": "Verify that Denver Rescue Mission Intake is a real, currently in-service ...",
+  "simulated_result": { "verified": true, "recommend_refer": true, "phone_masked": "+15••••01" }
+}
+```
+
+## 3. Safety guard: live mode refuses sample numbers
+
+```bash
+node scripts/verify-agency-call.mjs --live --need housing --agency "X" --to-phone "+15550101"
+```
+
+```json
+{ "ok": false, "error": "refusing to place a live call to a fictional sample number (+1 555 01xx)" }
+```
+
+## 4. Live verification (places ONE real outbound call to the agency)
+
+Only with the `calle` CLI installed + authenticated (`calle auth status` -> usable) and a **real,
+consented, non-sample** E.164 number:
+
+```bash
+export CALLE_SOURCE=skills_sh CALLE_INTEGRATION=skills_sh_skill CALLE_INTEGRATION_VERSION=0.1.0
+node scripts/verify-agency-call.mjs --live --need housing \
+  --agency "Denver Rescue Mission Intake" --to-phone "+1XXXXXXXXXX" \
+  --region US --language en --timezone America/New_York
+```
+
+Flow: `plan_call` (goal via `user_input`) -> supply `to_phone` -> `run_call` -> `get_call_run`.
+The call confirms the line is real/in service, asks intake hours and capacity, and returns a
+structured result. Refer the person **only** if the line is confirmed real and able to help;
+otherwise research another candidate or fall back to a verified national line.
+
+## 5. Live research for a real local agency (opt-in)
+
+Set a research endpoint that accepts `{ q, n }` and returns `{ ok, results:[...] }`:
+
+```bash
+export RESEARCH_URL="https://your-research-endpoint/news"
+export RESEARCH_TOKEN="..."   # optional bearer
+node scripts/find-local-agency.mjs --need dv --country US --region NY --city Buffalo --live
+```
+
+The host agent is responsible for confirming a result is a real service and extracting a phone
+number before any verification call.

--- a/skills/crisis-lifeline-bridge/references/safety.md
+++ b/skills/crisis-lifeline-bridge/references/safety.md
@@ -1,0 +1,34 @@
+# Safety & Crisis Boundaries
+
+This skill operates in a high-stakes context. These rules are mandatory.
+
+## 1. This is routing, not rescue
+`crisis-lifeline-bridge` connects a person to **ongoing human services** (shelters, food banks, DV advocates, legal aid, warmlines). It does **not** handle a live emergency, provide medical/legal/financial advice, counsel or diagnose, or act as the crisis line itself. If there is **imminent danger or active self-harm**, stop this workflow and direct the person to emergency services and the national crisis line for their country immediately (e.g. US: 911 and 988). Verification calls are never a substitute for an emergency.
+
+## 2. Verify before refer
+No local resource is given to the person until a call has confirmed it is real and reachable **this run**. A dead, wrong, or disconnected number handed to someone in crisis is worse than none. If verification fails, the agent must not present that number — it researches another candidate, or falls back to a known standing national line, and is honest that a local option could not be confirmed.
+
+## 3. Consent & the person's own number
+- The verification call is placed to a **service agency**, never to the person in crisis.
+- To ever call the person, the agent needs the person's **explicit consent and their own number**, provided by them. Never infer, store, or reuse it.
+- The caller on a verification call represents **nobody** — it confirms public service details (is this line real, intake hours, capacity). It never shares or implies the identity, location, or situation of the person in crisis.
+
+## 4. No guessing
+Never infer phone number, country code, region, timezone, or language from locale, IP, UTC offset, message text, or unrelated context. If a required field is missing, ask or fall back to a verified national resource. Pass the user's own words to CALL-E `plan_call` via `user_input` and let missing fields surface as plan questions.
+
+## 5. Phone numbers
+- E.164 format for any real call (`+<country><number>`).
+- All samples in this repo are fictional reserved samples (`+1 555 01xx`) and never dialed.
+- Mask numbers in any summary or log.
+
+## 6. Side effects & recurrence
+- A `--live` verification is a single one-off outbound call. There is no recurring job.
+- Dry-run (default) places no call at all, so there is nothing to cancel.
+- This skill never creates a schedule, daemon, or background worker.
+
+## 7. Credentials
+- CALL-E auth is handled by the local `calle` CLI token cache. Never print, log, or embed tokens.
+- Research endpoint credentials (`RESEARCH_TOKEN`) come from the environment. Never hardcode them.
+
+## 8. Data minimization
+Log only what is needed to operate: the need type, the (masked) agency number, the verification result. Do not persist the crisis person's message content, identity, or location beyond the run.

--- a/skills/crisis-lifeline-bridge/scripts/find-local-agency.mjs
+++ b/skills/crisis-lifeline-bridge/scripts/find-local-agency.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const args = parseArgs(process.argv.slice(2));
+const need = (args.need || "housing").toLowerCase();
+const country = (args.country || "US").toUpperCase();
+const region = args.region || "";
+const city = args.city || "";
+const live = Boolean(args.live);
+const NATIONAL = {
+  US: {
+    self_harm: { name: "988 Suicide & Crisis Lifeline", phone_e164: "+1988", hours: "24/7", url: "https://988lifeline.org", national: true },
+    dv: { name: "National Domestic Violence Hotline", phone_e164: "+18007997233", hours: "24/7", url: "https://www.thehotline.org", national: true },
+    housing: { name: "211 (United Way)", phone_e164: "+1211", hours: "24/7", url: "https://www.211.org", national: true },
+    food: { name: "211 (United Way)", phone_e164: "+1211", hours: "24/7", url: "https://www.211.org", national: true },
+    isolation: { name: "988 Suicide & Crisis Lifeline", phone_e164: "+1988", hours: "24/7", url: "https://988lifeline.org", national: true }
+  }
+};
+const SAMPLES = {
+  housing: [{ name: "Sample City Shelter Intake", phone_e164: "+15550101", hours: "Mon-Sun 8:00-20:00", url: "https://example.org/shelter", source: "sample-dataset" }],
+  food: [{ name: "Sample Community Food Bank", phone_e164: "+15550102", hours: "Mon-Fri 9:00-17:00", url: "https://example.org/food", source: "sample-dataset" }],
+  dv: [{ name: "Sample DV Advocacy & Safe Shelter", phone_e164: "+15550103", hours: "24/7", url: "https://example.org/dv", source: "sample-dataset" }],
+  deportation: [{ name: "Sample Immigrant Legal Aid Clinic", phone_e164: "+15550104", hours: "Mon-Fri 9:00-16:00", url: "https://example.org/legal", source: "sample-dataset" }],
+  medical: [{ name: "Sample Community Health Clinic", phone_e164: "+15550105", hours: "Mon-Sat 8:00-18:00", url: "https://example.org/clinic", source: "sample-dataset" }],
+  fraud: [{ name: "Sample Consumer Protection / APS", phone_e164: "+15550106", hours: "Mon-Fri 8:30-17:00", url: "https://example.org/protect", source: "sample-dataset" }],
+  self_harm: [{ name: "Sample Local Warmline", phone_e164: "+15550107", hours: "Daily 12:00-24:00", url: "https://example.org/warmline", source: "sample-dataset" }],
+  isolation: [{ name: "Sample Peer Support Warmline", phone_e164: "+15550108", hours: "Daily 16:00-24:00", url: "https://example.org/peer", source: "sample-dataset" }]
+};
+const place = [city, region, country].filter(Boolean).join(", ");
+const query = buildQuery(need, place);
+async function main() {
+  if (live && process.env.RESEARCH_URL) {
+    try { const results = await liveResearch(query); const nat = (NATIONAL[country]&&NATIONAL[country][need])||null; out({ ok:true, mode:"live", query, candidates:results, national_fallback:nat }); return; }
+    catch (e) { const nat=(NATIONAL[country]&&NATIONAL[country][need])||null; out({ ok:true, mode:"live_failed_fallback", query, error:String(e.message||e), candidates:(SAMPLES[need]||[]), national_fallback:nat }); return; }
+  }
+  const nat=(NATIONAL[country]&&NATIONAL[country][need])||null; out({ ok:true, mode:"dry-run", query, candidates:(SAMPLES[need]||[]), national_fallback:nat });
+}
+function buildQuery(need, place){const phrase={housing:"emergency homeless shelter intake",food:"food bank pantry help",dv:"domestic violence hotline safe shelter",deportation:"immigration legal aid know your rights",medical:"free community health clinic",fraud:"consumer fraud victim help legal aid",self_harm:"crisis line warmline mental health support",isolation:"peer support warmline loneliness"}[need]||"crisis help";return place?phrase+" "+place:phrase;}
+async function liveResearch(q){const url=process.env.RESEARCH_URL;const headers={"Content-Type":"application/json","User-Agent":"crisis-lifeline-bridge/0.1"};if(process.env.RESEARCH_TOKEN)headers["Authorization"]="Bearer "+process.env.RESEARCH_TOKEN;const resp=await fetch(url,{method:"POST",headers,body:JSON.stringify({q,n:10})});if(!resp.ok)throw new Error("research endpoint "+resp.status);const j=await resp.json();const rows=(j.results||j.items||[]);return rows.slice(0,10).map(r=>({name:r.title||r.name||"(unnamed)",url:r.link||r.url||"",source:r.source||"",snippet:r.snippet||r.summary||"",phone_e164:null,needs_verification:true}));}
+function parseArgs(argv){const o={};for(let i=0;i<argv.length;i++){const a=argv[i];if(a.startsWith("--")){const key=a.slice(2);const next=argv[i+1];if(next===undefined||next.startsWith("--")){o[key]=true;}else{o[key]=next;i++;}}}return o;}
+function out(obj){process.stdout.write(JSON.stringify(obj,null,2)+"\n");}
+main().catch(e=>{out({ok:false,error:String(e.message||e)});process.exit(1);});

--- a/skills/crisis-lifeline-bridge/scripts/verify-agency-call.mjs
+++ b/skills/crisis-lifeline-bridge/scripts/verify-agency-call.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+const args = parseArgs(process.argv.slice(2));
+const live = Boolean(args.live);
+const need = (args.need || "housing").toLowerCase();
+const agency = args.agency || "the service line";
+const toPhone = args["to-phone"] || "";
+const region = args.region || "US";
+const language = args.language || "en";
+const timezone = args.timezone || "America/New_York";
+const calleBin = args["calle-bin"] || "calle";
+const pollTimeout = args["poll-timeout"] || "120";
+const SAMPLE = /^\+1555010\d$/;
+const goal = buildGoal(need, agency);
+async function main() {
+  if (!live) {
+    out({ ok:true, mode:"dry-run", would_call:mask(toPhone), plan_goal:goal,
+      note:"No call placed. Re-run with --live and a real, consented E.164 number to verify for real.",
+      simulated_result:{ verified:true, agency_name:agency, phone_masked:mask(toPhone), line_status:"in_service (simulated)", intake_hours:"simulated 8:00-20:00 local", capacity_tonight:"simulated: space available", recommend_refer:true } });
+    return;
+  }
+  if (!toPhone) fail("live mode requires --to-phone in E.164 format");
+  if (!/^\+[1-9]\d{6,14}$/.test(toPhone)) fail("--to-phone must be E.164, e.g. +14155550142");
+  if (SAMPLE.test(toPhone)) fail("refusing to place a live call to a fictional sample number (+1 555 01xx)");
+  const env = { ...process.env, CALLE_SOURCE:process.env.CALLE_SOURCE||"skills_sh", CALLE_INTEGRATION:process.env.CALLE_INTEGRATION||"skills_sh_skill", CALLE_INTEGRATION_VERSION:process.env.CALLE_INTEGRATION_VERSION||"0.1.0" };
+  const planned = await calle(env, ["mcp","call","--args-json",JSON.stringify({user_input:goal+" The number to call is "+toPhone+"."}),"plan_call","--poll-timeout-seconds",pollTimeout,"--json"]);
+  const plan = extractStructured(planned);
+  const planId = plan && plan.plan_id;
+  if (!planId) fail("plan_call did not return a plan_id: "+JSON.stringify(planned).slice(0,400));
+  await calle(env, ["call","plan","--plan-id",planId,"--to-phone",toPhone,"--region",region,"--language",language,"--timezone",timezone,"--poll-timeout-seconds",pollTimeout,"--json"]);
+  await calle(env, ["call","run","--plan-id",planId,"--poll-timeout-seconds",pollTimeout,"--json"]);
+  const statusRaw = await calle(env, ["call","status","--plan-id",planId,"--json"]);
+  const status = extractStructured(statusRaw) || statusRaw;
+  out({ ok:true, mode:"live", plan_id:planId, phone_masked:mask(toPhone), agency_name:agency, plan_goal:goal, call_status:status, note:"Only refer the person if the line was confirmed real, in service, and able to help." });
+}
+function buildGoal(need, agency){const needPhrase={housing:"emergency shelter / housing intake",food:"food assistance",dv:"domestic-violence support and safe shelter",deportation:"immigration legal aid",medical:"non-emergency community health services",fraud:"fraud-victim assistance",self_harm:"crisis / mental-health support",isolation:"peer support"}[need]||"support services";return "Verify that "+agency+" is a real, currently in-service "+needPhrase+" line. Confirm it is legitimate and reachable, ask their current intake hours, and ask whether they have capacity to help someone today. You are confirming public service details only and represent no specific person; do not share anyone's identity or situation. If nobody answers, note that and end politely. Report back: is the line real and in service, intake hours, and whether they can help today.";}
+function calle(env, argv){return new Promise((resolve,reject)=>{const p=spawn(calleBin,argv,{env});let so="",se="";p.stdout.on("data",d=>so+=d.toString());p.stderr.on("data",d=>se+=d.toString());p.on("error",reject);p.on("close",code=>{if(code!==0&&!so.trim())return reject(new Error("calle "+argv[0]+" exit "+code+": "+se.slice(0,300)));try{resolve(JSON.parse(so));}catch{resolve({_raw:so});}});});}
+function extractStructured(resp){if(!resp)return null;const r=resp.result||resp;if(r&&r.structuredContent)return r.structuredContent;const content=r&&r.content;if(Array.isArray(content)&&content[0]&&content[0].text){try{return JSON.parse(content[0].text);}catch{return null;}}if(resp.structuredContent)return resp.structuredContent;return null;}
+function mask(phone){if(!phone)return "(none)";const s=String(phone);if(s.length<=5)return s;return s.slice(0,3)+"\u2022".repeat(Math.max(0,s.length-5))+s.slice(-2);}
+function parseArgs(argv){const o={};for(let i=0;i<argv.length;i++){const a=argv[i];if(a.startsWith("--")){const key=a.slice(2);const next=argv[i+1];if(next===undefined||next.startsWith("--")){o[key]=true;}else{o[key]=next;i++;}}}return o;}
+function out(obj){process.stdout.write(JSON.stringify(obj,null,2)+"\n");}
+function fail(msg){out({ok:false,error:msg});process.exit(1);}
+main().catch(e=>{out({ok:false,error:String(e.message||e)});process.exit(1);});


### PR DESCRIPTION
## crisis-lifeline-bridge — verify-before-refer for phone-call agents

**Contribution area:** Agent Skills (`skills/crisis-lifeline-bridge/`)

### What it does
When an AI agent detects that a person is in **acute crisis**, this skill finds a **real local human service** for their specific need and location, then uses CALL-E to place **one verification call** to that agency to confirm the line is real, in service, and can actually help — **before** the number is ever handed to the person.

It turns "here's a hotline, good luck" into "I called them, they're real, they're open, here's who to ask for."

### Why it matters
People in crisis get handed generic numbers constantly, and agent-surfaced numbers are often out of date, disconnected, wrong department, or a national line that can't help locally. A dead or wrong number given to someone in crisis is worse than none — it burns the one moment they were ready to reach out. **No resource is given to the person until a call has confirmed it is real and reachable.**

### Safety by design (matches this repo's emergency/medical/financial boundary rules)
- **Never replaces emergency services.** Imminent danger / active self-harm → direct to 911 + 988 immediately; this skill does not run in that case.
- **Consent-gated.** The verification call goes to the *agency*, never to the person in crisis. The caller represents no one and shares no one's identity.
- **No guessing.** Phone/region/language are never inferred; E.164 only; missing fields surface as plan questions.
- **Honesty rail.** Only names a resource verified *this run* or a known national line — never invents a hotline.
- **Dry-run by default.** Both scripts run with **no real call** and no credentials; live mode is opt-in and refuses to dial fictional sample numbers (`+1 555 01xx`).

### Contents
- `SKILL.md` + `references/{safety,examples,calle-cli-bootstrap,crisis-classification}.md`
- `scripts/find-local-agency.mjs` — candidate research, dry-run samples + real national fallbacks
- `scripts/verify-agency-call.mjs` — CALL-E `plan_call → run_call → get_call_run`, dry-run default, sample-number guard
- README resource-list entry

### Verification
- `python3 scripts/validate_repository.py` → **Repository validation passed.**
- Branch name passes `scripts/check_branch_name.py`.
- Scripts tested in dry-run; `plan_call` exercised live against the CALL-E MCP (planning only, no call placed).

Built for the CALL-E "Your Code Is Calling" hackathon.
