### PR TITLE
feat(accessproof): add venue verification skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Skills
 
+- [`accessproof`](skills/accessproof/) - User-authorized venue access-question workflow that returns condition-level staff-reported evidence with explicit unknowns.
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
 - [`deployment-approval-call`](skills/deployment-approval-call/) - Spoken, code-verified human approval before an agent or pipeline does something irreversible.
 - [`google-form-callback`](skills/google-form-callback/) - Google Form response workflow for safe one-off callback calls with dry-runs, scheduling plans, and Sheets writeback. See the [workflow guide](docs/google-form-callback/).

--- a/skills/accessproof/SKILL.md
+++ b/skills/accessproof/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: accessproof
+description: Prepare and run user-authorized CALL-E calls that ask public venues a fixed set of observable access questions, then return condition-level staff-reported evidence with explicit unknowns.
+license: MIT
+---
+
+# AccessProof venue verification
+
+Use this skill when a person wants an agent to call one to three public venues and ask exact, observable questions for a planned visit. It produces evidence for the person to interpret. It never certifies a venue or decides whether a venue is universally accessible.
+
+## When to use
+
+- Compare exact visit conditions across public venues.
+- Ask a venue about a route, measurement, seating arrangement, communication option, sensory condition, or other observable fact.
+- Recheck one unresolved condition with a separately authorized follow-up.
+- Return staff-reported answers with source, time, uncertainty, and limitations.
+
+## When not to use
+
+- Do not call private or residential numbers.
+- Do not infer a diagnosis or ask the user to disclose one.
+- Do not request a certification, legal conclusion, or whole-venue accessibility verdict.
+- Do not book, buy, pay, promise, negotiate, or accept an agreement.
+- Do not use this workflow for emergencies or for medical, legal, or financial advice.
+- Do not place a setup-time test call unless the user explicitly requests and authorizes it.
+
+## Required inputs
+
+Require all of the following before creating a live call plan:
+
+- a short visit context containing only what venue staff need to hear;
+- one to eight observable questions, each marked `must_verify` or `helpful_to_know`;
+- one to three venue names and confirmed public-business E.164 numbers;
+- the planned AI disclosure and action limits;
+- an explicit authorization covering the exact venues, numbers, and questions.
+
+Do not guess a number, country code, venue identity, condition, threshold, or user intent. Use reserved fictional numbers in examples and mask numbers in summaries.
+
+## Preview before side effects
+
+Default to a no-call preview. Show the user:
+
+1. the visit context that will be disclosed;
+2. each venue and masked destination number;
+3. the exact questions in call order;
+4. the AI identity and consent disclosure;
+5. allowed and prohibited actions;
+6. the data that may be retained;
+7. the number of outbound calls the plan can create.
+
+Editing the preview invalidates any earlier authorization. A live run must use an immutable snapshot of the final preview.
+
+## Live call workflow
+
+For each authorized venue, create at most one CALL-E call with a stable idempotency key:
+
+1. Confirm that the destination is still the reviewed public-business number.
+2. Introduce the caller as an AI assistant acting for a person planning a visit.
+3. Confirm venue identity before sharing visit context.
+4. Ask whether the respondent wishes to continue. End the call on decline.
+5. Ask `must_verify` questions first, one observable condition at a time.
+6. Permit only neutral clarification of an ambiguous answer.
+7. Preserve `unknown`, `not_asked`, contradiction, silence, voicemail, and failure states.
+8. Never treat provider completion as proof that a condition was confirmed.
+
+Read [references/safety.md](references/safety.md) before a live run. Use [references/result-contract.md](references/result-contract.md) when normalizing output.
+
+## Evidence workflow
+
+Return one terminal claim for every planned condition. A claim may be `confirmed`, `does_not_match`, `unclear`, `not_asked`, `could_not_reach`, or `conflicting`.
+
+`confirmed` requires all of these:
+
+- venue identity was confirmed;
+- the respondent accepted the conversation;
+- the normalized answer semantically agrees with the condition or deterministic threshold;
+- the supporting excerpt aligns to a respondent transcript turn.
+
+If any requirement is missing, do not confirm. Include the question, venue, status, normalized staff report, respondent role when available, capture time, source class, freshness, evidence reference, and limitation. The user decides whether the result works for the visit.
+
+## Retry and cancellation
+
+- Reuse the same idempotency key and logically identical payload after an ambiguous network response.
+- Never automatically redial voicemail, no-answer, decline, wrong number, failure, or a completed call.
+- Queued work may be cancelled before provider creation.
+- Do not promise active-call cancellation unless the selected CALL-E route has been verified to support it.
+- A focused follow-up requires a new preview, authorization, snapshot, and call run. It never overwrites prior evidence.
+- Keep a provider-create kill switch and a durable scheduler/reconciliation path outside the browser.
+
+## Credentials and privacy
+
+Keep CALL-E credentials and full destination numbers in the server-side execution environment. Never include secrets, full phone numbers, visit context, condition text, transcripts, or evidence excerpts in routine logs, analytics, issue comments, or commit messages. Recording is off unless a lawful deployment separately discloses it and obtains all required consent.
+
+## Output
+
+After a preview, report:
+
+- `status: preview only`;
+- venue count and masked numbers;
+- exact questions and priorities;
+- disclosure and action limits;
+- expected call side effects;
+- what must be authorized next.
+
+After a live run, report:
+
+- safe call references and terminal provider states;
+- one condition-level claim per planned question;
+- source, capture time, evidence availability, and freshness;
+- explicit unknowns and conflicts;
+- whether any follow-up is available;
+- how to delete retained data.
+
+Never claim that a call was created, completed, cancelled, or verified without runtime evidence from the selected host and provider.

--- a/skills/accessproof/references/examples.md
+++ b/skills/accessproof/references/examples.md
@@ -1,0 +1,75 @@
+# Examples
+
+All numbers and venues below are fictional. These examples are previews; they do not authorize or place a real call.
+
+## Preview one venue
+
+```text
+status: preview only
+visit: dinner for four at 6:30 PM
+venue: River Room
+destination: +1******1234
+public business number confirmed: yes
+
+must verify:
+1. Is there a step-free route from the public sidewalk to the reserved table?
+2. Is the clear width of the entrance used after 7 PM at least 32 inches?
+
+helpful to know:
+3. Is quieter seating available away from speakers?
+
+side effect after authorization: at most one outbound CALL-E call
+next step: review the disclosure, action limits, data treatment, and exact questions
+```
+
+## Conservative result
+
+```text
+venue: River Room
+destination: +1******1234
+provider state: completed
+
+condition 1: confirmed
+staff report: The host reported that the side entrance is level with the sidewalk.
+source: staff_reported, host
+captured: 2026-07-31T18:14:00Z
+evidence: respondent excerpt aligned to attempt 0, turn 6
+limitation: Staff-reported evidence, not an audit or guarantee.
+
+condition 2: unclear
+staff report: The respondent estimated the doorway was about 30 to 34 inches wide but did not measure it.
+source: staff_reported, host
+captured: 2026-07-31T18:14:00Z
+evidence: respondent excerpt aligned to attempt 0, turn 9
+limitation: The reported range does not establish the 32-inch threshold.
+
+condition 3: not_asked
+staff report: The call ended before this question.
+evidence: none
+limitation: No answer was collected.
+```
+
+Provider completion does not turn the unclear or unasked conditions into confirmation.
+
+## Decline
+
+```text
+provider state: completed
+venue identity: confirmed
+respondent consent: declined
+all planned conditions: not_asked
+retry: none
+```
+
+End the call after the decline. Do not automatically redial.
+
+## Focused follow-up preview
+
+```text
+status: preview only
+prior condition: entrance clear width at least 32 inches
+prior state: unclear
+new question: Could someone measure the clear opening of the entrance used after 7 PM at its narrowest point?
+side effect after new authorization: at most one outbound CALL-E follow-up call
+prior evidence: preserved and unchanged
+```

--- a/skills/accessproof/references/result-contract.md
+++ b/skills/accessproof/references/result-contract.md
@@ -1,0 +1,39 @@
+# Result contract
+
+Produce exactly one terminal claim for every planned condition.
+
+## Claim states
+
+- `confirmed`: the staff report supports the exact condition and all confirmation gates pass.
+- `does_not_match`: the staff report clearly conflicts with the condition or deterministic threshold.
+- `unclear`: the answer is ambiguous, hedged, guessed, incomplete, or lacks sufficient aligned evidence.
+- `not_asked`: the condition was not asked, including after a decline or invalid structured result.
+- `could_not_reach`: the venue could not provide an eligible respondent because of voicemail, no-answer, wrong number, or provider failure.
+- `conflicting`: material statements or a stated answer and measurement disagree.
+
+## Confirmation gates
+
+`confirmed` requires:
+
+1. confirmed venue identity;
+2. accepted respondent consent;
+3. semantic agreement with the exact condition or deterministic evaluation of its threshold;
+4. a respondent evidence excerpt aligned by attempt and turn index.
+
+If any gate fails, downgrade the claim. Never infer a positive answer from provider completion, sentiment, summary text, or missing fields.
+
+## Minimum safe output
+
+For each claim return:
+
+- condition identifier and exact question;
+- venue identifier and masked number;
+- terminal claim state;
+- normalized staff-reported detail;
+- respondent role when available;
+- source class `staff_reported`;
+- capture time and freshness;
+- evidence reference or an explicit statement that no aligned excerpt is available;
+- a limitation stating that the result is not an audit, guarantee, certification, or whole-venue verdict.
+
+Retain prior versions when a follow-up or later observation changes the current view.

--- a/skills/accessproof/references/safety.md
+++ b/skills/accessproof/references/safety.md
@@ -1,0 +1,38 @@
+# Safety contract
+
+AccessProof calls create real-world side effects. A plan is executable only after the user has reviewed and authorized its exact destinations, disclosure, questions, and limits.
+
+## Destination and consent
+
+- Accept only confirmed public-business E.164 numbers.
+- The user must authorize every destination and explicitly confirm that the number belongs to the intended venue.
+- The AI caller must identify itself before substantive questions.
+- Confirm venue identity before sharing visit context.
+- Ask the respondent for permission to continue and end immediately on decline.
+- Renew the disclosure and consent check after a transfer to a new respondent.
+
+## Disclosure budget
+
+Share only the authorized visit context. Do not disclose a diagnosis, medical history, identity detail, or reason that is not necessary to ask the observable questions.
+
+The caller may ask the reviewed questions, neutrally clarify an ambiguous answer, and end the call. It may not book, purchase, pay, negotiate, promise, certify, request medical details, or make a legal or compliance determination.
+
+## Failure behavior
+
+- Unknown, hedged, guessed, silent, missing, malformed, or contradictory output must remain non-confirmed.
+- A provider `completed` status is transport state, not evidence quality.
+- Voicemail, no-answer, wrong number, and decline are terminal and must not trigger a blind redial.
+- Provider webhooks are wake-up hints until their signing and payload contract are proven; fetch authoritative state with the authenticated provider API.
+- Reuse a stable idempotency key after an ambiguous create response.
+
+## Privacy
+
+- Keep credentials and full numbers server-side.
+- Mask numbers in summaries.
+- Do not log visit text, condition text, phone numbers, transcripts, or evidence excerpts.
+- Store only the minimum excerpt needed to explain a claim.
+- Support immediate deletion and prevent late provider events from recreating deleted content.
+
+## Cancellation
+
+Queued work may be cancelled before provider creation. Do not expose or promise active-call cancellation until the chosen CALL-E route has been tested and documented. Disable provider creation with a kill switch when scheduler recovery, quotas, suppression, or provider behavior is not proven.


### PR DESCRIPTION
## Summary

- Add a portable, preview-first skill for user-authorized public-venue access questions.
- Require immutable review, AI disclosure, respondent consent, stable idempotency, and conservative claim states.
- Document privacy, cancellation, retry, evidence-alignment, and failure behavior.
- Add fictional preview, result, decline, and focused-follow-up examples.
- Add the skill to the README list.

## Side effects

The skill defaults to a no-call preview. It forbids setup-time calls without explicit authorization, blind redials, hidden recurrence, private-number use, and unsupported active-call cancellation claims.

## Validation

- `python scripts/check_branch_name.py --branch feat/accessproof-venue-verification`
- `python scripts/validate_repository.py`