### PR TITLE
feat(apps): add permit status clarifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | App | Language | Purpose |
 | --- | --- | --- |
 | [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
+| [`apps/python/permit-status-clarifier`](apps/python/permit-status-clarifier/) | Python | Authorised municipal permit-status caller that returns a factual blocker-and-next-action brief after a masked preview. |
 | [`apps/python/batch-runner`](apps/python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`apps/python/broker-login-client`](apps/python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`apps/typescript/broker-login-client`](apps/typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |

--- a/apps/python/permit-status-clarifier/README.md
+++ b/apps/python/permit-status-clarifier/README.md
@@ -1,0 +1,112 @@
+# Permit Status Clarifier
+
+Permit Status Clarifier is a focused local web app and CLI that uses the CALL-E Python SDK to turn one authorised call to a municipal permit desk into a structured blocker-and-next-action brief.
+
+The default path is a masked preview. It never contacts CALL-E or places a call. Live mode requires recorded authority, confirmation that the recipient is a published department number, a second explicit live-call confirmation, and a server-side API key.
+
+## Why this workflow
+
+Small contractors and project owners often hear only that a permit is “under review.” The useful details—what is missing, who owns the next step, where corrections belong, and when a response expires—may be available only by phone. Permit Status Clarifier packages that narrow phone task without pretending to give legal advice or letting an agent make commitments.
+
+One completed call can return:
+
+- the recorded review status;
+- a plain blocker summary;
+- the exact next action;
+- a response or expiry deadline;
+- the official resubmission channel;
+- fee information without authorising payment; and
+- a public follow-up team, extension, or reference.
+
+## Setup
+
+Python 3.11 or later and `uv` are recommended:
+
+```bash
+cd apps/python/permit-status-clarifier
+uv sync --dev
+```
+
+## Run the local web app
+
+The server binds to `127.0.0.1` by default and starts in preview-only mode:
+
+```bash
+uv run python server.py
+```
+
+Open `http://127.0.0.1:8787`. The browser builds a masked call plan and displays the exact task, recipient region, result schema, and stable duplicate-call key before a live-call control can appear.
+
+The UI does not use analytics, persist form data, or send data to third parties in preview mode.
+
+## Preview from the CLI
+
+`example_request.json` uses a fictional reserved number. Copy it and replace the number only with a published department line that you are authorised to call.
+
+```bash
+uv run python client.py --request example_request.json
+```
+
+Add `--output new-plan.json` to create a private mode-`0600` file. Existing files are never overwritten.
+
+## Run one live CALL-E call
+
+API keys are server credentials. Keep them in an environment variable or secret manager, never in request files, browser storage, or source control.
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+export CALLE_BASE_URL="https://api.heycall-e.com"
+
+uv run python client.py \
+  --request your-authorised-request.json \
+  --execute \
+  --confirm-authority \
+  --confirm-public-number \
+  --output call-result.json
+```
+
+For the web UI, start `server.py` with the same environment variables. A live call still requires the two context checkboxes, a successful masked preview, and a separate “place one real call” checkbox.
+
+## Input contract
+
+The request JSON must contain:
+
+- `workflow_id`: a stable non-secret id used for duplicate-call prevention;
+- `phone`: one E.164 public department number;
+- `caller_has_authority`: literal `true`;
+- `recipient_is_public_department_number`: literal `true`;
+- `organization_display_name`: the caller identity disclosed to the desk;
+- `jurisdiction` and `department`;
+- `permit_reference`: a non-personal public or applicant-facing reference;
+- `project_type`: a short non-sensitive description;
+- `region` and `locale` supported by CALL-E; and
+- `questions`: two to seven supported factual question ids.
+
+Do not put a person’s name, home address, phone number, email address, credentials, payment data, or other personal information into the permit reference or project description.
+
+## Side effects and safety
+
+- A live run places exactly one real outbound phone call.
+- The agent discloses that it is an AI calling assistant and ends if the recipient declines an AI caller.
+- The call is limited to a factual permit-status inquiry. It does not request legal interpretation, dispute a decision, schedule an inspection, submit material, make a payment, accept terms, or promise work.
+- Fee details are recorded as information only. The app cannot authorise or transmit payment.
+- The workflow is not for emergency, medical, legal-advice, financial, collections, political, marketing, enforcement, or private-recipient calls.
+- Phone numbers and permit references are masked in previews. Phone numbers and email addresses are redacted from returned summary fields.
+- There is no scheduler, batch mode, hidden retry, or recurring call.
+
+## Cancellation and rollback
+
+Preview mode has no external side effect and needs no rollback. Before a live call, omit `--execute`, either CLI confirmation, or the final web confirmation. After CALL-E accepts a call task, this demo cannot guarantee cancellation; use the CALL-E dashboard or provider controls if a cancel action is available. No future job remains to remove.
+
+The stable `permitstatus-<workflow_id>` idempotency key prevents a repeated execution of the same workflow from creating a duplicate task when the provider honours the key.
+
+## Validation
+
+Default tests inject a fake CALL-E client and never place a call:
+
+```bash
+uv run pytest -q
+python3 ../../../scripts/validate_repository.py
+```
+
+For opt-in live verification, call only a published department test line or a phone you own and are authorised to use as a simulated permit desk. Keep the request and result private; commit only the masked demo evidence.

--- a/apps/python/permit-status-clarifier/client.py
+++ b/apps/python/permit-status-clarifier/client.py
@@ -1,0 +1,348 @@
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+E164_PATTERN = re.compile(r"^\+[1-9]\d{7,14}$")
+SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{2,63}$")
+REFERENCE_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9 ._/#-]{2,47}$")
+PHONE_LIKE_PATTERN = re.compile(r"(?<!\w)\+?[1-9]\d{7,14}(?!\w)")
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+SUPPORTED_REGIONS = {
+    "US", "SG", "MY", "IN", "AE", "AU", "CA", "GB", "VN",
+    "DE", "JP", "FR", "MX", "BR", "ID", "PH", "KE",
+}
+ALLOWED_QUESTIONS = {
+    "current_status": "What is the current permit status?",
+    "blocking_items": "Is review blocked by any missing or incorrect item?",
+    "next_action": "What exact next action should the applicant take?",
+    "response_deadline": "Is there a response or expiry deadline?",
+    "resubmission_channel": "Where should corrections or documents be submitted?",
+    "fee_information": "Is a fee recorded as due? Ask for information only; do not authorize or pay it.",
+    "followup_contact": "Which team, extension, or public contact should handle follow-up?",
+}
+
+
+@dataclass(frozen=True)
+class PermitStatusRequest:
+    workflow_id: str
+    phone: str
+    caller_has_authority: bool
+    recipient_is_public_department_number: bool
+    organization_display_name: str
+    jurisdiction: str
+    department: str
+    permit_reference: str
+    project_type: str
+    region: str
+    locale: str
+    questions: tuple[str, ...]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preview or run one information-only permit status call with CALL-E."
+    )
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional new JSON result path; existing files are never overwritten.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--preview", action="store_true", help="No-call preview (default).")
+    mode.add_argument("--execute", action="store_true", help="Place exactly one call.")
+    parser.add_argument(
+        "--confirm-authority",
+        action="store_true",
+        help="Required for live mode; confirms authority to make this inquiry.",
+    )
+    parser.add_argument(
+        "--confirm-public-number",
+        action="store_true",
+        help="Required for live mode; confirms the recipient is a public department number.",
+    )
+    parser.add_argument(
+        "--base-url", default=os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL)
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    return parser.parse_args(argv)
+
+
+def clean_text(value: Any, field: str, *, minimum: int, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = " ".join(value.split())
+    if len(cleaned) < minimum or len(cleaned) > maximum:
+        raise ValueError(f"{field} must contain {minimum}-{maximum} characters")
+    return cleaned
+
+
+def parse_request(raw: Any) -> PermitStatusRequest:
+    if not isinstance(raw, dict):
+        raise ValueError("request must be a JSON object")
+
+    workflow_id = clean_text(raw.get("workflow_id"), "workflow_id", minimum=3, maximum=64)
+    if not SAFE_ID_PATTERN.fullmatch(workflow_id):
+        raise ValueError("workflow_id may contain only letters, numbers, dot, underscore, and hyphen")
+
+    phone = clean_text(raw.get("phone"), "phone", minimum=8, maximum=16)
+    if not E164_PATTERN.fullmatch(phone):
+        raise ValueError("phone must use E.164 format, for example +12025550123")
+
+    if raw.get("caller_has_authority") is not True:
+        raise ValueError("caller_has_authority must be true")
+    if raw.get("recipient_is_public_department_number") is not True:
+        raise ValueError("recipient_is_public_department_number must be true")
+
+    permit_reference = clean_text(
+        raw.get("permit_reference"), "permit_reference", minimum=3, maximum=48
+    )
+    if not REFERENCE_PATTERN.fullmatch(permit_reference):
+        raise ValueError("permit_reference contains unsupported characters")
+    if PHONE_LIKE_PATTERN.search(permit_reference) or EMAIL_PATTERN.search(permit_reference):
+        raise ValueError("permit_reference must not contain a phone number or email address")
+
+    region = clean_text(raw.get("region"), "region", minimum=2, maximum=2).upper()
+    if region not in SUPPORTED_REGIONS:
+        raise ValueError(f"region must be one of: {', '.join(sorted(SUPPORTED_REGIONS))}")
+
+    locale = clean_text(raw.get("locale", "en-US"), "locale", minimum=2, maximum=16)
+    if not re.fullmatch(r"[a-z]{2,3}(?:-[A-Z]{2})?", locale):
+        raise ValueError("locale must look like en-US or fr-FR")
+
+    raw_questions = raw.get("questions")
+    if not isinstance(raw_questions, list) or not 2 <= len(raw_questions) <= len(ALLOWED_QUESTIONS):
+        raise ValueError("questions must contain 2-7 supported question ids")
+    if any(not isinstance(item, str) or item not in ALLOWED_QUESTIONS for item in raw_questions):
+        raise ValueError("questions contains an unsupported question id")
+    if len(set(raw_questions)) != len(raw_questions):
+        raise ValueError("questions must not contain duplicates")
+
+    return PermitStatusRequest(
+        workflow_id=workflow_id,
+        phone=phone,
+        caller_has_authority=True,
+        recipient_is_public_department_number=True,
+        organization_display_name=clean_text(
+            raw.get("organization_display_name"),
+            "organization_display_name",
+            minimum=2,
+            maximum=80,
+        ),
+        jurisdiction=clean_text(raw.get("jurisdiction"), "jurisdiction", minimum=2, maximum=100),
+        department=clean_text(raw.get("department"), "department", minimum=2, maximum=100),
+        permit_reference=permit_reference,
+        project_type=clean_text(raw.get("project_type"), "project_type", minimum=3, maximum=140),
+        region=region,
+        locale=locale,
+        questions=tuple(raw_questions),
+    )
+
+
+def load_request(path: Path) -> PermitStatusRequest:
+    with path.expanduser().open(encoding="utf-8") as handle:
+        return parse_request(json.load(handle))
+
+
+def mask_phone(phone: str) -> str:
+    return f"{phone[:3]}{'*' * max(4, len(phone) - 6)}{phone[-3:]}"
+
+
+def mask_reference(reference: str) -> str:
+    visible = reference[-4:] if len(reference) > 4 else reference[-1:]
+    return f"{'*' * max(3, len(reference) - len(visible))}{visible}"
+
+
+def build_task(request: PermitStatusRequest) -> str:
+    questions = " ".join(
+        f"{index}. {ALLOWED_QUESTIONS[question]}"
+        for index, question in enumerate(request.questions, start=1)
+    )
+    return (
+        f"Place one information-only permit status call to {request.department} in {request.jurisdiction} "
+        f"on behalf of {request.organization_display_name}. At the start, identify yourself as an AI calling assistant "
+        "making an authorized factual status inquiry. If the recipient does not accept an AI caller, apologize and end. "
+        f"The public permit reference is {request.permit_reference}; the project type is {request.project_type}. "
+        f"Ask only these questions: {questions} "
+        "Do not ask for names, addresses, dates of birth, account credentials, payment-card details, or other personal data. "
+        "Do not request legal interpretation, dispute a decision, schedule an inspection, submit a document, authorize or "
+        "pay a fee, accept terms, promise work, or represent that any correction has already been made. If a fee is mentioned, "
+        "record the amount and official payment channel as information only. Read back the blocker and next action once for "
+        "confirmation, ask for a public follow-up reference or department extension, and end politely."
+    )
+
+
+def build_result_schema() -> dict[str, Any]:
+    text_field = {"type": "string", "maxLength": 500}
+    return {
+        "type": "object",
+        "required": [
+            "reached_correct_department",
+            "current_status",
+            "blocker_summary",
+            "next_action",
+            "response_deadline",
+            "resubmission_channel",
+            "fee_information_only",
+            "followup_contact",
+            "followup_reference",
+            "evidence_summary",
+        ],
+        "properties": {
+            "reached_correct_department": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+            },
+            "current_status": {
+                "type": "string",
+                "enum": [
+                    "approved",
+                    "under_review",
+                    "corrections_required",
+                    "awaiting_payment",
+                    "on_hold",
+                    "closed",
+                    "unknown",
+                ],
+            },
+            "blocker_summary": text_field,
+            "next_action": text_field,
+            "response_deadline": text_field,
+            "resubmission_channel": text_field,
+            "fee_information_only": text_field,
+            "followup_contact": text_field,
+            "followup_reference": text_field,
+            "evidence_summary": text_field,
+        },
+        "additionalProperties": False,
+    }
+
+
+def idempotency_key(request: PermitStatusRequest) -> str:
+    return f"permitstatus-{request.workflow_id}"
+
+
+def build_call_arguments(request: PermitStatusRequest) -> dict[str, Any]:
+    return {
+        "task": build_task(request),
+        "recipients": [
+            {"phones": [request.phone], "region": request.region, "locale": request.locale}
+        ],
+        "result_schema": build_result_schema(),
+        "metadata": {
+            "workflow_id": request.workflow_id,
+            "workflow_type": "permit_status_clarification",
+            "jurisdiction": request.jurisdiction,
+        },
+        "idempotency_key": idempotency_key(request),
+    }
+
+
+def preview(request: PermitStatusRequest) -> dict[str, Any]:
+    arguments = build_call_arguments(request)
+    arguments["recipients"] = [
+        {
+            "phones": [mask_phone(request.phone)],
+            "region": request.region,
+            "locale": request.locale,
+        }
+    ]
+    arguments["task"] = arguments["task"].replace(
+        request.permit_reference, mask_reference(request.permit_reference)
+    )
+    return {
+        "mode": "preview",
+        "creates_phone_call": False,
+        "workflow_id": request.workflow_id,
+        "authority_recorded": request.caller_has_authority,
+        "public_department_number_recorded": request.recipient_is_public_department_number,
+        "call_arguments": arguments,
+    }
+
+
+def redact_sensitive_text(value: Any) -> Any:
+    if isinstance(value, str):
+        return EMAIL_PATTERN.sub("[email-redacted]", PHONE_LIKE_PATTERN.sub("[phone-redacted]", value))
+    if isinstance(value, list):
+        return [redact_sensitive_text(item) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_sensitive_text(item) for key, item in value.items()}
+    return value
+
+
+def execute(
+    request: PermitStatusRequest, client: Any, *, timeout_seconds: int
+) -> dict[str, Any]:
+    created = client.calls.create(**build_call_arguments(request))
+    call_id = created.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        raise RuntimeError("CALL-E create response did not contain a call id")
+    completed = client.calls.wait_for_result(
+        call_id, timeout_seconds=timeout_seconds, interval_seconds=2
+    )
+    return {
+        "mode": "execute",
+        "creates_phone_call": True,
+        "workflow_id": request.workflow_id,
+        "idempotency_key": idempotency_key(request),
+        "call_id": call_id,
+        "status": completed.get("status"),
+        "task_completed": completed.get("task_completed"),
+        "completion_confidence": completed.get("completion_confidence"),
+        "structured_result": redact_sensitive_text(completed.get("structured_result")),
+    }
+
+
+def write_output(path: Path | None, payload: dict[str, Any]) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if path is None:
+        sys.stdout.write(rendered)
+        return
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("x", encoding="utf-8") as handle:
+        handle.write(rendered)
+    destination.chmod(0o600)
+    sys.stdout.write(f"Wrote {destination}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        request = load_request(args.request)
+        if not args.execute:
+            write_output(args.output, preview(request))
+            return 0
+        if not args.confirm_authority or not args.confirm_public_number:
+            raise ValueError("--execute requires --confirm-authority and --confirm-public-number")
+        if args.timeout_seconds <= 0:
+            raise ValueError("--timeout-seconds must be positive")
+        api_key = os.environ.get("CALLE_API_KEY")
+        if not api_key:
+            raise ValueError("CALLE_API_KEY is required for --execute")
+        from calle import CalleClient
+
+        client = CalleClient(api_key=api_key, base_url=args.base_url)
+        write_output(args.output, execute(request, client, timeout_seconds=args.timeout_seconds))
+        return 0
+    except (
+        FileExistsError,
+        OSError,
+        ValueError,
+        RuntimeError,
+        json.JSONDecodeError,
+    ) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/permit-status-clarifier/example_request.json
+++ b/apps/python/permit-status-clarifier/example_request.json
@@ -1,0 +1,21 @@
+{
+  "workflow_id": "permit-demo-2026-001",
+  "phone": "+12025550123",
+  "caller_has_authority": true,
+  "recipient_is_public_department_number": true,
+  "organization_display_name": "Example Build Co",
+  "jurisdiction": "Example City",
+  "department": "Building and Safety Permit Desk",
+  "permit_reference": "BLD-2026-00421",
+  "project_type": "Interior commercial renovation",
+  "region": "US",
+  "locale": "en-US",
+  "questions": [
+    "current_status",
+    "blocking_items",
+    "next_action",
+    "response_deadline",
+    "resubmission_channel",
+    "followup_contact"
+  ]
+}

--- a/apps/python/permit-status-clarifier/pyproject.toml
+++ b/apps/python/permit-status-clarifier/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "calle-permit-status-clarifier-app"
+version = "0.1.0"
+description = "Information-only permit status clarification with the CALL-E Python SDK."
+requires-python = ">=3.11"
+dependencies = [
+  "calle-ai==0.2.0",
+]
+
+[dependency-groups]
+dev = [
+  "pytest>=9.0.0",
+]

--- a/apps/python/permit-status-clarifier/server.py
+++ b/apps/python/permit-status-clarifier/server.py
@@ -1,0 +1,140 @@
+import argparse
+import json
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from client import DEFAULT_BASE_URL, execute, parse_request, preview
+
+
+ROOT = Path(__file__).resolve().parent
+STATIC_ROOT = ROOT / "static"
+MAX_BODY_BYTES = 32_000
+ALLOWED_FILES = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/styles.css": ("styles.css", "text/css; charset=utf-8"),
+}
+
+
+def preview_payload(payload: Any) -> dict[str, Any]:
+    return preview(parse_request(payload))
+
+
+def execute_payload(payload: Any, client: Any, *, timeout_seconds: int = 600) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("request body must be a JSON object")
+    confirmations = payload.get("confirmations")
+    if not isinstance(confirmations, dict) or not all(
+        confirmations.get(key) is True
+        for key in ("authority", "public_number", "live_call")
+    ):
+        raise ValueError("live mode requires all three explicit confirmations")
+    return execute(
+        parse_request(payload.get("request")), client, timeout_seconds=timeout_seconds
+    )
+
+
+class PermitStatusHandler(BaseHTTPRequestHandler):
+    server_version = "PermitStatusClarifier/0.1"
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Avoid logging request bodies, phone numbers, or permit references.
+        return
+
+    def end_headers(self) -> None:
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", "default-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'")
+        super().end_headers()
+
+    def send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def read_json(self) -> Any:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError as exc:
+            raise ValueError("invalid Content-Length") from exc
+        if length <= 0 or length > MAX_BODY_BYTES:
+            raise ValueError("request body must contain 1-32000 bytes")
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path == "/api/health":
+            self.send_json(HTTPStatus.OK, {"ok": True, "live_ready": bool(os.environ.get("CALLE_API_KEY"))})
+            return
+        asset = ALLOWED_FILES.get(path)
+        if not asset:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        file_name, content_type = asset
+        body = (STATIC_ROOT / file_name).read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+        try:
+            payload = self.read_json()
+            if path == "/api/preview":
+                self.send_json(HTTPStatus.OK, preview_payload(payload))
+                return
+            if path == "/api/call":
+                api_key = os.environ.get("CALLE_API_KEY")
+                if not api_key:
+                    raise ValueError("CALLE_API_KEY is required for a live call")
+                from calle import CalleClient
+
+                result = execute_payload(
+                    payload,
+                    CalleClient(
+                        api_key=api_key,
+                        base_url=os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL),
+                    ),
+                )
+                self.send_json(HTTPStatus.OK, result)
+                return
+            self.send_error(HTTPStatus.NOT_FOUND)
+        except (json.JSONDecodeError, OSError, RuntimeError, ValueError) as exc:
+            self.send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the local Permit Status Clarifier demo.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.port <= 0 or args.port > 65535:
+        raise SystemExit("port must be between 1 and 65535")
+    server = ThreadingHTTPServer((args.host, args.port), PermitStatusHandler)
+    print(f"Permit Status Clarifier listening on http://{args.host}:{args.port}")
+    if not os.environ.get("CALLE_API_KEY"):
+        print("Preview mode only: CALLE_API_KEY is not set")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/permit-status-clarifier/static/app.js
+++ b/apps/python/permit-status-clarifier/static/app.js
@@ -1,0 +1,84 @@
+(() => {
+  "use strict";
+  const form = document.getElementById("permit-form");
+  const panel = document.getElementById("result-panel");
+  const status = document.getElementById("status");
+  const previewButton = document.getElementById("preview-button");
+  let liveReady = false;
+  let lastRequest = null;
+
+  const escapeHtml = (value) => String(value).replace(/[&<>'"]/g, (char) => ({"&":"&amp;","<":"&lt;",">":"&gt;","'":"&#39;",'"':"&quot;"})[char]);
+  const readRequest = () => {
+    const values = new FormData(form);
+    return {
+      workflow_id: values.get("workflow_id"),
+      phone: values.get("phone"),
+      caller_has_authority: document.getElementById("authority").checked,
+      recipient_is_public_department_number: document.getElementById("public-number").checked,
+      organization_display_name: values.get("organization_display_name"),
+      jurisdiction: values.get("jurisdiction"),
+      department: values.get("department"),
+      permit_reference: values.get("permit_reference"),
+      project_type: values.get("project_type"),
+      region: values.get("region"),
+      locale: values.get("locale"),
+      questions: values.getAll("questions"),
+    };
+  };
+  const post = async (url, body) => {
+    const response = await fetch(url, {method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || "Request failed");
+    return payload;
+  };
+  const renderError = (error) => { panel.innerHTML = `<div class="result-content"><div class="error"><b>Could not build the brief.</b><br>${escapeHtml(error.message)}</div></div>`; };
+  const renderPreview = (payload) => {
+    const args = payload.call_arguments;
+    const recipient = args.recipients[0];
+    panel.innerHTML = `<div class="result-content">
+      <span class="result-tag">Masked no-call preview</span>
+      <h2>Ready for a deliberate decision.</h2>
+      <div class="result-grid">
+        <div><b>Recipient</b><span>${escapeHtml(recipient.phones[0])}</span></div>
+        <div><b>Region / locale</b><span>${escapeHtml(recipient.region)} · ${escapeHtml(recipient.locale)}</span></div>
+        <div><b>Creates a call</b><span>No</span></div>
+        <div><b>Duplicate guard</b><span>${escapeHtml(args.idempotency_key)}</span></div>
+      </div>
+      <b class="result-tag">Exact CALL‑E task</b>
+      <div class="task">${escapeHtml(args.task)}</div>
+      <div class="live-box">
+        <label><input id="live-confirm" type="checkbox"> I reviewed this exact masked plan and want to place one real call now.</label>
+        <button id="live-button" type="button" ${liveReady ? "" : "disabled"}>${liveReady ? "Place one CALL‑E call" : "CALL‑E key not configured"}<span>☎</span></button>
+      </div>
+    </div>`;
+    const liveButton = document.getElementById("live-button");
+    liveButton?.addEventListener("click", runLiveCall);
+  };
+  const renderResult = (payload) => {
+    const result = payload.structured_result || {};
+    panel.innerHTML = `<div class="result-content"><span class="result-tag">Completed call</span><h2>${escapeHtml(result.current_status || payload.status || "Result received")}</h2>
+      <div class="result-grid"><div><b>Blocker</b><span>${escapeHtml(result.blocker_summary || "Unknown")}</span></div><div><b>Next action</b><span>${escapeHtml(result.next_action || "Unknown")}</span></div><div><b>Deadline</b><span>${escapeHtml(result.response_deadline || "Unknown")}</span></div><div><b>Follow-up</b><span>${escapeHtml(result.followup_contact || "Unknown")}</span></div></div>
+      <b class="result-tag">Evidence summary</b><div class="task">${escapeHtml(result.evidence_summary || "No summary returned")}</div></div>`;
+  };
+  async function runLiveCall() {
+    const confirmation = document.getElementById("live-confirm");
+    if (!confirmation?.checked) { renderError(new Error("Review the plan and confirm the one live call first.")); return; }
+    const button = document.getElementById("live-button");
+    button.disabled = true; button.firstChild.textContent = "Calling and waiting for the result…";
+    try {
+      const payload = await post("/api/call", {request:lastRequest,confirmations:{authority:true,public_number:true,live_call:true}});
+      renderResult(payload);
+    } catch (error) { renderError(error); }
+  }
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault(); previewButton.disabled = true; previewButton.firstChild.textContent = "Building preview…";
+    try { lastRequest = readRequest(); renderPreview(await post("/api/preview", lastRequest)); }
+    catch (error) { renderError(error); }
+    finally { previewButton.disabled = false; previewButton.firstChild.textContent = "Build masked preview "; }
+  });
+  fetch("/api/health").then((response) => response.json()).then((payload) => {
+    liveReady = Boolean(payload.live_ready);
+    status.classList.add(liveReady ? "ready" : "preview");
+    status.querySelector("span").textContent = liveReady ? "CALL‑E live mode ready" : "Preview mode · no API key";
+  }).catch(() => { status.querySelector("span").textContent = "Local preview"; });
+})();

--- a/apps/python/permit-status-clarifier/static/index.html
+++ b/apps/python/permit-status-clarifier/static/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Turn a permit desk phone call into a verified blocker and next-action brief.">
+    <title>Permit Status Clarifier</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header>
+      <div class="brand"><span>PSC</span><b>Permit Status Clarifier</b></div>
+      <div id="status" class="status"><i></i><span>Checking call readiness…</span></div>
+    </header>
+    <main>
+      <section class="intro">
+        <p class="eyebrow">CALL‑E workflow · one authorised call</p>
+        <h1>Turn “still under review” into an exact next action.</h1>
+        <p>Prepare a factual status inquiry for a municipal permit desk. Preview the complete call plan with masked identifiers before deciding whether to place one real call.</p>
+        <div class="guardrails">
+          <span>AI disclosed</span><span>No payments</span><span>No legal advice</span><span>No recurring calls</span>
+        </div>
+      </section>
+
+      <section class="workspace">
+        <form id="permit-form">
+          <div class="step"><b>01</b><span>Authorised context</span></div>
+          <div class="field-grid">
+            <label>Organisation shown to the desk<input name="organization_display_name" required maxlength="80" value="Example Build Co"></label>
+            <label>Workflow ID<input name="workflow_id" required maxlength="64" value="permit-demo-2026-001"></label>
+            <label>Jurisdiction<input name="jurisdiction" required maxlength="100" value="Example City"></label>
+            <label>Department<input name="department" required maxlength="100" value="Building and Safety Permit Desk"></label>
+            <label>Public department phone (E.164)<input name="phone" required maxlength="16" value="+12025550123" autocomplete="off"></label>
+            <label>Permit reference<input name="permit_reference" required maxlength="48" value="BLD-2026-00421" autocomplete="off"></label>
+            <label class="wide">Project type<input name="project_type" required maxlength="140" value="Interior commercial renovation"></label>
+            <label>Recipient region<select name="region"><option>US</option><option>GB</option><option>FR</option><option>DE</option><option>AU</option><option>CA</option><option>SG</option></select></label>
+            <label>Spoken locale<select name="locale"><option>en-US</option><option>en-GB</option><option>fr-FR</option><option>de-DE</option></select></label>
+          </div>
+
+          <div class="step"><b>02</b><span>Questions to resolve</span></div>
+          <div class="questions">
+            <label><input type="checkbox" name="questions" value="current_status" checked><span><b>Current status</b><small>Identify the recorded review state.</small></span></label>
+            <label><input type="checkbox" name="questions" value="blocking_items" checked><span><b>Blocking items</b><small>Capture missing or incorrect material.</small></span></label>
+            <label><input type="checkbox" name="questions" value="next_action" checked><span><b>Next action</b><small>Ask what the applicant should do next.</small></span></label>
+            <label><input type="checkbox" name="questions" value="response_deadline" checked><span><b>Deadline</b><small>Record response or expiry dates.</small></span></label>
+            <label><input type="checkbox" name="questions" value="resubmission_channel" checked><span><b>Submission route</b><small>Portal, email, counter or named team.</small></span></label>
+            <label><input type="checkbox" name="questions" value="fee_information"><span><b>Fee information</b><small>Information only—never authorise payment.</small></span></label>
+            <label><input type="checkbox" name="questions" value="followup_contact" checked><span><b>Follow-up contact</b><small>Public team, extension or reference.</small></span></label>
+          </div>
+
+          <div class="confirmations">
+            <label><input id="authority" type="checkbox" required> I am authorised to make this factual inquiry.</label>
+            <label><input id="public-number" type="checkbox" required> This is a published department number, not a private individual.</label>
+          </div>
+          <button id="preview-button" type="submit">Build masked preview <span>→</span></button>
+        </form>
+
+        <aside id="result-panel" class="result-panel" aria-live="polite">
+          <div class="empty-state">
+            <span>Call brief</span>
+            <h2>Nothing leaves this page yet.</h2>
+            <p>Complete the form to inspect the exact CALL‑E task, masked recipient, result schema and duplicate-call key.</p>
+          </div>
+        </aside>
+      </section>
+    </main>
+    <footer><span>Local demo · no analytics · no saved form data</span><span>CALL‑E is invoked only after a second live-call confirmation</span></footer>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/apps/python/permit-status-clarifier/static/styles.css
+++ b/apps/python/permit-status-clarifier/static/styles.css
@@ -1,0 +1,50 @@
+:root { --ink:#17242d; --muted:#63737b; --paper:#f3f1e9; --card:#fffefa; --line:#d5dbd6; --orange:#c45128; --blue:#11677e; --green:#2e7157; --red:#9d3c32; --serif:Georgia,"Times New Roman",serif; --sans:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; }
+* { box-sizing:border-box; }
+body { margin:0; color:var(--ink); background:var(--paper); font-family:var(--sans); line-height:1.45; }
+header { height:68px; display:flex; align-items:center; justify-content:space-between; padding:0 clamp(1rem,4vw,4rem); background:#fffefa; border-bottom:1px solid var(--line); }
+.brand { display:flex; align-items:center; gap:.75rem; font-size:.9rem; }
+.brand > span { width:34px; height:34px; display:grid; place-items:center; border:1px solid var(--ink); font:700 .67rem var(--sans); }
+.status { display:flex; align-items:center; gap:.5rem; color:var(--muted); font-size:.76rem; }
+.status i { width:8px; height:8px; border-radius:50%; background:#c5a23c; }
+.status.ready i { background:var(--green); }.status.preview i { background:#879399; }
+main { padding:clamp(2.5rem,6vw,6rem) clamp(1rem,4vw,4rem) 5rem; max-width:1480px; margin:auto; }
+.intro { max-width:980px; margin-bottom:3.5rem; }
+.eyebrow { margin:0 0 1rem; color:var(--blue); text-transform:uppercase; font-weight:800; letter-spacing:.13em; font-size:.72rem; }
+h1 { margin:0; font:400 clamp(3rem,6.5vw,6.8rem)/.92 var(--serif); letter-spacing:-.055em; max-width:1050px; }
+.intro > p:not(.eyebrow) { max-width:760px; font-size:1.1rem; color:#4a5b64; }
+.guardrails { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:1.5rem; }
+.guardrails span { padding:.4rem .65rem; border:1px solid #b8c8c8; color:#335860; background:#edf4f2; font-size:.72rem; font-weight:700; }
+.workspace { display:grid; grid-template-columns:minmax(0,1.15fr) minmax(360px,.85fr); gap:1rem; align-items:start; }
+form,.result-panel { background:var(--card); border:1px solid var(--line); box-shadow:0 14px 45px rgba(30,45,50,.05); }
+form { padding:clamp(1rem,2.5vw,2.2rem); }
+.step { display:flex; align-items:center; gap:.75rem; padding-bottom:.8rem; margin-bottom:1.1rem; border-bottom:1px solid var(--line); }
+.step:not(:first-child) { margin-top:2.2rem; }
+.step b { color:var(--orange); font:400 1.5rem var(--serif); }.step span { font-weight:800; font-size:.82rem; text-transform:uppercase; letter-spacing:.08em; }
+.field-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; }
+label { color:#40515a; font-size:.74rem; font-weight:700; }
+label.wide { grid-column:1/-1; }
+input:not([type=checkbox]),select { display:block; width:100%; margin-top:.4rem; padding:.78rem .8rem; border:1px solid #bdc7c5; background:white; color:var(--ink); font:500 .9rem var(--sans); border-radius:0; }
+input:focus,select:focus,button:focus { outline:3px solid rgba(17,103,126,.2); outline-offset:1px; }
+.questions { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.65rem; }
+.questions label { display:flex; gap:.65rem; padding:.85rem; border:1px solid var(--line); background:#fbfbf7; cursor:pointer; }
+.questions input { margin-top:.18rem; flex:none; accent-color:var(--orange); }
+.questions b,.questions small { display:block; }.questions b { color:var(--ink); font-size:.8rem; }.questions small { margin-top:.2rem; color:var(--muted); font-weight:400; line-height:1.35; }
+.confirmations { display:grid; gap:.6rem; margin:1.5rem 0 1rem; padding:1rem; background:#eef3f2; border-left:3px solid var(--blue); }
+.confirmations label { display:flex; gap:.6rem; align-items:flex-start; }.confirmations input { margin-top:.15rem; accent-color:var(--blue); }
+button { width:100%; border:0; padding:1rem 1.1rem; display:flex; justify-content:space-between; color:white; background:var(--ink); font:750 .9rem var(--sans); cursor:pointer; }
+button:hover { background:#263842; } button:disabled { opacity:.55; cursor:not-allowed; }
+.result-panel { min-height:560px; position:sticky; top:1rem; overflow:hidden; }
+.empty-state { min-height:560px; padding:2rem; display:grid; align-content:center; background:#18262e; color:white; }
+.empty-state > span,.result-tag { color:#f0a879; text-transform:uppercase; letter-spacing:.13em; font-size:.7rem; font-weight:800; }
+.empty-state h2 { margin:.7rem 0; font:400 2.5rem/1 var(--serif); }.empty-state p { color:#bac6ca; max-width:36ch; }
+.result-content { padding:1.6rem; }
+.result-content h2 { margin:.5rem 0 1rem; font:400 2rem/1 var(--serif); }
+.result-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:.65rem; margin-bottom:1rem; }
+.result-grid div { padding:.75rem; border:1px solid var(--line); }.result-grid b,.result-grid span { display:block; }.result-grid b { font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.07em; }.result-grid span { margin-top:.25rem; font-size:.83rem; }
+.task { padding:1rem; max-height:260px; overflow:auto; background:#f0eee6; border:1px solid var(--line); color:#3c4c54; font-size:.78rem; white-space:pre-wrap; }
+.live-box { margin-top:1rem; padding:1rem; border:1px solid #e5c0b4; background:#fff5ef; }
+.live-box label { display:flex; gap:.6rem; }.live-box button { margin-top:.8rem; background:var(--orange); }
+.error { padding:1rem; color:var(--red); background:#fff1ef; border:1px solid #e5bbb5; font-size:.82rem; }
+footer { display:flex; justify-content:space-between; gap:1rem; padding:1.2rem clamp(1rem,4vw,4rem); background:#101a20; color:#aab6bb; font-size:.7rem; }
+@media(max-width:900px){ .workspace{grid-template-columns:1fr}.result-panel{position:static}.field-grid,.questions{grid-template-columns:1fr}label.wide{grid-column:auto} }
+@media(max-width:560px){ header{align-items:flex-start;height:auto;padding-top:.8rem;padding-bottom:.8rem;gap:.6rem}.status{max-width:145px;text-align:right}.intro{margin-bottom:2rem}footer{flex-direction:column} }

--- a/apps/python/permit-status-clarifier/test_client.py
+++ b/apps/python/permit-status-clarifier/test_client.py
@@ -1,0 +1,158 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+APP_ROOT = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("permit_status_client", APP_ROOT / "client.py")
+assert SPEC and SPEC.loader
+client_module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = client_module
+SPEC.loader.exec_module(client_module)
+
+
+def valid_payload() -> dict:
+    return {
+        "workflow_id": "permit-demo-2026-001",
+        "phone": "+12025550123",
+        "caller_has_authority": True,
+        "recipient_is_public_department_number": True,
+        "organization_display_name": "Example Build Co",
+        "jurisdiction": "Example City",
+        "department": "Building and Safety Permit Desk",
+        "permit_reference": "BLD-2026-00421",
+        "project_type": "Interior commercial renovation",
+        "region": "US",
+        "locale": "en-US",
+        "questions": [
+            "current_status",
+            "blocking_items",
+            "next_action",
+            "response_deadline",
+            "resubmission_channel",
+            "followup_contact",
+        ],
+    }
+
+
+def test_preview_masks_recipient_and_reference(tmp_path):
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(valid_payload()), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "client.py", "--request", str(request_path)],
+        cwd=APP_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "+12025550123" not in result.stdout
+    assert "BLD-2026-00421" not in result.stdout
+    parsed = json.loads(result.stdout)
+    assert parsed["creates_phone_call"] is False
+    assert parsed["call_arguments"]["idempotency_key"] == "permitstatus-permit-demo-2026-001"
+
+
+def test_live_mode_requires_two_separate_confirmations(tmp_path):
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(valid_payload()), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "client.py", "--request", str(request_path), "--execute"],
+        cwd=APP_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "--confirm-authority and --confirm-public-number" in result.stderr
+
+
+def test_request_rejects_missing_authority_private_number_and_personal_reference():
+    for key in ("caller_has_authority", "recipient_is_public_department_number"):
+        payload = valid_payload()
+        payload[key] = False
+        try:
+            client_module.parse_request(payload)
+        except ValueError as exc:
+            assert key in str(exc)
+        else:
+            raise AssertionError(f"{key}=false was accepted")
+
+    payload = valid_payload()
+    payload["permit_reference"] = "person@example.com"
+    try:
+        client_module.parse_request(payload)
+    except ValueError as exc:
+        assert "unsupported characters" in str(exc) or "must not contain" in str(exc)
+    else:
+        raise AssertionError("personal permit reference was accepted")
+
+
+def test_task_has_information_only_boundaries():
+    request = client_module.parse_request(valid_payload())
+    task = client_module.build_task(request)
+    assert "identify yourself as an AI" in task
+    assert "Do not request legal interpretation" in task
+    assert "authorize or pay a fee" in task
+    assert "Ask only these questions" in task
+
+
+class FakeCalls:
+    def __init__(self):
+        self.created = None
+
+    def create(self, **kwargs):
+        self.created = kwargs
+        return {"id": "call_permit_demo"}
+
+    def wait_for_result(self, call_id, **kwargs):
+        assert call_id == "call_permit_demo"
+        assert kwargs == {"timeout_seconds": 30, "interval_seconds": 2}
+        return {
+            "status": "completed",
+            "task_completed": True,
+            "completion_confidence": {"score": 0.9, "label": "high"},
+            "structured_result": {
+                "reached_correct_department": "yes",
+                "current_status": "corrections_required",
+                "blocker_summary": "Upload the revised plan set.",
+                "next_action": "Use the applicant portal.",
+                "response_deadline": "Unknown",
+                "resubmission_channel": "Applicant portal",
+                "fee_information_only": "No fee stated",
+                "followup_contact": "Plans review team",
+                "followup_reference": "Follow-up by public line +12025550123",
+                "evidence_summary": "The desk confirmed person@example.com should use the portal.",
+            },
+        }
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = FakeCalls()
+
+
+def test_execute_calls_calle_once_with_idempotency_and_redacts_result():
+    request = client_module.parse_request(valid_payload())
+    fake = FakeClient()
+    result = client_module.execute(request, fake, timeout_seconds=30)
+    assert fake.calls.created["idempotency_key"] == "permitstatus-permit-demo-2026-001"
+    assert fake.calls.created["recipients"] == [
+        {"phones": ["+12025550123"], "region": "US", "locale": "en-US"}
+    ]
+    assert result["structured_result"]["followup_reference"].endswith("[phone-redacted]")
+    assert "[email-redacted]" in result["structured_result"]["evidence_summary"]
+
+
+def test_output_refuses_overwrite(tmp_path):
+    path = tmp_path / "result.json"
+    path.write_text("keep me", encoding="utf-8")
+    try:
+        client_module.write_output(path, {"ok": True})
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError("existing output was overwritten")
+    assert path.read_text(encoding="utf-8") == "keep me"

--- a/apps/python/permit-status-clarifier/test_server.py
+++ b/apps/python/permit-status-clarifier/test_server.py
@@ -1,0 +1,76 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+APP_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(APP_ROOT))
+SPEC = importlib.util.spec_from_file_location("permit_status_server", APP_ROOT / "server.py")
+assert SPEC and SPEC.loader
+server_module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = server_module
+SPEC.loader.exec_module(server_module)
+
+
+def valid_payload() -> dict:
+    return {
+        "workflow_id": "web-demo-001",
+        "phone": "+12025550123",
+        "caller_has_authority": True,
+        "recipient_is_public_department_number": True,
+        "organization_display_name": "Example Build Co",
+        "jurisdiction": "Example City",
+        "department": "Building and Safety Permit Desk",
+        "permit_reference": "BLD-2026-00421",
+        "project_type": "Interior commercial renovation",
+        "region": "US",
+        "locale": "en-US",
+        "questions": ["current_status", "blocking_items", "next_action"],
+    }
+
+
+def test_web_preview_is_no_call_and_masked():
+    result = server_module.preview_payload(valid_payload())
+    assert result["creates_phone_call"] is False
+    rendered = str(result)
+    assert "+12025550123" not in rendered
+    assert "BLD-2026-00421" not in rendered
+
+
+class FakeCalls:
+    def __init__(self):
+        self.count = 0
+
+    def create(self, **kwargs):
+        self.count += 1
+        return {"id": "call_web_demo"}
+
+    def wait_for_result(self, call_id, **kwargs):
+        return {"status": "completed", "structured_result": {"current_status": "under_review"}}
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = FakeCalls()
+
+
+def test_web_live_requires_all_confirmations_and_calls_once():
+    request = valid_payload()
+    for missing in ("authority", "public_number", "live_call"):
+        confirmations = {"authority": True, "public_number": True, "live_call": True}
+        confirmations[missing] = False
+        try:
+            server_module.execute_payload({"request": request, "confirmations": confirmations}, FakeClient())
+        except ValueError as exc:
+            assert "all three" in str(exc)
+        else:
+            raise AssertionError(f"missing {missing} confirmation was accepted")
+
+    fake = FakeClient()
+    result = server_module.execute_payload(
+        {"request": request, "confirmations": {"authority": True, "public_number": True, "live_call": True}},
+        fake,
+        timeout_seconds=10,
+    )
+    assert result["creates_phone_call"] is True
+    assert fake.calls.count == 1


### PR DESCRIPTION
## Problem

Municipal permit desks often report only that an application is "under review," leaving applicants without a precise blocker or next action.

## Solution

Adds **Permit Status Clarifier**, a runnable Python CALL-E app with a local web UI and CLI. It prepares one authorised, information-only call to a public permit desk and returns a structured status, blocker, next action, deadline, resubmission channel, fee information, and public follow-up reference.

## Safety and side effects

- Masked preview is the default and creates no call.
- Live mode requires explicit authority, public-number, and live-call confirmations.
- One stable idempotency key prevents accidental duplicate calls.
- The task forbids personal-data collection, legal interpretation, scheduling, submissions, payments, commitments, retries, and recurring calls.
- Structured output redacts phone numbers and email addresses.
- No credentials, analytics, persistence, or request-body logging.

## Validation

- `python -m pytest -q apps/python/permit-status-clarifier` ? 8 passed
- `python scripts/validate_repository.py` ? passed
- Local preview endpoint and desktop UI verified

## Live verification status

Preview and mocked CALL-E paths are fully verified. One authenticated CALL-E test call is still pending because this environment does not contain a `CALLE_API_KEY`; that is why this PR is opened as a draft.
