### PR TITLE
fix(outbound-call-skill-creator): accept CRLF frontmatter

### DIFF
--- a/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
+++ b/skills/outbound-call-skill-creator/scripts/check-generated-skill.mjs
@@ -408,19 +408,20 @@ function readText(filePath) {
 }
 
 function parseFrontmatter(text, filePath) {
-  if (!text.startsWith("---\n")) {
+  const opening = /^---\r?\n/.exec(text);
+  if (!opening) {
     fail(`Missing YAML frontmatter: ${filePath}`);
     return {};
   }
 
-  const end = text.indexOf("\n---", 4);
+  const end = text.indexOf("\n---", opening[0].length);
   if (end === -1) {
     fail(`Unterminated YAML frontmatter: ${filePath}`);
     return {};
   }
 
   const result = {};
-  const block = text.slice(4, end).trim();
+  const block = text.slice(opening[0].length, end).trim();
   for (const line of block.split(/\r?\n/)) {
     if (!line.trim() || line.trim().startsWith("#")) {
       continue;


### PR DESCRIPTION
## Problem

`validate_repository.py` fails on a clean checkout on Windows, before it reaches any contributed files:

```
ERROR: Generated outbound skill checker smoke test failed:
ERROR: Missing YAML frontmatter: ...\generated-callback-skill\SKILL.md
ERROR: Generated skill frontmatter must include only name and description
ERROR: Skill name '' must match directory 'generated-callback-skill'
ERROR: Skill description must be at least 40 characters
```

The validator's own smoke test writes `SKILL.md` through Python's text mode, which emits CRLF on Windows. `check-generated-skill.mjs` then rejects the file it just generated.

## Cause

`parseFrontmatter` tested `text.startsWith("---\n")`, while every other line-split in the same file already tolerates `\r?\n` (lines 424, 513, 550, 631, 671). Node's `readFileSync(path, "utf8")` does no newline translation, so a CRLF file starts with `---\r\n` and the check fails.

The Python `parse_frontmatter` in `validate_repository.py` is unaffected, because `read_text` applies universal newlines — which is why the mismatch only shows up through the `.mjs` checker.

## Fix

Match the tolerance already used elsewhere in the file, and slice the block by the matched opening length instead of a hardcoded `4`.

## Verification

`python3 scripts/validate_repository.py` now passes on Windows. The LF path is unchanged: the regex matches `---\n` exactly as before, and `\n---` still terminates the block.
