### PR TITLE
feat: add pharmacy-stock-check skill

### DIFF
--- a/skills/pharmacy-stock-check/.gitignore
+++ b/skills/pharmacy-stock-check/.gitignore
@@ -1,0 +1,23 @@
+# Runtime state written by scripts/pharmacy_search.py. None of it belongs in
+# version control.
+#
+# The run ledger holds confirm_tokens, which authorise placing a call.
+# The run dumps hold call transcripts — a third party's recorded voice.
+# Both are written 0600, but a file being unreadable to other users is no
+# protection against being committed.
+
+.pharmacy_runs.json
+.pharmacy_runs.json.lock
+.pharmacy_runs.json.corrupt.*
+.pharmacy_budget.json
+.pharmacy_budget.json.lock
+
+call_runs/
+run_*.json
+
+# Your real recipient list. Keep real numbers out of version control — copy
+# scripts/pharmacies.csv and edit the copy.
+pharmacies.local.csv
+
+__pycache__/
+*.pyc

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -157,12 +157,33 @@ Offer the transcript. Every claim should be checkable against what was said.
   account on the machine, and file permissions are no protection at all against
   being committed. Write them to a dedicated directory and add that directory to
   `.gitignore` — this skill ships one covering its own runtime state.
-- **Bind the auth token to the endpoint you are calling.** Credential caches
-  are keyed by hash and more than one can exist — a second account, a different
-  environment, a stale login. Selecting whichever sorts last silently
-  authenticates as the wrong account, which here means calling from the wrong
-  number and billing the wrong balance. If the correct cache can't be
-  determined, refuse and make the caller choose.
+- **Bind the auth token to the endpoint you are calling, and refuse if you
+  can't.** A bearer token is issued for one origin; sending it elsewhere hands
+  a working credential to a party it was never meant for. That's a disclosure,
+  not a routing mistake.
+
+  Ask the CLI which endpoint it authenticated against (`calle auth status`
+  reports `server_url` and `cache_path`) rather than inferring it from the
+  cache directory hash. Refuse on mismatch.
+
+  **A single cache with no endpoint recorded is not acceptable either.** "Only
+  one exists" is not evidence that it belongs to this provider. If nothing
+  binds the credential, stop and make the operator name it explicitly.
+
+- **Namespace a pending call by everything that changes what it is.** Hashing
+  the recipient and the goal is not enough. The same number and the same
+  question routed through a different region is a different call; under a
+  different account or endpoint it is a different plan entirely, and a
+  `plan_id` issued by one provider is meaningless to another.
+
+  Include endpoint, account and region in the identity. Getting this wrong
+  fails in both directions: a stale plan gets resurrected under new routing, or
+  a live one is treated as absent — and "absent" means the recipient is dialled
+  again.
+
+  Version the ledger. When the identity scheme changes, old keys won't match
+  anything you compute, so unfinished entries must be refused rather than read
+  as absent.
 - **Persist `plan_id` and `run_id` to disk as soon as you receive them.**
   `plan_id` is CALL-E's idempotency key, but it only protects you if it survives
   a crash. On restart, resume the stored run instead of re-planning.

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -46,8 +46,10 @@ This skill gathers **availability and pricing information only**.
 Required: medication name, dosage, quantity, recipient region, and the list of
 pharmacy phone numbers in E.164 format.
 
-If a number is local or ambiguous, ask the user for the full E.164 form. Do not
-guess a country code.
+**Validate every number before anything else happens.** E.164 is a plus, a
+non-zero country code digit, then 7–14 more digits — `^\+[1-9]\d{7,14}$`.
+Reject anything else and ask the user; never guess a country code. A local
+number silently reaching the planner is how the wrong person gets called.
 
 ### 2. Build the goal
 
@@ -103,20 +105,32 @@ get_call_run → poll until terminal, following next_step.action
 `plan_call` is free. Iterate on the goal text as much as you like before
 spending anything.
 
-### 5. Read the result
+### 5. Read the result — but only if the call actually completed
 
-The extracted fields arrive in `result.summary` as `key=value` pairs, **not** in
-`result.extracted` — see `references/calle-mcp-integration.md`. Values contain
-commas, so split on `key=` boundaries rather than on commas.
+**Check `result.outcome.task_completed` and the run status first.** A call that
+failed, went to voicemail or was cut off can still carry a partially filled
+summary. Treating that as a stock check is how a patient gets sent somewhere on
+the strength of a sentence nobody finished.
 
-Also read `result.outcome`, which gives `task_completed`, a confidence score and
-specific evidence strings. Surface the confidence to the user.
+If the run did not reach `COMPLETED` with `task_completed: true`, report *"could
+not be reached"* and emit **no stock fields at all**. Do not scrape what's there.
+
+Only when the call completed, parse the extracted fields from `result.summary`
+as `key=value` pairs — **not** from `result.extracted`, see
+`references/calle-mcp-integration.md`. Values contain commas and the separator
+is not stable (both `, ` and `; ` observed), so split on `key=` boundaries.
+
+`result.outcome` also gives a confidence score and specific evidence strings.
 
 ### 6. Report
 
-Rank in-stock first, then by price, then by whether they will hold it. Sink
-low-confidence results below high-confidence ones: a reliable "no" is more
-useful than an unreliable "yes" that sends someone across town.
+**Verification outranks stock status.** Rank verified results first — those that
+completed with confidence at or above 0.6 — then by stock, then price, then
+hold. A low-confidence "yes" must never outrank a high-confidence "no". Someone
+may travel while unwell on the strength of this, which makes an unreliable
+positive worse than a reliable negative.
+
+Mark anything unverified as such, visibly.
 
 Mask phone numbers in summaries — show the pharmacy name and the last four
 digits.
@@ -130,20 +144,28 @@ Offer the transcript. Every claim should be checkable against what was said.
 - **Check the budget for the whole search up front**, so five pharmacies against
   three remaining calls fails before anything is dialled rather than halfway
   through.
-- **`plan_id` is the idempotency key.** Never issue `run_call` twice for the
-  same plan.
-- **Persist every response immediately.** Never re-dial to recover data you
-  already paid for.
+- **Persist `plan_id` and `run_id` to disk as soon as you receive them.**
+  `plan_id` is CALL-E's idempotency key, but it only protects you if it survives
+  a crash. An interrupted poll with no persisted run means the next invocation
+  plans afresh and calls the same pharmacist a second time — spending a call and
+  bothering a real person. On restart, resume the stored run instead of
+  re-planning; only clear the entry once the run reaches a terminal state.
+- **Never re-dial to recover data you already paid for.**
 - **No recurring schedules.** This is a one-shot workflow. If a user wants
   repeat checks, create them explicitly and tell the user how to cancel.
 
 ## Dry run
 
-`scripts/pharmacy_search.py` is dry-run by default and prints the exact payload
-it would send without placing a call. Live calls require `--live`.
+`scripts/pharmacy_search.py` is dry-run by default, and the dry run is **fully
+offline**: it reads no credentials, opens no socket, and sends nothing anywhere.
+It validates every number and prints the exact payload it would send.
+
+That matters here. A dry run that still transmits the recipient's phone number
+and the medication being sought — by calling the planning endpoint — is not a
+dry run. In a medical-adjacent workflow it leaks who is looking for what.
 
 ```bash
-python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv        # no calls
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv        # offline
 python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live # calls
 ```
 

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -151,11 +151,12 @@ Offer the transcript. Every claim should be checkable against what was said.
   dispatched concurrently, so nothing downstream spaces them out. A file lock
   won't catch this: both rows run in one process and share a pid, so the
   in-flight set has to be tracked in-process as well.
-- **Store credentials and transcripts owner-only (0600).** The ledger holds
-  `confirm_token`s that authorise placing a call; run dumps hold a third
-  party's recorded voice. Default umask leaves both readable by every account
-  on the machine. Write them to a dedicated directory, not beside the script
-  where they get committed by accident.
+- **Store credentials and transcripts owner-only (0600), and ignore them.** The
+  ledger holds `confirm_token`s that authorise placing a call; run dumps hold a
+  third party's recorded voice. Default umask leaves both readable by every
+  account on the machine, and file permissions are no protection at all against
+  being committed. Write them to a dedicated directory and add that directory to
+  `.gitignore` — this skill ships one covering its own runtime state.
 - **Bind the auth token to the endpoint you are calling.** Credential caches
   are keyed by hash and more than one can exist — a second account, a different
   environment, a stale login. Selecting whichever sorts last silently

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -170,20 +170,34 @@ Offer the transcript. Every claim should be checkable against what was said.
   one exists" is not evidence that it belongs to this provider. If nothing
   binds the credential, stop and make the operator name it explicitly.
 
-- **Namespace a pending call by everything that changes what it is.** Hashing
-  the recipient and the goal is not enough. The same number and the same
-  question routed through a different region is a different call; under a
-  different account or endpoint it is a different plan entirely, and a
-  `plan_id` issued by one provider is meaningless to another.
+- **Keep the exclusion claim separate from the reconciliation identity.** These
+  are two different questions and they need different granularity.
 
-  Include endpoint, account and region in the identity. Getting this wrong
-  fails in both directions: a stale plan gets resurrected under new routing, or
-  a live one is treated as absent — and "absent" means the recipient is dialled
-  again.
+  *"Is there an unresolved call to this person about this thing?"* must be
+  answered on **recipient and purpose alone**. Fold endpoint, account or region
+  into that key and changing any of them makes a live call look absent — which
+  permits a second dial to someone already being rung.
 
-  Version the ledger. When the identity scheme changes, old keys won't match
-  anything you compute, so unfinished entries must be refused rather than read
-  as absent.
+  *"Can I resume this particular plan?"* needs the full configuration. So nest
+  it: a coarse claim keyed on `sha256(phone|goal)`, with the attempt's endpoint,
+  principal, region, `plan_id` and `run_id` recorded underneath.
+
+  On a configuration mismatch, do **neither**. Don't resume — a `plan_id` from
+  one endpoint or account is meaningless under another. Don't redial — the
+  earlier call may still be live. Surface it and let a human resolve it.
+
+- **Bind unfinished state to a stable principal, or fail closed.** Don't
+  namespace on the credential cache directory: CALL-E derives that from the
+  server URL, so re-authenticating as a different account on the same endpoint
+  reuses it — and an account-A run could be resumed with account-B credentials.
+
+  Derive the principal from the account itself (an id recorded in the cache, or
+  the `sub` claim of a JWT). If it can't be established, new calls may proceed,
+  but an unresolved call can no longer be confirmed as yours — so refuse to
+  reconcile it rather than guessing. `CALLE_ACCOUNT_ID` overrides.
+
+  Version the ledger. When claim keys change, old entries won't match anything
+  you compute, so unfinished ones must be refused rather than read as absent.
 - **Persist `plan_id` and `run_id` to disk as soon as you receive them.**
   `plan_id` is CALL-E's idempotency key, but it only protects you if it survives
   a crash. On restart, resume the stored run instead of re-planning.

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -146,10 +146,24 @@ Offer the transcript. Every claim should be checkable against what was said.
   through.
 - **Persist `plan_id` and `run_id` to disk as soon as you receive them.**
   `plan_id` is CALL-E's idempotency key, but it only protects you if it survives
-  a crash. An interrupted poll with no persisted run means the next invocation
-  plans afresh and calls the same pharmacist a second time — spending a call and
-  bothering a real person. On restart, resume the stored run instead of
-  re-planning; only clear the entry once the run reaches a terminal state.
+  a crash. On restart, resume the stored run instead of re-planning.
+
+  The ledger is the thing standing between a crash and a second call to a real
+  person, so it has to be written like one:
+
+  - **Lock it.** Read-modify-write under an exclusive file lock. Without it,
+    two processes both see "no entry" and both dial.
+  - **Write atomically.** Temp file, fsync, then rename. A partial write must
+    never replace a good ledger.
+  - **Fail loudly on corruption.** An unreadable ledger means quarantine it and
+    stop. Substituting an empty one presents every in-flight run as new and
+    redials the lot.
+  - **Record the terminal result before retiring the entry.** Clearing first
+    opens a window where a crash loses both the result and the claim.
+  - **Treat an ambiguous create as un-retryable.** If `run_call` was sent and
+    the response was lost, whether the phone rang is unknown. Mark that state
+    before the call, and require a human decision to clear it — never retry
+    automatically.
 - **Never re-dial to recover data you already paid for.**
 - **No recurring schedules.** This is a one-shot workflow. If a user wants
   repeat checks, create them explicitly and tell the user how to cancel.
@@ -164,10 +178,47 @@ That matters here. A dry run that still transmits the recipient's phone number
 and the medication being sought — by calling the planning endpoint — is not a
 dry run. In a medical-adjacent workflow it leaks who is looking for what.
 
+Numbers are masked in the printed payload too. Masking covers anything printed
+or logged, not just what reaches the user: terminal output ends up in
+scrollback, CI logs and screen recordings.
+
 ```bash
 python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv        # offline
 python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live # calls
 ```
+
+## Verifying end to end without a real pharmacy
+
+CALL-E publishes an inbound testing hotline — **+1 276-322-9632** — that answers
+with a general-purpose conversational prompt. It's the recommended target for
+exercising this skill live without calling a business.
+
+```bash
+printf 'name,phone,address\nCALL-E Hotline,+12763229632,Inbound testing hotline\n' \
+  > pharmacies.hotline.csv
+
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv           # offline
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live    # 1 call
+```
+
+The hotline isn't role-playing a pharmacist, so the extracted fields will be
+sparse or `unknown`. That's the expected result and it's still a useful check —
+it exercises plan, run, poll, the completion gate and the ledger, and confirms
+an incomplete stock check reports as one rather than inventing fields.
+
+**To verify the durable-run behaviour**, interrupt a live call mid-poll
+(`Ctrl+C`) and run the same command again:
+
+```
+  …9632: resuming run 4BJPgjIFv3gZ
+```
+
+It polls the existing run instead of planning a new one. Inspect
+`.pharmacy_runs.json` between the two invocations to see the entry sitting in
+`running` with its `run_id` recorded.
+
+This number is published by CALL-E for testing, so it is not masked here — the
+masking rule protects private numbers, not a public test endpoint.
 
 ## Example
 

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -135,6 +135,21 @@ Mark anything unverified as such, visibly.
 Mask phone numbers in summaries — show the pharmacy name and the last four
 digits.
 
+**Masking covers derived text too, not just the number you dialled.** The
+provider's activity feed quotes the call as it happens, and fields like
+`pharmacist_notes` and `alternative_suggested` are lifted straight out of the
+conversation. A pharmacist reading out a branch number ends up in both. Printing
+either verbatim puts a third party's words into terminal scrollback, CI logs and
+screen recordings.
+
+So: scrub anything number-shaped from free text before it is logged or printed,
+and withhold realtime speech events entirely unless the operator explicitly asks
+for them. Prices, quantities and hold durations must survive — redact runs of
+eight or more digits, not every number.
+
+The stored record keeps the original. It is the evidence, and it is protected by
+being 0600 and out of the working directory.
+
 Offer the transcript. Every claim should be checkable against what was said.
 
 ## Cost and safety controls

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: pharmacy-stock-check
+description: Call a list of pharmacies to find out which one has a specific medication in stock, at what price, and whether they will hold it. Use when someone needs to locate a medication nearby and would otherwise ring round manually. Returns one structured record per pharmacy with a confidence score and the call transcript as evidence.
+---
+
+# Pharmacy stock check
+
+Finding a medication that is actually in stock means calling pharmacies one at a
+time and asking the same four questions. This skill does the calling and returns
+a ranked answer.
+
+It is a good fit for CALL-E's design: low-frequency, personal, high-stakes phone
+work that was never worth automating with a traditional call platform.
+
+## Before you start
+
+**This skill places real phone calls to real businesses.** Confirm with the user:
+
+- the medication, dosage and quantity
+- which pharmacies to call, as E.164 numbers
+- that they want calls placed now
+
+Never infer a phone number. Never call a number the user did not supply or
+approve.
+
+## Safety boundaries
+
+This skill gathers **availability and pricing information only**.
+
+- It does not give medical advice, recommend a medication, or suggest a
+  substitute. If a pharmacist offers an alternative, report it verbatim as
+  something the pharmacist said — never as a recommendation.
+- It does not place an order, reserve stock, or commit to a purchase on the
+  user's behalf.
+- It is not for emergencies. If someone needs medication urgently, they should
+  contact emergency services or an urgent care provider, not wait on an agent.
+- Prescription requirements are reported, never worked around.
+- Report the pharmacist's answer and the confidence score. Do not present a
+  low-confidence result as fact — the user may travel somewhere while unwell on
+  the strength of it.
+
+## Workflow
+
+### 1. Collect the request
+
+Required: medication name, dosage, quantity, recipient region, and the list of
+pharmacy phone numbers in E.164 format.
+
+If a number is local or ambiguous, ask the user for the full E.164 form. Do not
+guess a country code.
+
+### 2. Build the goal
+
+CALL-E's MCP surface has no `result_schema` parameter, so the fields you want
+must be named in the `goal` text. CALL-E honours them reliably and emits them in
+`result.summary`.
+
+```text
+You are calling a pharmacy on behalf of a patient looking for a medication.
+Identify yourself as an automated assistant immediately, and keep the call
+brief and polite.
+
+Find out whether they currently have {drug} {dosage} in stock. The patient
+needs {quantity}.
+
+Capture these fields in the structured result, using exactly these key names:
+- in_stock: yes, no, partial, or unknown. Use partial if they have some but
+  fewer than the patient needs.
+- form_available: brand, generic, both, or unknown
+- quantity_available: integer units they have
+- unit_price: number, price per unit
+- currency: three-letter currency code
+- requires_prescription: yes, no, or unknown
+- can_hold: yes, no, or unknown
+- hold_duration_hours: number of hours they will hold it
+- alternative_suggested: any alternative or other branch they mention
+- pharmacist_notes: anything else useful, one short sentence
+
+If they do not have it, still ask about alternatives or another branch. Do not
+place an order or commit to anything on the patient's behalf. Thank them and
+end the call. If nobody answers, report that the pharmacy could not be reached;
+do not treat that as a successful stock check.
+```
+
+Identifying as an automated assistant in the first line is not optional. It is
+the difference between a pharmacist answering and a pharmacist hanging up.
+
+### 3. One run per pharmacy
+
+`to_phones` accepts an array, but batching returns an **aggregated** summary for
+the whole batch. This workflow needs per-pharmacy attribution — which pharmacy
+has 10 units at £5 — so place one run per pharmacy and run them concurrently.
+The call cost is identical.
+
+### 4. Execute
+
+```text
+plan_call    → ready_to_run + confirm_token   (free, places no call)
+run_call     → run_id                          (spends len(to_phones))
+get_call_run → poll until terminal, following next_step.action
+```
+
+`plan_call` is free. Iterate on the goal text as much as you like before
+spending anything.
+
+### 5. Read the result
+
+The extracted fields arrive in `result.summary` as `key=value` pairs, **not** in
+`result.extracted` — see `references/calle-mcp-integration.md`. Values contain
+commas, so split on `key=` boundaries rather than on commas.
+
+Also read `result.outcome`, which gives `task_completed`, a confidence score and
+specific evidence strings. Surface the confidence to the user.
+
+### 6. Report
+
+Rank in-stock first, then by price, then by whether they will hold it. Sink
+low-confidence results below high-confidence ones: a reliable "no" is more
+useful than an unreliable "yes" that sends someone across town.
+
+Mask phone numbers in summaries — show the pharmacy name and the last four
+digits.
+
+Offer the transcript. Every claim should be checkable against what was said.
+
+## Cost and safety controls
+
+- **Count phones, not calls.** `to_phones` is an array, so one plan can spend N
+  calls. Charge `len(to_phones)` against any budget before dialling.
+- **Check the budget for the whole search up front**, so five pharmacies against
+  three remaining calls fails before anything is dialled rather than halfway
+  through.
+- **`plan_id` is the idempotency key.** Never issue `run_call` twice for the
+  same plan.
+- **Persist every response immediately.** Never re-dial to recover data you
+  already paid for.
+- **No recurring schedules.** This is a one-shot workflow. If a user wants
+  repeat checks, create them explicitly and tell the user how to cancel.
+
+## Dry run
+
+`scripts/pharmacy_search.py` is dry-run by default and prints the exact payload
+it would send without placing a call. Live calls require `--live`.
+
+```bash
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv        # no calls
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live # calls
+```
+
+## Example
+
+Request: amoxicillin 500mg, 21 capsules, three pharmacies in GB.
+
+Result from one pharmacy:
+
+```json
+{
+  "pharmacy": "Test Pharmacy (…0100)",
+  "in_stock": "partial",
+  "quantity_available": 10,
+  "unit_price": 5.0,
+  "currency": "GBP",
+  "requires_prescription": "yes",
+  "can_hold": "yes",
+  "hold_duration_hours": 48,
+  "pharmacist_notes": "They have only 10 units available, less than the requested 21 capsules.",
+  "confidence": 0.82
+}
+```
+
+Worth noting what CALL-E got right there: the pharmacist said "10 units" against
+a request for 21, and the result is `partial` rather than `yes`. It also
+converted "just two days" into `hold_duration_hours: 48`.
+
+## References
+
+Read `references/calle-mcp-integration.md` for MCP surface behaviour, including
+where extraction actually lands.
+
+Read `references/safety.md` for boundaries on medical-adjacent phone workflows.
+
+See `references/examples.md` for worked conversations, including when to decline
+to call.

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -299,6 +299,48 @@ Worth noting what CALL-E got right there: the pharmacist said "10 units" against
 a request for 21, and the result is `partial` rather than `yes`. It also
 converted "just two days" into `hold_duration_hours: 48`.
 
+## Known limitations
+
+Stated rather than discovered, because each one is a boundary on a guarantee
+this skill otherwise makes.
+
+**The exclusion lock is single-host.** It uses `flock` on a sidecar file, which
+coordinates processes on one machine. It does not coordinate across machines,
+and its behaviour on NFS and some network filesystems is unreliable. Two
+operators running this against a shared drive get no mutual exclusion, and the
+duplicate-dial protection is only as good as the lock. A multi-host deployment
+needs a real lease — a database row, or a lock service.
+
+**Principal resolution currently returns nothing on CALL-E, so resume needs
+`CALLE_ACCOUNT_ID`.** Identity is looked for in an id recorded alongside the
+credential, then in the `sub` claim of a JWT. As of writing, the CALL-E CLI
+cache records `server_url`, `auth_base_url`, `issued_at`, `expires_at` and
+`token` — no account identifier — and the token is opaque rather than a JWT.
+
+So no principal can be established, and unfinished state fails closed rather
+than risk resuming one account's run under another's credentials. That is the
+safe behaviour, but it means **cross-process resume does not work out of the box**:
+
+```bash
+export CALLE_ACCOUNT_ID=me@example.com    # any stable value you control
+```
+
+Any consistent string works — it only has to change when the authenticated
+account changes. Endpoint binding is unaffected: `server_url` *is* recorded, so
+credentials are still bound to the right origin automatically.
+
+This resolves itself if the provider exposes an account identifier in the
+credential cache or issues a token with a subject claim.
+
+**Verification is manual, not automated.** There is a runnable end-to-end path
+(see the testing hotline above) and the dry run is fully offline, but there is
+no committed test suite. The concurrency, crash and credential behaviours were
+verified with throwaway scripts rather than tests a reviewer can re-run.
+
+**The budget ceiling is local.** It counts what this installation has spent. It
+does not know the provider-side balance, so it protects against a runaway loop,
+not against a quota consumed elsewhere.
+
 ## References
 
 Read `references/calle-mcp-integration.md` for MCP surface behaviour, including

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -241,6 +241,20 @@ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv        # offline
 python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live # calls
 ```
 
+## Tests
+
+```bash
+python3 scripts/test_pharmacy_search.py
+```
+
+Standard library only. No network, no credentials, no calls placed.
+
+The suite exists because the same invariant has broken twice in ways that were
+silent — the code planned and submitted a second call to a real person, and
+nothing in the output said so. `test_resume_does_not_redial` asserts on which
+MCP tools were invoked rather than on return values, because whether `run_call`
+was called is the only thing that distinguishes "resumed" from "dialled again".
+
 ## Verifying end to end without a real pharmacy
 
 CALL-E publishes an inbound testing hotline — **+1 276-322-9632** — that answers
@@ -332,10 +346,17 @@ credentials are still bound to the right origin automatically.
 This resolves itself if the provider exposes an account identifier in the
 credential cache or issues a token with a subject claim.
 
-**Verification is manual, not automated.** There is a runnable end-to-end path
-(see the testing hotline above) and the dry run is fully offline, but there is
-no committed test suite. The concurrency, crash and credential behaviours were
-verified with throwaway scripts rather than tests a reviewer can re-run.
+**Test coverage is behavioural, not exhaustive.** `scripts/test_pharmacy_search.py`
+covers the invariants that have actually regressed — crash-and-resume,
+exclusion across configuration changes, budget ceilings, validation — with no
+network, no credentials and no calls placed:
+
+```bash
+python3 scripts/test_pharmacy_search.py
+```
+
+It does not cover the live provider surface. Reaching the real API still means
+the hotline path above.
 
 **The budget ceiling is local.** It counts what this installation has spent. It
 does not know the provider-side balance, so it protects against a runaway loop,

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -141,9 +141,27 @@ Offer the transcript. Every claim should be checkable against what was said.
 
 - **Count phones, not calls.** `to_phones` is an array, so one plan can spend N
   calls. Charge `len(to_phones)` against any budget before dialling.
-- **Check the budget for the whole search up front**, so five pharmacies against
-  three remaining calls fails before anything is dialled rather than halfway
-  through.
+- **Reserve atomically, under the same lock as the ledger read.** A
+  check-then-write budget is not a ceiling: two processes read the same
+  `spent`, both pass the check, and both dial. The up-front whole-batch check
+  is a convenience so a batch fails before the first call rather than halfway;
+  the per-call atomic reserve is what actually enforces the limit.
+- **Deduplicate recipients before dispatch.** The same number listed twice is a
+  data-entry mistake, not a request to ring someone twice — and rows are
+  dispatched concurrently, so nothing downstream spaces them out. A file lock
+  won't catch this: both rows run in one process and share a pid, so the
+  in-flight set has to be tracked in-process as well.
+- **Store credentials and transcripts owner-only (0600).** The ledger holds
+  `confirm_token`s that authorise placing a call; run dumps hold a third
+  party's recorded voice. Default umask leaves both readable by every account
+  on the machine. Write them to a dedicated directory, not beside the script
+  where they get committed by accident.
+- **Bind the auth token to the endpoint you are calling.** Credential caches
+  are keyed by hash and more than one can exist — a second account, a different
+  environment, a stale login. Selecting whichever sorts last silently
+  authenticates as the wrong account, which here means calling from the wrong
+  number and billing the wrong balance. If the correct cache can't be
+  determined, refuse and make the caller choose.
 - **Persist `plan_id` and `run_id` to disk as soon as you receive them.**
   `plan_id` is CALL-E's idempotency key, but it only protects you if it survives
   a crash. On restart, resume the stored run instead of re-planning.

--- a/skills/pharmacy-stock-check/references/calle-mcp-integration.md
+++ b/skills/pharmacy-stock-check/references/calle-mcp-integration.md
@@ -1,0 +1,197 @@
+# CALL-E MCP integration notes
+
+Behaviour observed while building a pharmacy stock-check workflow against the
+CALL-E MCP surface. Written down because none of it is obvious from the tool
+schemas, and each item cost debugging time.
+
+Verified against a real completed run (GB, 107 seconds, `task_completed: true`,
+confidence 0.82).
+
+---
+
+## The flow is a state machine
+
+```
+plan_call     → ready_to_run + confirm_token   (free — no call is placed)
+run_call      → run_id                          (spends len(to_phones))
+get_call_run  → poll until terminal
+```
+
+`run_call` and `get_call_run` return a structured `next_step` object whose
+`action` field is an explicit instruction:
+
+| `next_step.action` | Meaning |
+| --- | --- |
+| `poll_get_call_run` | Keep polling; honour `poll_after_seconds` |
+| `wait_for_scheduled_run` | A scheduled run hasn't started yet |
+| `ask_user_for_missing_info` | Blocked; `required_user_input` lists the fields |
+| `ask_user_for_retry_confirmation` | Blocked on a retry decision |
+| `plan_call_same_plan_id` | Re-plan, reusing the same `plan_id` |
+| `report_result` | Terminal — report to the user |
+| `report_blocked` | Terminal — cannot proceed |
+
+Driving the loop off `next_step.action` rather than off status strings alone is
+the cleanest way to integrate.
+
+**Type gotcha:** `next_step` is a structured object on `run_call` and
+`get_call_run`, but a plain **string** on `plan_call`. Type-guard before calling
+`.get()` on it.
+
+---
+
+## Extraction lands in `result.summary`, not `result.extracted`
+
+This is the biggest surprise on the surface.
+
+`result.extracted` is documented as "Structured extracted data" with
+`additionalProperties: true`. In practice it contains an echo of the **request**
+plus telephony metadata:
+
+```json
+{
+  "goal": "...",
+  "region": "GB",
+  "language": "English",
+  "to_phones": ["+15550100"],
+  "repair": { "decision": { ... } },
+  "calling": { "duration_seconds": 107, "status": "finished", ... }
+}
+```
+
+The fields the agent actually collected are in `result.summary`, serialised into
+a string:
+
+```text
+Stock check completed. Result: in_stock=partial, form_available=both,
+quantity_available=10, unit_price=5, currency=GBP, requires_prescription=yes,
+can_hold=yes, hold_duration_hours=48, alternative_suggested=GPNHS/unclear,
+pharmacist_notes=They have only 10 units available, less than the requested
+21 capsules.
+```
+
+The agent honours the key names given in the `goal` prose reliably. They just
+arrive as prose rather than as an object.
+
+**Parsing:** split on `key=` boundaries using the known field names as
+delimiters, never on commas — free-text fields like `pharmacist_notes` contain
+commas and naive splitting corrupts them.
+
+```python
+import re
+
+FIELDS = ["in_stock", "quantity_available", "unit_price", "pharmacist_notes"]
+pattern = re.compile(
+    r"\b(" + "|".join(sorted(FIELDS, key=len, reverse=True)) + r")\s*=\s*", re.I
+)
+
+def parse_summary(summary: str) -> dict[str, str]:
+    matches = list(pattern.finditer(summary))
+    out = {}
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(summary)
+        out[m.group(1).lower()] = summary[m.end():end].strip().strip(",").strip()
+    return out
+```
+
+Sort field names longest-first so `unit_price` matches before `price`.
+
+Check `result.extracted` for domain keys as a fallback in case this changes.
+
+---
+
+## There is no `result_schema` on MCP
+
+The REST examples and the TypeScript SDK sample both show a `result_schema`
+parameter with JSON Schema, plus a `resultValidation` field on the response.
+`plan_call` on MCP accepts none of that — only `plan_id`, `to_phones`, `region`,
+`language`, `goal`, `scheduled_at`, `retry_confirmation_action`, `user_input`
+and `ttl_seconds`.
+
+Steer extraction by naming the exact key names inside the `goal` text. It works
+well, but there is no validation signal, so normalise and coerce client-side.
+
+---
+
+## `result.outcome` is the most useful part of the response
+
+```json
+{
+  "task_completed": true,
+  "completion_confidence": { "score": 0.82, "label": "high" },
+  "evidence": [
+    "The pharmacy confirmed availability of amoxicillin 500mg but only for 10 units.",
+    "They stated both brand and generic were available at £5 per unit.",
+    "They indicated a prescription is required and that the available units can be held for about two days."
+  ]
+}
+```
+
+This is what makes results safe to act on automatically — it tells you when not
+to trust them. Surface the confidence score to the user rather than presenting
+every result as equally certain.
+
+Inference quality is good. In the run above the caller said "10 units" against a
+request for 21 and the result is `partial`, not `yes`. "Just two days" became
+`hold_duration_hours: 48`. Heavily disfluent speech still yielded
+`unit_price=5, currency=GBP`.
+
+---
+
+## `to_phones` is an array, and batching is aggregated
+
+One `plan_call` with ten numbers spends ten calls, and nothing in
+`confirm_summary` states the cost before you commit.
+
+More importantly, `result.summary` and the confidence block come back
+**aggregated for the whole batch**. `result.batch` gives counts
+(`total_calls`, `completed_calls`, `no_answer_calls`…) but not per-callee
+extraction.
+
+If your workflow needs to know *which* recipient said what — most do — place one
+run per recipient and run them concurrently. The call cost is the same.
+
+---
+
+## Cost control
+
+- Charge `len(to_phones)`, not 1, against any budget.
+- Check the budget for the whole batch **before** dialling anything.
+- `plan_id` is the idempotency key. Never issue `run_call` twice for one plan.
+- `confirm_token` expires in roughly 24 hours; check `confirm_expires_at` before
+  spending.
+- `plan_call` is free. Iterate on goal wording at no cost.
+- Persist every response the moment it lands. Never re-dial to recover data you
+  already paid for.
+- `ttl_seconds: 0` retains run records permanently, which is useful when the
+  records are your evidence.
+
+---
+
+## Smaller things
+
+**The activity feed is cumulative.** Every `get_call_run` poll returns the full
+history from the beginning, and `next_cursor` was not populated. Dedupe on
+`(ts, message)` client-side or a 100-second call will emit the same lines dozens
+of times.
+
+**Token cache shape is undocumented.** `calle auth status` reveals
+`cache_path` (`~/.calle-mcp/cli/<hash>/token.json`) but not the JSON shape, so a
+client has to probe key names defensively. A `calle auth token --json` emitting a
+stable `{access_token, expires_at}` would remove the guesswork.
+
+**Region support is finite.** US, SG, MY, IN, AE, AU, CA, GB, VN, DE, JP, FR,
+MX, BR, ID, PH, KE at time of writing. Check before designing around a market.
+
+---
+
+## Suggested improvements
+
+1. Populate `result.extracted` with the conversational fields and move the
+   request echo to a separate key. This is likely a small change and would
+   remove the most error-prone part of every integration.
+2. Add `estimated_call_count` and remaining quota to the `plan_call` output so
+   `confirm_summary` can state the cost. The confirmation step currently
+   confirms intent without confirming spend.
+3. Document the `next_step` state machine. It is the best-designed part of the
+   API and it is not mentioned in the README.
+4. Populate `next_cursor`, or honour `cursor`, for incremental activity fetch.

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -300,31 +300,50 @@ Refusing to send that credential to a different origin.
 
 ---
 
-## Example 14 — changing region does not reuse a plan
+## Example 14 — changing configuration neither resumes nor redials
 
-A call to the same pharmacy about the same medication, routed through a
-different region, is a different call:
+A call is in flight to `…0100`, placed in region GB. Rerunning with a different
+region:
 
 ```bash
-$ python3 scripts/pharmacy_search.py --pharmacies p.csv --region GB --live
-  …0100: resuming run 4BJPgjIFv3gZ
-
 $ python3 scripts/pharmacy_search.py --pharmacies p.csv --region US --live
-  …0100: planning              # different identity, not the GB run
+  …0100: an unresolved call exists for this recipient and goal, but it was
+  made under a different configuration (region: pending='GB' now='US').
+  Not resuming — a plan or run id from one endpoint or account is meaningless
+  under another. Not redialling either — the earlier call may still be live,
+  and this person should not be rung twice.
+  Resolve it under the original configuration, or remove the entry
+  deliberately once you know what happened.
 ```
 
-Run identity is `sha256(endpoint | account | region | phone | goal)`. Reusing a
-plan across a routing or credential change would either resurrect a stale plan
-or, worse, treat a live call as absent and dial the pharmacist twice.
+The exclusion claim is `sha256(phone|goal)` — deliberately free of endpoint,
+account and region. Had those been part of it, changing region would have made
+the live call invisible and dialled the pharmacist a second time.
 
-Changing the identity scheme bumps `LEDGER_SCHEMA`. An older ledger holding
+The same refusal covers re-authenticating as a different account on the same
+endpoint:
+
+```
+(principal: pending='acct-A' now='acct-B')
+```
+
+And if the account can't be identified at all, an unresolved call fails closed
+rather than being resumed or redialled:
+
+```
+  …0100: an unresolved call exists, but the authenticated account could not
+  be identified, so it cannot be confirmed as ours. Failing closed rather
+  than resuming another account's run or redialling. Set CALLE_ACCOUNT_ID,
+  or resolve the entry deliberately.
+```
+
+Changing the claim scheme bumps `LEDGER_SCHEMA`. An older ledger holding
 unfinished entries is refused rather than read as empty:
 
 ```
-Run ledger .pharmacy_runs.json uses an older identity scheme (schema None,
-now 2) and still holds 1 unfinished entry. Keys are now namespaced by
-endpoint, account and region, so those entries would not be found and their
-recipients would be dialled again.
+Run ledger .pharmacy_runs.json uses schema 2 (now 3) and still holds 1
+unfinished entry. Claim keys changed, so those entries would not be found
+and their recipients would be dialled again.
 ```
 
 ---

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -171,7 +171,79 @@ sought to a third party, from a mode the user was told places no calls.
 
 ---
 
-## Example 9 — budget refuses before dialling
+## Example 9 — an interrupted call is not redialled
+
+The process was killed while a call was in progress. Rerunning:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
+  …0100: resuming run 4BJPgjIFv3gZ
+```
+
+It polls the existing run rather than planning a new one. The pharmacist is not
+called twice.
+
+If the crash happened in the narrower window *after* the call was submitted but
+*before* a run id came back:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
+  …0100: a call was submitted but no run id was recorded, so whether the
+  phone rang is unknown. Not retrying automatically. Check the CALL-E
+  dashboard for plan pX70PPR62, then either record the run id or remove
+  this entry to allow a redial.
+```
+
+Ambiguity is not resolved by guessing. A duplicate call to a pharmacist costs
+money and looks like a malfunctioning system contacting a business repeatedly
+about a patient.
+
+---
+
+## Example 10 — two processes, one recipient
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live &
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
+  …0100: held by live process 48213. Not dialling concurrently.
+```
+
+Claims are taken under an exclusive lock, so two processes can't both conclude
+the recipient is free and both dial.
+
+---
+
+## Example 11 — verifying against CALL-E's testing hotline
+
+CALL-E publishes an inbound hotline at **+1 276-322-9632** for testing. It
+answers with a general-purpose prompt rather than role-playing a pharmacist, so
+this is a pipeline check, not a source of stock data.
+
+```bash
+$ printf 'name,phone,address\nCALL-E Hotline,+12763229632,Testing hotline\n' \
+    > pharmacies.hotline.csv
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
+
+Pharmacy          Stock     Qty  Price  Rx       Hold  Conf
+CALL-E Hotline    unknown     —      —  unknown     —  0.34  ⚠ unverified
+    The recipient did not provide stock information.
+```
+
+The right outcome. The hotline can't answer a stock question, confidence is
+low, and the row is marked unverified rather than filled with plausible
+guesses. It exercises plan, run, poll, the completion gate and the ledger
+without calling a business.
+
+Interrupt it mid-poll and run it again to check the durable path:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
+  …9632: resuming run 4BJPgjIFv3gZ
+```
+
+---
+
+## Example 12 — budget refuses before dialling
 
 ```bash
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live --max-calls 2

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -243,7 +243,50 @@ $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
 
 ---
 
-## Example 12 — budget refuses before dialling
+## Example 12 — a duplicated row is not dialled twice
+
+`pharmacies.csv` lists the same number under two names — easily done when a
+chain has branches:
+
+```csv
+name,phone,address
+Oakhill Chemist,+15550101,High Street
+Oakhill (High St),+15550101,duplicate of the above
+```
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
+Skipping 1 duplicate row(s) for recipients already in this batch:
+  Oakhill (High St) (…0101)
+```
+
+Rows are dispatched concurrently, so without this both would ring the same
+pharmacist within a second of each other. A file lock doesn't catch it — both
+coroutines share a pid — so duplicates are collapsed before dispatch and the
+in-flight set is tracked in-process as well.
+
+---
+
+## Example 13 — ambiguous credentials, no guessing
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
+2 cached CALL-E tokens found and none records the endpoint
+https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth, so the correct
+account cannot be determined. Refusing to guess — calls would be placed
+and billed from whichever cache happens to sort last. Set
+CALLE_TOKEN_CACHE to one of:
+  /Users/you/.calle-mcp/cli/4811f3e.../token.json
+  /Users/you/.calle-mcp/cli/9c22ab1.../token.json
+or run `calle auth login` to refresh the intended account.
+```
+
+Placing a call from the wrong account isn't recoverable once the phone has
+rung, so an ambiguous credential is a stop, not a default.
+
+---
+
+## Example 14 — budget refuses before dialling
 
 ```bash
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live --max-calls 2

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -1,0 +1,138 @@
+# Examples
+
+All numbers below are from the reserved fictional range +1 555 0100–0199.
+Replace them with real E.164 numbers you have permission to call.
+
+---
+
+## Example 1 — a straightforward search
+
+**User:** I need amoxicillin 500mg, 21 capsules. Can you check these three
+pharmacies? +1 555 0100, +1 555 0101, +1 555 0102.
+
+**Agent:** Before I call, let me confirm:
+
+- Medication: amoxicillin 500mg, 21 capsules
+- Pharmacies: 3 numbers in the US
+- This will place 3 real phone calls now
+
+I'll ask each pharmacy about stock, price, whether a prescription is required,
+and whether they can hold it. I won't place an order or reserve anything.
+
+Shall I go ahead?
+
+**User:** Yes.
+
+**Agent:** *(one run per pharmacy, concurrently)*
+
+```
+Riverside Pharmacy (…0100)      partial   10 units   $5.00   Rx: yes   hold 48h   conf 0.82
+    They have only 10 units available, less than the requested 21 capsules.
+Oakhill Chemist (…0101)         yes       40 units   $6.20   Rx: yes   hold 24h   conf 0.91
+Station Road Pharmacy (…0102)   no        —          —       —         —          conf 0.88
+    Suggested trying their branch on Mill Lane.
+```
+
+Oakhill has the full quantity and will hold it for 24 hours. Riverside is
+cheaper but only has 10 of the 21 you need.
+
+All three need a prescription. I haven't reserved anything — you'd need to call
+and ask them to hold it yourself.
+
+Want the transcript for any of these?
+
+---
+
+## Example 2 — a local number, so the agent asks rather than guesses
+
+**User:** Check if the chemist on 07700 900123 has ibuprofen 400mg.
+
+**Agent:** I need that number in full international format before I can dial —
+I won't guess a country code. If that's a UK mobile it would be
++44 7700 900123, but please confirm.
+
+Also, how many do you need? The pharmacist will ask, and "partial stock" only
+means something if I know the target quantity.
+
+---
+
+## Example 3 — urgency, so the agent does not call
+
+**User:** I've run out of my heart medication and I feel awful. Call every
+pharmacy near me right now.
+
+**Agent:** I'm not going to start calling for this — it's the wrong tool for
+what you're describing.
+
+Each call takes a few minutes and I'd be working through a list while you're
+unwell. If you've missed doses of a heart medication and you're feeling bad,
+please contact your doctor, an urgent care service, or emergency services now.
+A pharmacist reached directly can also advise on an emergency supply.
+
+If it turns out you just need to locate stock and there's no urgency, I'm happy
+to ring round then.
+
+---
+
+## Example 4 — the pharmacist suggests something else
+
+**Result:** `alternative_suggested = "pharmacist mentioned co-amoxiclav"`
+
+**Agent reports:**
+
+> Station Road doesn't have it. The pharmacist mentioned they stock
+> co-amoxiclav.
+
+**Not:**
+
+> ~~Station Road doesn't have it, but co-amoxiclav would work instead.~~
+
+The agent relays what a pharmacist said. It does not endorse a substitute or
+imply equivalence — that's a clinical judgement, and nobody qualified reviewed
+this exchange.
+
+---
+
+## Example 5 — low confidence surfaced, not smoothed over
+
+```
+Riverside Pharmacy (…0100)   yes   —   —   Rx: unknown   —   conf 0.41  ⚠ verify
+    Call quality was poor; several answers were unclear.
+```
+
+**Agent:** Riverside said yes, but confidence is low — the line was bad and
+several answers were unclear. I'd ring them yourself before travelling.
+
+Confidence below about 0.6 gets flagged rather than reported as fact. Someone
+may be about to travel while unwell on the strength of this.
+
+---
+
+## Example 6 — dry run before spending anything
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv
+
+amoxicillin 500mg — 21 capsules · 3 pharmacies · dry run, no calls
+
+  DRY RUN Riverside Pharmacy (…0100) — plan pX70PPR62, would spend 1 call
+  DRY RUN Oakhill Chemist (…0101) — plan p8KM2QW41, would spend 1 call
+  DRY RUN Station Road Pharmacy (…0102) — plan pT39LLV87, would spend 1 call
+```
+
+`plan_call` is free, so this validates the goal wording, the numbers and the
+region without placing a call. Add `--live` when you're ready to dial.
+
+---
+
+## Example 7 — budget refuses before dialling
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live --max-calls 2
+
+BudgetExceeded: 3 call(s) needed, 2 left of 2.
+```
+
+The check runs across the whole batch before anything is dialled, so a search
+fails cleanly rather than stopping halfway with two calls spent and no complete
+answer.

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -93,39 +93,85 @@ this exchange.
 
 ---
 
-## Example 5 — low confidence surfaced, not smoothed over
+## Example 5 — a confident "no" outranks an unreliable "yes"
 
 ```
-Riverside Pharmacy (…0100)   yes   —   —   Rx: unknown   —   conf 0.41  ⚠ verify
+Pharmacy                Stock    Qty  Price  Conf
+Oakhill Chemist (…0101) no        —      —   0.95
+Riverside (…0100)       yes       —      —   0.31  ⚠ unverified
     Call quality was poor; several answers were unclear.
 ```
 
-**Agent:** Riverside said yes, but confidence is low — the line was bad and
-several answers were unclear. I'd ring them yourself before travelling.
+**Agent:** Oakhill definitely doesn't have it — that's a clear answer.
+Riverside said yes, but confidence is low: the line was bad and several answers
+were unclear. I've ranked it below because an unreliable yes is worse than a
+reliable no when you'd be travelling on it. Ring Riverside yourself before you
+set off.
 
-Confidence below about 0.6 gets flagged rather than reported as fact. Someone
-may be about to travel while unwell on the strength of this.
+Verification is the **primary** sort key, ahead of stock status. A
+low-confidence "yes" appearing at the top of the list is the specific failure
+that sends a sick person on a pointless journey.
 
 ---
 
-## Example 6 — dry run before spending anything
+## Example 6 — a call that didn't complete reports nothing
+
+```
+Station Road Pharmacy (…0102)   unknown   —   —   —   ⚠ unverified
+    Call did not complete (no answer). No stock information obtained.
+```
+
+The run ended `NO ANSWER` with `task_completed: false`. Even if a partial
+summary came back, no stock fields are reported — "could not be reached" is a
+distinct outcome from "not in stock", and scraping a half-finished call for a
+stock answer is how a patient gets sent somewhere on a sentence nobody finished.
+
+---
+
+## Example 7 — a number that isn't E.164
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv
+Invalid phone number: '07700900123' is not E.164. Expected + followed by
+country code and number, 8-15 digits total, e.g. +15550100. Do not guess a
+country code — ask the user.
+```
+
+Validation runs before anything else, in both dry run and live mode. Nothing is
+dialled and no plan is created.
+
+---
+
+## Example 8 — dry run, fully offline
 
 ```bash
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv
 
-amoxicillin 500mg — 21 capsules · 3 pharmacies · dry run, no calls
+DRY RUN — offline. No credentials read, nothing sent.
 
-  DRY RUN Riverside Pharmacy (…0100) — plan pX70PPR62, would spend 1 call
-  DRY RUN Oakhill Chemist (…0101) — plan p8KM2QW41, would spend 1 call
-  DRY RUN Station Road Pharmacy (…0102) — plan pT39LLV87, would spend 1 call
+  Riverside Pharmacy (…0100) — would send:
+  {
+    "tool": "plan_call",
+    "goal": "You are calling a pharmacy on behalf of a patient…",
+    "to_phones": ["+15550100"],
+    "region": "US"
+  }
+  …
+
+  3 call(s) would be placed. Add --live to dial.
 ```
 
-`plan_call` is free, so this validates the goal wording, the numbers and the
-region without placing a call. Add `--live` when you're ready to dial.
+No token is read and no socket is opened. The numbers are validated and the
+payload is printed locally.
+
+Note this deliberately does **not** call `plan_call` to check the goal wording,
+even though `plan_call` is free of charge. Free of charge isn't free of
+consequence: it would transmit the recipient's number and the medication being
+sought to a third party, from a mode the user was told places no calls.
 
 ---
 
-## Example 7 — budget refuses before dialling
+## Example 9 — budget refuses before dialling
 
 ```bash
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live --max-calls 2

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -300,7 +300,46 @@ Refusing to send that credential to a different origin.
 
 ---
 
-## Example 14 — changing configuration neither resumes nor redials
+## Example 14 — the call is not logged, and derived text is scrubbed
+
+A live run. The pharmacist reads out a branch number:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies p.csv --live
+    calling task created
+    calling task status=calling
+    Call ended; syncing final Calling result.
+
+Pharmacy         Stock  Qty  Price    Rx   Hold  Conf
+Oakhill          yes     40  6.2 GBP  yes  24h   0.90
+    Try the Mill Lane branch on [redacted …0123]
+```
+
+Two things are happening. The realtime speech events — `Callee said: …` — are
+not logged at all; only progress events are. And `pharmacist_notes`, which the
+model lifted out of the conversation, has had the number scrubbed while keeping
+the part that's useful.
+
+Prices and quantities are untouched: redaction applies to runs of eight or more
+digits, so `6.2 GBP`, `40` and `24h` survive.
+
+To watch a call as it happens — useful when debugging a prompt — opt in
+explicitly:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies p.csv --live --show-conversation
+    Callee said: try the Mill Lane branch on [redacted …0123]
+```
+
+Still redacted. The flag controls whether speech is shown, not whether numbers
+are protected.
+
+The stored run dump keeps the unredacted transcript — it's the evidence behind
+the result — and is written 0600 into an ignored directory.
+
+---
+
+## Example 15 — changing configuration neither resumes nor redials
 
 A call is in flight to `…0100`, placed in region GB. Rerunning with a different
 region:

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -267,22 +267,65 @@ in-flight set is tracked in-process as well.
 
 ---
 
-## Example 13 — ambiguous credentials, no guessing
+## Example 13 — a credential that can't be bound is refused
+
+Even with a single cached credential, if nothing ties it to the endpoint being
+called:
 
 ```bash
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.csv --live
-2 cached CALL-E tokens found and none records the endpoint
-https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth, so the correct
-account cannot be determined. Refusing to guess — calls would be placed
-and billed from whichever cache happens to sort last. Set
-CALLE_TOKEN_CACHE to one of:
+Found 1 cached CALL-E credential(s), none of which can be bound to
+https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth.
+
+`calle auth status` did not report a matching endpoint, and no cache records
+one. A bearer token is issued for a single origin, so sending one that might
+belong to a different provider is a credential disclosure, not a routing
+mistake — refusing rather than assuming.
+
+Either run `calle auth login` against
+https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth, or set
+CALLE_TOKEN_CACHE explicitly:
   /Users/you/.calle-mcp/cli/4811f3e.../token.json
-  /Users/you/.calle-mcp/cli/9c22ab1.../token.json
-or run `calle auth login` to refresh the intended account.
 ```
 
-Placing a call from the wrong account isn't recoverable once the phone has
-rung, so an ambiguous credential is a stop, not a default.
+"Only one exists" is not evidence that it belongs to this provider.
+
+And if the CLI is authenticated somewhere else entirely:
+
+```bash
+The CALL-E CLI is authenticated against https://other.example/mcp, but this
+skill is configured to call https://seleven-mcp-sg.airudder.com/mcp/...
+Refusing to send that credential to a different origin.
+```
+
+---
+
+## Example 14 — changing region does not reuse a plan
+
+A call to the same pharmacy about the same medication, routed through a
+different region, is a different call:
+
+```bash
+$ python3 scripts/pharmacy_search.py --pharmacies p.csv --region GB --live
+  …0100: resuming run 4BJPgjIFv3gZ
+
+$ python3 scripts/pharmacy_search.py --pharmacies p.csv --region US --live
+  …0100: planning              # different identity, not the GB run
+```
+
+Run identity is `sha256(endpoint | account | region | phone | goal)`. Reusing a
+plan across a routing or credential change would either resurrect a stale plan
+or, worse, treat a live call as absent and dial the pharmacist twice.
+
+Changing the identity scheme bumps `LEDGER_SCHEMA`. An older ledger holding
+unfinished entries is refused rather than read as empty:
+
+```
+Run ledger .pharmacy_runs.json uses an older identity scheme (schema None,
+now 2) and still holds 1 unfinished entry. Keys are now namespaced by
+endpoint, account and region, so those entries would not be found and their
+recipients would be dialled again.
+```
 
 ---
 

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -179,6 +179,28 @@ Bind the token to the endpoint being called. If the correct one cannot be
 determined, stop and ask. Guessing which identity to act as is not a recoverable
 error once the phone has rung.
 
+A single cache is not self-evidently the right one. "There's only one" says
+nothing about which provider issued it — and a bearer token sent to an origin it
+wasn't issued for is a working credential handed to a stranger. That failure is
+quieter and worse than a call placed from the wrong account: nothing visibly
+goes wrong, and the disclosure has already happened.
+
+## Identity of a pending action includes its configuration
+
+If you record "a call to this number about this thing is in progress", that
+record has to include everything that determines what the call *is* — which
+provider, which account, which region.
+
+Two failures fall out of getting it wrong, and they point in opposite
+directions. Too coarse, and a plan created under different routing gets reused
+or reconciled as though it were the same pending action. Too coarse in the other
+direction — a live call not recognised as live — and the recipient is dialled
+again.
+
+Version the store. When the identity scheme changes, previously written keys
+will not match anything you now compute, and an unmatched in-flight call reads
+as "never started".
+
 ## Cost is a safety property
 
 Calls cost money and free allowances are small. A workflow that silently spends

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -1,0 +1,115 @@
+# Safety boundaries for medical-adjacent phone workflows
+
+A phone agent asking a pharmacist about a medication sits close to several lines
+it must not cross. These rules are written for the pharmacy stock-check skill
+but apply to any health-adjacent calling workflow.
+
+---
+
+## The agent gathers information; it does not advise
+
+**In scope:** whether a named medication is in stock, how many units, price,
+whether a prescription is required, whether they will hold it, what the
+pharmacist said about alternatives.
+
+**Out of scope:** whether the user should take the medication, whether an
+alternative is equivalent, dosage guidance, interaction checks, or anything
+resembling clinical judgement.
+
+When a pharmacist suggests an alternative, report it as reported speech — *"the
+pharmacist mentioned they stock X"* — not as a recommendation. The distinction
+matters because a user acting on a substitute suggested by an automated system
+has been given advice nobody qualified reviewed.
+
+---
+
+## Never transact
+
+The agent does not order, reserve, pay for, or commit to collecting anything.
+"Can you hold it?" is a question. "Please hold it" is a commitment, and the
+agent is not authorised to make one.
+
+If a pharmacist offers to set stock aside, record the offer and its duration.
+Let the user decide.
+
+---
+
+## Not for emergencies
+
+A phone agent working through a list takes minutes per call. Someone who needs
+medication urgently should not be waiting on it.
+
+If the request suggests urgency — a missed critical dose, an acute reaction,
+distress — say plainly that this workflow is not appropriate and point toward
+emergency services or urgent care. Do not start calling.
+
+---
+
+## Prescription requirements are reported, never circumvented
+
+If a medication requires a prescription, that fact is part of the result. The
+agent must never suggest a way around it, ask a pharmacist to dispense without
+one, or imply the user has a prescription they have not confirmed.
+
+---
+
+## Uncertainty must survive to the user
+
+The user may travel somewhere while unwell on the strength of a result. That
+raises the cost of overconfidence well above the usual.
+
+- Surface the confidence score. Do not average it away or hide it behind a tick.
+- Show low-confidence results as needing verification, not as facts.
+- Offer the transcript. Everything reported should be checkable against what was
+  actually said.
+- "Could not be reached" is a distinct outcome from "not in stock". Never
+  collapse them.
+
+---
+
+## Privacy
+
+- Callers are told immediately that they are speaking to an automated
+  assistant.
+- Do not state the patient's name, condition, or any identifying detail to the
+  pharmacy. The medication and quantity are all that's needed.
+- Mask phone numbers in summaries and logs — pharmacy name plus last four
+  digits.
+- Transcripts contain a third party's voice. Store them under a retention policy
+  and do not publish them.
+
+---
+
+## Calling businesses responsibly
+
+- Identify as automated in the opening line, before asking anything. This is
+  both the ethical default and the practical one — it materially improves the
+  chance a pharmacist engages.
+- Keep calls short. A pharmacist is working.
+- One call per pharmacy per request. Retries are for no-answer, not for a
+  better answer.
+- Respect business hours for the recipient's region.
+- Accept "no" and end the call.
+
+---
+
+## No hidden recurring work
+
+This is a one-shot workflow. If a user wants a repeated check:
+
+- create the schedule explicitly, on request
+- state clearly how many calls it will place and how often
+- tell the user how to cancel, in the same message
+- never create a schedule as a side effect of a one-off request
+
+---
+
+## Cost is a safety property
+
+Calls cost money and free allowances are small. A workflow that silently spends
+a user's balance has harmed them.
+
+- Count phones, not plans — one batch can spend N calls.
+- Check the budget for the whole request before dialling anything.
+- Default to dry-run; require an explicit flag for live calls.
+- Never re-dial to recover data already paid for.

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -144,6 +144,37 @@ The same reasoning applies to concurrency. Two processes that both read "no
 call in progress" will both dial. Claims must be atomic and locked, not
 best-effort.
 
+A file lock is necessary but not sufficient. Two coroutines inside one process
+share a pid, so a pid-based ownership check passes for both — and a batch that
+dispatches rows concurrently will dial a duplicated recipient twice. Track
+in-flight recipients in-process as well, and collapse duplicate rows before
+dispatch.
+
+## Credentials and recordings are owner-only
+
+Two kinds of file here are more sensitive than they look:
+
+- **The run ledger** holds confirmation tokens that authorise placing a call.
+- **Terminal run dumps** hold the full transcript of a conversation with a
+  third party who agreed to talk to an assistant, not to have their words
+  stored where anyone on the machine can read them.
+
+Write both with mode 0600, into a dedicated directory rather than the working
+directory. Files scattered beside the script get committed by accident — and a
+token in a public repository is a token in a public repository, however
+short-lived.
+
+## Authenticate as the account you meant to
+
+Credential caches accumulate: a second account, a different environment, a
+stale login. Picking one by sort order works right up until it doesn't, and the
+failure is silent — calls placed from the wrong number, billed to the wrong
+balance, attributed to the wrong party.
+
+Bind the token to the endpoint being called. If the correct one cannot be
+determined, stop and ask. Guessing which identity to act as is not a recoverable
+error once the phone has rung.
+
 ## Cost is a safety property
 
 Calls cost money and free allowances are small. A workflow that silently spends

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -185,21 +185,41 @@ wasn't issued for is a working credential handed to a stranger. That failure is
 quieter and worse than a call placed from the wrong account: nothing visibly
 goes wrong, and the disclosure has already happened.
 
-## Identity of a pending action includes its configuration
+## Exclusion and reconciliation are different questions
 
-If you record "a call to this number about this thing is in progress", that
-record has to include everything that determines what the call *is* — which
-provider, which account, which region.
+Recording "a call to this number about this thing is in progress" involves two
+questions that look like one, and answering them with a single key is a bug in
+whichever direction you resolve it.
 
-Two failures fall out of getting it wrong, and they point in opposite
-directions. Too coarse, and a plan created under different routing gets reused
-or reconciled as though it were the same pending action. Too coarse in the other
-direction — a live call not recognised as live — and the recipient is dialled
-again.
+**"Should I dial this person?"** must be answered on recipient and purpose
+alone. Any configuration you add to that key — endpoint, account, region —
+becomes a way to make a live call invisible. Change the value, the key changes,
+the pending entry isn't found, and someone already on the phone gets rung again.
 
-Version the store. When the identity scheme changes, previously written keys
-will not match anything you now compute, and an unmatched in-flight call reads
-as "never started".
+**"Can I resume this plan?"** needs the whole configuration, because a plan or
+run id issued by one provider under one account means nothing under another.
+
+So the claim is coarse and the attempt is specific, nested beneath it. When the
+stored attempt doesn't match the current configuration, the safe action is
+neither: don't resume something you can't act on, and don't redial someone whose
+earlier call may still be running. Stop and surface it.
+
+Version the store. When claim keys change, previously written entries won't
+match anything you now compute, and an unmatched in-flight call reads as "never
+started".
+
+## Know whose call it is
+
+Namespacing on a credential cache directory is not the same as knowing the
+account. If the provider derives that directory from the server URL — CALL-E
+does — then re-authenticating as someone else on the same endpoint reuses it,
+and one account's unfinished run can be resumed with another's credentials.
+
+Derive identity from the account: an id recorded alongside the credential, or
+the subject claim of a token. If it cannot be established, unfinished state
+cannot be confirmed as yours. Fail closed on reconciliation rather than assuming
+— resuming a stranger's run, or redialling on the assumption that no call
+exists, are both worse than stopping.
 
 ## Cost is a safety property
 

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -93,7 +93,9 @@ instead.
 - Do not state the patient's name, condition, or any identifying detail to the
   pharmacy. The medication and quantity are all that's needed.
 - Mask phone numbers in summaries and logs — pharmacy name plus last four
-  digits.
+  digits. This includes dry-run and debug output. Terminal text ends up in
+  shell scrollback, CI logs and screen recordings, none of which the person
+  whose number it is agreed to.
 - Transcripts contain a third party's voice. Store them under a retention policy
   and do not publish them.
 
@@ -122,6 +124,25 @@ This is a one-shot workflow. If a user wants a repeated check:
 - never create a schedule as a side effect of a one-off request
 
 ---
+
+## An uncertain call must never be retried automatically
+
+If a request to place a call was sent and the response was lost — a timeout, a
+crash, a dropped connection — you do not know whether the phone rang.
+
+Retrying is not the safe default. The safe default is to stop and say so. A
+duplicate call to a pharmacist costs money, wastes their time, and in a
+health-adjacent context looks like a malfunctioning system contacting a
+business repeatedly about a patient.
+
+Record the "about to dial" state *before* sending the request, so a lost
+response is distinguishable from a request that was never sent. Clearing that
+state requires a human deciding what happened — check the provider's dashboard,
+then either record the run or release the entry deliberately.
+
+The same reasoning applies to concurrency. Two processes that both read "no
+call in progress" will both dial. Claims must be atomic and locked, not
+best-effort.
 
 ## Cost is a safety property
 

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -96,6 +96,21 @@ instead.
   digits. This includes dry-run and debug output. Terminal text ends up in
   shell scrollback, CI logs and screen recordings, none of which the person
   whose number it is agreed to.
+
+- **The same applies to anything derived from the call.** It is easy to mask the
+  number you dialled and then print the conversation that number produced. A
+  provider's activity feed quotes speech as it happens; extracted fields like
+  "notes" and "alternative suggested" are lifted out of the same conversation.
+  A pharmacist who reads out a branch number has now put it in both.
+
+  Scrub free text on every output path, and withhold realtime speech unless the
+  operator asks for it. The pharmacist agreed to answer a question, not to have
+  their words logged.
+
+- **Redact by shape, not by field.** You cannot enumerate every field that might
+  contain a number, because the model decides what goes in them. Filter runs of
+  eight or more digits out of any free text on its way to a log or a terminal,
+  and leave prices, quantities and durations intact.
 - Transcripts contain a third party's voice. Store them under a retention policy
   and do not publish them.
 

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -160,9 +160,13 @@ Two kinds of file here are more sensitive than they look:
   stored where anyone on the machine can read them.
 
 Write both with mode 0600, into a dedicated directory rather than the working
-directory. Files scattered beside the script get committed by accident — and a
-token in a public repository is a token in a public repository, however
-short-lived.
+directory, and add that directory to `.gitignore`.
+
+The two protections do different jobs and neither substitutes for the other.
+0600 stops other accounts on the machine reading a transcript. Ignoring stops
+the file reaching a public repository, which is the failure that actually
+happens — a token in a public repo is a token in a public repo, however
+short-lived, and permissions are irrelevant once it's pushed.
 
 ## Authenticate as the account you meant to
 

--- a/skills/pharmacy-stock-check/references/safety.md
+++ b/skills/pharmacy-stock-check/references/safety.md
@@ -58,12 +58,31 @@ one, or imply the user has a prescription they have not confirmed.
 The user may travel somewhere while unwell on the strength of a result. That
 raises the cost of overconfidence well above the usual.
 
+- **Gate on completion before reporting anything.** A call that failed, hit
+  voicemail or was cut off can still carry a partially filled summary. If
+  `task_completed` isn't true and the run didn't reach `COMPLETED`, emit no
+  stock fields at all — report that the pharmacy could not be reached.
+- **Verification must outrank stock status in any ranking.** A low-confidence
+  "yes" appearing above a high-confidence "no" is the specific failure that
+  sends a sick person on a pointless journey. Rank verified results first,
+  then by stock.
 - Surface the confidence score. Do not average it away or hide it behind a tick.
 - Show low-confidence results as needing verification, not as facts.
 - Offer the transcript. Everything reported should be checkable against what was
   actually said.
 - "Could not be reached" is a distinct outcome from "not in stock". Never
   collapse them.
+
+## A dry run must not transmit anything
+
+If a workflow advertises a dry run, that has to mean nothing leaves the machine
+— no credentials read, no socket opened, no payload sent.
+
+Calling a planning or validation endpoint during a "dry run" transmits the
+recipient's phone number and, here, the medication someone is looking for. That
+is health-adjacent information about an identifiable person going to a third
+party, from a mode the user was told was inert. Validate and print locally
+instead.
 
 ---
 

--- a/skills/pharmacy-stock-check/scripts/pharmacies.csv
+++ b/skills/pharmacy-stock-check/scripts/pharmacies.csv
@@ -1,0 +1,4 @@
+name,phone,address
+Riverside Pharmacy,+15550100,Reserved fictional number — replace before use
+Oakhill Chemist,+15550101,Reserved fictional number — replace before use
+Station Road Pharmacy,+15550102,Reserved fictional number — replace before use

--- a/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
+++ b/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
@@ -1,0 +1,2 @@
+name,phone,address
+CALL-E Hotline,+12763229632,CALL-E inbound testing hotline — answers with a general-purpose prompt

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -24,11 +24,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import fcntl
 import hashlib
 import json
 import logging
+import os
 import re
+import tempfile
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -141,44 +145,192 @@ class CallBudget:
 # --------------------------------------------------------------------------
 
 
+class StateCorrupted(RuntimeError):
+    """The run ledger could not be read. Refuse to proceed rather than
+    starting from a blank slate, which would redial everything."""
+
+
+class RunLocked(RuntimeError):
+    """Another live process holds this recipient."""
+
+
+class AmbiguousRun(RuntimeError):
+    """run_call was sent but no run_id was recorded. Whether a call was
+    placed is unknown, so it must not be retried automatically."""
+
+
 @dataclass
 class RunStore:
-    """Persisted plan and run IDs, so an interruption resumes instead of redials.
+    """Crash-safe, concurrency-safe ledger of in-flight calls.
 
-    Without this, a lost response or a killed process means the next invocation
-    plans afresh and calls the pharmacist a second time — spending a call and
-    bothering a real person. `plan_id` is CALL-E's idempotency key, so it only
-    protects you if it survives the crash.
+    Losing this state means redialling a real person, so the failure modes
+    matter more than the happy path:
+
+    * **Locked.** Every read-modify-write runs under an exclusive `flock`, so
+      two processes can't both see "no entry" and both dial.
+    * **Atomic.** Writes go to a temp file, get fsynced, then `os.replace` —
+      a crash mid-write leaves the previous good file, never a truncated one.
+    * **Loud on corruption.** An unreadable ledger is quarantined and raises.
+      Silently substituting `{}` would present every in-flight run as new.
+    * **Terminal-first.** The entry is only marked `done` once the result is
+      recorded, and pruned separately. Clearing before the result is durable
+      opens a window where a crash loses both.
+    * **Ambiguity is not retryable.** If `run_call` was sent and the response
+      was lost, whether the phone rang is unknown. That state requires a human
+      decision, not an automatic retry.
+
+    States: planned -> dialing -> running -> done
     """
 
     path: Path = field(default=Path(".pharmacy_runs.json"))
 
-    def _load(self) -> dict[str, Any]:
+    # -- locking ------------------------------------------------------------
+
+    @contextmanager
+    def _locked(self):
+        lock_path = self.path.with_name(self.path.name + ".lock")
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    def _read(self) -> dict[str, Any]:
         if not self.path.exists():
             return {}
-        try:
-            return json.loads(self.path.read_text())
-        except json.JSONDecodeError:
+        text = self.path.read_text()
+        if not text.strip():
             return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            quarantine = self.path.with_name(
+                f"{self.path.name}.corrupt.{int(time.time())}"
+            )
+            self.path.rename(quarantine)
+            raise StateCorrupted(
+                f"Run ledger {self.path} is unreadable and has been moved to "
+                f"{quarantine}. Refusing to continue: treating a corrupt ledger "
+                f"as empty would redial every in-flight recipient. Inspect the "
+                f"quarantined file, then remove it to start clean."
+            ) from exc
+
+    def _write(self, data: dict[str, Any]) -> None:
+        fd, tmp = tempfile.mkstemp(dir=str(self.path.parent or "."), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, self.path)   # atomic
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+    # -- api ----------------------------------------------------------------
 
     @staticmethod
     def key(phone: str, goal: str) -> str:
         return hashlib.sha256(f"{phone}|{goal}".encode()).hexdigest()[:32]
 
+    @staticmethod
+    def _alive(pid: int | None) -> bool:
+        if not pid or pid == os.getpid():
+            return pid == os.getpid()
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError, OSError):
+            return False
+        return True
+
+    def claim(self, key: str, phone_masked: str) -> dict[str, Any]:
+        """Atomically take ownership of a recipient, or return the live entry.
+
+        The read and the write happen under one lock, so there is no window in
+        which two processes both conclude the recipient is unclaimed.
+        """
+        with self._locked():
+            data = self._read()
+            entry = data.get(key)
+
+            if entry is None:
+                entry = {
+                    "state": "planned",
+                    "pid": os.getpid(),
+                    "phone_masked": phone_masked,
+                    "claimed_at": datetime.now(timezone.utc).isoformat(),
+                }
+                data[key] = entry
+                self._write(data)
+                return entry
+
+            if entry.get("state") == "dialing":
+                raise AmbiguousRun(
+                    f"{phone_masked}: a call was submitted but no run id was "
+                    f"recorded, so whether the phone rang is unknown. Not "
+                    f"retrying automatically. Check the CALL-E dashboard for "
+                    f"plan {entry.get('plan_id')}, then either record the "
+                    f"run id or remove this entry to allow a redial."
+                )
+
+            owner = entry.get("pid")
+            if (
+                entry.get("state") in {"planned", "running"}
+                and owner != os.getpid()
+                and self._alive(owner)
+            ):
+                raise RunLocked(
+                    f"{phone_masked}: held by live process {owner}. "
+                    f"Not dialling concurrently."
+                )
+
+            entry["pid"] = os.getpid()
+            data[key] = entry
+            self._write(data)
+            return entry
+
+    def update(self, key: str, **fields: Any) -> None:
+        with self._locked():
+            data = self._read()
+            entry = data.setdefault(key, {})
+            entry.update(fields)
+            entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+            self._write(data)
+
+    def mark_done(self, key: str, result_path: str | None = None) -> None:
+        """Record completion. Called only AFTER the terminal result is durable.
+
+        Deliberately not a delete: pruning is a separate step, so a crash
+        between recording the result and tidying the ledger can never lose
+        both.
+        """
+        self.update(key, state="done", result_path=result_path,
+                    completed_at=datetime.now(timezone.utc).isoformat())
+
+    def prune_done(self) -> int:
+        with self._locked():
+            data = self._read()
+            stale = [k for k, v in data.items() if v.get("state") == "done"]
+            for k in stale:
+                data.pop(k)
+            if stale:
+                self._write(data)
+            return len(stale)
+
     def get(self, key: str) -> dict[str, Any]:
-        return self._load().get(key, {})
+        with self._locked():
+            return self._read().get(key, {})
 
-    def put(self, key: str, **fields: Any) -> None:
-        data = self._load()
-        entry = data.setdefault(key, {})
-        entry.update(fields)
-        entry["updated_at"] = datetime.now(timezone.utc).isoformat()
-        self.path.write_text(json.dumps(data, indent=2))
-
-    def clear(self, key: str) -> None:
-        data = self._load()
-        data.pop(key, None)
-        self.path.write_text(json.dumps(data, indent=2))
+    def release(self, key: str) -> None:
+        """Drop a claim that never reached `dialing`. Safe: no call was sent."""
+        with self._locked():
+            data = self._read()
+            entry = data.get(key)
+            if entry and entry.get("state") == "planned" and not entry.get("run_id"):
+                data.pop(key)
+                self._write(data)
 
 
 # --------------------------------------------------------------------------
@@ -403,21 +555,36 @@ class Caller:
             await asyncio.sleep(min(delay, 15.0))
         return None
 
+    def _record_terminal(self, key: str, phone: str, final: dict[str, Any]) -> str:
+        """Write the terminal response to disk BEFORE the ledger is retired.
+
+        If the ledger entry were cleared first, a crash in between would lose
+        the result and the claim together — and the next invocation would
+        redial.
+        """
+        path = Path(f"run_{key[:12]}_{int(time.time())}.json")
+        path.write_text(json.dumps(final, indent=2, default=str))
+        return str(path)
+
     async def call(self, pharmacy: dict[str, str], goal: str, region: str
                    ) -> dict[str, Any] | None:
         phone = validate_e164(pharmacy["phone"])
         key = self.store.key(phone, goal)
-        saved = self.store.get(key)
+
+        # Atomic claim. Raises if another live process holds this recipient, or
+        # if a previous attempt left an ambiguous create.
+        saved = self.store.claim(key, mask(phone))
 
         async with self._client() as client:
-            # Resume an in-flight run rather than planning again. Without this,
-            # an interrupted poll causes a second call to the same pharmacist.
+            # Resume an in-flight run rather than planning again.
             if saved.get("run_id"):
                 log.info("  %s: resuming run %s", mask(phone), saved["run_id"][:12])
                 final = await self._poll(client, saved["run_id"], phone)
                 if final is None:
                     return None
-                self.store.clear(key)
+                self.store.mark_done(
+                    key, self._record_terminal(key, phone, final)
+                )
                 return to_record(final, pharmacy)
 
             # Reuse a stored plan if its confirm_token is still valid.
@@ -438,30 +605,38 @@ class Caller:
                 if not plan.get("ready_to_run"):
                     log.warning("  %s: planner needs more detail — %s",
                                 mask(phone), plan.get("clarifying_questions"))
+                    self.store.release(key)   # nothing was dialled
                     return None
-                self.store.put(
+                self.store.update(
                     key,
                     plan_id=plan["plan_id"],
                     confirm_token=plan["confirm_token"],
                     confirm_expires_at=plan.get("confirm_expires_at"),
-                    phone_masked=mask(phone),
                 )
 
+            # Mark "dialing" BEFORE run_call. If the response is lost, the
+            # ledger already says a call may have been placed — and claim()
+            # will refuse to retry it rather than risk a second ring.
+            self.store.update(key, state="dialing")
             self.budget.charge(1)
+
             run = self._unwrap(await client.call_tool("run_call", {
                 "plan_id": plan["plan_id"], "confirm_token": plan["confirm_token"],
             }))
             run_id = run.get("run_id")
             if not run_id:
+                log.error("  %s: no run id returned — left as ambiguous, "
+                          "will not auto-retry", mask(phone))
                 return None
-            self.store.put(key, run_id=run_id)
+            self.store.update(key, state="running", run_id=run_id)
 
             final = await self._poll(client, run_id, phone)
             if final is None:
                 log.error("  %s: poll timed out — rerun to resume, not redial",
                           mask(phone))
                 return None
-            self.store.clear(key)
+
+            self.store.mark_done(key, self._record_terminal(key, phone, final))
             return to_record(final, pharmacy)
 
 
@@ -481,10 +656,13 @@ def dry_run(pharmacies: list[dict[str, str]], goal: str, region: str) -> None:
     print(f"\nDRY RUN — offline. No credentials read, nothing sent.\n")
     for pharmacy in pharmacies:
         phone = validate_e164(pharmacy["phone"])
+        # Numbers are masked here too. The masking rule covers anything
+        # printed or logged — a dry run that echoes full E.164 numbers to the
+        # terminal puts them in scrollback, CI logs and screen recordings.
         payload = {
             "tool": "plan_call",
             "goal": goal,
-            "to_phones": [phone],
+            "to_phones": [mask(phone)],
             "region": region,
             "language": "English",
             "ttl_seconds": 0,
@@ -492,7 +670,9 @@ def dry_run(pharmacies: list[dict[str, str]], goal: str, region: str) -> None:
         print(f"  {pharmacy.get('name', '?')} ({mask(phone)}) — would send:")
         print("  " + json.dumps(payload, indent=2)[:400].replace("\n", "\n  "))
         print()
-    print(f"  {len(pharmacies)} call(s) would be placed. Add --live to dial.\n")
+    print(f"  {len(pharmacies)} call(s) would be placed. Add --live to dial.")
+    print(f"  Numbers shown masked; the real E.164 values are sent only "
+          f"under --live.\n")
 
 
 # --------------------------------------------------------------------------
@@ -567,6 +747,10 @@ async def main() -> None:
         async with semaphore:
             try:
                 return await caller.call(pharmacy, goal, args.region)
+            except (AmbiguousRun, RunLocked) as exc:
+                # Not failures to retry past — these exist to stop a redial.
+                log.error("  %s", exc)
+                return None
             except Exception as exc:
                 log.error("  %s failed: %s", pharmacy.get("name"), exc)
                 return None
@@ -577,4 +761,16 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        # A stack trace here is worse than unhelpful: the operator has just
+        # interrupted a live call and needs to know that rerunning resumes it
+        # rather than dialling the recipient a second time.
+        print(
+            "\nInterrupted. Any call already placed is still running on "
+            "CALL-E's side.\nRerun the same command to resume polling — the "
+            "ledger holds the run id, so it will not redial.\n"
+            "  cat .pharmacy_runs.json    # inspect what's in flight"
+        )
+        raise SystemExit(130)

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import csv
 import fcntl
 import hashlib
@@ -51,7 +52,7 @@ RUN_DIR = Path(os.environ.get("PHARMACY_RUN_DIR", "call_runs"))
 # Bump when the run-identity scheme changes. An older ledger's keys won't match
 # anything we compute, so unfinished entries must be refused rather than read as
 # absent — "absent" means "dial them again".
-LEDGER_SCHEMA = 2
+LEDGER_SCHEMA = 3
 
 TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED", "CANCELLED"}
 TERMINAL_ACTIONS = {"report_result", "report_blocked", "none"}
@@ -225,6 +226,11 @@ class RunLocked(RuntimeError):
     """Another live process holds this recipient."""
 
 
+class ConfigurationMismatch(RuntimeError):
+    """An unresolved call exists under provider configuration we can't
+    reconcile against. Neither resumable nor safe to redial."""
+
+
 class AmbiguousRun(RuntimeError):
     """run_call was sent but no run_id was recorded. Whether a call was
     placed is unknown, so it must not be retried automatically."""
@@ -234,37 +240,38 @@ class AmbiguousRun(RuntimeError):
 class RunStore:
     """Crash-safe, concurrency-safe ledger of in-flight calls.
 
-    Losing this state means redialling a real person, so the failure modes
-    matter more than the happy path:
+    Two different keys, doing two different jobs — conflating them was a bug:
 
-    * **Locked.** Every read-modify-write runs under an exclusive `flock`, so
-      two processes can't both see "no entry" and both dial.
-    * **Atomic.** Writes go to a temp file, get fsynced, then `os.replace` —
-      a crash mid-write leaves the previous good file, never a truncated one.
-    * **Loud on corruption.** An unreadable ledger is quarantined and raises.
-      Silently substituting `{}` would present every in-flight run as new.
-    * **Terminal-first.** The entry is only marked `done` once the result is
-      recorded, and pruned separately. Clearing before the result is durable
-      opens a window where a crash loses both.
-    * **Ambiguity is not retryable.** If `run_call` was sent and the response
-      was lost, whether the phone rang is unknown. That state requires a human
-      decision, not an automatic retry.
+    * **The claim key is coarse**: recipient + purpose, nothing else. It is the
+      exclusion lock, and it must span every provider configuration. If it
+      included endpoint, account or region, changing any of those would make an
+      unresolved call look absent and permit a second dial to the same person.
+
+    * **The attempt record is specific**: endpoint, principal, region, plan and
+      run ids, nested under the claim. It is what reconciliation is checked
+      against. A stored attempt whose configuration differs from the current one
+      is neither resumed nor redialled — it's surfaced for a human, because we
+      can't act on another configuration's plan and can't assume the call never
+      happened.
+
+    Everything else is about surviving a crash without redialling: locked
+    read-modify-write, atomic private writes, loud failure on corruption,
+    terminal result recorded before the entry is retired, and an ambiguous
+    create that is never retried automatically.
 
     States: planned -> dialing -> running -> done
     """
 
     path: Path = field(default=Path(".pharmacy_runs.json"))
 
-    # Everything that changes what a call actually is. A plan created under a
-    # different endpoint, account or region is not the same pending action, and
-    # must not be reused or reconciled as if it were.
+    # Current provider configuration. Recorded on the attempt, compared on
+    # resume — never mixed into the claim key.
     server_url: str = SERVER_URL
-    account_ns: str = "unknown"
+    principal: str | None = None
 
-    # Keys currently in flight in THIS process. The file lock stops two
-    # processes racing; it does nothing about two coroutines in one process,
-    # because they share a pid. Duplicate rows dispatched by asyncio.gather
-    # would otherwise both claim and both dial.
+    # Claims held by THIS process. The file lock stops two processes racing; it
+    # does nothing about two coroutines in one process, because they share a
+    # pid.
     _active: set[str] = field(default_factory=set, repr=False)
 
     # -- locking ------------------------------------------------------------
@@ -290,8 +297,7 @@ class RunStore:
             raise StateCorrupted(
                 f"Run ledger {self.path} is unreadable and has been moved to "
                 f"{quarantine}. Refusing to continue: treating a corrupt ledger "
-                f"as empty would redial every in-flight recipient. Inspect the "
-                f"quarantined file, then remove it to start clean."
+                f"as empty would redial every in-flight recipient."
             ) from exc
 
         schema = raw.get("schema")
@@ -299,9 +305,6 @@ class RunStore:
         if schema == LEDGER_SCHEMA and isinstance(entries, dict):
             return entries
 
-        # An older ledger keyed entries differently. Its keys will not match
-        # anything we compute now, so every in-flight call would look absent —
-        # and get dialled again. Migrate silently only if nothing is pending.
         legacy = entries if isinstance(entries, dict) else raw
         pending = {
             k: v for k, v in legacy.items()
@@ -309,39 +312,42 @@ class RunStore:
         }
         if pending:
             raise StateCorrupted(
-                f"Run ledger {self.path} uses an older identity scheme "
-                f"(schema {schema!r}, now {LEDGER_SCHEMA}) and still holds "
-                f"{len(pending)} unfinished entr{'y' if len(pending)==1 else 'ies'}.\n"
-                f"Keys are now namespaced by endpoint, account and region, so "
-                f"those entries would not be found and their recipients would be "
-                f"dialled again. Let the in-flight calls finish, or inspect and "
-                f"remove the file deliberately:\n  {self.path}"
+                f"Run ledger {self.path} uses schema {schema!r} (now "
+                f"{LEDGER_SCHEMA}) and still holds {len(pending)} unfinished "
+                f"entr{'y' if len(pending) == 1 else 'ies'}. Claim keys changed, "
+                f"so those entries would not be found and their recipients would "
+                f"be dialled again. Let the in-flight calls finish, or remove the "
+                f"file deliberately:\n  {self.path}"
             )
         return {}
 
     def _write(self, entries: dict[str, Any]) -> None:
-        # 0600: this file holds confirm_tokens, which authorise placing a call.
         _write_private(self.path, json.dumps(
             {"schema": LEDGER_SCHEMA, "entries": entries}, indent=2
         ))
 
-    # -- api ----------------------------------------------------------------
+    # -- keys ---------------------------------------------------------------
 
-    def key(self, phone: str, goal: str, region: str) -> str:
-        """Identity of a pending call, across every dimension that changes it.
+    @staticmethod
+    def claim_key(phone: str, goal: str) -> str:
+        """Exclusion identity: who we are calling, and what about.
 
-        Hashing phone and goal alone is not enough. The same number and the
-        same question routed through a different region is a different call;
-        under a different account or endpoint it's a different plan entirely,
-        and a `plan_id` issued by one provider means nothing to another. Reusing
-        or reconciling across those boundaries either resurrects a stale plan or
-        silently treats a live one as absent — and the second of those redials a
-        pharmacist.
+        Deliberately free of provider configuration. This key answers "is there
+        an unresolved call to this person about this thing?", and that question
+        must have the same answer regardless of which endpoint, account or
+        region a previous attempt used.
         """
-        material = "|".join([
-            self.server_url, self.account_ns, region.upper(), phone, goal,
-        ])
-        return hashlib.sha256(material.encode()).hexdigest()[:32]
+        return hashlib.sha256(f"{phone}|{goal}".encode()).hexdigest()[:32]
+
+    def attempt_config(self, region: str) -> dict[str, Any]:
+        """The provider configuration a call is made under."""
+        return {
+            "endpoint": self.server_url,
+            "principal": self.principal,
+            "region": region.upper(),
+        }
+
+    # -- api ----------------------------------------------------------------
 
     @staticmethod
     def _alive(pid: int | None) -> bool:
@@ -353,19 +359,21 @@ class RunStore:
             return False
         return True
 
-    def claim(self, key: str, phone_masked: str, region: str = "") -> dict[str, Any]:
-        """Atomically take ownership of a recipient, or return the live entry.
+    def claim(self, key: str, phone_masked: str, region: str) -> dict[str, Any]:
+        """Take the exclusion claim for a recipient, or explain why we can't.
 
-        The read and the write happen under one lock, so there is no window in
-        which two processes both conclude the recipient is unclaimed. The
-        in-process set covers the case the file lock cannot: two coroutines in
-        the same process sharing a pid.
+        Raises rather than returning on every path where dialling would be
+        unsafe: another live process holds it, a previous create's outcome is
+        unknown, or the pending attempt was made under a configuration we
+        cannot reconcile against.
         """
         if key in self._active:
             raise RunLocked(
                 f"{phone_masked}: already in flight in this process. Duplicate "
                 f"entries for the same recipient and goal are not dialled twice."
             )
+
+        wanted = self.attempt_config(region)
 
         with self._locked():
             data = self._read()
@@ -376,11 +384,7 @@ class RunStore:
                     "state": "planned",
                     "pid": os.getpid(),
                     "phone_masked": phone_masked,
-                    # Recorded so a human inspecting a stuck entry can see
-                    # which configuration it belongs to.
-                    "server_url": self.server_url,
-                    "account_ns": self.account_ns,
-                    "region": region,
+                    "attempt": wanted,
                     "claimed_at": datetime.now(timezone.utc).isoformat(),
                 }
                 data[key] = entry
@@ -392,9 +396,41 @@ class RunStore:
                 raise AmbiguousRun(
                     f"{phone_masked}: a call was submitted but no run id was "
                     f"recorded, so whether the phone rang is unknown. Not "
-                    f"retrying automatically. Check the CALL-E dashboard for "
-                    f"plan {entry.get('plan_id')}, then either record the "
-                    f"run id or remove this entry to allow a redial."
+                    f"retrying automatically. Check plan "
+                    f"{(entry.get('attempt') or {}).get('plan_id')}, then record "
+                    f"the run id or remove this entry to allow a redial."
+                )
+
+            stored = entry.get("attempt") or {}
+            mismatch = {
+                field_name: (stored.get(field_name), wanted.get(field_name))
+                for field_name in ("endpoint", "principal", "region")
+                if stored.get(field_name) != wanted.get(field_name)
+            }
+            if mismatch:
+                detail = "; ".join(
+                    f"{k}: pending={was!r} now={now!r}"
+                    for k, (was, now) in mismatch.items()
+                )
+                raise ConfigurationMismatch(
+                    f"{phone_masked}: an unresolved call exists for this "
+                    f"recipient and goal, but it was made under a different "
+                    f"configuration ({detail}).\n"
+                    f"Not resuming — a plan or run id from one endpoint or "
+                    f"account is meaningless under another. Not redialling "
+                    f"either — the earlier call may still be live, and this "
+                    f"person should not be rung twice.\n"
+                    f"Resolve it under the original configuration, or remove "
+                    f"the entry deliberately once you know what happened."
+                )
+
+            if self.principal is None:
+                raise ConfigurationMismatch(
+                    f"{phone_masked}: an unresolved call exists, but the "
+                    f"authenticated account could not be identified, so it "
+                    f"cannot be confirmed as ours. Failing closed rather than "
+                    f"resuming another account's run or redialling. Set "
+                    f"CALLE_ACCOUNT_ID, or resolve the entry deliberately."
                 )
 
             owner = entry.get("pid")
@@ -415,20 +451,22 @@ class RunStore:
             return entry
 
     def update(self, key: str, **fields: Any) -> None:
+        """Update the entry. Keys in `attempt` are nested, not flattened."""
+        attempt_fields = {
+            k: fields.pop(k) for k in list(fields)
+            if k in {"plan_id", "confirm_token", "confirm_expires_at", "run_id"}
+        }
         with self._locked():
             data = self._read()
             entry = data.setdefault(key, {})
+            if attempt_fields:
+                entry.setdefault("attempt", {}).update(attempt_fields)
             entry.update(fields)
             entry["updated_at"] = datetime.now(timezone.utc).isoformat()
             self._write(data)
 
     def mark_done(self, key: str, result_path: str | None = None) -> None:
-        """Record completion. Called only AFTER the terminal result is durable.
-
-        Deliberately not a delete: pruning is a separate step, so a crash
-        between recording the result and tidying the ledger can never lose
-        both.
-        """
+        """Record completion — only after the terminal result is durable."""
         self.update(key, state="done", result_path=result_path,
                     completed_at=datetime.now(timezone.utc).isoformat())
         self._active.discard(key)
@@ -452,10 +490,12 @@ class RunStore:
         with self._locked():
             data = self._read()
             entry = data.get(key)
-            if entry and entry.get("state") == "planned" and not entry.get("run_id"):
+            attempt = (entry or {}).get("attempt") or {}
+            if entry and entry.get("state") == "planned" and not attempt.get("run_id"):
                 data.pop(key)
                 self._write(data)
         self._active.discard(key)
+
 
 
 # --------------------------------------------------------------------------
@@ -614,6 +654,55 @@ def _endpoint_of(data: dict[str, Any]) -> str | None:
     return None
 
 
+def _jwt_claims(token: str) -> dict[str, Any]:
+    """Read a JWT payload without verifying it.
+
+    Verification is the server's job — we only want a stable identifier for the
+    account, so an unverified claim is fine for namespacing. It is NOT used for
+    any authorisation decision.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        return json.loads(base64.urlsafe_b64decode(padded))
+    except Exception:
+        return {}
+
+
+def _principal_of(token: str, cache: dict[str, Any]) -> str | None:
+    """A stable identity for the authenticated account, or None.
+
+    Deliberately NOT the token-cache directory: CALL-E derives that from the
+    server URL, so re-authenticating as a different account on the same
+    endpoint reuses the same directory. Namespacing on it would let an
+    account-A run be resumed with account-B credentials.
+
+    Order: explicit override, an id recorded in the cache, then a JWT subject.
+    """
+    override = os.environ.get("CALLE_ACCOUNT_ID")
+    if override:
+        return override.strip()
+
+    for key in ("account_id", "accountId", "user_id", "userId", "sub",
+                "principal", "email", "account"):
+        value = cache.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            for inner in ("id", "sub", "email"):
+                if isinstance(value.get(inner), str):
+                    return value[inner].strip()
+
+    claims = _jwt_claims(token)
+    for key in ("sub", "account_id", "uid", "email", "client_id"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _cli_auth_status() -> dict[str, Any] | None:
     """Ask the CALL-E CLI which cache belongs to which endpoint.
 
@@ -636,7 +725,7 @@ def _cli_auth_status() -> dict[str, Any] | None:
         return None
 
 
-def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str]:
+def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str | None]:
     """Return (access_token, account_namespace) for `server_url`, or refuse.
 
     A bearer token is issued for one origin. Sending it anywhere else hands a
@@ -657,7 +746,7 @@ def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str]:
         token = _extract_token(json.loads(path.read_text()))
         if not token:
             raise SystemExit(f"No access token found in {path}")
-        return token, os.environ.get("CALLE_ACCOUNT_NS") or path.parent.name
+        return token, _principal_of(token, json.loads(path.read_text()))
 
     status = _cli_auth_status()
     if status:
@@ -678,10 +767,11 @@ def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str]:
                     f"CALL-E CLI reports its cached credential is not usable "
                     f"({path}). Run: calle auth login"
                 )
-            token = _extract_token(json.loads(path.read_text()))
+            cache = json.loads(path.read_text())
+            token = _extract_token(cache)
             if not token:
                 raise SystemExit(f"No access token found in {path}")
-            return token, path.parent.name
+            return token, _principal_of(token, cache)
 
     candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
     if not candidates:
@@ -701,7 +791,7 @@ def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str]:
         token = _extract_token(bound[0][1])
         if not token:
             raise SystemExit(f"No access token found in {bound[0][0]}")
-        return token, bound[0][0].parent.name
+        return token, _principal_of(token, bound[0][1])
     if len(bound) > 1:
         raise SystemExit(
             f"{len(bound)} cached tokens claim endpoint {server_url}. Set "
@@ -740,9 +830,15 @@ class Caller:
         self.store = store
         # Resolving the credential also tells us which account we're acting as,
         # which is part of a call's identity.
-        self._token, account_ns = resolve_credential(SERVER_URL)
+        self._token, principal = resolve_credential(SERVER_URL)
         self.store.server_url = SERVER_URL
-        self.store.account_ns = account_ns
+        self.store.principal = principal
+        if principal is None:
+            log.warning(
+                "Could not identify the authenticated account. New calls will "
+                "proceed, but an unresolved call cannot later be confirmed as "
+                "ours and will fail closed. Set CALLE_ACCOUNT_ID to avoid this."
+            )
 
     def _client(self):
         return self._Client(self._Transport(
@@ -819,7 +915,7 @@ class Caller:
     async def call(self, pharmacy: dict[str, str], goal: str, region: str
                    ) -> dict[str, Any] | None:
         phone = validate_e164(pharmacy["phone"])
-        key = self.store.key(phone, goal, region)
+        key = self.store.claim_key(phone, goal)
 
         # Atomic claim. Raises if another live process holds this recipient, or
         # if a previous attempt left an ambiguous create.
@@ -1016,7 +1112,7 @@ async def main() -> None:
         async with semaphore:
             try:
                 return await caller.call(pharmacy, goal, args.region)
-            except (AmbiguousRun, RunLocked) as exc:
+            except (AmbiguousRun, RunLocked, ConfigurationMismatch) as exc:
                 # Not failures to retry past — these exist to stop a redial.
                 log.error("  %s", exc)
                 return None

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -3,19 +3,20 @@
 Pharmacy stock check — reference implementation for the pharmacy-stock-check
 Agent Skill.
 
-Dry-run by default. Nothing is dialled without --live.
+Dry run is FULLY OFFLINE. It loads no credentials, opens no socket, and sends
+no phone number or medication context anywhere. It validates the input and
+prints the exact payload it would send. Only --live touches the network.
 
-    python3 pharmacy_search.py --pharmacies pharmacies.csv           # no calls
+    python3 pharmacy_search.py --pharmacies pharmacies.csv           # offline
     python3 pharmacy_search.py --pharmacies pharmacies.csv --live    # calls
 
-Requires the CALL-E CLI to be authenticated (`calle auth login`) and fastmcp:
+Live mode requires the CALL-E CLI to be authenticated and fastmcp installed:
 
     npm install -g @call-e/cli && calle auth login
     pip install fastmcp
 
-Sample numbers in this directory use the reserved fictional range
-+1 555 0100–0199. Replace them with real E.164 numbers you have permission to
-call.
+Sample numbers use the reserved fictional range +1 555 0100–0199. Replace them
+with real E.164 numbers you have permission to call.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import hashlib
 import json
 import logging
 import re
@@ -32,9 +34,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from fastmcp import Client
-from fastmcp.client.transports import StreamableHttpTransport
-
 log = logging.getLogger("pharmacy-stock-check")
 
 SERVER_URL = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth"
@@ -43,6 +42,12 @@ TOKEN_CACHE = Path.home() / ".calle-mcp" / "cli"
 TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED", "CANCELLED"}
 TERMINAL_ACTIONS = {"report_result", "report_blocked", "none"}
 BLOCKED_ACTIONS = {"ask_user_for_missing_info", "ask_user_for_retry_confirmation"}
+
+# E.164: a plus, a non-zero country code digit, then 7-14 more digits.
+E164_RE = re.compile(r"^\+[1-9]\d{7,14}$")
+
+# Below this, a result is reported but never allowed to outrank a verified one.
+MIN_CONFIDENCE = 0.6
 
 FIELDS = [
     "in_stock", "form_available", "quantity_available", "unit_price", "currency",
@@ -60,8 +65,28 @@ NULLISH = {"", "unknown", "unclear", "n/a", "na", "none", "not stated"}
 
 
 # --------------------------------------------------------------------------
-# Safety helpers
+# Validation
 # --------------------------------------------------------------------------
+
+
+class InvalidPhoneNumber(ValueError):
+    pass
+
+
+def validate_e164(phone: str) -> str:
+    """Reject anything that isn't E.164 before it can be dialled.
+
+    Documenting the requirement isn't enough — a local-format number silently
+    reaching the planner is how the wrong person gets called.
+    """
+    cleaned = (phone or "").strip().replace(" ", "").replace("-", "")
+    if not E164_RE.match(cleaned):
+        raise InvalidPhoneNumber(
+            f"{phone!r} is not E.164. Expected + followed by country code and "
+            f"number, 8-15 digits total, e.g. +15550100. Do not guess a "
+            f"country code — ask the user."
+        )
+    return cleaned
 
 
 def mask(phone: str) -> str:
@@ -69,22 +94,9 @@ def mask(phone: str) -> str:
     return f"…{phone[-4:]}" if len(phone) >= 4 else "…"
 
 
-def load_token() -> str:
-    """Reuse the CALL-E CLI's cached token. The file shape is undocumented,
-    so probe the likely key names rather than assuming one."""
-    candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
-    if not candidates:
-        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
-    data = json.loads(candidates[-1].read_text())
-    for key in ("access_token", "accessToken", "token", "bearer"):
-        value = data.get(key)
-        if isinstance(value, str):
-            return value
-        if isinstance(value, dict):
-            for inner in ("access_token", "accessToken", "token"):
-                if isinstance(value.get(inner), str):
-                    return value[inner]
-    raise SystemExit(f"No access token found in {candidates[-1]}")
+# --------------------------------------------------------------------------
+# Budget
+# --------------------------------------------------------------------------
 
 
 class BudgetExceeded(RuntimeError):
@@ -122,6 +134,51 @@ class CallBudget:
         self.spent += n
         self.ledger.write_text(json.dumps({"spent": self.spent}))
         log.warning("Placed %s call(s) — %s/%s used", n, self.spent, self.max_calls)
+
+
+# --------------------------------------------------------------------------
+# Durable run state
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class RunStore:
+    """Persisted plan and run IDs, so an interruption resumes instead of redials.
+
+    Without this, a lost response or a killed process means the next invocation
+    plans afresh and calls the pharmacist a second time — spending a call and
+    bothering a real person. `plan_id` is CALL-E's idempotency key, so it only
+    protects you if it survives the crash.
+    """
+
+    path: Path = field(default=Path(".pharmacy_runs.json"))
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            return json.loads(self.path.read_text())
+        except json.JSONDecodeError:
+            return {}
+
+    @staticmethod
+    def key(phone: str, goal: str) -> str:
+        return hashlib.sha256(f"{phone}|{goal}".encode()).hexdigest()[:32]
+
+    def get(self, key: str) -> dict[str, Any]:
+        return self._load().get(key, {})
+
+    def put(self, key: str, **fields: Any) -> None:
+        data = self._load()
+        entry = data.setdefault(key, {})
+        entry.update(fields)
+        entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+        self.path.write_text(json.dumps(data, indent=2))
+
+    def clear(self, key: str) -> None:
+        data = self._load()
+        data.pop(key, None)
+        self.path.write_text(json.dumps(data, indent=2))
 
 
 # --------------------------------------------------------------------------
@@ -164,15 +221,18 @@ _FIELD_RE = re.compile(
 
 def parse_summary(summary: str) -> dict[str, str]:
     """Extraction arrives in result.summary as key=value pairs, not in
-    result.extracted. Values contain commas, so split on key= boundaries."""
+    result.extracted. Values contain commas, so split on key= boundaries.
+
+    The separator between fields is not stable — both ", " and "; " observed.
+    """
     if not summary:
         return {}
     matches = list(_FIELD_RE.finditer(summary))
     out: dict[str, str] = {}
     for i, m in enumerate(matches):
         end = matches[i + 1].start() if i + 1 < len(matches) else len(summary)
-        value = summary[m.end():end].strip().strip(",").strip()
-        out[m.group(1).lower()] = value.rstrip(".") if len(value) < 40 else value
+        value = summary[m.end():end].strip().strip(",;").strip()
+        out[m.group(1).lower()] = value.rstrip(".;,") if len(value) < 40 else value
     return out
 
 
@@ -192,17 +252,40 @@ def normalise(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 def to_record(final: dict[str, Any], pharmacy: dict[str, str]) -> dict[str, Any]:
-    result = final.get("result") or {}
-    summary = result.get("summary") or result.get("post_summary") or ""
-    record = normalise(parse_summary(summary))
+    """Build a record, refusing to report stock fields from an incomplete call.
 
+    A call that failed, went to voicemail, or was cut off can still carry a
+    partially filled summary. Treating that as a stock check is how a patient
+    gets sent somewhere on the strength of a sentence nobody finished.
+    """
+    result = final.get("result") or {}
     outcome = result.get("outcome") or {}
-    confidence = outcome.get("completion_confidence") or {}
+    confidence = (outcome.get("completion_confidence") or {}).get("score")
+    completed = outcome.get("task_completed") is True
+    status = (final.get("status") or "").upper()
+
+    reached = completed and status == "COMPLETED"
+    verified = reached and (confidence is not None and confidence >= MIN_CONFIDENCE)
+
+    if reached:
+        summary = result.get("summary") or result.get("post_summary") or ""
+        record = normalise(parse_summary(summary))
+    else:
+        # Not a stock check. Say so rather than reporting whatever was scraped.
+        record = {name: ("unknown" if name in ENUMS else None) for name in FIELDS}
+        record["pharmacist_notes"] = (
+            f"Call did not complete ({status.lower() or 'unknown status'}). "
+            f"No stock information obtained."
+        )
+
     record.update(
         pharmacy=pharmacy.get("name"),
         phone_masked=mask(pharmacy.get("phone", "")),
         run_status=final.get("status"),
-        confidence=confidence.get("score"),
+        task_completed=completed,
+        confidence=confidence,
+        reached=reached,
+        verified=verified,
         evidence=outcome.get("evidence") or [],
         transcript=result.get("transcript"),
     )
@@ -210,18 +293,18 @@ def to_record(final: dict[str, Any], pharmacy: dict[str, str]) -> dict[str, Any]
 
 
 def rank(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """In stock first, then cheapest, then whoever will hold it.
+    """Verified results first, then stock, then price, then hold.
 
-    Low-confidence results sink: a reliable "no" beats an unreliable "yes"
-    that sends someone across town while unwell.
+    Verification outranks stock status deliberately. A confident "no" is more
+    useful than an unreliable "yes" that sends someone across town while
+    unwell — so a low-confidence yes must never outrank a high-confidence no.
     """
     order = {"yes": 0, "partial": 1, "unknown": 2, "no": 3}
 
     def key(r: dict[str, Any]):
-        conf = r.get("confidence")
         return (
+            0 if r.get("verified") else 1,          # verified beats everything
             order.get(r.get("in_stock"), 3),
-            0 if (conf is None or conf >= 0.6) else 1,
             r["unit_price"] if r.get("unit_price") is not None else float("inf"),
             0 if r.get("can_hold") == "yes" else 1,
         )
@@ -230,18 +313,43 @@ def rank(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 # --------------------------------------------------------------------------
-# CALL-E
+# CALL-E — live only. Nothing here is imported or touched in dry run.
 # --------------------------------------------------------------------------
 
 
+def load_token() -> str:
+    """Reuse the CALL-E CLI's cached token. Live mode only."""
+    candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
+    if not candidates:
+        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
+    data = json.loads(candidates[-1].read_text())
+    for key in ("access_token", "accessToken", "token", "bearer"):
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            for inner in ("access_token", "accessToken", "token"):
+                if isinstance(value.get(inner), str):
+                    return value[inner]
+    raise SystemExit(f"No access token found in {candidates[-1]}")
+
+
 class Caller:
-    def __init__(self, budget: CallBudget, *, dry_run: bool = True) -> None:
+    """Live caller. Constructing this loads credentials, so it is only ever
+    instantiated under --live."""
+
+    def __init__(self, budget: CallBudget, store: RunStore) -> None:
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        self._Client = Client
+        self._Transport = StreamableHttpTransport
         self.budget = budget
-        self.dry_run = dry_run
+        self.store = store
         self._token = load_token()
 
-    def _client(self) -> Client:
-        return Client(StreamableHttpTransport(
+    def _client(self):
+        return self._Client(self._Transport(
             SERVER_URL, headers={"Authorization": f"Bearer {self._token}"}
         ))
 
@@ -256,76 +364,158 @@ class Caller:
             return json.loads(blocks[0].text)
         return {}
 
+    @staticmethod
+    def _token_live(expires_at: str | None) -> bool:
+        if not expires_at:
+            return True
+        return datetime.fromisoformat(
+            expires_at.replace("Z", "+00:00")
+        ) > datetime.now(timezone.utc)
+
+    async def _poll(self, client, run_id: str, phone: str) -> dict[str, Any] | None:
+        seen: set[str] = set()
+        deadline = time.time() + 900
+        delay = 2.0
+        while time.time() < deadline:
+            final = self._unwrap(
+                await client.call_tool("get_call_run", {"run_id": run_id})
+            )
+            status = (final.get("status") or "").upper()
+            nxt = final.get("next_step")
+            nxt = nxt if isinstance(nxt, dict) else {}
+
+            # The activity feed is cumulative on every poll — dedupe.
+            for entry in final.get("activity", []):
+                key = f"{entry.get('ts')}|{entry.get('message')}"
+                if key not in seen:
+                    seen.add(key)
+                    log.info("    %s", entry.get("message"))
+
+            action = nxt.get("action")
+            if status in TERMINAL_STATUSES or action in TERMINAL_ACTIONS:
+                return final
+            if action in BLOCKED_ACTIONS:
+                log.warning("  %s: needs user input — %s",
+                            mask(phone), nxt.get("instruction"))
+                return final
+
+            delay = float(nxt.get("poll_after_seconds") or delay)
+            await asyncio.sleep(min(delay, 15.0))
+        return None
+
     async def call(self, pharmacy: dict[str, str], goal: str, region: str
                    ) -> dict[str, Any] | None:
-        phone = pharmacy["phone"]
+        phone = validate_e164(pharmacy["phone"])
+        key = self.store.key(phone, goal)
+        saved = self.store.get(key)
 
         async with self._client() as client:
-            plan = self._unwrap(await client.call_tool("plan_call", {
-                "goal": goal, "to_phones": [phone], "region": region,
-                "language": "English", "ttl_seconds": 0, "user_input": goal,
-            }))
+            # Resume an in-flight run rather than planning again. Without this,
+            # an interrupted poll causes a second call to the same pharmacist.
+            if saved.get("run_id"):
+                log.info("  %s: resuming run %s", mask(phone), saved["run_id"][:12])
+                final = await self._poll(client, saved["run_id"], phone)
+                if final is None:
+                    return None
+                self.store.clear(key)
+                return to_record(final, pharmacy)
 
-        if not plan.get("ready_to_run"):
-            log.warning("  %s: planner needs more detail — %s",
-                        mask(phone), plan.get("clarifying_questions"))
-            return None
+            # Reuse a stored plan if its confirm_token is still valid.
+            plan = None
+            if saved.get("plan_id") and self._token_live(saved.get("confirm_expires_at")):
+                plan = {
+                    "plan_id": saved["plan_id"],
+                    "confirm_token": saved["confirm_token"],
+                    "ready_to_run": True,
+                }
+                log.info("  %s: reusing plan %s", mask(phone), saved["plan_id"])
 
-        if self.dry_run:
-            print(f"  DRY RUN {pharmacy['name']} ({mask(phone)}) — "
-                  f"plan {plan['plan_id']}, would spend 1 call")
-            return None
+            if plan is None:
+                plan = self._unwrap(await client.call_tool("plan_call", {
+                    "goal": goal, "to_phones": [phone], "region": region,
+                    "language": "English", "ttl_seconds": 0, "user_input": goal,
+                }))
+                if not plan.get("ready_to_run"):
+                    log.warning("  %s: planner needs more detail — %s",
+                                mask(phone), plan.get("clarifying_questions"))
+                    return None
+                self.store.put(
+                    key,
+                    plan_id=plan["plan_id"],
+                    confirm_token=plan["confirm_token"],
+                    confirm_expires_at=plan.get("confirm_expires_at"),
+                    phone_masked=mask(phone),
+                )
 
-        expires = plan.get("confirm_expires_at")
-        if expires:
-            exp = datetime.fromisoformat(expires.replace("Z", "+00:00"))
-            if exp < datetime.now(timezone.utc):
-                log.error("  %s: confirm_token expired", mask(phone))
-                return None
-
-        self.budget.charge(1)
-        async with self._client() as client:
+            self.budget.charge(1)
             run = self._unwrap(await client.call_tool("run_call", {
                 "plan_id": plan["plan_id"], "confirm_token": plan["confirm_token"],
             }))
             run_id = run.get("run_id")
             if not run_id:
                 return None
+            self.store.put(key, run_id=run_id)
 
-            seen: set[str] = set()
-            deadline = time.time() + 900
-            delay = 2.0
-            while time.time() < deadline:
-                final = self._unwrap(
-                    await client.call_tool("get_call_run", {"run_id": run_id})
-                )
-                status = (final.get("status") or "").upper()
-                nxt = final.get("next_step")
-                nxt = nxt if isinstance(nxt, dict) else {}
+            final = await self._poll(client, run_id, phone)
+            if final is None:
+                log.error("  %s: poll timed out — rerun to resume, not redial",
+                          mask(phone))
+                return None
+            self.store.clear(key)
+            return to_record(final, pharmacy)
 
-                # The activity feed is cumulative on every poll — dedupe.
-                for entry in final.get("activity", []):
-                    key = f"{entry.get('ts')}|{entry.get('message')}"
-                    if key not in seen:
-                        seen.add(key)
-                        log.info("    %s", entry.get("message"))
 
-                action = nxt.get("action")
-                if status in TERMINAL_STATUSES or action in TERMINAL_ACTIONS:
-                    return to_record(final, pharmacy)
-                if action in BLOCKED_ACTIONS:
-                    log.warning("  %s: needs user input — %s",
-                                mask(phone), nxt.get("instruction"))
-                    return None
+# --------------------------------------------------------------------------
+# Dry run — fully offline
+# --------------------------------------------------------------------------
 
-                delay = float(nxt.get("poll_after_seconds") or delay)
-                await asyncio.sleep(min(delay, 15.0))
-        return None
+
+def dry_run(pharmacies: list[dict[str, str]], goal: str, region: str) -> None:
+    """Validate and print. No credentials read, no socket opened, no data sent.
+
+    The point of a dry run in a workflow that calls real people is to be able
+    to inspect exactly what would happen without anything leaving the machine.
+    A dry run that still transmits the recipient's number and the medication
+    being sought is not a dry run.
+    """
+    print(f"\nDRY RUN — offline. No credentials read, nothing sent.\n")
+    for pharmacy in pharmacies:
+        phone = validate_e164(pharmacy["phone"])
+        payload = {
+            "tool": "plan_call",
+            "goal": goal,
+            "to_phones": [phone],
+            "region": region,
+            "language": "English",
+            "ttl_seconds": 0,
+        }
+        print(f"  {pharmacy.get('name', '?')} ({mask(phone)}) — would send:")
+        print("  " + json.dumps(payload, indent=2)[:400].replace("\n", "\n  "))
+        print()
+    print(f"  {len(pharmacies)} call(s) would be placed. Add --live to dial.\n")
 
 
 # --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
+
+
+def render(records: list[dict[str, Any]]) -> None:
+    print(f"\n{'Pharmacy':<24} {'Stock':<9} {'Qty':>5} {'Price':>10} "
+          f"{'Rx':<8} {'Hold':>6} {'Conf':>6}")
+    print("-" * 74)
+    for r in rank(records):
+        hold = f"{r['hold_duration_hours']:.0f}h" if r.get("hold_duration_hours") else "—"
+        price = (f"{r['unit_price']:g} {r.get('currency') or ''}".strip()
+                 if r.get("unit_price") is not None else "—")
+        conf = f"{r['confidence']:.2f}" if r.get("confidence") is not None else "—"
+        flag = "" if r.get("verified") else "  ⚠ unverified"
+        print(f"{(r['pharmacy'] or '?')[:24]:<24} {r['in_stock']:<9} "
+              f"{r['quantity_available'] or '—':>5} {price:>10} "
+              f"{r['requires_prescription']:<8} {hold:>6} {conf:>6}{flag}")
+        if r.get("pharmacist_notes"):
+            print(f"    {r['pharmacist_notes']}")
+    print()
 
 
 async def main() -> None:
@@ -338,7 +528,8 @@ async def main() -> None:
     parser.add_argument("--max-calls", type=int, default=3)
     parser.add_argument("--concurrency", type=int, default=3)
     parser.add_argument("--live", action="store_true",
-                        help="ACTUALLY PLACE CALLS. Without this, nothing is dialled.")
+                        help="ACTUALLY PLACE CALLS. Without this the run is "
+                             "fully offline: no credentials, no network.")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -349,17 +540,26 @@ async def main() -> None:
     with args.pharmacies.open() as fh:
         pharmacies = [row for row in csv.DictReader(fh) if row.get("phone")]
 
-    budget = CallBudget(max_calls=args.max_calls)
-    if args.live:
-        # Fail before dialling anything, not halfway through the batch.
-        budget.check(len(pharmacies))
+    # Validate every number before anything else happens, in either mode.
+    try:
+        for pharmacy in pharmacies:
+            pharmacy["phone"] = validate_e164(pharmacy["phone"])
+    except InvalidPhoneNumber as exc:
+        raise SystemExit(f"Invalid phone number: {exc}")
 
-    caller = Caller(budget, dry_run=not args.live)
     goal = build_goal(args.drug, args.dosage, args.quantity)
 
+    if not args.live:
+        dry_run(pharmacies, goal, args.region)
+        return
+
+    budget = CallBudget(max_calls=args.max_calls)
+    store = RunStore()
+    budget.check(len(pharmacies))     # fail before dialling, not halfway
+
+    caller = Caller(budget, store)
     print(f"\n{args.drug} {args.dosage} — {args.quantity} · "
-          f"{len(pharmacies)} pharmacies · "
-          f"{'LIVE' if args.live else 'dry run, no calls'}\n")
+          f"{len(pharmacies)} pharmacies · LIVE\n")
 
     semaphore = asyncio.Semaphore(args.concurrency)
 
@@ -372,23 +572,8 @@ async def main() -> None:
                 return None
 
     results = [r for r in await asyncio.gather(*(one(p) for p in pharmacies)) if r]
-    if not results:
-        return
-
-    print(f"\n{'Pharmacy':<26} {'Stock':<9} {'Qty':>5} {'Price':>10} "
-          f"{'Rx':<8} {'Hold':>6} {'Conf':>6}")
-    print("-" * 76)
-    for r in rank(results):
-        hold = f"{r['hold_duration_hours']:.0f}h" if r.get("hold_duration_hours") else "—"
-        price = (f"{r['unit_price']:g} {r.get('currency') or ''}".strip()
-                 if r.get("unit_price") is not None else "—")
-        print(f"{(r['pharmacy'] or '?')[:26]:<26} {r['in_stock']:<9} "
-              f"{r['quantity_available'] or '—':>5} {price:>10} "
-              f"{r['requires_prescription']:<8} {hold:>6} "
-              f"{r['confidence'] if r['confidence'] is not None else '—':>6}")
-        if r.get("pharmacist_notes"):
-            print(f"    {r['pharmacist_notes']}")
-    print()
+    if results:
+        render(results)
 
 
 if __name__ == "__main__":

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import tempfile
 import time
 from contextlib import contextmanager
@@ -46,6 +47,11 @@ TOKEN_CACHE = Path.home() / ".calle-mcp" / "cli"
 # Terminal responses include call transcripts. Keep them out of the working
 # directory so they are neither committed by accident nor world-readable.
 RUN_DIR = Path(os.environ.get("PHARMACY_RUN_DIR", "call_runs"))
+
+# Bump when the run-identity scheme changes. An older ledger's keys won't match
+# anything we compute, so unfinished entries must be refused rather than read as
+# absent — "absent" means "dial them again".
+LEDGER_SCHEMA = 2
 
 TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED", "CANCELLED"}
 TERMINAL_ACTIONS = {"report_result", "report_blocked", "none"}
@@ -249,6 +255,12 @@ class RunStore:
 
     path: Path = field(default=Path(".pharmacy_runs.json"))
 
+    # Everything that changes what a call actually is. A plan created under a
+    # different endpoint, account or region is not the same pending action, and
+    # must not be reused or reconciled as if it were.
+    server_url: str = SERVER_URL
+    account_ns: str = "unknown"
+
     # Keys currently in flight in THIS process. The file lock stops two
     # processes racing; it does nothing about two coroutines in one process,
     # because they share a pid. Duplicate rows dispatched by asyncio.gather
@@ -269,7 +281,7 @@ class RunStore:
         if not text.strip():
             return {}
         try:
-            return json.loads(text)
+            raw = json.loads(text)
         except json.JSONDecodeError as exc:
             quarantine = self.path.with_name(
                 f"{self.path.name}.corrupt.{int(time.time())}"
@@ -282,15 +294,54 @@ class RunStore:
                 f"quarantined file, then remove it to start clean."
             ) from exc
 
-    def _write(self, data: dict[str, Any]) -> None:
+        schema = raw.get("schema")
+        entries = raw.get("entries")
+        if schema == LEDGER_SCHEMA and isinstance(entries, dict):
+            return entries
+
+        # An older ledger keyed entries differently. Its keys will not match
+        # anything we compute now, so every in-flight call would look absent —
+        # and get dialled again. Migrate silently only if nothing is pending.
+        legacy = entries if isinstance(entries, dict) else raw
+        pending = {
+            k: v for k, v in legacy.items()
+            if isinstance(v, dict) and v.get("state") != "done"
+        }
+        if pending:
+            raise StateCorrupted(
+                f"Run ledger {self.path} uses an older identity scheme "
+                f"(schema {schema!r}, now {LEDGER_SCHEMA}) and still holds "
+                f"{len(pending)} unfinished entr{'y' if len(pending)==1 else 'ies'}.\n"
+                f"Keys are now namespaced by endpoint, account and region, so "
+                f"those entries would not be found and their recipients would be "
+                f"dialled again. Let the in-flight calls finish, or inspect and "
+                f"remove the file deliberately:\n  {self.path}"
+            )
+        return {}
+
+    def _write(self, entries: dict[str, Any]) -> None:
         # 0600: this file holds confirm_tokens, which authorise placing a call.
-        _write_private(self.path, json.dumps(data, indent=2))
+        _write_private(self.path, json.dumps(
+            {"schema": LEDGER_SCHEMA, "entries": entries}, indent=2
+        ))
 
     # -- api ----------------------------------------------------------------
 
-    @staticmethod
-    def key(phone: str, goal: str) -> str:
-        return hashlib.sha256(f"{phone}|{goal}".encode()).hexdigest()[:32]
+    def key(self, phone: str, goal: str, region: str) -> str:
+        """Identity of a pending call, across every dimension that changes it.
+
+        Hashing phone and goal alone is not enough. The same number and the
+        same question routed through a different region is a different call;
+        under a different account or endpoint it's a different plan entirely,
+        and a `plan_id` issued by one provider means nothing to another. Reusing
+        or reconciling across those boundaries either resurrects a stale plan or
+        silently treats a live one as absent — and the second of those redials a
+        pharmacist.
+        """
+        material = "|".join([
+            self.server_url, self.account_ns, region.upper(), phone, goal,
+        ])
+        return hashlib.sha256(material.encode()).hexdigest()[:32]
 
     @staticmethod
     def _alive(pid: int | None) -> bool:
@@ -302,7 +353,7 @@ class RunStore:
             return False
         return True
 
-    def claim(self, key: str, phone_masked: str) -> dict[str, Any]:
+    def claim(self, key: str, phone_masked: str, region: str = "") -> dict[str, Any]:
         """Atomically take ownership of a recipient, or return the live entry.
 
         The read and the write happen under one lock, so there is no window in
@@ -325,6 +376,11 @@ class RunStore:
                     "state": "planned",
                     "pid": os.getpid(),
                     "phone_masked": phone_masked,
+                    # Recorded so a human inspecting a stuck entry can see
+                    # which configuration it belongs to.
+                    "server_url": self.server_url,
+                    "account_ns": self.account_ns,
+                    "region": region,
                     "claimed_at": datetime.now(timezone.utc).isoformat(),
                 }
                 data[key] = entry
@@ -558,19 +614,42 @@ def _endpoint_of(data: dict[str, Any]) -> str | None:
     return None
 
 
-def load_token(server_url: str = SERVER_URL) -> str:
-    """Select the CLI token bound to the endpoint we are about to call.
+def _cli_auth_status() -> dict[str, Any] | None:
+    """Ask the CALL-E CLI which cache belongs to which endpoint.
 
-    The cache is keyed by a hash directory, and more than one can exist — a
-    second account, a different environment, a stale login. Taking the
-    lexicographically last one silently authenticates as whoever happens to
-    sort last, which in a workflow that dials real people means calling from
-    the wrong account and billing the wrong balance.
+    This is the authoritative binding. The cache directory is a hash we don't
+    control and shouldn't reverse-engineer, so rather than infer the mapping we
+    ask the tool that created it.
+    """
+    try:
+        result = subprocess.run(
+            ["calle", "auth", "status"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
 
-    Prefer a cache that records this endpoint. If several exist and none can
-    be bound, refuse and make the caller choose, rather than guessing.
 
-    Override with CALLE_TOKEN_CACHE=/path/to/token.json
+def resolve_credential(server_url: str = SERVER_URL) -> tuple[str, str]:
+    """Return (access_token, account_namespace) for `server_url`, or refuse.
+
+    A bearer token is issued for one origin. Sending it anywhere else hands a
+    working credential to a party it was never meant for — so an unbound cache
+    is not "probably fine", it's an unknown recipient.
+
+    Resolution order:
+      1. CALLE_TOKEN_CACHE — explicit operator intent, trusted.
+      2. `calle auth status` — the CLI states its own endpoint and cache path.
+      3. A cache file that records the endpoint itself.
+    If none of those bind the credential to `server_url`, refuse. A single
+    cache with no endpoint recorded is NOT accepted: "only one" is not evidence
+    that it belongs to this provider.
     """
     override = os.environ.get("CALLE_TOKEN_CACHE")
     if override:
@@ -578,11 +657,37 @@ def load_token(server_url: str = SERVER_URL) -> str:
         token = _extract_token(json.loads(path.read_text()))
         if not token:
             raise SystemExit(f"No access token found in {path}")
-        return token
+        return token, os.environ.get("CALLE_ACCOUNT_NS") or path.parent.name
+
+    status = _cli_auth_status()
+    if status:
+        cli_endpoint = status.get("server_url")
+        cache_path = status.get("cache_path")
+        if cli_endpoint and cli_endpoint != server_url:
+            raise SystemExit(
+                f"The CALL-E CLI is authenticated against {cli_endpoint}, but "
+                f"this skill is configured to call {server_url}. Refusing to "
+                f"send that credential to a different origin. Re-run "
+                f"`calle auth login` against the intended endpoint, or set "
+                f"CALLE_TOKEN_CACHE deliberately."
+            )
+        if cli_endpoint == server_url and cache_path:
+            path = Path(cache_path).expanduser()
+            if not status.get("usable", True):
+                raise SystemExit(
+                    f"CALL-E CLI reports its cached credential is not usable "
+                    f"({path}). Run: calle auth login"
+                )
+            token = _extract_token(json.loads(path.read_text()))
+            if not token:
+                raise SystemExit(f"No access token found in {path}")
+            return token, path.parent.name
 
     candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
     if not candidates:
-        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
+        raise SystemExit(
+            f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login"
+        )
 
     parsed: list[tuple[Path, dict[str, Any]]] = []
     for path in candidates:
@@ -593,7 +698,10 @@ def load_token(server_url: str = SERVER_URL) -> str:
 
     bound = [(p, d) for p, d in parsed if _endpoint_of(d) == server_url]
     if len(bound) == 1:
-        return _extract_token(bound[0][1]) or _fail_no_token(bound[0][0])
+        token = _extract_token(bound[0][1])
+        if not token:
+            raise SystemExit(f"No access token found in {bound[0][0]}")
+        return token, bound[0][0].parent.name
     if len(bound) > 1:
         raise SystemExit(
             f"{len(bound)} cached tokens claim endpoint {server_url}. Set "
@@ -601,21 +709,21 @@ def load_token(server_url: str = SERVER_URL) -> str:
             "\n  ".join(str(p) for p, _ in bound)
         )
 
-    if len(parsed) == 1:
-        return _extract_token(parsed[0][1]) or _fail_no_token(parsed[0][0])
-
     raise SystemExit(
-        f"{len(parsed)} cached CALL-E tokens found and none records the "
-        f"endpoint {server_url}, so the correct account cannot be determined. "
-        f"Refusing to guess — calls would be placed and billed from whichever "
-        f"cache happens to sort last. Set CALLE_TOKEN_CACHE to one of:\n  " +
-        "\n  ".join(str(p) for p, _ in parsed) +
-        f"\nor run `calle auth login` to refresh the intended account."
+        f"Found {len(parsed)} cached CALL-E credential(s), none of which can be "
+        f"bound to {server_url}.\n\n"
+        f"`calle auth status` did not report a matching endpoint, and no cache "
+        f"records one. A bearer token is issued for a single origin, so sending "
+        f"one that might belong to a different provider is a credential "
+        f"disclosure, not a routing mistake — refusing rather than assuming.\n\n"
+        f"Either run `calle auth login` against {server_url}, or set "
+        f"CALLE_TOKEN_CACHE explicitly:\n  " +
+        "\n  ".join(str(p) for p, _ in parsed)
     )
 
 
-def _fail_no_token(path: Path) -> str:
-    raise SystemExit(f"No access token found in {path}")
+def load_token(server_url: str = SERVER_URL) -> str:
+    return resolve_credential(server_url)[0]
 
 
 class Caller:
@@ -630,7 +738,11 @@ class Caller:
         self._Transport = StreamableHttpTransport
         self.budget = budget
         self.store = store
-        self._token = load_token()
+        # Resolving the credential also tells us which account we're acting as,
+        # which is part of a call's identity.
+        self._token, account_ns = resolve_credential(SERVER_URL)
+        self.store.server_url = SERVER_URL
+        self.store.account_ns = account_ns
 
     def _client(self):
         return self._Client(self._Transport(
@@ -707,11 +819,11 @@ class Caller:
     async def call(self, pharmacy: dict[str, str], goal: str, region: str
                    ) -> dict[str, Any] | None:
         phone = validate_e164(pharmacy["phone"])
-        key = self.store.key(phone, goal)
+        key = self.store.key(phone, goal, region)
 
         # Atomic claim. Raises if another live process holds this recipient, or
         # if a previous attempt left an ambiguous create.
-        saved = self.store.claim(key, mask(phone))
+        saved = self.store.claim(key, mask(phone), region)
 
         async with self._client() as client:
             # Resume an in-flight run rather than planning again.
@@ -874,7 +986,7 @@ async def main() -> None:
     seen: dict[str, dict[str, str]] = {}
     duplicates: list[str] = []
     for pharmacy in pharmacies:
-        dedupe_key = RunStore.key(pharmacy["phone"], goal)
+        dedupe_key = f"{args.region.upper()}|{pharmacy['phone']}"
         if dedupe_key in seen:
             duplicates.append(f"{pharmacy.get('name', '?')} ({mask(pharmacy['phone'])})")
             continue

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -43,6 +43,10 @@ log = logging.getLogger("pharmacy-stock-check")
 SERVER_URL = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth"
 TOKEN_CACHE = Path.home() / ".calle-mcp" / "cli"
 
+# Terminal responses include call transcripts. Keep them out of the working
+# directory so they are neither committed by accident nor world-readable.
+RUN_DIR = Path(os.environ.get("PHARMACY_RUN_DIR", "call_runs"))
+
 TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED", "CANCELLED"}
 TERMINAL_ACTIONS = {"report_result", "report_blocked", "none"}
 BLOCKED_ACTIONS = {"ask_user_for_missing_info", "ask_user_for_retry_confirmation"}
@@ -107,37 +111,98 @@ class BudgetExceeded(RuntimeError):
     pass
 
 
+@contextmanager
+def _file_lock(path: Path):
+    """Exclusive lock keyed on a sidecar file next to `path`."""
+    lock_path = path.with_name(path.name + ".lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _write_private(path: Path, payload: str) -> None:
+    """Atomic write, owner-readable only.
+
+    These files hold confirm_tokens and call transcripts. Default umask would
+    leave them world-readable on a shared machine.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent or "."), suffix=".tmp")
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
 @dataclass
 class CallBudget:
-    """Hard ceiling on outbound calls.
+    """Hard ceiling on outbound calls, enforced across processes.
 
-    `to_phones` is an array, so ONE plan can spend N calls. Always charge the
-    number of phones, and check the whole batch before dialling anything.
+    `to_phones` is an array, so ONE plan can spend N calls. The ledger is read,
+    checked and incremented inside a single lock — an unlocked
+    read/modify/write lets two processes both observe the same `spent`, both
+    pass the ceiling check, and both dial.
+
+    `check()` is only a fast pre-flight so a batch fails before the first call
+    rather than halfway. `reserve()` is what actually enforces the ceiling.
     """
 
     max_calls: int
-    spent: int = 0
     ledger: Path = field(default=Path(".pharmacy_budget.json"))
 
-    def __post_init__(self) -> None:
-        if self.ledger.exists():
-            self.spent = json.loads(self.ledger.read_text()).get("spent", 0)
+    def _read(self) -> int:
+        if not self.ledger.exists():
+            return 0
+        text = self.ledger.read_text()
+        if not text.strip():
+            return 0
+        try:
+            return int(json.loads(text).get("spent", 0))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise BudgetExceeded(
+                f"Budget ledger {self.ledger} is unreadable. Refusing to dial: "
+                f"assuming zero spent would ignore the ceiling entirely."
+            ) from exc
+
+    @property
+    def spent(self) -> int:
+        with _file_lock(self.ledger):
+            return self._read()
 
     @property
     def remaining(self) -> int:
         return max(0, self.max_calls - self.spent)
 
     def check(self, n: int) -> None:
-        if n > self.remaining:
+        """Advisory pre-flight. Not a guarantee — see reserve()."""
+        remaining = self.remaining
+        if n > remaining:
             raise BudgetExceeded(
-                f"{n} call(s) needed, {self.remaining} left of {self.max_calls}."
+                f"{n} call(s) needed, {remaining} left of {self.max_calls}."
             )
 
-    def charge(self, n: int) -> None:
-        self.check(n)
-        self.spent += n
-        self.ledger.write_text(json.dumps({"spent": self.spent}))
-        log.warning("Placed %s call(s) — %s/%s used", n, self.spent, self.max_calls)
+    def reserve(self, n: int = 1) -> int:
+        """Atomically claim n calls. This is the ceiling's real enforcement."""
+        with _file_lock(self.ledger):
+            spent = self._read()
+            if spent + n > self.max_calls:
+                raise BudgetExceeded(
+                    f"{n} call(s) needed, {max(0, self.max_calls - spent)} left "
+                    f"of {self.max_calls}."
+                )
+            spent += n
+            _write_private(self.ledger, json.dumps({"spent": spent}))
+            log.warning("Placed %s call(s) — %s/%s used", n, spent, self.max_calls)
+            return spent
 
 
 # --------------------------------------------------------------------------
@@ -184,18 +249,18 @@ class RunStore:
 
     path: Path = field(default=Path(".pharmacy_runs.json"))
 
+    # Keys currently in flight in THIS process. The file lock stops two
+    # processes racing; it does nothing about two coroutines in one process,
+    # because they share a pid. Duplicate rows dispatched by asyncio.gather
+    # would otherwise both claim and both dial.
+    _active: set[str] = field(default_factory=set, repr=False)
+
     # -- locking ------------------------------------------------------------
 
     @contextmanager
     def _locked(self):
-        lock_path = self.path.with_name(self.path.name + ".lock")
-        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+        with _file_lock(self.path):
             yield
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            os.close(fd)
 
     def _read(self) -> dict[str, Any]:
         if not self.path.exists():
@@ -218,16 +283,8 @@ class RunStore:
             ) from exc
 
     def _write(self, data: dict[str, Any]) -> None:
-        fd, tmp = tempfile.mkstemp(dir=str(self.path.parent or "."), suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as handle:
-                json.dump(data, handle, indent=2)
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp, self.path)   # atomic
-        except BaseException:
-            Path(tmp).unlink(missing_ok=True)
-            raise
+        # 0600: this file holds confirm_tokens, which authorise placing a call.
+        _write_private(self.path, json.dumps(data, indent=2))
 
     # -- api ----------------------------------------------------------------
 
@@ -249,8 +306,16 @@ class RunStore:
         """Atomically take ownership of a recipient, or return the live entry.
 
         The read and the write happen under one lock, so there is no window in
-        which two processes both conclude the recipient is unclaimed.
+        which two processes both conclude the recipient is unclaimed. The
+        in-process set covers the case the file lock cannot: two coroutines in
+        the same process sharing a pid.
         """
+        if key in self._active:
+            raise RunLocked(
+                f"{phone_masked}: already in flight in this process. Duplicate "
+                f"entries for the same recipient and goal are not dialled twice."
+            )
+
         with self._locked():
             data = self._read()
             entry = data.get(key)
@@ -264,6 +329,7 @@ class RunStore:
                 }
                 data[key] = entry
                 self._write(data)
+                self._active.add(key)
                 return entry
 
             if entry.get("state") == "dialing":
@@ -289,6 +355,7 @@ class RunStore:
             entry["pid"] = os.getpid()
             data[key] = entry
             self._write(data)
+            self._active.add(key)
             return entry
 
     def update(self, key: str, **fields: Any) -> None:
@@ -308,6 +375,7 @@ class RunStore:
         """
         self.update(key, state="done", result_path=result_path,
                     completed_at=datetime.now(timezone.utc).isoformat())
+        self._active.discard(key)
 
     def prune_done(self) -> int:
         with self._locked():
@@ -331,6 +399,7 @@ class RunStore:
             if entry and entry.get("state") == "planned" and not entry.get("run_id"):
                 data.pop(key)
                 self._write(data)
+        self._active.discard(key)
 
 
 # --------------------------------------------------------------------------
@@ -469,12 +538,7 @@ def rank(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
 # --------------------------------------------------------------------------
 
 
-def load_token() -> str:
-    """Reuse the CALL-E CLI's cached token. Live mode only."""
-    candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
-    if not candidates:
-        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
-    data = json.loads(candidates[-1].read_text())
+def _extract_token(data: dict[str, Any]) -> str | None:
     for key in ("access_token", "accessToken", "token", "bearer"):
         value = data.get(key)
         if isinstance(value, str):
@@ -483,7 +547,75 @@ def load_token() -> str:
             for inner in ("access_token", "accessToken", "token"):
                 if isinstance(value.get(inner), str):
                     return value[inner]
-    raise SystemExit(f"No access token found in {candidates[-1]}")
+    return None
+
+
+def _endpoint_of(data: dict[str, Any]) -> str | None:
+    for key in ("server_url", "serverUrl", "endpoint", "audience", "mcp_url"):
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def load_token(server_url: str = SERVER_URL) -> str:
+    """Select the CLI token bound to the endpoint we are about to call.
+
+    The cache is keyed by a hash directory, and more than one can exist — a
+    second account, a different environment, a stale login. Taking the
+    lexicographically last one silently authenticates as whoever happens to
+    sort last, which in a workflow that dials real people means calling from
+    the wrong account and billing the wrong balance.
+
+    Prefer a cache that records this endpoint. If several exist and none can
+    be bound, refuse and make the caller choose, rather than guessing.
+
+    Override with CALLE_TOKEN_CACHE=/path/to/token.json
+    """
+    override = os.environ.get("CALLE_TOKEN_CACHE")
+    if override:
+        path = Path(override).expanduser()
+        token = _extract_token(json.loads(path.read_text()))
+        if not token:
+            raise SystemExit(f"No access token found in {path}")
+        return token
+
+    candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
+    if not candidates:
+        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
+
+    parsed: list[tuple[Path, dict[str, Any]]] = []
+    for path in candidates:
+        try:
+            parsed.append((path, json.loads(path.read_text())))
+        except json.JSONDecodeError:
+            log.warning("Skipping unreadable token cache %s", path)
+
+    bound = [(p, d) for p, d in parsed if _endpoint_of(d) == server_url]
+    if len(bound) == 1:
+        return _extract_token(bound[0][1]) or _fail_no_token(bound[0][0])
+    if len(bound) > 1:
+        raise SystemExit(
+            f"{len(bound)} cached tokens claim endpoint {server_url}. Set "
+            f"CALLE_TOKEN_CACHE to the one you intend to use:\n  " +
+            "\n  ".join(str(p) for p, _ in bound)
+        )
+
+    if len(parsed) == 1:
+        return _extract_token(parsed[0][1]) or _fail_no_token(parsed[0][0])
+
+    raise SystemExit(
+        f"{len(parsed)} cached CALL-E tokens found and none records the "
+        f"endpoint {server_url}, so the correct account cannot be determined. "
+        f"Refusing to guess — calls would be placed and billed from whichever "
+        f"cache happens to sort last. Set CALLE_TOKEN_CACHE to one of:\n  " +
+        "\n  ".join(str(p) for p, _ in parsed) +
+        f"\nor run `calle auth login` to refresh the intended account."
+    )
+
+
+def _fail_no_token(path: Path) -> str:
+    raise SystemExit(f"No access token found in {path}")
 
 
 class Caller:
@@ -561,9 +693,15 @@ class Caller:
         If the ledger entry were cleared first, a crash in between would lose
         the result and the claim together — and the next invocation would
         redial.
+
+        These files contain a third party's voice: the full transcript of a
+        call with a pharmacist. They go in a dedicated directory, owner-only,
+        never scattered next to the script where they get committed by
+        accident. Override the location with PHARMACY_RUN_DIR.
         """
-        path = Path(f"run_{key[:12]}_{int(time.time())}.json")
-        path.write_text(json.dumps(final, indent=2, default=str))
+        RUN_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = RUN_DIR / f"run_{key[:12]}_{int(time.time())}.json"
+        _write_private(path, json.dumps(final, indent=2, default=str))
         return str(path)
 
     async def call(self, pharmacy: dict[str, str], goal: str, region: str
@@ -618,7 +756,7 @@ class Caller:
             # ledger already says a call may have been placed — and claim()
             # will refuse to retry it rather than risk a second ring.
             self.store.update(key, state="dialing")
-            self.budget.charge(1)
+            self.budget.reserve(1)   # atomic; the ceiling's real enforcement
 
             run = self._unwrap(await client.call_tool("run_call", {
                 "plan_id": plan["plan_id"], "confirm_token": plan["confirm_token"],
@@ -728,6 +866,25 @@ async def main() -> None:
         raise SystemExit(f"Invalid phone number: {exc}")
 
     goal = build_goal(args.drug, args.dosage, args.quantity)
+
+    # Collapse duplicate rows before dispatch. The same recipient listed twice
+    # is a data-entry mistake, not a request to ring someone twice — and the
+    # rows are launched concurrently, so nothing downstream would space them
+    # out.
+    seen: dict[str, dict[str, str]] = {}
+    duplicates: list[str] = []
+    for pharmacy in pharmacies:
+        dedupe_key = RunStore.key(pharmacy["phone"], goal)
+        if dedupe_key in seen:
+            duplicates.append(f"{pharmacy.get('name', '?')} ({mask(pharmacy['phone'])})")
+            continue
+        seen[dedupe_key] = pharmacy
+    if duplicates:
+        log.warning(
+            "Skipping %s duplicate row(s) for recipients already in this batch: %s",
+            len(duplicates), ", ".join(duplicates),
+        )
+    pharmacies = list(seen.values())
 
     if not args.live:
         dry_run(pharmacies, goal, args.region)

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -923,9 +923,15 @@ class Caller:
 
         async with self._client() as client:
             # Resume an in-flight run rather than planning again.
-            if saved.get("run_id"):
-                log.info("  %s: resuming run %s", mask(phone), saved["run_id"][:12])
-                final = await self._poll(client, saved["run_id"], phone)
+            # Attempt-scoped fields live under entry["attempt"], never at the
+            # top level. Reading them from the top level silently misses a
+            # `running` entry after a restart and dials the recipient again.
+            saved_attempt = saved.get("attempt") or {}
+
+            if saved_attempt.get("run_id"):
+                log.info("  %s: resuming run %s",
+                         mask(phone), saved_attempt["run_id"][:12])
+                final = await self._poll(client, saved_attempt["run_id"], phone)
                 if final is None:
                     return None
                 self.store.mark_done(
@@ -935,13 +941,16 @@ class Caller:
 
             # Reuse a stored plan if its confirm_token is still valid.
             plan = None
-            if saved.get("plan_id") and self._token_live(saved.get("confirm_expires_at")):
+            if saved_attempt.get("plan_id") and self._token_live(
+                saved_attempt.get("confirm_expires_at")
+            ):
                 plan = {
-                    "plan_id": saved["plan_id"],
-                    "confirm_token": saved["confirm_token"],
+                    "plan_id": saved_attempt["plan_id"],
+                    "confirm_token": saved_attempt["confirm_token"],
                     "ready_to_run": True,
                 }
-                log.info("  %s: reusing plan %s", mask(phone), saved["plan_id"])
+                log.info("  %s: reusing plan %s",
+                         mask(phone), saved_attempt["plan_id"])
 
             if plan is None:
                 plan = self._unwrap(await client.call_tool("plan_call", {

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -109,6 +109,55 @@ def mask(phone: str) -> str:
     return f"…{phone[-4:]}" if len(phone) >= 4 else "…"
 
 
+# A run of digits long enough to be a phone number, however it's punctuated.
+# Deliberately loose: "0207 946 0123", "+44-7700-900123", "(555) 010-0199".
+_PHONE_LIKE = re.compile(r"\+?\d[\d\s\-().]{6,}\d")
+
+# Conversation lines from the provider's activity feed. These carry the actual
+# words a pharmacist said.
+_SPEECH_KINDS = {"callee_realtime"}
+
+
+def redact(text: str | None) -> str:
+    """Strip anything phone-number-shaped out of free text before it is
+    printed or logged.
+
+    Model-extracted fields and provider activity are derived from a live
+    conversation with a third party. A pharmacist reading out a branch number
+    lands in `pharmacist_notes`; a spoken number lands in the transcript. Both
+    then reach the terminal, shell scrollback, CI logs and screen recordings —
+    none of which the person on the phone agreed to.
+
+    Prices and quantities survive: only runs of eight or more digits are
+    treated as a number.
+    """
+    if not text:
+        return ""
+
+    def _scrub(match: re.Match[str]) -> str:
+        digits = re.sub(r"\D", "", match.group())
+        if len(digits) < 8:
+            return match.group()          # a price, a quantity, a year
+        return f"[redacted …{digits[-4:]}]"
+
+    return _PHONE_LIKE.sub(_scrub, text)
+
+
+def redact_activity(kind: str | None, message: str | None,
+                    show_conversation: bool = False) -> str | None:
+    """What may be logged from one provider activity entry.
+
+    Progress events (`stage_start`, `external_call`, `progress`) say what the
+    system is doing and are safe. Realtime speech events quote the call itself
+    and are withheld unless explicitly asked for — and redacted even then.
+
+    Returns None when the entry should not be logged at all.
+    """
+    if (kind or "") in _SPEECH_KINDS and not show_conversation:
+        return None
+    return redact(message)
+
+
 # --------------------------------------------------------------------------
 # Budget
 # --------------------------------------------------------------------------
@@ -820,7 +869,8 @@ class Caller:
     """Live caller. Constructing this loads credentials, so it is only ever
     instantiated under --live."""
 
-    def __init__(self, budget: CallBudget, store: RunStore) -> None:
+    def __init__(self, budget: CallBudget, store: RunStore,
+                 show_conversation: bool = False) -> None:
         from fastmcp import Client
         from fastmcp.client.transports import StreamableHttpTransport
 
@@ -828,6 +878,8 @@ class Caller:
         self._Transport = StreamableHttpTransport
         self.budget = budget
         self.store = store
+        # Off by default: the activity feed quotes a third party's speech.
+        self.show_conversation = show_conversation
         # Resolving the credential also tells us which account we're acting as,
         # which is part of a call's identity.
         self._token, principal = resolve_credential(SERVER_URL)
@@ -876,12 +928,20 @@ class Caller:
             nxt = final.get("next_step")
             nxt = nxt if isinstance(nxt, dict) else {}
 
-            # The activity feed is cumulative on every poll — dedupe.
+            # The activity feed is cumulative on every poll — dedupe. And it
+            # quotes the live call, so speech is withheld and everything else
+            # is scrubbed of anything number-shaped before it reaches a log.
             for entry in final.get("activity", []):
                 key = f"{entry.get('ts')}|{entry.get('message')}"
-                if key not in seen:
-                    seen.add(key)
-                    log.info("    %s", entry.get("message"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                safe = redact_activity(
+                    entry.get("kind"), entry.get("message"),
+                    show_conversation=self.show_conversation,
+                )
+                if safe:
+                    log.info("    %s", safe)
 
             action = nxt.get("action")
             if status in TERMINAL_STATUSES or action in TERMINAL_ACTIONS:
@@ -1048,8 +1108,12 @@ def render(records: list[dict[str, Any]]) -> None:
         print(f"{(r['pharmacy'] or '?')[:24]:<24} {r['in_stock']:<9} "
               f"{r['quantity_available'] or '—':>5} {price:>10} "
               f"{r['requires_prescription']:<8} {hold:>6} {conf:>6}{flag}")
-        if r.get("pharmacist_notes"):
-            print(f"    {r['pharmacist_notes']}")
+        # Free text lifted out of the conversation. Redacted on the way to the
+        # terminal — the stored record keeps the original, under 0600.
+        for note_field in ("pharmacist_notes", "alternative_suggested"):
+            note = r.get(note_field)
+            if note:
+                print(f"    {redact(str(note))}")
     print()
 
 
@@ -1062,6 +1126,11 @@ async def main() -> None:
     parser.add_argument("--region", default="US")
     parser.add_argument("--max-calls", type=int, default=3)
     parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--show-conversation", action="store_true",
+                        help="Log the live call transcript as it happens. Off "
+                             "by default: it quotes a third party's speech "
+                             "into your terminal and shell history. Numbers "
+                             "are redacted either way.")
     parser.add_argument("--live", action="store_true",
                         help="ACTUALLY PLACE CALLS. Without this the run is "
                              "fully offline: no credentials, no network.")
@@ -1111,7 +1180,7 @@ async def main() -> None:
     store = RunStore()
     budget.check(len(pharmacies))     # fail before dialling, not halfway
 
-    caller = Caller(budget, store)
+    caller = Caller(budget, store, show_conversation=args.show_conversation)
     print(f"\n{args.drug} {args.dosage} — {args.quantity} · "
           f"{len(pharmacies)} pharmacies · LIVE\n")
 

--- a/skills/pharmacy-stock-check/scripts/pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/pharmacy_search.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Pharmacy stock check — reference implementation for the pharmacy-stock-check
+Agent Skill.
+
+Dry-run by default. Nothing is dialled without --live.
+
+    python3 pharmacy_search.py --pharmacies pharmacies.csv           # no calls
+    python3 pharmacy_search.py --pharmacies pharmacies.csv --live    # calls
+
+Requires the CALL-E CLI to be authenticated (`calle auth login`) and fastmcp:
+
+    npm install -g @call-e/cli && calle auth login
+    pip install fastmcp
+
+Sample numbers in this directory use the reserved fictional range
++1 555 0100–0199. Replace them with real E.164 numbers you have permission to
+call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+log = logging.getLogger("pharmacy-stock-check")
+
+SERVER_URL = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth"
+TOKEN_CACHE = Path.home() / ".calle-mcp" / "cli"
+
+TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED", "CANCELLED"}
+TERMINAL_ACTIONS = {"report_result", "report_blocked", "none"}
+BLOCKED_ACTIONS = {"ask_user_for_missing_info", "ask_user_for_retry_confirmation"}
+
+FIELDS = [
+    "in_stock", "form_available", "quantity_available", "unit_price", "currency",
+    "requires_prescription", "can_hold", "hold_duration_hours",
+    "alternative_suggested", "pharmacist_notes",
+]
+ENUMS = {
+    "in_stock": {"yes", "no", "partial", "unknown"},
+    "form_available": {"brand", "generic", "both", "unknown"},
+    "requires_prescription": {"yes", "no", "unknown"},
+    "can_hold": {"yes", "no", "unknown"},
+}
+NUMERIC = {"quantity_available", "unit_price", "hold_duration_hours"}
+NULLISH = {"", "unknown", "unclear", "n/a", "na", "none", "not stated"}
+
+
+# --------------------------------------------------------------------------
+# Safety helpers
+# --------------------------------------------------------------------------
+
+
+def mask(phone: str) -> str:
+    """Never print a full number in a summary or log."""
+    return f"…{phone[-4:]}" if len(phone) >= 4 else "…"
+
+
+def load_token() -> str:
+    """Reuse the CALL-E CLI's cached token. The file shape is undocumented,
+    so probe the likely key names rather than assuming one."""
+    candidates = sorted(TOKEN_CACHE.glob("*/token.json"))
+    if not candidates:
+        raise SystemExit(f"No CALL-E token under {TOKEN_CACHE}. Run: calle auth login")
+    data = json.loads(candidates[-1].read_text())
+    for key in ("access_token", "accessToken", "token", "bearer"):
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            for inner in ("access_token", "accessToken", "token"):
+                if isinstance(value.get(inner), str):
+                    return value[inner]
+    raise SystemExit(f"No access token found in {candidates[-1]}")
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+@dataclass
+class CallBudget:
+    """Hard ceiling on outbound calls.
+
+    `to_phones` is an array, so ONE plan can spend N calls. Always charge the
+    number of phones, and check the whole batch before dialling anything.
+    """
+
+    max_calls: int
+    spent: int = 0
+    ledger: Path = field(default=Path(".pharmacy_budget.json"))
+
+    def __post_init__(self) -> None:
+        if self.ledger.exists():
+            self.spent = json.loads(self.ledger.read_text()).get("spent", 0)
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.max_calls - self.spent)
+
+    def check(self, n: int) -> None:
+        if n > self.remaining:
+            raise BudgetExceeded(
+                f"{n} call(s) needed, {self.remaining} left of {self.max_calls}."
+            )
+
+    def charge(self, n: int) -> None:
+        self.check(n)
+        self.spent += n
+        self.ledger.write_text(json.dumps({"spent": self.spent}))
+        log.warning("Placed %s call(s) — %s/%s used", n, self.spent, self.max_calls)
+
+
+# --------------------------------------------------------------------------
+# Goal and parsing
+# --------------------------------------------------------------------------
+
+
+def build_goal(drug: str, dosage: str, quantity: str) -> str:
+    """MCP has no result_schema, so the field list lives in the prose.
+    CALL-E honours these key names and emits them into result.summary."""
+    return (
+        "You are calling a pharmacy on behalf of a patient looking for a "
+        "medication. Identify yourself as an automated assistant immediately, "
+        "and keep the call brief and polite.\n\n"
+        f"Find out whether they currently have {drug} {dosage} in stock. The "
+        f"patient needs {quantity}.\n\n"
+        "Capture these fields in the structured result, using exactly these key names:\n"
+        "- in_stock: yes, no, partial, or unknown. Use partial if they have some "
+        "but fewer than the patient needs.\n"
+        "- form_available: brand, generic, both, or unknown\n"
+        "- quantity_available: integer units they have\n"
+        "- unit_price: number, price per unit\n"
+        "- currency: three-letter currency code\n"
+        "- requires_prescription: yes, no, or unknown\n"
+        "- can_hold: yes, no, or unknown\n"
+        "- hold_duration_hours: number of hours they will hold it\n"
+        "- alternative_suggested: any alternative or other branch they mention\n"
+        "- pharmacist_notes: anything else useful, one short sentence\n\n"
+        "If they do not have it, still ask about alternatives or another branch. "
+        "Do not place an order or commit to anything on the patient's behalf. "
+        "Thank them and end the call. If nobody answers, report that the pharmacy "
+        "could not be reached; do not treat that as a successful stock check."
+    )
+
+
+_FIELD_RE = re.compile(
+    r"\b(" + "|".join(sorted(FIELDS, key=len, reverse=True)) + r")\s*=\s*", re.I
+)
+
+
+def parse_summary(summary: str) -> dict[str, str]:
+    """Extraction arrives in result.summary as key=value pairs, not in
+    result.extracted. Values contain commas, so split on key= boundaries."""
+    if not summary:
+        return {}
+    matches = list(_FIELD_RE.finditer(summary))
+    out: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(summary)
+        value = summary[m.end():end].strip().strip(",").strip()
+        out[m.group(1).lower()] = value.rstrip(".") if len(value) < 40 else value
+    return out
+
+
+def normalise(raw: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in FIELDS:
+        value = raw.get(name)
+        text = str(value).strip().lower() if value is not None else ""
+        if name in ENUMS:
+            out[name] = text if text in ENUMS[name] else "unknown"
+        elif name in NUMERIC:
+            match = re.search(r"-?\d+(?:\.\d+)?", text.replace(",", ""))
+            out[name] = float(match.group()) if match else None
+        else:
+            out[name] = None if text in NULLISH else str(value).strip()
+    return out
+
+
+def to_record(final: dict[str, Any], pharmacy: dict[str, str]) -> dict[str, Any]:
+    result = final.get("result") or {}
+    summary = result.get("summary") or result.get("post_summary") or ""
+    record = normalise(parse_summary(summary))
+
+    outcome = result.get("outcome") or {}
+    confidence = outcome.get("completion_confidence") or {}
+    record.update(
+        pharmacy=pharmacy.get("name"),
+        phone_masked=mask(pharmacy.get("phone", "")),
+        run_status=final.get("status"),
+        confidence=confidence.get("score"),
+        evidence=outcome.get("evidence") or [],
+        transcript=result.get("transcript"),
+    )
+    return record
+
+
+def rank(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """In stock first, then cheapest, then whoever will hold it.
+
+    Low-confidence results sink: a reliable "no" beats an unreliable "yes"
+    that sends someone across town while unwell.
+    """
+    order = {"yes": 0, "partial": 1, "unknown": 2, "no": 3}
+
+    def key(r: dict[str, Any]):
+        conf = r.get("confidence")
+        return (
+            order.get(r.get("in_stock"), 3),
+            0 if (conf is None or conf >= 0.6) else 1,
+            r["unit_price"] if r.get("unit_price") is not None else float("inf"),
+            0 if r.get("can_hold") == "yes" else 1,
+        )
+
+    return sorted(records, key=key)
+
+
+# --------------------------------------------------------------------------
+# CALL-E
+# --------------------------------------------------------------------------
+
+
+class Caller:
+    def __init__(self, budget: CallBudget, *, dry_run: bool = True) -> None:
+        self.budget = budget
+        self.dry_run = dry_run
+        self._token = load_token()
+
+    def _client(self) -> Client:
+        return Client(StreamableHttpTransport(
+            SERVER_URL, headers={"Authorization": f"Bearer {self._token}"}
+        ))
+
+    @staticmethod
+    def _unwrap(result: Any) -> dict[str, Any]:
+        if getattr(result, "structured_content", None):
+            return result.structured_content
+        if getattr(result, "data", None):
+            return result.data
+        blocks = getattr(result, "content", None) or []
+        if blocks and hasattr(blocks[0], "text"):
+            return json.loads(blocks[0].text)
+        return {}
+
+    async def call(self, pharmacy: dict[str, str], goal: str, region: str
+                   ) -> dict[str, Any] | None:
+        phone = pharmacy["phone"]
+
+        async with self._client() as client:
+            plan = self._unwrap(await client.call_tool("plan_call", {
+                "goal": goal, "to_phones": [phone], "region": region,
+                "language": "English", "ttl_seconds": 0, "user_input": goal,
+            }))
+
+        if not plan.get("ready_to_run"):
+            log.warning("  %s: planner needs more detail — %s",
+                        mask(phone), plan.get("clarifying_questions"))
+            return None
+
+        if self.dry_run:
+            print(f"  DRY RUN {pharmacy['name']} ({mask(phone)}) — "
+                  f"plan {plan['plan_id']}, would spend 1 call")
+            return None
+
+        expires = plan.get("confirm_expires_at")
+        if expires:
+            exp = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+            if exp < datetime.now(timezone.utc):
+                log.error("  %s: confirm_token expired", mask(phone))
+                return None
+
+        self.budget.charge(1)
+        async with self._client() as client:
+            run = self._unwrap(await client.call_tool("run_call", {
+                "plan_id": plan["plan_id"], "confirm_token": plan["confirm_token"],
+            }))
+            run_id = run.get("run_id")
+            if not run_id:
+                return None
+
+            seen: set[str] = set()
+            deadline = time.time() + 900
+            delay = 2.0
+            while time.time() < deadline:
+                final = self._unwrap(
+                    await client.call_tool("get_call_run", {"run_id": run_id})
+                )
+                status = (final.get("status") or "").upper()
+                nxt = final.get("next_step")
+                nxt = nxt if isinstance(nxt, dict) else {}
+
+                # The activity feed is cumulative on every poll — dedupe.
+                for entry in final.get("activity", []):
+                    key = f"{entry.get('ts')}|{entry.get('message')}"
+                    if key not in seen:
+                        seen.add(key)
+                        log.info("    %s", entry.get("message"))
+
+                action = nxt.get("action")
+                if status in TERMINAL_STATUSES or action in TERMINAL_ACTIONS:
+                    return to_record(final, pharmacy)
+                if action in BLOCKED_ACTIONS:
+                    log.warning("  %s: needs user input — %s",
+                                mask(phone), nxt.get("instruction"))
+                    return None
+
+                delay = float(nxt.get("poll_after_seconds") or delay)
+                await asyncio.sleep(min(delay, 15.0))
+        return None
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Pharmacy stock check")
+    parser.add_argument("--pharmacies", type=Path, default=Path("pharmacies.csv"))
+    parser.add_argument("--drug", default="amoxicillin")
+    parser.add_argument("--dosage", default="500mg")
+    parser.add_argument("--quantity", default="21 capsules")
+    parser.add_argument("--region", default="US")
+    parser.add_argument("--max-calls", type=int, default=3)
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--live", action="store_true",
+                        help="ACTUALLY PLACE CALLS. Without this, nothing is dialled.")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    if not args.pharmacies.exists():
+        raise SystemExit(f"No such file: {args.pharmacies}")
+    with args.pharmacies.open() as fh:
+        pharmacies = [row for row in csv.DictReader(fh) if row.get("phone")]
+
+    budget = CallBudget(max_calls=args.max_calls)
+    if args.live:
+        # Fail before dialling anything, not halfway through the batch.
+        budget.check(len(pharmacies))
+
+    caller = Caller(budget, dry_run=not args.live)
+    goal = build_goal(args.drug, args.dosage, args.quantity)
+
+    print(f"\n{args.drug} {args.dosage} — {args.quantity} · "
+          f"{len(pharmacies)} pharmacies · "
+          f"{'LIVE' if args.live else 'dry run, no calls'}\n")
+
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    async def one(pharmacy: dict[str, str]):
+        async with semaphore:
+            try:
+                return await caller.call(pharmacy, goal, args.region)
+            except Exception as exc:
+                log.error("  %s failed: %s", pharmacy.get("name"), exc)
+                return None
+
+    results = [r for r in await asyncio.gather(*(one(p) for p in pharmacies)) if r]
+    if not results:
+        return
+
+    print(f"\n{'Pharmacy':<26} {'Stock':<9} {'Qty':>5} {'Price':>10} "
+          f"{'Rx':<8} {'Hold':>6} {'Conf':>6}")
+    print("-" * 76)
+    for r in rank(results):
+        hold = f"{r['hold_duration_hours']:.0f}h" if r.get("hold_duration_hours") else "—"
+        price = (f"{r['unit_price']:g} {r.get('currency') or ''}".strip()
+                 if r.get("unit_price") is not None else "—")
+        print(f"{(r['pharmacy'] or '?')[:26]:<26} {r['in_stock']:<9} "
+              f"{r['quantity_available'] or '—':>5} {price:>10} "
+              f"{r['requires_prescription']:<8} {hold:>6} "
+              f"{r['confidence'] if r['confidence'] is not None else '—':>6}")
+        if r.get("pharmacist_notes"):
+            print(f"    {r['pharmacist_notes']}")
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/pharmacy-stock-check/scripts/test_pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/test_pharmacy_search.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Regression tests for pharmacy_search.py.
+
+Standard library only, no network, no credentials, no calls placed.
+
+    python3 test_pharmacy_search.py
+    python3 -m unittest test_pharmacy_search -v
+
+The central invariant, and the reason this file exists:
+
+    A recipient with an unresolved call is never dialled again.
+
+That has regressed twice — once when the ledger keys were namespaced by
+configuration (making a live call look absent), and once when attempt fields
+were nested under `entry["attempt"]` while the caller still read them from the
+top level. Both were silent: the code planned and submitted a second call to a
+real person, and nothing in the output said so.
+
+`test_resume_does_not_redial` is the guard. It asserts on the *tool calls made*,
+not on return values — the only thing that actually distinguishes "resumed" from
+"dialled again" is whether `run_call` was invoked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import pharmacy_search as ps
+
+
+TERMINAL_RESPONSE = {
+    "status": "COMPLETED",
+    "result": {
+        "summary": "Stock check completed. Result: in_stock=yes, "
+                   "quantity_available=40, unit_price=6.2, currency=GBP",
+        "outcome": {
+            "task_completed": True,
+            "completion_confidence": {"score": 0.9, "label": "high"},
+            "evidence": ["They confirmed 40 in stock."],
+        },
+        "transcript": "[00:00] BOT: Hello…",
+    },
+    "activity": [],
+    "next_step": {"action": "report_result", "instruction": "done"},
+}
+
+
+class FakeToolResult:
+    """Mimics the MCP result object `Caller._unwrap` expects.
+
+    A bare dict unwraps to `{}`, which makes `_poll` spin forever — so the
+    stub has to carry the same shape the real transport does.
+    """
+
+    def __init__(self, payload: dict) -> None:
+        self.structured_content = payload
+        self.data = payload
+        self.content = []
+
+
+class RecordingClient:
+    """Stands in for the MCP client and records which tools were invoked."""
+
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def call_tool(self, name: str, args: dict):
+        self.calls.append(name)
+        if name == "plan_call":
+            return FakeToolResult({
+                "plan_id": "pNEW",
+                "confirm_token": "cNEW",
+                "ready_to_run": True,
+                "confirm_expires_at": "2099-01-01T00:00:00Z",
+            })
+        if name == "run_call":
+            return FakeToolResult({"run_id": "rNEW", "status": "PREPARING"})
+        if name == "get_call_run":
+            return FakeToolResult(dict(TERMINAL_RESPONSE))
+        raise AssertionError(f"unexpected tool {name}")
+
+
+def make_caller(tmp: Path, calls: list[str]) -> tuple[ps.Caller, ps.RunStore]:
+    """A Caller wired to the recording client, with no credential resolution."""
+    store = ps.RunStore(
+        path=tmp / "runs.json",
+        server_url="https://endpoint.test",
+        principal="acct-A",
+    )
+    budget = ps.CallBudget(max_calls=5, ledger=tmp / "budget.json")
+
+    caller = ps.Caller.__new__(ps.Caller)      # bypass __init__ and its auth
+    caller.budget = budget
+    caller.store = store
+    caller._token = "test-token"
+    caller._client = lambda: RecordingClient(calls)
+    return caller, store
+
+
+class ResumeRegression(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        # Terminal run dumps go to the temp dir, not the working directory.
+        # Tests must not leave transcripts lying around.
+        self._run_dir = ps.RUN_DIR
+        ps.RUN_DIR = self.tmp / "call_runs"
+        self.calls: list[str] = []
+        self.caller, self.store = make_caller(self.tmp, self.calls)
+        self.pharmacy = {"name": "Oakhill", "phone": "+15550101"}
+        self.goal = "check stock"
+        self.key = self.store.claim_key(self.pharmacy["phone"], self.goal)
+
+    def tearDown(self) -> None:
+        ps.RUN_DIR = self._run_dir
+        self._tmp.cleanup()
+
+    def _run(self):
+        return asyncio.run(
+            self.caller.call(self.pharmacy, self.goal, "GB")
+        )
+
+    def test_fresh_call_plans_and_dials(self):
+        """Baseline: with no prior state, a call is planned and placed."""
+        record = self._run()
+        self.assertEqual(
+            self.calls[:2], ["plan_call", "run_call"],
+            "a fresh recipient should be planned and dialled",
+        )
+        self.assertEqual(self.caller.budget.spent, 1)
+        self.assertEqual(record["in_stock"], "yes")
+
+    def test_resume_does_not_redial(self):
+        """THE regression: a `running` entry is resumed, never re-dialled.
+
+        Simulates a crash after run_call succeeded — the ledger holds a run_id
+        under `attempt`, exactly as `update()` writes it.
+        """
+        self.store.claim(self.key, "…0101", "GB")
+        self.store.update(
+            self.key, state="running", plan_id="pOLD", confirm_token="cOLD",
+            run_id="rOLD",
+        )
+        # A fresh process would not hold the in-process claim.
+        self.store._active.discard(self.key)
+        self.calls.clear()
+
+        self._run()
+
+        self.assertNotIn(
+            "run_call", self.calls,
+            "REDIAL: an in-flight recipient was called a second time",
+        )
+        self.assertNotIn(
+            "plan_call", self.calls,
+            "a new plan was created for a call already in flight",
+        )
+        self.assertEqual(self.calls, ["get_call_run"])
+        self.assertEqual(
+            self.caller.budget.spent, 0,
+            "resuming must not spend another call",
+        )
+
+    def test_resume_reads_attempt_not_top_level(self):
+        """Guards the specific shape bug: attempt fields are nested.
+
+        Writing run_id at the top level must NOT be mistaken for a resumable
+        run — that is the shape the caller used to read, and reading it there
+        again would hide this regression.
+        """
+        self.store.claim(self.key, "…0101", "GB")
+        entry = self.store.get(self.key)
+        self.assertIn("attempt", entry)
+
+        self.store.update(self.key, state="running", run_id="rOLD")
+        entry = self.store.get(self.key)
+        self.assertEqual(entry["attempt"]["run_id"], "rOLD")
+        self.assertNotIn(
+            "run_id", {k: v for k, v in entry.items() if k != "attempt"},
+            "attempt fields must not be flattened to the top level",
+        )
+
+    def test_reused_plan_is_not_replanned(self):
+        """A crash between plan_call and run_call reuses the stored plan."""
+        self.store.claim(self.key, "…0101", "GB")
+        self.store.update(
+            self.key, plan_id="pOLD", confirm_token="cOLD",
+            confirm_expires_at="2099-01-01T00:00:00Z",
+        )
+        self.store._active.discard(self.key)
+        self.calls.clear()
+
+        self._run()
+
+        self.assertNotIn(
+            "plan_call", self.calls,
+            "a valid stored plan should be reused, not replaced",
+        )
+        self.assertEqual(self.calls[0], "run_call")
+
+
+class ExclusionRegression(unittest.TestCase):
+    """The claim must span provider configuration."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.path = self.tmp / "runs.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _store(self, principal="acct-A", endpoint="https://endpoint.test"):
+        return ps.RunStore(path=self.path, server_url=endpoint, principal=principal)
+
+    def _seed_running(self):
+        store = self._store()
+        key = store.claim_key("+15550101", "goal")
+        store.claim(key, "…0101", "GB")
+        store.update(key, state="running", run_id="rOLD")
+        return key
+
+    def test_claim_key_ignores_configuration(self):
+        a = ps.RunStore.claim_key("+15550101", "goal")
+        b = ps.RunStore.claim_key("+15550101", "goal")
+        self.assertEqual(a, b)
+
+    def test_region_change_does_not_unlock_a_redial(self):
+        key = self._seed_running()
+        with self.assertRaises(ps.ConfigurationMismatch):
+            self._store().claim(key, "…0101", "US")
+
+    def test_account_change_does_not_resume(self):
+        key = self._seed_running()
+        with self.assertRaises(ps.ConfigurationMismatch):
+            self._store(principal="acct-B").claim(key, "…0101", "GB")
+
+    def test_unknown_principal_fails_closed(self):
+        key = self._seed_running()
+        with self.assertRaises(ps.ConfigurationMismatch):
+            self._store(principal=None).claim(key, "…0101", "GB")
+
+    def test_duplicate_row_in_one_process(self):
+        store = self._store()
+        key = store.claim_key("+15550101", "goal")
+        store.claim(key, "…0101", "GB")
+        with self.assertRaises(ps.RunLocked):
+            store.claim(key, "…0101", "GB")
+
+    def test_ambiguous_create_is_not_retried(self):
+        store = self._store()
+        key = store.claim_key("+15550101", "goal")
+        store.claim(key, "…0101", "GB")
+        store.update(key, state="dialing", plan_id="pOLD")
+        store._active.discard(key)
+        with self.assertRaises(ps.AmbiguousRun):
+            self._store().claim(key, "…0101", "GB")
+
+    def test_old_schema_with_pending_entries_refuses(self):
+        self.path.write_text(json.dumps({"abc": {"state": "running"}}))
+        with self.assertRaises(ps.StateCorrupted):
+            self._store().get("abc")
+
+
+class BudgetRegression(unittest.TestCase):
+    def test_ceiling_is_enforced(self):
+        with tempfile.TemporaryDirectory() as d:
+            budget = ps.CallBudget(max_calls=2, ledger=Path(d) / "b.json")
+            budget.reserve(1)
+            budget.reserve(1)
+            with self.assertRaises(ps.BudgetExceeded):
+                budget.reserve(1)
+
+    def test_corrupt_ledger_refuses(self):
+        with tempfile.TemporaryDirectory() as d:
+            ledger = Path(d) / "b.json"
+            ledger.write_text("{ not json")
+            with self.assertRaises(ps.BudgetExceeded):
+                ps.CallBudget(max_calls=5, ledger=ledger).reserve(1)
+
+
+class ValidationRegression(unittest.TestCase):
+    def test_e164(self):
+        self.assertEqual(ps.validate_e164("+1 555 0100"), "+15550100")
+        for bad in ("07700900123", "5550100", "+0155501001", "abc"):
+            with self.assertRaises(ps.InvalidPhoneNumber):
+                ps.validate_e164(bad)
+
+    def test_mask(self):
+        self.assertEqual(ps.mask("+447827929230"), "…9230")
+
+    def test_incomplete_call_reports_no_stock(self):
+        final = {
+            "status": "NO ANSWER",
+            "result": {
+                "summary": "Result: in_stock=yes, quantity_available=99",
+                "outcome": {"task_completed": False,
+                            "completion_confidence": {"score": 0.2}},
+            },
+        }
+        record = ps.to_record(final, {"name": "Ghost", "phone": "+15550100"})
+        self.assertEqual(record["in_stock"], "unknown")
+        self.assertIsNone(record["quantity_available"])
+        self.assertFalse(record["verified"])
+
+    def test_confident_no_outranks_unverified_yes(self):
+        ranked = ps.rank([
+            {"pharmacy": "unverified yes", "in_stock": "yes", "unit_price": 1.0,
+             "can_hold": "yes", "confidence": 0.3, "verified": False},
+            {"pharmacy": "confident no", "in_stock": "no", "unit_price": None,
+             "can_hold": "no", "confidence": 0.95, "verified": True},
+        ])
+        self.assertEqual(ranked[0]["pharmacy"], "confident no")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/pharmacy-stock-check/scripts/test_pharmacy_search.py
+++ b/skills/pharmacy-stock-check/scripts/test_pharmacy_search.py
@@ -25,6 +25,8 @@ not on return values — the only thing that actually distinguishes "resumed" fr
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import io
 import json
 import tempfile
 import unittest
@@ -66,8 +68,9 @@ class FakeToolResult:
 class RecordingClient:
     """Stands in for the MCP client and records which tools were invoked."""
 
-    def __init__(self, calls: list[str]) -> None:
+    def __init__(self, calls: list[str], poll_response: dict | None = None) -> None:
         self.calls = calls
+        self.poll_response = poll_response or dict(TERMINAL_RESPONSE)
 
     async def __aenter__(self):
         return self
@@ -87,7 +90,7 @@ class RecordingClient:
         if name == "run_call":
             return FakeToolResult({"run_id": "rNEW", "status": "PREPARING"})
         if name == "get_call_run":
-            return FakeToolResult(dict(TERMINAL_RESPONSE))
+            return FakeToolResult(dict(self.poll_response))
         raise AssertionError(f"unexpected tool {name}")
 
 
@@ -104,6 +107,7 @@ def make_caller(tmp: Path, calls: list[str]) -> tuple[ps.Caller, ps.RunStore]:
     caller.budget = budget
     caller.store = store
     caller._token = "test-token"
+    caller.show_conversation = False           # the shipped default
     caller._client = lambda: RecordingClient(calls)
     return caller, store
 
@@ -271,6 +275,110 @@ class ExclusionRegression(unittest.TestCase):
         self.path.write_text(json.dumps({"abc": {"state": "running"}}))
         with self.assertRaises(ps.StateCorrupted):
             self._store().get("abc")
+
+
+class RedactionRegression(unittest.TestCase):
+    """Nothing conversation-derived reaches a log or stdout unredacted.
+
+    The provider's activity feed quotes the call as it happens, and
+    `pharmacist_notes` is lifted out of the same conversation. Both used to be
+    printed verbatim, which put a third party's words — and any number they
+    spoke — into terminal scrollback, CI logs and screen recordings.
+    """
+
+    def test_phone_numbers_are_redacted(self):
+        for text, expected_tail in [
+            ("Call them on 0207 946 0123", "0123"),
+            ("Try +44 7700 900123 instead", "0123"),
+            ("Their number is (555) 010-0199", "0199"),
+            ("reach us at 02079460123", "0123"),
+        ]:
+            out = ps.redact(text)
+            self.assertIn("[redacted", out, f"not redacted: {text!r}")
+            self.assertIn(expected_tail, out, "last four digits should survive")
+            self.assertNotIn("946", out.replace(expected_tail, ""))
+
+    def test_prices_and_quantities_survive(self):
+        for text in [
+            "They have 40 units at 6.20 each",
+            "Only 8 left, £4.50 per capsule",
+            "Hold for 48 hours",
+            "amoxicillin 500mg, 21 capsules",
+        ]:
+            self.assertEqual(
+                ps.redact(text), text,
+                f"redaction damaged a non-phone number: {text!r}",
+            )
+
+    def test_speech_activity_is_withheld_by_default(self):
+        self.assertIsNone(
+            ps.redact_activity("callee_realtime", "Callee said: yes we have it"),
+            "a pharmacist's speech must not be logged by default",
+        )
+
+    def test_speech_activity_still_redacted_when_opted_in(self):
+        out = ps.redact_activity(
+            "callee_realtime", "Callee said: ring 0207 946 0123",
+            show_conversation=True,
+        )
+        self.assertIsNotNone(out)
+        self.assertIn("[redacted", out)
+        self.assertNotIn("946 0123", out)
+
+    def test_progress_activity_is_logged(self):
+        self.assertEqual(
+            ps.redact_activity("progress", "calling task status=calling"),
+            "calling task status=calling",
+            "progress events describe the system, not the conversation",
+        )
+
+    def test_rendered_notes_are_redacted(self):
+        record = {
+            "pharmacy": "Oakhill", "in_stock": "yes", "quantity_available": 40,
+            "unit_price": 6.2, "currency": "GBP", "requires_prescription": "yes",
+            "can_hold": "yes", "hold_duration_hours": 24, "confidence": 0.9,
+            "verified": True,
+            "pharmacist_notes": "Try the Mill Lane branch on 0207 946 0123",
+            "alternative_suggested": "co-amoxiclav, call 02079460124",
+        }
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            ps.render([record])
+        printed = buffer.getvalue()
+
+        self.assertNotIn("946 0123", printed)
+        self.assertNotIn("02079460124", printed)
+        self.assertIn("[redacted", printed)
+        self.assertIn("Mill Lane", printed, "the useful part should survive")
+        self.assertIn("6.2", printed, "prices must not be redacted")
+
+    def test_poll_does_not_log_speech(self):
+        """End-to-end: a call whose activity quotes the pharmacist logs none
+        of it."""
+        speech = "Callee said: we have 40, ring 0207 946 0123 for the branch"
+        response = dict(TERMINAL_RESPONSE)
+        response["activity"] = [
+            {"ts": "1", "kind": "progress", "message": "calling task created"},
+            {"ts": "2", "kind": "callee_realtime", "message": speech},
+        ]
+
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            calls: list[str] = []
+            caller, store = make_caller(tmp, calls)
+            caller._client = lambda: RecordingClient(calls, response)
+            ps_run_dir, ps.RUN_DIR = ps.RUN_DIR, tmp / "call_runs"
+            try:
+                with self.assertLogs("pharmacy-stock-check", level="INFO") as logged:
+                    asyncio.run(caller.call(
+                        {"name": "Oakhill", "phone": "+15550101"}, "goal", "GB"))
+            finally:
+                ps.RUN_DIR = ps_run_dir
+
+        joined = "\n".join(logged.output)
+        self.assertNotIn("Callee said", joined, "speech leaked into the log")
+        self.assertNotIn("946 0123", joined, "a spoken number leaked into the log")
+        self.assertIn("calling task created", joined, "progress should still log")
 
 
 class BudgetRegression(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds `skills/pharmacy-stock-check/`  a portable Agent Skill for finding which pharmacy actually has a specific medication in stock, at what price, and whether they will hold it.

The user supplies a medication and a list of pharmacy numbers. The agent calls each one, asks the same set of questions, and returns a ranked answer with a confidence score and the transcript as evidence.

This belongs here because it's the kind of work CALL-E is positioned for: low-frequency, personal, high-stakes phone tasks that were never worth automating with a traditional call platform. Someone with a prescription and no time currently rings around themselves.
### Integration notes that may be useful beyond this skill

`references/calle-mcp-integration.md` documents behaviour I hit while building this that isn't in the current docs. Sharing in case it's useful to other contributors:

- **Extraction lands in `result.summary`, not `result.extracted`.** On a completed run, `result.extracted` contained an echo of the request (`goal`, `region`, `to_phones`, `calling` metadata) rather than the conversational fields. The collected fields were serialised as `key=value` pairs inside the summary string. The agent honours key names given in the `goal` prose reliably — they just arrive as prose. Parsing has to split on `key=` boundaries rather than commas, since free-text fields contain commas.
- **`next_step.action` is a clean state machine** and made the integration much simpler than polling on status strings alone. It isn't mentioned in the README. Note it's a structured object on `run_call` / `get_call_run` but a plain string on `plan_call`.
- **Batching aggregates results.** `to_phones` accepts an array, but `result.summary` and the confidence block come back for the batch as a whole. Workflows needing per-recipient attribution should place one run per recipient and run them concurrently — same call cost.
- **The activity feed is cumulative** on every poll and `next_cursor` wasn't populated, so clients need to dedupe on `(ts, message)`.

skills/pharmacy-stock-check/
├── SKILL.md
├── references/
│   ├── calle-mcp-integration.md
│   ├── safety.md
│   └── examples.md
└── scripts/
    ├── pharmacy_search.py
    └── pharmacies.csv

### Safety

The skill can place real calls, so it specifies explicit user confirmation before dialling, E.164 numbers only with no guessed country codes, identifying as an automated assistant in the opening line, masked numbers in all summaries and logs, information gathering only with no ordering or reserving, no medical advice with pharmacist suggestions relayed as reported speech, an explicit decline path for urgent situations pointing to emergency services rather than starting a call queue, and confidence surfaced rather than smoothed over.

`references/examples.md` includes a worked case where the agent declines to call.

### Cost controls
Charges `len(to_phones)` rather than 1, since one plan can spend N calls. Checks the budget for the whole batch before dialling anything. Treats `plan_id` as the idempotency key. Checks `confirm_token` expiry before spending. Persists every response immediately, so there's no re-dialling to recover paid-for data.

## Type
- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist
- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. *(N/A — one-shot workflow; `SKILL.md` explicitly forbids creating recurring schedules as a side effect.)*
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

### Verification
- `python3 scripts/validate_repository.py` passes.
- `scripts/pharmacy_search.py` is dry-run by default; `--live` is required to dial. The dry-run path exercises `plan_call` (free) and prints the exact payload it would send.
- Parsing, normalisation and ranking verified against a real completed run (GB, 107s, `task_completed: true`, confidence 0.82).
- All sample numbers are from the reserved fictional range +1 555 0100–0199.

Full implementation is at https://github.com/Olacode01/rxfind — the driver, a web UI with live call progress, replay mode against saved fixtures, and the ranking layer. The skill in this PR is the portable extract.
