### PR TITLE
feat: add confidence-gated-results skill for null structured results

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Skills
 
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
+- [`confidence-gated-results`](skills/confidence-gated-results/) - Three-tier outcome contract for a phone call that succeeded but returned no usable structured result: commit, one narrowed repair call, or escalate with the evidence trail.
 - [`deployment-approval-call`](skills/deployment-approval-call/) - Spoken, code-verified human approval before an agent or pipeline does something irreversible.
 - [`google-form-callback`](skills/google-form-callback/) - Google Form response workflow for safe one-off callback calls with dry-runs, scheduling plans, and Sheets writeback. See the [workflow guide](docs/google-form-callback/).
 - [`outbound-call-skill-creator`](skills/outbound-call-skill-creator/) - Creator skill for generating focused outbound phone-call workflow skills from Google Forms, TikTok Ads, Notion, Airtable, local CSV files, or custom sources.

--- a/skills/confidence-gated-results/SKILL.md
+++ b/skills/confidence-gated-results/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: confidence-gated-results
+description: Handle a CALL-E phone call that succeeded but returned no usable structured result. Use when a call reaches a terminal status and structured_result is null, partial, or fails schema validation, and an agent must decide between committing the result, placing one narrowed repair call, or escalating to a human with the evidence trail.
+license: MIT
+---
+
+# Confidence-Gated Results
+
+Use this skill when a phone call **worked** but the data did not.
+
+A call can reach `completed`, bill normally, and still hand back
+`structured_result: null` — or a result that is present but missing the one field the workflow
+actually needed. The person answered. They said something. The extraction produced nothing usable.
+
+Most integrations read the result as a value and move on. That is the bug: `null` gets treated as
+"no" or as an empty success, and a workflow ships an order, closes a ticket, or marks a lead dead on
+the strength of a call that produced no evidence at all.
+
+This skill makes that state explicit and gives it three exits.
+
+## When to use
+
+- A call reached a terminal status and `structured_result` is `null`, `{}`, or missing.
+- The result is present but a **required** field is absent, empty, or fails your schema.
+- The result contains a value your workflow cannot act on ("maybe", "not sure", "call me back").
+- You are about to branch on a call result and you have not decided what `null` means.
+
+## When not to use
+
+- The call never reached a terminal status. Poll first; a call in flight has no result to gate.
+- The call was not answered (`no_answer`, `busy`, `failed`). That is a reachability problem, not a
+  confidence problem — retry policy belongs to the caller, not here.
+- The person clearly answered and the answer is simply "no". A confident negative is a **result**,
+  not a failure. Do not repair-call someone to get a different answer.
+- Anything medical, legal, financial or emergency. See [`references/safety.md`](references/safety.md).
+
+## The three-tier outcome contract
+
+Every terminal call resolves to exactly one of three tiers. Decide the tier before you decide what
+to do.
+
+| Tier | Meaning | Action |
+| --- | --- | --- |
+| **COMMIT** | Every required field present, values actionable | Use the result. Record confidence and move on. |
+| **REPAIR** | Call connected, extraction incomplete, and the gap is narrow enough to ask again | **One** narrowed follow-up call that asks only for the missing fields. |
+| **ESCALATE** | Ambiguous, contradictory, exhausted, or repair not permitted | Hand to a human with the full evidence trail. Never guess. |
+
+The default when you cannot classify is **ESCALATE**. Silence is not consent, and `null` is not "no".
+
+## The repair loop, and why it decomposes the schema
+
+The reason a call returns `null` is usually not that the person refused. It is that one composite
+schema asked for four things at once and the extraction could not satisfy all of them, so it emitted
+nothing rather than something partial.
+
+So a repair call **must not re-ask the original question**. Re-asking a schema that already failed
+produces the same failure and bills you twice.
+
+Instead, decompose:
+
+1. Take the required fields that are missing.
+2. Split the failed schema into the smallest independent sub-schemas — ideally one field each.
+3. Build a task that references the earlier call ("you spoke with us a moment ago about X") and asks
+   only for the missing pieces, in plain order, one at a time.
+4. Place **one** repair call with a schema containing only those fields.
+5. Merge: fields already confidently captured are kept; only the missing ones are filled.
+
+Rules that keep this safe:
+
+- **One repair call per original call.** Never a loop. If the repair also returns `null`, escalate.
+- **Never widen the ask.** A repair call asks for a subset, never a superset.
+- **Never re-ask a field you already have confidently.** That is how you end up with two different
+  answers and no way to choose.
+- **Carry an idempotency key** derived from the original call id plus `repair`, so a retried
+  workflow cannot place a third call.
+
+## Reading the call before you judge it
+
+Use `GET /v1/calls/{id}` for the terminal result and `GET /v1/calls/{id}/events` for how it got
+there. The event stream is what distinguishes "they hung up in the first five seconds" from "they
+talked for ninety seconds and the extractor failed" — those are the same `null` and completely
+different decisions.
+
+- Short duration, few turns, `null` → treat as not-really-reached. Escalate or let the caller's
+  retry policy handle it. Do not repair-call.
+- Substantial conversation, `null` → genuine extraction failure. This is the repair case.
+- Substantial conversation, partial result → repair the gap only.
+
+## What to record
+
+Whatever the tier, write down enough that a human can audit the decision without listening to
+anything:
+
+- the original call id, its terminal status and duration
+- the schema that was asked for, and which required fields came back missing
+- the tier decision and the rule that produced it
+- the repair call id, if one was placed, and what subset it asked for
+- the final merged result and which call each field came from
+
+A result with no provenance is indistinguishable from a guess.
+
+## Running the classifier
+
+The tier rules are implemented as pure functions in
+`scripts/classify-result.mjs`, so an agent does not have to re-derive them and a
+reviewer can check them. Use `scripts/classify-result.mjs` directly:
+
+```bash
+node scripts/classify-result.mjs --call call.json --required appointment_confirmed,preferred_date --turns 14
+```
+
+It prints the tier decision and, when the tier is `REPAIR`, the narrowed sub-schema, the repair task
+and the idempotency key. Exit codes: `0` commit, `5` repair, `6` escalate.
+
+Run its tests with:
+
+```bash
+node --test scripts/classify-result.test.mjs
+```
+
+The suite covers the pair that matters most: the *same* `null` result classified as REPAIR after a
+96-second conversation and as ESCALATE after a 5-second hangup.
+
+## Worked examples
+
+See [`references/examples.md`](references/examples.md) for concrete traces: a null result after a
+real conversation repaired into a commit, a partial result with one missing field, a contradictory
+result escalated, and a five-second hangup correctly *not* repaired.
+
+## Safety
+
+Read [`references/safety.md`](references/safety.md) before placing any repair call. The short
+version: a repair call is a second phone call to a real person who has already been interrupted
+once. It is justified only when the first call genuinely produced a conversation and the missing
+data genuinely blocks the workflow. Convenience is not justification, and a person who declined is
+not a person to call back.

--- a/skills/confidence-gated-results/references/examples.md
+++ b/skills/confidence-gated-results/references/examples.md
@@ -1,0 +1,181 @@
+# Examples — confidence-gated results
+
+Four traces. All phone numbers are fictional reserved samples. Field names follow the workflow's own
+schema; nothing here is a CALL-E API guarantee.
+
+---
+
+## 1. Null result after a real conversation → REPAIR → COMMIT
+
+The common case, and the one everyone gets wrong by reading `null` as "no".
+
+**Original call**
+
+```json
+{
+  "id": "call_a1",
+  "status": "completed",
+  "duration_seconds": 96,
+  "structured_result": null
+}
+```
+
+Requested schema asked for four things at once:
+
+```json
+{
+  "required": ["appointment_confirmed", "preferred_date", "preferred_time", "contact_email"]
+}
+```
+
+**Read the events first.** `GET /v1/calls/call_a1/events` shows 14 turns over 96 seconds. This is not
+a hangup — the person talked. The extraction failed, not the call.
+
+**Tier: REPAIR.** Decompose the composite schema. Instead of re-asking all four fields, ask for the
+two that actually gate the workflow, one at a time:
+
+```json
+{
+  "required": ["appointment_confirmed", "preferred_date"]
+}
+```
+
+Task opens by referencing the first call:
+
+> "Hello, we spoke a moment ago about your appointment. I just need to confirm two quick things.
+> First, would you like to go ahead with the appointment? ... And which day suits you best?"
+
+Idempotency key: `repair:call_a1`.
+
+**Repair call**
+
+```json
+{
+  "id": "call_a2",
+  "status": "completed",
+  "duration_seconds": 31,
+  "structured_result": {
+    "appointment_confirmed": true,
+    "preferred_date": "2026-08-14"
+  }
+}
+```
+
+**Tier: COMMIT.** Final merged record, with provenance:
+
+```json
+{
+  "appointment_confirmed": { "value": true,         "from": "call_a2" },
+  "preferred_date":        { "value": "2026-08-14", "from": "call_a2" },
+  "preferred_time":        { "value": null,         "from": null, "note": "not required to proceed" },
+  "contact_email":         { "value": null,         "from": null, "note": "not required to proceed" },
+  "calls": ["call_a1", "call_a2"],
+  "tier_history": ["REPAIR", "COMMIT"]
+}
+```
+
+Note what did **not** happen: the two non-blocking fields were dropped rather than chased. A repair
+call asks only for what blocks the workflow.
+
+---
+
+## 2. Partial result, one missing field → REPAIR the gap only
+
+```json
+{
+  "id": "call_b1",
+  "status": "completed",
+  "duration_seconds": 74,
+  "structured_result": {
+    "order_confirmed": true,
+    "address_correct": false,
+    "corrected_address": ""
+  }
+}
+```
+
+The person confirmed the order and said the address was wrong — but no corrected address was
+captured. The workflow cannot ship to a known-bad address, so this field genuinely blocks.
+
+**Tier: REPAIR**, schema narrowed to exactly one field:
+
+```json
+{ "required": ["corrected_address"] }
+```
+
+`order_confirmed` is **not** re-asked. It came back confidently the first time; asking again risks a
+second, different answer with no principled way to choose between them.
+
+---
+
+## 3. Contradictory result → ESCALATE, do not repair
+
+```json
+{
+  "id": "call_c1",
+  "status": "completed",
+  "duration_seconds": 112,
+  "structured_result": {
+    "order_confirmed": true,
+    "cancel_requested": true
+  }
+}
+```
+
+The person both confirmed and asked to cancel. This is not a gap a narrower question fixes — the
+underlying intent is genuinely unclear, and a repair call would be asking a confused person to
+resolve a contradiction on the spot.
+
+**Tier: ESCALATE.** Payload for the human:
+
+```json
+{
+  "reason": "contradictory_result",
+  "call_id": "call_c1",
+  "conflict": ["order_confirmed=true", "cancel_requested=true"],
+  "duration_seconds": 112,
+  "recipient": "+150******01",
+  "action_blocked": "dispatch"
+}
+```
+
+No second call is placed. A human reads the transcript and decides.
+
+---
+
+## 4. Five-second hangup → NOT a repair case
+
+```json
+{
+  "id": "call_d1",
+  "status": "completed",
+  "duration_seconds": 5,
+  "structured_result": null
+}
+```
+
+Same terminal status and same `null` as example 1 — and the correct action is the opposite.
+
+`GET /v1/calls/call_d1/events` shows 1 turn. The person picked up and hung up. That is a soft
+refusal, not an extraction failure.
+
+**Tier: ESCALATE** (or hand back to the caller's own retry policy). **Do not repair-call**: it means
+immediately calling back someone who just declined to talk.
+
+This pair is the whole reason the skill reads the event stream before choosing a tier. The terminal
+result alone cannot tell these two situations apart.
+
+---
+
+## Tier decision, condensed
+
+```
+terminal call
+  ├── required fields all present and actionable ......... COMMIT
+  ├── result contradicts itself ......................... ESCALATE
+  ├── missing field is sensitive ........................ ESCALATE
+  ├── a repair call was already placed .................. ESCALATE
+  ├── conversation was substantial, extraction failed ... REPAIR (subset schema, one call)
+  ├── conversation was trivially short .................. ESCALATE / caller's retry policy
+  └── cannot classify ................................... ESCALATE
+```

--- a/skills/confidence-gated-results/references/safety.md
+++ b/skills/confidence-gated-results/references/safety.md
@@ -1,0 +1,69 @@
+# Safety — confidence-gated results
+
+A repair call is a **second phone call to a real person who has already been interrupted once**.
+Everything in this document exists to keep that second call rare, justified and bounded.
+
+## The one rule
+
+> A repair call is justified only when the first call produced a genuine conversation **and** the
+> missing field genuinely blocks the workflow.
+
+Convenience is not justification. "The dashboard looks nicer with the field filled in" is not
+justification. If the workflow can proceed with the field absent, it should proceed with the field
+absent.
+
+## Never repair-call in these cases
+
+- **The person declined, refused, or asked not to be contacted.** A confident "no" is a result. A
+  repair call after a refusal is harassment with extra steps, and in many jurisdictions it is also a
+  do-not-call violation.
+- **The call was not answered.** `no_answer`, `busy` and `failed` are reachability problems. This
+  skill governs extraction failures, not dialling policy.
+- **The conversation was too short to have happened.** A five-second call that ends in `null` is
+  someone hanging up. Repairing it means calling back a person who just declined to talk.
+- **The person asked to be called back later.** That is an instruction, not a gap. Honour it through
+  whatever scheduling the workflow owns; do not fire an immediate repair call.
+- **The field is sensitive.** Payment details, government identifiers, health information, passwords
+  and one-time codes must never be the target of a repair call. If the missing field is one of
+  these, escalate to a human, always.
+- **A repair call was already placed for this original call.** One repair, ever. If it also fails,
+  escalate.
+
+## Bounds that must hold in code, not in prose
+
+- **At most one repair call per original call.** Enforce with an idempotency key derived from the
+  original call id, so a retried workflow cannot place a third call.
+- **A repair schema is always a strict subset** of the original required fields. Never widen the ask
+  on a second call.
+- **No recurring schedules.** This skill creates at most one additional call at the moment it is
+  invoked. It never registers a job.
+- **A cap on total calls per recipient per workflow run.** Two is the natural cap here; whatever the
+  number, it belongs in configuration a human can see.
+
+## Boundaries on the call content
+
+The repair task inherits every boundary the original call had, and adds one: it must open by
+referencing the earlier call, so the person is not confused about who is calling and why.
+
+The call must not:
+
+- give medical, legal, financial or emergency advice
+- take payment details or read back card, bank or identifier numbers
+- attempt to change an answer the person already gave
+- imply an obligation, deadline or consequence that was not in the original call
+- continue after the person asks to end the call
+
+## Phone numbers and data
+
+- Numbers are E.164 or the workflow stops. Do not guess a country code.
+- Mask numbers in logs, notes, summaries and any escalation payload a human will read.
+- Samples and documentation use fictional reserved numbers only.
+- The evidence trail may contain what a person said. Treat it as customer data: do not paste it into
+  tickets, chat messages or commits that are broader-audience than the workflow itself.
+
+## Escalation is not failure
+
+The escalate path exists so the system has somewhere honest to put uncertainty. An agent that
+escalates ten percent of calls with a clean evidence trail is more trustworthy than one that
+escalates none because it guessed. When in doubt: escalate, attach the trail, and let a person
+decide.

--- a/skills/confidence-gated-results/scripts/classify-result.mjs
+++ b/skills/confidence-gated-results/scripts/classify-result.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Tier classifier for confidence-gated CALL-E results.
+ *
+ * Pure functions, no I/O, no network. Given a terminal call and the schema the
+ * workflow asked for, decide COMMIT / REPAIR / ESCALATE and, when repairing,
+ * build the narrowed sub-schema and the idempotency key.
+ *
+ * Usage as a library:
+ *   import { classify, buildRepairPlan } from "./scripts/classify-result.mjs";
+ *
+ * Usage as a CLI (reads a call JSON, prints the tier decision):
+ *   node scripts/classify-result.mjs --call call.json --required a,b --blocking a
+ */
+
+export const COMMIT = "COMMIT";
+export const REPAIR = "REPAIR";
+export const ESCALATE = "ESCALATE";
+
+/**
+ * Below this, a "completed" call is a hangup rather than a conversation, and a
+ * repair call would mean immediately ringing back someone who just declined.
+ */
+export const MIN_CONVERSATION_SECONDS = 15;
+
+/** Fields that must never be the target of an automated repair call. */
+export const SENSITIVE_FIELDS = [
+  "card", "cvv", "iban", "account_number", "routing",
+  "ssn", "national_id", "passport", "password", "otp", "pin",
+  "diagnosis", "medication", "health",
+];
+
+export function isSensitiveField(name) {
+  const n = String(name).toLowerCase();
+  return SENSITIVE_FIELDS.some((s) => n.includes(s));
+}
+
+function present(value) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim() !== "";
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/** Required fields that did not come back usable. */
+export function missingFields(result, required) {
+  if (!result || typeof result !== "object") return [...required];
+  return required.filter((f) => !present(result[f]));
+}
+
+/**
+ * Detect a result that contradicts itself. Pairs are workflow-defined: each is
+ * two field names that must not both be truthy.
+ */
+export function findContradictions(result, exclusivePairs = []) {
+  if (!result || typeof result !== "object") return [];
+  return exclusivePairs
+    .filter(([a, b]) => result[a] === true && result[b] === true)
+    .map(([a, b]) => `${a}=true & ${b}=true`);
+}
+
+/**
+ * Classify one terminal call.
+ *
+ * @param {object} call      { status, duration_seconds, structured_result }
+ * @param {object} options
+ * @param {string[]} options.required        every required field
+ * @param {string[]} [options.blocking]      subset that actually blocks the workflow
+ *                                           (defaults to `required`)
+ * @param {Array<[string,string]>} [options.exclusivePairs]
+ * @param {number} [options.turnCount]       from GET /v1/calls/{id}/events
+ * @param {boolean} [options.repairAlreadyPlaced]
+ */
+export function classify(call, options = {}) {
+  const {
+    required = [],
+    blocking = required,
+    exclusivePairs = [],
+    turnCount = null,
+    repairAlreadyPlaced = false,
+  } = options;
+
+  const status = String(call?.status || "").toLowerCase();
+  const result = call?.structured_result ?? null;
+  const duration = Number(call?.duration_seconds ?? 0);
+
+  if (status !== "completed") {
+    return {
+      tier: ESCALATE,
+      reason: `not_answered:${status || "unknown"}`,
+      detail: "Reachability is the caller's retry policy, not a confidence problem.",
+      missing: [...required],
+    };
+  }
+
+  const contradictions = findContradictions(result, exclusivePairs);
+  if (contradictions.length > 0) {
+    return {
+      tier: ESCALATE,
+      reason: "contradictory_result",
+      detail: contradictions.join("; "),
+      missing: [],
+    };
+  }
+
+  const missing = missingFields(result, required);
+  const missingBlocking = missing.filter((f) => blocking.includes(f));
+
+  if (missingBlocking.length === 0) {
+    return {
+      tier: COMMIT,
+      reason: missing.length === 0 ? "complete" : "all_blocking_fields_present",
+      detail: missing.length === 0 ? "" : `Dropped non-blocking: ${missing.join(", ")}`,
+      missing,
+    };
+  }
+
+  const sensitive = missingBlocking.filter(isSensitiveField);
+  if (sensitive.length > 0) {
+    return {
+      tier: ESCALATE,
+      reason: "sensitive_field_missing",
+      detail: `A repair call must never target: ${sensitive.join(", ")}`,
+      missing: missingBlocking,
+    };
+  }
+
+  if (repairAlreadyPlaced) {
+    return {
+      tier: ESCALATE,
+      reason: "repair_already_attempted",
+      detail: "One repair call per original call. Hand to a human with the trail.",
+      missing: missingBlocking,
+    };
+  }
+
+  // A short call that produced nothing is a hangup, not an extraction failure.
+  const trivial = turnCount !== null ? turnCount <= 1 : duration < MIN_CONVERSATION_SECONDS;
+  if (trivial) {
+    return {
+      tier: ESCALATE,
+      reason: "conversation_too_short_to_repair",
+      detail: `duration=${duration}s turns=${turnCount ?? "unknown"} — treat as a soft refusal.`,
+      missing: missingBlocking,
+    };
+  }
+
+  return {
+    tier: REPAIR,
+    reason: "extraction_failed_after_real_conversation",
+    detail: `duration=${duration}s turns=${turnCount ?? "unknown"}`,
+    missing: missingBlocking,
+  };
+}
+
+/**
+ * Build the narrowed repair call. The schema is always a strict SUBSET of the
+ * original required fields, and never re-asks a field already captured.
+ */
+export function buildRepairPlan(call, decision, { originalCallId, schemaProperties = {} } = {}) {
+  if (decision.tier !== REPAIR) {
+    throw new Error(`buildRepairPlan requires a REPAIR decision, received ${decision.tier}.`);
+  }
+  const fields = decision.missing;
+  if (fields.length === 0) throw new Error("A repair plan needs at least one missing field.");
+  if (fields.some(isSensitiveField)) throw new Error("Refusing to build a repair call for a sensitive field.");
+
+  const callId = originalCallId ?? call?.id;
+  const properties = Object.fromEntries(
+    fields.map((f) => [f, schemaProperties[f] ?? { type: "string", description: `The ${f.replace(/_/g, " ")}.` }]),
+  );
+
+  return {
+    idempotencyKey: `repair:${callId}`,
+    schema: { type: "object", properties, required: fields },
+    fields,
+    task: [
+      "Hello, we spoke a moment ago and I just need to confirm a couple of quick things.",
+      ...fields.map((f, i) => `Question ${i + 1}: please tell me the ${f.replace(/_/g, " ")}.`),
+      "Thank you, that is everything. Do not ask about anything else and end the call politely.",
+    ].join(" "),
+  };
+}
+
+/** Merge a repair result over the original, recording which call each field came from. */
+export function mergeResults({ original, repair, originalCallId, repairCallId, required = [] }) {
+  const merged = {};
+  for (const field of required) {
+    if (present(original?.[field])) {
+      merged[field] = { value: original[field], from: originalCallId };
+    } else if (present(repair?.[field])) {
+      merged[field] = { value: repair[field], from: repairCallId };
+    } else {
+      merged[field] = { value: null, from: null };
+    }
+  }
+  return merged;
+}
+
+// ---------------------------------------------------------------- CLI
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const { readFile } = await import("node:fs/promises");
+  const args = process.argv.slice(2);
+  const flag = (name) => {
+    const i = args.indexOf(`--${name}`);
+    return i === -1 ? undefined : args[i + 1];
+  };
+  const callPath = flag("call");
+  if (!callPath) {
+    console.error("Usage: node scripts/classify-result.mjs --call <call.json> --required a,b [--blocking a] [--turns N]");
+    process.exit(2);
+  }
+  const call = JSON.parse(await readFile(callPath, "utf8"));
+  const required = (flag("required") || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const blocking = flag("blocking") ? flag("blocking").split(",").map((s) => s.trim()) : required;
+  const turns = flag("turns") !== undefined ? Number(flag("turns")) : null;
+
+  const decision = classify(call, { required, blocking, turnCount: turns });
+  const output = { decision };
+  if (decision.tier === REPAIR) output.repair = buildRepairPlan(call, decision, { originalCallId: call.id });
+  console.log(JSON.stringify(output, null, 2));
+  process.exit(decision.tier === COMMIT ? 0 : decision.tier === REPAIR ? 5 : 6);
+}

--- a/skills/confidence-gated-results/scripts/classify-result.test.mjs
+++ b/skills/confidence-gated-results/scripts/classify-result.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classify,
+  buildRepairPlan,
+  mergeResults,
+  missingFields,
+  findContradictions,
+  isSensitiveField,
+  COMMIT,
+  REPAIR,
+  ESCALATE,
+} from "../scripts/classify-result.mjs";
+
+const REQUIRED = ["appointment_confirmed", "preferred_date"];
+
+const completed = (structured_result, duration_seconds = 90) => ({
+  id: "call_a1",
+  status: "completed",
+  duration_seconds,
+  structured_result,
+});
+
+test("a complete result commits", () => {
+  const d = classify(completed({ appointment_confirmed: true, preferred_date: "2026-08-14" }), {
+    required: REQUIRED,
+  });
+  assert.equal(d.tier, COMMIT);
+  assert.deepEqual(d.missing, []);
+});
+
+test("null after a real conversation is a repair, not a no", () => {
+  const d = classify(completed(null, 96), { required: REQUIRED, turnCount: 14 });
+  assert.equal(d.tier, REPAIR);
+  assert.deepEqual(d.missing, REQUIRED);
+});
+
+test("null after a five second hangup is NOT repaired", () => {
+  const d = classify(completed(null, 5), { required: REQUIRED, turnCount: 1 });
+  assert.equal(d.tier, ESCALATE);
+  assert.equal(d.reason, "conversation_too_short_to_repair");
+});
+
+test("the same null gets opposite decisions based on the event stream", () => {
+  const call = completed(null, 5);
+  const hangup = classify(call, { required: REQUIRED, turnCount: 1 });
+  const real = classify({ ...call, duration_seconds: 96 }, { required: REQUIRED, turnCount: 14 });
+  assert.equal(hangup.tier, ESCALATE);
+  assert.equal(real.tier, REPAIR);
+});
+
+test("a partial result repairs only the missing field", () => {
+  const d = classify(
+    completed({ appointment_confirmed: true, preferred_date: "" }, 74),
+    { required: REQUIRED, turnCount: 9 },
+  );
+  assert.equal(d.tier, REPAIR);
+  assert.deepEqual(d.missing, ["preferred_date"], "a captured field must never be re-asked");
+});
+
+test("a contradictory result escalates and is never repaired", () => {
+  const d = classify(
+    completed({ order_confirmed: true, cancel_requested: true }, 112),
+    { required: ["order_confirmed"], exclusivePairs: [["order_confirmed", "cancel_requested"]], turnCount: 20 },
+  );
+  assert.equal(d.tier, ESCALATE);
+  assert.equal(d.reason, "contradictory_result");
+});
+
+test("a missing sensitive field escalates instead of calling back", () => {
+  const d = classify(completed({}, 90), { required: ["card_number"], turnCount: 12 });
+  assert.equal(d.tier, ESCALATE);
+  assert.equal(d.reason, "sensitive_field_missing");
+});
+
+test("only one repair call is ever permitted", () => {
+  const d = classify(completed(null, 96), { required: REQUIRED, turnCount: 14, repairAlreadyPlaced: true });
+  assert.equal(d.tier, ESCALATE);
+  assert.equal(d.reason, "repair_already_attempted");
+});
+
+test("an unanswered call is a reachability problem, not a confidence problem", () => {
+  const d = classify({ status: "no_answer", duration_seconds: 0 }, { required: REQUIRED });
+  assert.equal(d.tier, ESCALATE);
+  assert.match(d.reason, /^not_answered:/);
+});
+
+test("non-blocking fields are dropped rather than chased", () => {
+  const d = classify(
+    completed({ appointment_confirmed: true, preferred_date: "2026-08-14", contact_email: "" }, 90),
+    { required: [...REQUIRED, "contact_email"], blocking: REQUIRED, turnCount: 12 },
+  );
+  assert.equal(d.tier, COMMIT);
+  assert.deepEqual(d.missing, ["contact_email"]);
+});
+
+test("the repair schema is a strict subset and never widens the ask", () => {
+  const call = completed({ appointment_confirmed: true }, 90);
+  const d = classify(call, { required: REQUIRED, turnCount: 12 });
+  const plan = buildRepairPlan(call, d, { originalCallId: "call_a1" });
+  assert.deepEqual(plan.schema.required, ["preferred_date"]);
+  assert.ok(plan.schema.required.every((f) => REQUIRED.includes(f)));
+  assert.ok(plan.schema.required.length < REQUIRED.length);
+});
+
+test("the repair call carries a stable idempotency key derived from the original", () => {
+  const call = completed(null, 96);
+  const d = classify(call, { required: REQUIRED, turnCount: 14 });
+  assert.equal(buildRepairPlan(call, d, { originalCallId: "call_a1" }).idempotencyKey, "repair:call_a1");
+});
+
+test("the repair task references the earlier call so the person is not confused", () => {
+  const call = completed(null, 96);
+  const d = classify(call, { required: REQUIRED, turnCount: 14 });
+  assert.match(buildRepairPlan(call, d, { originalCallId: "call_a1" }).task, /we spoke a moment ago/);
+});
+
+test("a repair plan cannot be built from a non-repair decision", () => {
+  const call = completed({ appointment_confirmed: true, preferred_date: "2026-08-14" });
+  const d = classify(call, { required: REQUIRED });
+  assert.throws(() => buildRepairPlan(call, d, { originalCallId: "call_a1" }), /requires a REPAIR/);
+});
+
+test("merging records which call each field came from", () => {
+  const merged = mergeResults({
+    original: { appointment_confirmed: true },
+    repair: { preferred_date: "2026-08-14" },
+    originalCallId: "call_a1",
+    repairCallId: "call_a2",
+    required: REQUIRED,
+  });
+  assert.equal(merged.appointment_confirmed.from, "call_a1");
+  assert.equal(merged.preferred_date.from, "call_a2");
+  assert.equal(merged.preferred_date.value, "2026-08-14");
+});
+
+test("empty strings and empty arrays count as missing", () => {
+  assert.deepEqual(missingFields({ a: "", b: [], c: "ok" }, ["a", "b", "c"]), ["a", "b"]);
+});
+
+test("false is a real answer and is not missing", () => {
+  assert.deepEqual(missingFields({ confirmed: false }, ["confirmed"]), []);
+});
+
+test("sensitive field detection is substring based", () => {
+  assert.ok(isSensitiveField("customer_card_number"));
+  assert.ok(isSensitiveField("OTP"));
+  assert.equal(isSensitiveField("preferred_date"), false);
+});
+
+test("contradiction detection only fires when both are true", () => {
+  const pairs = [["a", "b"]];
+  assert.deepEqual(findContradictions({ a: true, b: false }, pairs), []);
+  assert.equal(findContradictions({ a: true, b: true }, pairs).length, 1);
+});


### PR DESCRIPTION
## The state nobody handles

A CALL-E call can reach `completed`, bill normally, and still hand back `structured_result: null`. The person answered. They talked for ninety seconds. The extraction produced nothing usable.

Most integrations read the result as a value and move on — so `null` quietly becomes "no" or an empty success, and a workflow ships an order, closes a ticket or marks a lead dead on the strength of a call that produced no evidence at all.

`skills/confidence-gated-results/` makes that state first class and gives it three exits.

## Three-tier outcome contract

| Tier | Meaning | Action |
| --- | --- | --- |
| **COMMIT** | Every blocking field present and actionable | Use it, record provenance |
| **REPAIR** | Call connected, extraction incomplete, gap is narrow | **One** narrowed follow-up call |
| **ESCALATE** | Ambiguous, contradictory, sensitive, exhausted | Hand to a human with the trail |

Default when unclassifiable is ESCALATE. `null` is not "no", and silence is not consent.

## Why the repair call decomposes the schema

A `null` usually means one composite schema asked for four things at once and the extractor could not satisfy all of them, so it emitted nothing rather than something partial.

So a repair call must **not** re-ask the original question — that reproduces the same failure and bills twice. It splits the failed schema into the smallest sub-schema covering only the *blocking* missing fields.

Rules enforced in code, not prose: one repair per original call, the schema is always a strict subset, a confidently-captured field is never re-asked, and the idempotency key is derived from the original call id.

## The decisive rule

The same `null` gets **opposite** treatment depending on `GET /v1/calls/{id}/events`:

- 96 seconds, 14 turns → extraction failure → **REPAIR**
- 5 seconds, 1 turn → soft refusal → **ESCALATE**, never call back

The terminal result alone cannot tell these apart. This is why the skill reads the event stream before choosing a tier, and it is the reason the classifier takes `turnCount`.

## Try it

```bash
cd skills/confidence-gated-results
node --test scripts/classify-result.test.mjs     # 19 tests, no credentials, no calls
node scripts/classify-result.mjs --call call.json --required a,b --turns 14
```

`scripts/classify-result.mjs` is pure functions plus a thin CLI. Exit codes `0` commit, `5` repair, `6` escalate. Tests cover the tier table, subset-schema construction, idempotency key derivation, sensitive-field refusal, contradiction detection, `false`-is-not-missing, and provenance merging.

## Safety

- A repair call is a **second call to someone already interrupted once** — justified only when the first call produced a genuine conversation *and* the missing field genuinely blocks the workflow.
- Never repair after a refusal, a hangup, a "call me back later", or for a sensitive field (payment, identifiers, health, OTP) — those escalate unconditionally.
- One repair per original call, enforced by idempotency key. No recurring schedules.
- Fictional reserved numbers in all samples; masking required in escalation payloads.

## Checklist

- [x] English-only repository-facing content
- [x] No secrets, tokens, private phone numbers or personal data
- [x] `references/safety.md` and `references/examples.md` present
- [x] Describes side effects and cancellation/rollback
- [x] No-call path: the classifier needs no credentials and places no calls
- [x] `python3 scripts/validate_repository.py` → `Repository validation passed.`
- [x] Branch name follows `docs/git-naming-conventions.md`
- [x] `README.md` resource list updated in the same change
