### PR TITLE
feat(calle-hardware-intake): add CALL-E hardware support intake app and skill

### DIFF
--- a/apps/python/calle-hardware-intake/.env.example
+++ b/apps/python/calle-hardware-intake/.env.example
@@ -1,2 +1,5 @@
 # Copy this file to .env and fill in real values. .env is gitignored.
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Shared secret required to plan/run live calls (send as X-API-Key header).
+API_KEY=your_random_secret_here

--- a/apps/python/calle-hardware-intake/.env.example
+++ b/apps/python/calle-hardware-intake/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in real values. .env is gitignored.
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/apps/python/calle-hardware-intake/.gitignore
+++ b/apps/python/calle-hardware-intake/.gitignore
@@ -1,0 +1,22 @@
+# Secrets - never commit these
+.env
+
+# Python
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+
+# OS / editor
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+
+# Stray downloaded installers
+*.exe
+
+# Local databases
+*.db
+*.sqlite3

--- a/apps/python/calle-hardware-intake/README.md
+++ b/apps/python/calle-hardware-intake/README.md
@@ -1,11 +1,12 @@
 # CALL-E Hardware Support Intake Agent
 
-Voice AI intake agent for technical-support desks and hardware repair shops.
+Voice AI intake agent for technical-support desks and hardware repair shops,
+built for the **CALL-E: Your Code Is Calling** hackathon.
+
 CALL-E owns the phone call (plan → dial → converse → structured result); a
-FastAPI backend drives CALL-E via its CLI/MCP and uses **Gemini function
-calling** to turn each conversation into a structured repair ticket, a
-diagnostic appointment, or a status lookup — persisted in SQLite and exposed
-over a small API.
+FastAPI backend drives CALL-E and uses **Gemini function calling** to turn each
+conversation into a structured repair ticket, a diagnostic appointment, or a
+status lookup — persisted in SQLite and exposed over a small API.
 
 ## Architecture
 
@@ -35,8 +36,8 @@ uv pip install -r requirements.txt
 npm install -g @call-e/cli
 calle auth login                          # opens browser, approve
 
-# 3. Gemini key
-cp .env.example .env                      # paste GEMINI_API_KEY
+# 3. Keys
+cp .env.example .env                      # paste GEMINI_API_KEY; set API_KEY
 ```
 
 ## Run
@@ -52,13 +53,18 @@ Then open http://127.0.0.1:8000/docs (auto-generated Swagger UI).
 | Method | Path | Purpose |
 |---|---|---|
 | GET  | `/health` | server + CALL-E auth status |
-| POST | `/api/intake` | `{"transcript": "..."}` → Gemini parses, logs a ticket |
+| POST | `/api/intake` | `{"transcript": "..."}` → Gemini parses, logs a ticket (no call) |
 | GET  | `/api/tickets` | list tickets |
 | GET  | `/api/tickets/{id}` | one ticket |
-| POST | `/api/calls` | `{"phone": "+15551234567", "goal": "..."}` → plan + run a real call |
+| POST | `/api/calls` | 🔒 `X-API-Key` · `{"phone":"+15551234567","goal":"...","idempotency_key":"..."}` → **plans only, never dials** |
+| POST | `/api/calls/{id}/run` | 🔒 `X-API-Key` · explicit confirmation that **executes** a planned call |
 | GET  | `/api/calls/{id}` | live call status |
 
-## Try it without making a call
+**Live-call auth:** planning (`POST /api/calls`) and executing (`POST
+/api/calls/{id}/run`) require the `X-API-Key` header set to your `API_KEY` env
+var. These endpoints fail closed (`503`) when `API_KEY` is empty.
+
+### Try it without a call
 
 ```bash
 curl -X POST http://127.0.0.1:8000/api/intake \
@@ -66,41 +72,36 @@ curl -X POST http://127.0.0.1:8000/api/intake \
   -d '{"transcript": "Customer named Alice says her Dell laptop won't boot after a Windows update. Agreed to drop it off Thursday at 10:30am. Priority urgent."}'
 ```
 
-`/api/intake` and `/health` never place calls. To check a CALL-E plan without
-dialing, run:
+### Make a real call (uses a CALL-E credit)
 
+Via the script (plans + runs + logs a ticket):
 ```bash
-python scripts/test_call.py +15551234567 "Confirm the appointment" --dry-plan
+python scripts/test_call.py +15551234567 "Confirm the 10:30am laptop diagnostic appointment"
+# add --dry-plan to only plan without dialing
 ```
 
-## Making a real call (live verification)
-
+Via the API — **two-step, so a call is never placed without confirmation**:
 ```bash
-python scripts/test_call.py +15551234567 "Intake a hardware repair request: ask the device, the issue, and urgency"
+# 1. Plan (never dials)
+curl -X POST http://127.0.0.1:8000/api/calls -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d '{"phone":"+15551234567","goal":"Confirm the appointment","idempotency_key":"call-1"}'
+# -> returns {"id":1,"status":"planned",...}
+
+# 2. Explicitly execute
+curl -X POST http://127.0.0.1:8000/api/calls/1/run -H "X-API-Key: $API_KEY"
 ```
-
-This is the opt-in live path. Run it only when you explicitly want CALL-E to
-dial a real phone number.
-
-## Side effects & safety
-
-- **Each outbound call spends one CALL-E credit** and dials a real phone
-  number in E.164 format (e.g. `+15551234567`). It may reach voicemail.
-- **Use `--dry-plan` or `/api/intake` for a no-call path.** Planning only
-  validates the goal and never dials.
-- **Credentials:** CALL-E uses OAuth via `calle auth login` (no API key). The
-  Gemini key lives in `.env`, which is gitignored — never commit it.
-- **Phone numbers:** samples above are fictional reserved numbers. Mask any
-  real numbers in transcripts/summaries you share.
-- **No recurring jobs:** this app places one-off calls only; there is nothing
-  scheduled or recurring to cancel.
-- **Boundaries:** CALL-E governs outbound behavior; keep goals to legitimate
-  business calls and avoid medical/legal/financial/emergency content.
 
 ## Notes
 
 - **IPv4 fix:** `app/netfix.py` forces IPv4 name resolution because the dev
   machine's IPv6 route is broken; harmless elsewhere.
-- **Model:** `gemini-flash-latest` (older Gemini models are retired for new
-  accounts).
-- Tickets live in `calle_agent.db` (SQLite).
+- **Model:** `gemini-flash-latest` (older Gemini models are retired for new accounts).
+- Tickets live in `calle_agent.db` (SQLite). Never commit `.env`.
+
+## Submission (awesome-phone-call-agents)
+
+The `templates/agent_skills/SKILL.md` is the Agent-Skill layout for the PR.
+Adapt this app into `apps/python/` of the
+[awesome-phone-call-agents](https://github.com/CALLE-AI/awesome-phone-call-agents)
+repo, then open the PR and link it on Devpost with the demo video.

--- a/apps/python/calle-hardware-intake/README.md
+++ b/apps/python/calle-hardware-intake/README.md
@@ -1,0 +1,106 @@
+# CALL-E Hardware Support Intake Agent
+
+Voice AI intake agent for technical-support desks and hardware repair shops.
+CALL-E owns the phone call (plan → dial → converse → structured result); a
+FastAPI backend drives CALL-E via its CLI/MCP and uses **Gemini function
+calling** to turn each conversation into a structured repair ticket, a
+diagnostic appointment, or a status lookup — persisted in SQLite and exposed
+over a small API.
+
+## Architecture
+
+```
+[ Your phone ]  ←  CALL-E dials/converses  →  [ calle CLI / MCP ]
+                                                  │
+                        plan_call → run_call → get_call_run
+                                                  │
+                                        [ FastAPI backend ]
+                                                  │
+                                          ┌───────┴────────┐
+                                          ▼                ▼
+                                   [ Gemini API ]    [ SQLite (tickets) ]
+                                   intent parsing     + call sessions
+                                   + tool calling
+```
+
+## Setup
+
+```bash
+# 1. Python env + deps (uv recommended)
+uv venv .venv --python 3.11
+source .venv/Scripts/activate            # PowerShell: .venv\Scripts\Activate.ps1
+uv pip install -r requirements.txt
+
+# 2. CALL-E CLI (Node.js) + auth — OAuth, NOT an API key
+npm install -g @call-e/cli
+calle auth login                          # opens browser, approve
+
+# 3. Gemini key
+cp .env.example .env                      # paste GEMINI_API_KEY
+```
+
+## Run
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Then open http://127.0.0.1:8000/docs (auto-generated Swagger UI).
+
+### API
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET  | `/health` | server + CALL-E auth status |
+| POST | `/api/intake` | `{"transcript": "..."}` → Gemini parses, logs a ticket |
+| GET  | `/api/tickets` | list tickets |
+| GET  | `/api/tickets/{id}` | one ticket |
+| POST | `/api/calls` | `{"phone": "+15551234567", "goal": "..."}` → plan + run a real call |
+| GET  | `/api/calls/{id}` | live call status |
+
+## Try it without making a call
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/intake \
+  -H "Content-Type: application/json" \
+  -d '{"transcript": "Customer named Alice says her Dell laptop won't boot after a Windows update. Agreed to drop it off Thursday at 10:30am. Priority urgent."}'
+```
+
+`/api/intake` and `/health` never place calls. To check a CALL-E plan without
+dialing, run:
+
+```bash
+python scripts/test_call.py +15551234567 "Confirm the appointment" --dry-plan
+```
+
+## Making a real call (live verification)
+
+```bash
+python scripts/test_call.py +15551234567 "Intake a hardware repair request: ask the device, the issue, and urgency"
+```
+
+This is the opt-in live path. Run it only when you explicitly want CALL-E to
+dial a real phone number.
+
+## Side effects & safety
+
+- **Each outbound call spends one CALL-E credit** and dials a real phone
+  number in E.164 format (e.g. `+15551234567`). It may reach voicemail.
+- **Use `--dry-plan` or `/api/intake` for a no-call path.** Planning only
+  validates the goal and never dials.
+- **Credentials:** CALL-E uses OAuth via `calle auth login` (no API key). The
+  Gemini key lives in `.env`, which is gitignored — never commit it.
+- **Phone numbers:** samples above are fictional reserved numbers. Mask any
+  real numbers in transcripts/summaries you share.
+- **No recurring jobs:** this app places one-off calls only; there is nothing
+  scheduled or recurring to cancel.
+- **Boundaries:** CALL-E governs outbound behavior; keep goals to legitimate
+  business calls and avoid medical/legal/financial/emergency content.
+
+## Notes
+
+- **IPv4 fix:** `app/netfix.py` forces IPv4 name resolution because the dev
+  machine's IPv6 route is broken; harmless elsewhere.
+- **Model:** `gemini-flash-latest` (older Gemini models are retired for new
+  accounts).
+- Tickets live in `calle_agent.db` (SQLite).

--- a/apps/python/calle-hardware-intake/app/__init__.py
+++ b/apps/python/calle-hardware-intake/app/__init__.py
@@ -1,0 +1,3 @@
+"""CALL-E hardware & tech support intake agent."""
+
+__version__ = "0.1.0"

--- a/apps/python/calle-hardware-intake/app/calle_client.py
+++ b/apps/python/calle-hardware-intake/app/calle_client.py
@@ -79,6 +79,8 @@ def _run(args: list[str], timeout: int = 600) -> dict:
         cli_command(args),
         capture_output=True,
         text=True,
+        encoding="utf-8",  # calle emits UTF-8; cp1252 would crash on typographic chars
+        errors="replace",
         timeout=timeout,
     )
     if proc.returncode != 0:

--- a/apps/python/calle-hardware-intake/app/calle_client.py
+++ b/apps/python/calle-hardware-intake/app/calle_client.py
@@ -1,0 +1,147 @@
+"""Thin wrapper around the ``calle`` CLI (CALL-E).
+
+CALL-E owns the phone conversation. The flow is:
+
+    plan_call(to_phone, goal) -> {plan_id, confirm_token, ready_to_run, ...}
+    run_call(plan_id, confirm_token) -> {run_id, ...}
+    get_call_status(run_id) -> {status, summary, transcript, ...}
+
+``calle`` is authenticated once via ``calle auth login`` (OAuth). These are
+sync functions that block for the duration of the subprocess; call them from
+async code with ``asyncio.to_thread``.
+"""
+import json
+import os
+import shutil
+import subprocess
+
+from .config import settings
+
+
+class CalleError(Exception):
+    """Raised when the calle CLI fails."""
+
+
+def _get(data: dict, *keys):
+    """Case-insensitive, multi-spelling lookup of a key in a dict."""
+    lowered = {str(k).lower(): v for k, v in (data or {}).items()}
+    for key in keys:
+        if key in data:
+            return data[key]
+        if key.lower() in lowered:
+            return lowered[key.lower()]
+    return None
+
+
+def _unwrap(data: dict) -> dict:
+    """Dig the payload out of the CLI's wrapper envelope.
+
+    ``calle`` emits ``{"ok": true, "result": {"structuredContent": {...}}|...}``
+    (or the same object JSON-stringified under ``result.content[0].text``).
+    Return the innermost dict of actual data.
+    """
+    result = data.get("result") if isinstance(data, dict) else None
+    if not isinstance(result, dict):
+        return data
+    sc = result.get("structuredContent")
+    if isinstance(sc, dict):
+        return sc
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        text = content[0].get("text")
+        if isinstance(text, str):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+    return result
+
+
+def cli_command(args: list[str]) -> list[str]:
+    """Resolve the `calle` CLI to an executable subprocess can actually run.
+
+    npm installs `calle.cmd` shims on Windows; Python's subprocess cannot run
+    a `.cmd` via PATH (only `.exe`), so we resolve the real path and delegate
+    to ``cmd /c`` when needed.
+    """
+    exe = shutil.which(settings.calle_cli)
+    if not exe:
+        return [settings.calle_cli, *args]
+    if os.name == "nt" and exe.lower().endswith((".cmd", ".bat")):
+        return ["cmd", "/c", exe, *args]
+    return [exe, *args]
+
+
+def _run(args: list[str], timeout: int = 600) -> dict:
+    proc = subprocess.run(
+        cli_command(args),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise CalleError(f"calle {' '.join(args)} failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise CalleError(f"calle returned non-JSON: {proc.stdout[:300]!r}") from exc
+    if isinstance(data, dict) and data.get("ok") is False:
+        # The CLI exits 0 even on logical failures (e.g. transient call errors).
+        msg = data.get("result")
+        if isinstance(msg, dict):
+            msg = msg.get("content") or msg
+        raise CalleError(f"calle {args[0]} failed: {str(msg)[:300]}")
+    return data
+
+
+def plan_call(to_phone: str, goal: str) -> dict:
+    """Plan a call. Does NOT dial. Returns plan_id/confirm_token/ready_to_run."""
+    return _run(["call", "plan", "--to-phone", to_phone, "--goal", goal])
+
+
+def run_call(plan_id: str, confirm_token: str, timeout: int = 600) -> dict:
+    """Execute a planned call; blocks until the call finishes."""
+    return _run(
+        ["call", "run", "--plan-id", plan_id, "--confirm-token", confirm_token],
+        timeout=timeout,
+    )
+
+
+def get_call_status(run_id: str) -> dict:
+    """Fetch the latest status of a running/completed call."""
+    return _run(["call", "status", "--run-id", run_id])
+
+
+def extract_plan(data: dict) -> dict:
+    """Normalize a plan_call response."""
+    data = _unwrap(data)
+    return {
+        "plan_id": _get(data, "plan_id", "planId"),
+        "confirm_token": _get(data, "confirm_token", "confirmToken"),
+        "ready_to_run": _get(data, "ready_to_run", "readyToRun"),
+        "clarifying_questions": _get(data, "clarifying_questions", "questions"),
+    }
+
+
+def extract_run(data: dict) -> dict:
+    """Normalize a run_call / get_call_status response."""
+    data = _unwrap(data)
+    nested = data.get("result") if isinstance(data.get("result"), dict) else {}
+
+    def find(*keys):
+        # summary/transcript/outcome live under `result` in the payload.
+        v = _get(data, *keys)
+        if v is None:
+            v = _get(nested, *keys)
+        return v
+
+    return {
+        "run_id": _get(data, "run_id", "runId"),
+        "status": find("status"),
+        "summary": find("summary", "call_summary"),
+        "transcript": find("transcript"),
+        "outcome": find("outcome", "task_completed"),
+        "result": _get(data, "result", "structured_result", "structuredResult"),
+    }

--- a/apps/python/calle-hardware-intake/app/config.py
+++ b/apps/python/calle-hardware-intake/app/config.py
@@ -1,0 +1,26 @@
+"""Environment & API configuration (loaded from .env)."""
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+    # Google AI Studio key -> https://aistudio.google.com/apikey
+    gemini_api_key: str = ""
+    # Newer models are retired for new accounts; use the -latest alias.
+    gemini_model: str = "gemini-flash-latest"
+
+    # SQLite file created next to the app.
+    database_url: str = "sqlite:///./calle_agent.db"
+
+    # CALL-E is driven through the `calle` CLI (installed via npm, authed
+    # via `calle auth login`). OAuth, not an API key.
+    calle_cli: str = "calle"
+
+    # How long to poll a running call before giving up (seconds).
+    call_poll_timeout: int = 600
+
+
+settings = Settings()

--- a/apps/python/calle-hardware-intake/app/config.py
+++ b/apps/python/calle-hardware-intake/app/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     # Newer models are retired for new accounts; use the -latest alias.
     gemini_model: str = "gemini-flash-latest"
 
+    # Shared secret required to plan/run live calls (X-API-Key header).
+    # Live-call endpoints fail closed when this is empty.
+    api_key: str = ""
+
     # SQLite file created next to the app.
     database_url: str = "sqlite:///./calle_agent.db"
 

--- a/apps/python/calle-hardware-intake/app/database.py
+++ b/apps/python/calle-hardware-intake/app/database.py
@@ -1,0 +1,82 @@
+"""SQLAlchemy models and session management (SQLite)."""
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from .config import settings
+
+Base = declarative_base()
+
+
+def _utcnow():
+    return datetime.now(timezone.utc)
+
+
+class Ticket(Base):
+    """A repair/support ticket created from a call."""
+
+    __tablename__ = "tickets"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    ticket_number = Column(String, unique=True, index=True)
+    device_type = Column(String, nullable=True)
+    issue_description = Column(Text, nullable=True)
+    priority = Column(String, default="normal")
+    status = Column(String, default="open")
+    customer_name = Column(String, nullable=True)
+    scheduled_date = Column(String, nullable=True)   # e.g. 2026-08-03
+    scheduled_time = Column(String, nullable=True)   # e.g. 10:30
+    created_at = Column(DateTime, default=_utcnow)
+
+    calls = relationship("CallSession", back_populates="ticket")
+
+
+class CallSession(Base):
+    """One outbound CALL-E phone call and its outcome."""
+
+    __tablename__ = "call_sessions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    run_id = Column(String, unique=True, index=True, nullable=True)
+    plan_id = Column(String, nullable=True)
+    confirm_token = Column(String, nullable=True)
+    phone = Column(String)
+    goal = Column(Text)
+    # created -> planned -> running -> completed | failed | plan_not_ready
+    status = Column(String, default="created")
+    transcript = Column(Text, nullable=True)
+    summary = Column(Text, nullable=True)
+    structured_result = Column(Text, nullable=True)  # JSON from CALL-E
+    error = Column(Text, nullable=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id"), nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+    ticket = relationship("Ticket", back_populates="calls")
+
+
+engine = create_engine(
+    settings.database_url, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/apps/python/calle-hardware-intake/app/database.py
+++ b/apps/python/calle-hardware-intake/app/database.py
@@ -49,6 +49,7 @@ class CallSession(Base):
     run_id = Column(String, unique=True, index=True, nullable=True)
     plan_id = Column(String, nullable=True)
     confirm_token = Column(String, nullable=True)
+    idempotency_key = Column(String, unique=True, index=True, nullable=True)
     phone = Column(String)
     goal = Column(Text)
     # created -> planned -> running -> completed | failed | plan_not_ready

--- a/apps/python/calle-hardware-intake/app/gemini_engine.py
+++ b/apps/python/calle-hardware-intake/app/gemini_engine.py
@@ -1,0 +1,260 @@
+"""Gemini intent parsing + tool calling for the intake agent.
+
+Takes a phone-call transcript/notes and turns it into structured actions via
+Gemini function calling:
+  * create_repair_ticket()      -> creates a ticket in the DB
+  * schedule_diagnostic_slot()  -> records a repair-appointment slot
+  * check_repair_status()       -> looks up an existing ticket
+
+The ``calle`` flow owns the phone call; this engine owns the "understand the
+conversation and log a ticket" half.
+
+We talk to Gemini over its REST API with httpx directly (not the google-genai
+SDK): the SDK drops the ``thoughtSignature`` that the newer API requires on
+echoed function calls, and raw REST also sidesteps the broken-IPv6 quirk.
+"""
+from datetime import datetime
+from typing import Callable, Optional
+
+import httpx
+
+from . import netfix  # noqa: F401  (force IPv4 before any network call)
+from .config import settings
+from .database import SessionLocal, Ticket
+
+GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+SYSTEM_PROMPT = """You are the intake engine for a hardware & tech-support repair desk.
+You listen to phone-call transcripts between a support agent and a customer,
+then log structured actions using your tools.
+
+Rules:
+- ALWAYS use create_repair_ticket when the customer reports a device problem.
+  Infer device_type (laptop, phone, motherboard, OS, printer, etc.), write a
+  concise issue_description, and pick priority: low|normal|high|urgent.
+  Use customer_name if the caller identifies themselves.
+- Use schedule_diagnostic_slot when an appointment date/time is agreed.
+- Use check_repair_status when the caller asks about an existing ticket.
+- If nothing is actionable, say so in one line and call no tools.
+- After calling tools, reply with a one-line summary of what you did.
+Never invent phone numbers, ticket ids, dates, or times that are not in the transcript."""
+
+# --- Tool implementations (take a DB session) --------------------------------
+
+def _new_ticket_number() -> str:
+    stamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    return f"TKT-{stamp}"
+
+
+def _make_tools(db_session) -> tuple[dict[str, Callable], list[Ticket]]:
+    # Tracks tickets actually created by THIS analysis run, so callers only
+    # see fresh tickets, not whatever happened to be the newest row in the DB.
+    created_this_run: list[Ticket] = []
+
+    def create_repair_ticket(
+        device_type: str,
+        issue_description: str,
+        priority: str = "normal",
+        customer_name: Optional[str] = None,
+    ) -> dict:
+        ticket = Ticket(
+            ticket_number=_new_ticket_number(),
+            device_type=device_type,
+            issue_description=issue_description,
+            priority=priority,
+            customer_name=customer_name,
+            status="open",
+        )
+        db_session.add(ticket)
+        db_session.commit()
+        db_session.refresh(ticket)
+        created_this_run.append(ticket)
+        return {
+            "ticket_id": ticket.id,
+            "ticket_number": ticket.ticket_number,
+            "device_type": ticket.device_type,
+            "priority": ticket.priority,
+        }
+
+    def schedule_diagnostic_slot(
+        date: str, time_slot: str, user_name: str, ticket_id: Optional[int] = None
+    ) -> dict:
+        ticket = None
+        if ticket_id is not None:
+            ticket = db_session.get(Ticket, ticket_id)
+        if ticket is not None:
+            ticket.scheduled_date = date
+            ticket.scheduled_time = time_slot
+            db_session.commit()
+        return {
+            "scheduled": True,
+            "date": date,
+            "time_slot": time_slot,
+            "user_name": user_name,
+            "ticket_id": ticket.id if ticket else None,
+        }
+
+    def check_repair_status(ticket_id: Optional[int] = None, ticket_number: Optional[str] = None) -> dict:
+        ticket = None
+        if ticket_id is not None:
+            ticket = db_session.get(Ticket, ticket_id)
+        elif ticket_number:
+            ticket = db_session.query(Ticket).filter_by(ticket_number=ticket_number).first()
+        if ticket is None:
+            return {"found": False, "message": "No matching ticket found."}
+        return {
+            "found": True,
+            "ticket_number": ticket.ticket_number,
+            "device_type": ticket.device_type,
+            "status": ticket.status,
+            "scheduled_date": ticket.scheduled_date,
+            "scheduled_time": ticket.scheduled_time,
+        }
+
+    return {
+        "create_repair_ticket": create_repair_ticket,
+        "schedule_diagnostic_slot": schedule_diagnostic_slot,
+        "check_repair_status": check_repair_status,
+    }, created_this_run
+
+
+# --- Gemini tool declarations (REST format) ----------------------------------
+
+TOOLS = [
+    {
+        "functionDeclarations": [
+            {
+                "name": "create_repair_ticket",
+                "description": "Create a repair ticket for a reported hardware/software issue.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "device_type": {"type": "string", "description": "e.g. laptop, phone, motherboard, OS"},
+                        "issue_description": {"type": "string"},
+                        "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
+                        "customer_name": {"type": "string"},
+                    },
+                    "required": ["device_type", "issue_description"],
+                },
+            },
+            {
+                "name": "schedule_diagnostic_slot",
+                "description": "Schedule a diagnostic appointment slot for a customer.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "date": {"type": "string", "description": "YYYY-MM-DD"},
+                        "time_slot": {"type": "string", "description": "e.g. 10:30"},
+                        "user_name": {"type": "string"},
+                        "ticket_id": {"type": "integer"},
+                    },
+                    "required": ["date", "time_slot", "user_name"],
+                },
+            },
+            {
+                "name": "check_repair_status",
+                "description": "Look up the status of an existing repair ticket.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "ticket_id": {"type": "integer"},
+                        "ticket_number": {"type": "string"},
+                    },
+                },
+            },
+        ]
+    }
+]
+
+
+def _generate(client: httpx.Client, payload: dict) -> dict:
+    url = f"{GEMINI_BASE}/models/{settings.gemini_model}:generateContent"
+    resp = client.post(
+        url,
+        headers={"x-goog-api-key": settings.gemini_api_key},
+        json=payload,
+        timeout=60,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def analyze_call(transcript: str) -> dict:
+    """Run Gemini over ``transcript`` and execute any tool calls.
+
+    Returns ``{"ticket": {...}|None, "actions": [...], "notes": str}``.
+    """
+    db = SessionLocal()
+    try:
+        tools, created_this_run = _make_tools(db)
+        contents: list[dict] = [{"role": "user", "parts": [{"text": transcript}]}]
+        actions: list[str] = []
+        final_text = ""
+
+        with httpx.Client() as client:
+            for _ in range(6):  # bound the tool loop
+                payload = {
+                    "systemInstruction": {"parts": [{"text": SYSTEM_PROMPT}]},
+                    "contents": contents,
+                    "tools": TOOLS,
+                    "generationConfig": {"temperature": 0.2},
+                }
+                data = _generate(client, payload)
+                try:
+                    parts = data["candidates"][0]["content"]["parts"]
+                except (KeyError, IndexError):
+                    final_text = str(data)
+                    break
+
+                call_parts = [p for p in parts if "functionCall" in p]
+                if not call_parts:
+                    final_text = "".join(p.get("text", "") for p in parts)
+                    break
+
+                # Echo the model turn, preserving thoughtSignature (it sits at
+                # the PART level in the response) + the function call id.
+                model_parts = []
+                for p in call_parts:
+                    fc = p["functionCall"]
+                    echo = {"name": fc["name"], "args": fc.get("args", {})}
+                    if fc.get("id"):
+                        echo["id"] = fc["id"]
+                    part_echo = {"functionCall": echo}
+                    if p.get("thoughtSignature"):
+                        part_echo["thoughtSignature"] = p["thoughtSignature"]
+                    model_parts.append(part_echo)
+                contents.append({"role": "model", "parts": model_parts})
+
+                # Execute each tool and send the function responses back.
+                for p in call_parts:
+                    fc = p["functionCall"]
+                    fn = tools.get(fc["name"])
+                    if fn is None:
+                        result = {"error": f"unknown tool {fc['name']}"}
+                    else:
+                        try:
+                            result = fn(**fc.get("args", {}))
+                        except Exception as exc:  # surface tool errors to the model
+                            result = {"error": str(exc)}
+                    actions.append(f"{fc['name']}({fc.get('args', {})})")
+                    contents.append(
+                        {
+                            "role": "user",
+                            "parts": [
+                                {
+                                    "functionResponse": {
+                                        "name": fc["name"],
+                                        "response": result,
+                                    }
+                                }
+                            ],
+                        }
+                    )
+
+        return {
+            "ticket": created_this_run[-1] if created_this_run else None,
+            "actions": actions,
+            "notes": final_text,
+        }
+    finally:
+        db.close()

--- a/apps/python/calle-hardware-intake/app/main.py
+++ b/apps/python/calle-hardware-intake/app/main.py
@@ -1,0 +1,208 @@
+"""FastAPI backend for the CALL-E hardware & tech-support intake agent.
+
+Endpoints
+---------
+GET  /health            -> server + CALL-E auth status
+POST /api/intake        -> Gemini parses a transcript; creates/logs a ticket
+GET  /api/tickets       -> list tickets
+GET  /api/tickets/{id}  -> one ticket
+POST /api/calls         -> plan + run a real CALL-E call (background)
+GET  /api/calls/{id}    -> call session + live status
+
+Run:  uvicorn app.main:app --reload
+"""
+import asyncio
+import json
+
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.orm import Session
+
+from . import netfix  # noqa: F401  (force IPv4 for Python networking)
+from . import calle_client, gemini_engine
+from .config import settings
+from .database import CallSession, SessionLocal, Ticket, get_db, init_db
+from .models import CallCreate, CallOut, IntakeRequest, IntakeResponse, TicketOut
+
+app = FastAPI(
+    title="CALL-E Hardware Support Intake Agent",
+    description="Voice AI agent for repair-shop tech support: takes calls, "
+    "logs tickets, schedules diagnostics via CALL-E + Gemini.",
+    version="0.1.0",
+)
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    init_db()
+
+
+# --- Helpers ----------------------------------------------------------------
+
+TERMINAL = {"completed", "done", "finished", "failed", "error", "cancelled", "canceled", "ended", "no_answer", "voicemail"}
+
+# Keep references to background call tasks so the event loop doesn't GC them.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _is_terminal(status: str | None) -> bool:
+    if not status:
+        return False
+    s = status.lower()
+    return s in TERMINAL or "fail" in s or "error" in s or "complete" in s
+
+
+async def _execute_call(session_id: int) -> None:
+    """Run a planned call to completion in the background and log a ticket."""
+    db = SessionLocal()
+    try:
+        session = db.get(CallSession, session_id)
+        if session is None:
+            return
+        session.status = "running"
+        db.commit()
+
+        run_info = await asyncio.to_thread(
+            calle_client.run_call, session.plan_id, session.confirm_token
+        )
+        run = calle_client.extract_run(run_info)
+        run_id = run["run_id"]
+        if run_id:
+            session.run_id = run_id
+            db.commit()
+
+        # Poll until the call reaches a terminal state.
+        elapsed = 0
+        while elapsed < settings.call_poll_timeout:
+            await asyncio.sleep(5)
+            elapsed += 5
+            try:
+                status_data = await asyncio.to_thread(
+                    calle_client.get_call_status, run_id
+                )
+                current = calle_client.extract_run(status_data)
+            except Exception:
+                continue
+            if current["status"]:
+                session.status = current["status"]
+            if current["summary"]:
+                session.summary = current["summary"]
+            if current["transcript"]:
+                session.transcript = current["transcript"]
+            if current["result"]:
+                session.structured_result = json.dumps(current["result"])
+            db.commit()
+            if _is_terminal(current["status"]):
+                break
+
+        # Feed whatever CALL-E returned into Gemini to log a ticket.
+        text = session.summary or session.transcript
+        if text:
+            try:
+                result = await asyncio.to_thread(gemini_engine.analyze_call, text)
+                if result.get("ticket") is not None:
+                    session.ticket_id = result["ticket"].id
+                db.commit()
+            except Exception:
+                # Logging the ticket must not break call tracking.
+                pass
+    except Exception as exc:
+        db.rollback()
+        session = db.get(CallSession, session_id)
+        if session is not None:
+            session.status = "failed"
+            session.error = str(exc)[:1000]
+            db.commit()
+    finally:
+        db.close()
+
+
+# --- Health -----------------------------------------------------------------
+
+@app.get("/health")
+async def health() -> dict:
+    try:
+        import subprocess
+
+        auth = await asyncio.to_thread(
+            lambda: subprocess.run(
+                calle_client.cli_command(["auth", "status"]),
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        )
+        usable = '"usable": true' in auth.stdout or '"status": "logged_in"' in auth.stdout
+        return {
+            "status": "ok",
+            "gemini_model": settings.gemini_model,
+            "calle_cli": usable,
+            "calle_raw": auth.stdout[:200],
+        }
+    except Exception as exc:
+        return {"status": "ok", "calle_cli": False, "calle_error": str(exc)}
+
+
+# --- Intake (Gemini tool calling) --------------------------------------------
+
+@app.post("/api/intake", response_model=IntakeResponse)
+async def intake(body: IntakeRequest, db: Session = Depends(get_db)) -> IntakeResponse:
+    if not body.transcript.strip():
+        raise HTTPException(status_code=400, detail="transcript is required")
+    result = await asyncio.to_thread(gemini_engine.analyze_call, body.transcript)
+    ticket = result.get("ticket")
+    return IntakeResponse(
+        ticket=TicketOut.model_validate(ticket) if ticket is not None else None,
+        actions=result.get("actions", []),
+        notes=result.get("notes", ""),
+    )
+
+
+# --- Tickets ------------------------------------------------------------------
+
+@app.get("/api/tickets", response_model=list[TicketOut])
+async def list_tickets(db: Session = Depends(get_db)) -> list[Ticket]:
+    return db.query(Ticket).order_by(Ticket.id.desc()).all()
+
+
+@app.get("/api/tickets/{ticket_id}", response_model=TicketOut)
+async def get_ticket(ticket_id: int, db: Session = Depends(get_db)) -> Ticket:
+    ticket = db.get(Ticket, ticket_id)
+    if ticket is None:
+        raise HTTPException(status_code=404, detail="ticket not found")
+    return ticket
+
+
+# --- Calls --------------------------------------------------------------------
+
+@app.post("/api/calls", response_model=CallOut, status_code=201)
+async def create_call(body: CallCreate, db: Session = Depends(get_db)) -> CallSession:
+    session = CallSession(phone=body.phone, goal=body.goal, status="created")
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    try:
+        plan_data = await asyncio.to_thread(calle_client.plan_call, body.phone, body.goal)
+    except calle_client.CalleError as exc:
+        session.status = "failed"
+        session.error = str(exc)
+        db.commit()
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    plan = calle_client.extract_plan(plan_data)
+    session.plan_id = plan["plan_id"]
+    session.confirm_token = plan["confirm_token"] or ""
+
+    if not plan["ready_to_run"]:
+        session.status = "plan_not_ready"
+        db.commit()
+        return session  # CALL-E needs clarification; check plan card / ask user
+
+    session.status = "planned"
+    db.commit()
+
+    # Fire the call in the background so the request returns immediately.
+    task = asyncio.create_task(_execute_call(session.id))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return session

--- a/apps/python/calle-hardware-intake/app/main.py
+++ b/apps/python/calle-hardware-intake/app/main.py
@@ -14,7 +14,7 @@ Run:  uvicorn app.main:app --reload
 import asyncio
 import json
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from . import netfix  # noqa: F401  (force IPv4 for Python networking)
@@ -44,6 +44,17 @@ TERMINAL = {"completed", "done", "finished", "failed", "error", "cancelled", "ca
 _background_tasks: set[asyncio.Task] = set()
 
 
+def require_api_key(x_api_key: str = Header(default="")) -> None:
+    """Gate live-call endpoints. Fails closed when no API key is configured."""
+    if not settings.api_key:
+        raise HTTPException(
+            status_code=503,
+            detail="Live-call API not configured: set API_KEY in .env",
+        )
+    if x_api_key != settings.api_key:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
 def _is_terminal(status: str | None) -> bool:
     if not status:
         return False
@@ -64,7 +75,7 @@ async def _execute_call(session_id: int) -> None:
         run_info = await asyncio.to_thread(
             calle_client.run_call, session.plan_id, session.confirm_token
         )
-        run = calle_client.extract_run(run_info)
+        current = run = calle_client.extract_run(run_info)
         run_id = run["run_id"]
         if run_id:
             session.run_id = run_id
@@ -94,9 +105,14 @@ async def _execute_call(session_id: int) -> None:
             if _is_terminal(current["status"]):
                 break
 
-        # Feed whatever CALL-E returned into Gemini to log a ticket.
+        # Log a ticket ONLY from a call that COMPLETED with a successful
+        # outcome. Voicemail / declined / failed calls must not auto-create
+        # tickets from incomplete provider output.
+        outcome = (current.get("outcome") or {})
+        task_completed = outcome.get("task_completed") is True
+        completed = "complete" in (current.get("status") or "").lower()
         text = session.summary or session.transcript
-        if text:
+        if text and completed and task_completed:
             try:
                 result = await asyncio.to_thread(gemini_engine.analyze_call, text)
                 if result.get("ticket") is not None:
@@ -174,13 +190,36 @@ async def get_ticket(ticket_id: int, db: Session = Depends(get_db)) -> Ticket:
 
 # --- Calls --------------------------------------------------------------------
 
-@app.post("/api/calls", response_model=CallOut, status_code=201)
+@app.post(
+    "/api/calls",
+    response_model=CallOut,
+    status_code=201,
+    dependencies=[Depends(require_api_key)],
+)
 async def create_call(body: CallCreate, db: Session = Depends(get_db)) -> CallSession:
-    session = CallSession(phone=body.phone, goal=body.goal, status="created")
+    # Idempotency: a client-supplied key returns the existing plan instead of
+    # creating a duplicate call on retries.
+    if body.idempotency_key:
+        existing = (
+            db.query(CallSession)
+            .filter_by(idempotency_key=body.idempotency_key)
+            .first()
+        )
+        if existing is not None:
+            return existing
+
+    session = CallSession(
+        phone=body.phone,
+        goal=body.goal,
+        idempotency_key=body.idempotency_key,
+        status="created",
+    )
     db.add(session)
     db.commit()
     db.refresh(session)
 
+    # Planning NEVER dials. Execution requires an explicit confirmation call to
+    # POST /api/calls/{id}/run.
     try:
         plan_data = await asyncio.to_thread(calle_client.plan_call, body.phone, body.goal)
     except calle_client.CalleError as exc:
@@ -194,14 +233,37 @@ async def create_call(body: CallCreate, db: Session = Depends(get_db)) -> CallSe
     session.confirm_token = plan["confirm_token"] or ""
 
     if not plan["ready_to_run"]:
-        session.status = "plan_not_ready"
-        db.commit()
-        return session  # CALL-E needs clarification; check plan card / ask user
+        session.status = "plan_not_ready"  # CALL-E needs clarification
+    else:
+        session.status = "planned"         # dialable, but not dialed yet
+    db.commit()
+    return session
+
+
+@app.post(
+    "/api/calls/{session_id}/run",
+    response_model=CallOut,
+    dependencies=[Depends(require_api_key)],
+)
+async def run_call_endpoint(session_id: int, db: Session = Depends(get_db)) -> CallSession:
+    """Explicit confirmation step: execute a previously planned call."""
+    session = db.get(CallSession, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="call session not found")
+    if not session.plan_id:
+        raise HTTPException(status_code=400, detail="no plan for this session")
+    if session.status == "running":
+        return session
+    if session.status in {"completed", "failed"}:
+        raise HTTPException(status_code=409, detail=f"session already {session.status}")
+    if session.status == "plan_not_ready":
+        raise HTTPException(
+            status_code=400,
+            detail="plan needs clarification and is not dialable",
+        )
 
     session.status = "planned"
     db.commit()
-
-    # Fire the call in the background so the request returns immediately.
     task = asyncio.create_task(_execute_call(session.id))
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)

--- a/apps/python/calle-hardware-intake/app/models.py
+++ b/apps/python/calle-hardware-intake/app/models.py
@@ -1,0 +1,58 @@
+"""Pydantic request/response schemas for the API."""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TicketCreate(BaseModel):
+    device_type: str
+    issue_description: str
+    priority: str = "normal"
+    customer_name: Optional[str] = None
+    status: str = "open"
+
+
+class TicketOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    ticket_number: str
+    device_type: Optional[str] = None
+    issue_description: Optional[str] = None
+    priority: Optional[str] = None
+    status: Optional[str] = None
+    customer_name: Optional[str] = None
+    scheduled_date: Optional[str] = None
+    scheduled_time: Optional[str] = None
+    created_at: datetime
+
+
+class CallCreate(BaseModel):
+    phone: str = Field(description="Destination number in E.164, e.g. +15551234567")
+    goal: str = Field(description="What the agent should accomplish on the call")
+
+
+class CallOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    run_id: Optional[str] = None
+    plan_id: Optional[str] = None
+    phone: str
+    goal: str
+    status: str
+    summary: Optional[str] = None
+    error: Optional[str] = None
+    ticket: Optional[TicketOut] = None
+    created_at: datetime
+
+
+class IntakeRequest(BaseModel):
+    transcript: str = Field(description="Raw call transcript / notes to analyze")
+
+
+class IntakeResponse(BaseModel):
+    ticket: Optional[TicketOut] = None
+    actions: list[str] = []
+    notes: str = ""

--- a/apps/python/calle-hardware-intake/app/models.py
+++ b/apps/python/calle-hardware-intake/app/models.py
@@ -29,8 +29,16 @@ class TicketOut(BaseModel):
 
 
 class CallCreate(BaseModel):
-    phone: str = Field(description="Destination number in E.164, e.g. +15551234567")
+    phone: str = Field(
+        pattern=r"^\+[1-9]\d{1,14}$",
+        description="Destination number in E.164, e.g. +15551234567",
+    )
     goal: str = Field(description="What the agent should accomplish on the call")
+    idempotency_key: Optional[str] = Field(
+        default=None,
+        description="Optional client-supplied key; reusing it returns the "
+        "existing plan instead of creating a duplicate call",
+    )
 
 
 class CallOut(BaseModel):

--- a/apps/python/calle-hardware-intake/app/netfix.py
+++ b/apps/python/calle-hardware-intake/app/netfix.py
@@ -1,0 +1,25 @@
+"""Force IPv4 for Python networking.
+
+This machine has a broken IPv6 route: ``socket.getaddrinfo`` returns the IPv6
+address first and connecting to it hangs, which makes httpx, urllib, and the
+google-genai SDK all time out. curl works because it falls back to IPv4.
+
+We patch ``socket.getaddrinfo`` so name resolution always returns IPv4
+addresses. Import this module before any outbound network call — the patch is
+process-global, so importing it once at app/script startup covers everything
+(including background threads).
+
+See memory: [[windows-python-ipv6-hang]].
+"""
+import socket
+
+_orig_getaddrinfo = socket.getaddrinfo
+
+
+def _force_ipv4(host, port, family=0, type=0, proto=0, flags=0):
+    if family == 0:  # AF_UNSPEC -> force IPv4
+        family = socket.AF_INET
+    return _orig_getaddrinfo(host, port, family, type, proto, flags)
+
+
+socket.getaddrinfo = _force_ipv4

--- a/apps/python/calle-hardware-intake/requirements.txt
+++ b/apps/python/calle-hardware-intake/requirements.txt
@@ -1,0 +1,9 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.28.0
+pydantic>=2.6.0
+pydantic-settings>=2.2.0
+python-dotenv>=1.0.1
+google-genai>=0.1.0
+requests>=2.31.0
+httpx>=0.27.0
+sqlalchemy>=2.0.28

--- a/apps/python/calle-hardware-intake/scripts/test_call.py
+++ b/apps/python/calle-hardware-intake/scripts/test_call.py
@@ -1,0 +1,81 @@
+"""Trigger a real outbound CALL-E call and log a ticket from the result.
+
+This makes an actual phone call (consumes a CALL-E credit). Usage:
+
+    python scripts/test_call.py +15551234567 "Confirm the 10am diagnostic slot"
+
+Options:
+    --dry-plan   Only plan the call; never dial. Good for verifying the CLI shape.
+
+Requirements: CALL-E logged in (`calle auth login`) and Gemini key in `.env`.
+"""
+import asyncio
+import json
+import sys
+import time
+
+sys.path.insert(0, ".")  # allow `import app.*`
+
+from app import calle_client, gemini_engine  # noqa: E402
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    dry_plan = "--dry-plan" in sys.argv
+    if len(args) < 2:
+        print(__doc__)
+        return 2
+    phone, goal = args[0], " ".join(args[1:])
+
+    print(f"== Planning call to {phone}: {goal}")
+    plan = calle_client.extract_plan(calle_client.plan_call(phone, goal))
+    print(json.dumps(plan, indent=2))
+
+    if dry_plan or not plan["ready_to_run"]:
+        print("(dry-plan or plan needs clarification — not dialing)")
+        return 0
+
+    print("== Running call (dialing — have the phone ready)...")
+    run = calle_client.extract_run(calle_client.run_call(plan["plan_id"], plan["confirm_token"]))
+    run_id = run["run_id"]
+    print(f"run_id: {run_id}, status: {run['status']}")
+    print("== run_call returns immediately; polling get_call_status every 5s...")
+
+    TERMINAL = ("complete", "fail", "error", "done", "ended", "no_answer", "voicemail")
+
+    def is_terminal(status):
+        return bool(status) and any(t in str(status).lower() for t in TERMINAL)
+
+    last = run
+    for i in range(96):  # ~8 minutes max
+        if is_terminal(last["status"]):
+            break
+        time.sleep(5)
+        try:
+            last = calle_client.extract_run(calle_client.get_call_status(run_id))
+        except calle_client.CalleError as exc:
+            print(f"  (poll {i}: {str(exc)[:120]})")  # transient — keep polling
+            continue
+        if i % 3 == 0:
+            print(f"  poll {i}: status={last['status']!r}")
+
+    print("== Final status:")
+    print(json.dumps(last, indent=2, default=str))
+
+    # Feed the whole conversation into Gemini -> structured ticket.
+    result = gemini_engine.analyze_call(
+        (last.get("transcript") or "") + "\n" + (last.get("summary") or "")
+    )
+    print("== Gemini analysis:")
+    print(f"actions: {result['actions']}")
+    print(f"notes: {result['notes']}")
+    if result["ticket"] is not None:
+        t = result["ticket"]
+        print(f"TICKET CREATED: {t.ticket_number} | {t.device_type} | {t.priority} | {t.issue_description}")
+    else:
+        print("(no ticket — the conversation may not have described a repair issue)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/calle-hardware-intake/scripts/test_call.py
+++ b/apps/python/calle-hardware-intake/scripts/test_call.py
@@ -19,6 +19,13 @@ sys.path.insert(0, ".")  # allow `import app.*`
 from app import calle_client, gemini_engine  # noqa: E402
 
 
+def _mask_phone(phone: str) -> str:
+    """Show only the country prefix + last 4 digits (e.g. +91******0746)."""
+    if len(phone) >= 7 and phone.startswith("+"):
+        return phone[:3] + "******" + phone[-4:]
+    return "<masked>"
+
+
 def main() -> int:
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
     dry_plan = "--dry-plan" in sys.argv
@@ -27,9 +34,12 @@ def main() -> int:
         return 2
     phone, goal = args[0], " ".join(args[1:])
 
-    print(f"== Planning call to {phone}: {goal}")
+    print(f"== Planning call to {_mask_phone(phone)}: {goal}")
     plan = calle_client.extract_plan(calle_client.plan_call(phone, goal))
-    print(json.dumps(plan, indent=2))
+    redacted = dict(plan)
+    if redacted.get("confirm_token"):
+        redacted["confirm_token"] = "********"  # never print the run token
+    print(json.dumps(redacted, indent=2))
 
     if dry_plan or not plan["ready_to_run"]:
         print("(dry-plan or plan needs clarification — not dialing)")

--- a/skills/calle-hardware-intake/SKILL.md
+++ b/skills/calle-hardware-intake/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: calle-hardware-intake
+description: Log hardware/tech-support repair tickets from phone calls via CALL-E + Gemini
+metadata:
+  type: agent-skill
+  call-e-integration: MCP
+---
+
+# CALL-E Hardware Support Intake
+
+A phone-call intake agent for repair shops: CALL-E places/receives calls, a
+FastAPI backend drives the call through `plan_call` → `run_call` →
+`get_call_run`, and Gemini parses the conversation to log structured repair
+tickets and schedule diagnostic slots into SQLite.
+
+## Requirements
+
+- `calle` CLI installed and authenticated (`calle auth login`)
+- Gemini API key in `.env` (`GEMINI_API_KEY`)
+- Python 3.10+, FastAPI, SQLAlchemy (see repo `requirements.txt`)
+
+## Install
+
+```bash
+uv venv .venv --python 3.11 && source .venv/Scripts/activate
+uv pip install -r requirements.txt
+cp .env.example .env   # add GEMINI_API_KEY
+```
+
+## Run
+
+```bash
+uvicorn app.main:app --reload
+```
+
+- `POST /api/calls` `{"phone": "+15551234567", "goal": "..."}` — plan + run a call
+- `GET  /api/calls/{id}` — live call status
+- `GET  /api/tickets` — logged tickets
+- `POST /api/intake` `{"transcript": "..."}` — parse a transcript into a ticket
+
+## Notes
+
+- CALL-E uses OAuth (not an API key): `calle auth login` once.
+- This repo forces IPv4 in Python because the dev machine's IPv6 route is broken
+  (`app/netfix.py`) — harmless elsewhere.
+- Tickets are stored in `calle_agent.db` (SQLite).

--- a/skills/calle-hardware-intake/references/call-e-integration.md
+++ b/skills/calle-hardware-intake/references/call-e-integration.md
@@ -1,0 +1,55 @@
+# CALL-E Integration Reference
+
+How this skill drives CALL-E to make real phone calls and parse the results.
+
+## Prerequisites
+
+- `calle` CLI installed: `npm install -g @call-e/cli`
+- Authenticated once via OAuth: `calle auth login` (opens a browser; there is
+  **no** CALL-E API key to paste).
+
+## Call lifecycle
+
+1. **Plan** — `calle call plan --to-phone +15551234567 --goal "<goal>"`
+   Returns `plan_id`, `confirm_token`, `ready_to_run`. Never dials. If
+   `ready_to_run` is `false`, CALL-E needs clarification (see
+   `clarifying_questions`) before it will dial.
+2. **Run** — `calle call run --plan-id <plan_id> --confirm-token <token>`
+   Returns immediately with `run_id` and status `PREPARING`. The bot is spun
+   up and the dial happens asynchronously.
+3. **Poll** — `calle call status --run-id <run_id>` every ~5-10s until the
+   status reaches a terminal value (e.g. `COMPLETED`). The payload includes the
+   full transcript, a summary, and a structured outcome.
+
+## CLI output shape
+
+`calle` wraps every result in an envelope:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "content": [{"type": "text", "text": "<json string>"}],
+    "structuredContent": { "...": "the real payload" }
+  }
+}
+```
+
+Use `structuredContent` when present, else parse `content[0].text`.
+`ok: false` means a logical failure even when the process exits 0.
+
+## MCP tools
+
+The CLI is a thin wrapper over CALL-E's MCP server
+(`https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth`). Tools available:
+`plan_call`, `run_call`, `get_call_run`, `track_ui_events`. The same
+plan → run → poll flow is available via `calle mcp call <tool> --args-json ...`.
+
+## Known gotchas
+
+- On Windows, `calle` is an npm `.cmd` shim. Python `subprocess` cannot launch
+  `.cmd` files via PATH — resolve the real path and run through `cmd /c`.
+- Calls spend one credit each and may reach voicemail; design the goal to
+  handle no-answer (CALL-E can leave a short voicemail).
+- Keep goal text explicit about what the agent should ask for and when to hang
+  up.

--- a/skills/calle-hardware-intake/references/examples.md
+++ b/skills/calle-hardware-intake/references/examples.md
@@ -1,0 +1,58 @@
+# Examples
+
+Fictional numbers only (`+15550101234` is a reserved fictional example).
+
+## Example 1 — repair intake (leads to a ticket)
+
+Goal:
+
+```
+Call the customer to intake a hardware repair request. Ask what device is
+having problems, what the issue is, and whether it is urgent. Let the customer
+describe the problem; do not schedule anything. Thank them and end the call.
+```
+
+Plausible transcript:
+
+```
+[00:00] BOT: Hi, I'm calling to collect details for a hardware repair request.
+[00:05] USER: Hi, my laptop won't turn on after a Windows update.
+[00:08] BOT: Which device is it, and how urgent is this?
+[00:11] USER: A Dell laptop. It's urgent — I work from home.
+[00:14] BOT: Thank you, I've noted that. Goodbye.
+```
+
+Result: Gemini calls `create_repair_ticket(device_type="laptop", ...)` and the
+backend logs a ticket.
+
+## Example 2 — appointment confirmation (no ticket)
+
+Goal:
+
+```
+Call and confirm tomorrow's 10:30am laptop diagnostic appointment. If they
+confirm, thank them and end the call. If nobody answers, leave a short
+voicemail.
+```
+
+Outcome: CALL-E returns a summary ("the appointment was confirmed") and Gemini
+correctly creates **no** ticket because no repair issue was described.
+
+## Example 3 — status check
+
+Goal:
+
+```
+Call and ask whether the customer has the ticket number for their in-progress
+repair, and check the current status.
+```
+
+`check_repair_status` is invoked when the caller references an existing ticket
+number or id.
+
+## No-call paths
+
+- `POST /api/intake {"transcript": "..."}` — parse any text into a ticket without
+  any phone call.
+- `python scripts/test_call.py +15550101234 "<goal>" --dry-plan` — plan only,
+  never dial.

--- a/skills/calle-hardware-intake/references/safety.md
+++ b/skills/calle-hardware-intake/references/safety.md
@@ -1,0 +1,64 @@
+# Safety Reference
+
+Phone calls are real-world side effects. `calle-hardware-intake` must preserve
+explicit user control over dialing and strict boundaries at runtime.
+
+## Explicit Intent
+
+Place a call only when the user explicitly asks to make a call. Planning a call
+(`calle call plan` / `--dry-plan`) is safe and never dials. Executing a call
+(`calle call run`) dials a real phone number and spends one CALL-E credit —
+require an explicit go-ahead first.
+
+The `POST /api/calls` endpoint and `scripts/test_call.py` (without `--dry-plan`)
+are live-dial paths. `/api/intake` and `/health` never place calls.
+
+## Phone Numbers
+
+Use E.164 numbers only (e.g. `+15551234567`). Do not guess country codes or
+reformat ambiguous numbers — ask the user.
+
+Mask phone numbers in any user-facing summary or log. A common mask shows the
+first two characters and last four digits, e.g. `+91******0746`. Full numbers
+may appear only where execution requires them.
+
+Documentation examples must use reserved fictional numbers, such as
+`+15550101234`.
+
+## Credentials
+
+Never expose:
+
+- API keys
+- OAuth tokens (CALL-E uses OAuth via `calle auth login`)
+- Gemini API keys
+- confirmation tokens
+- transcript or summary data that reveals private phone numbers
+
+The Gemini key lives in `.env`, which is gitignored. Never commit it. Do not
+ask users to paste credentials into chat or logs.
+
+## Consent
+
+Only call numbers the user explicitly provided and intends to be called. For
+third-party numbers, require the user to state that the recipient consents.
+
+## Recurring / Duplicate Jobs
+
+This app places one-off calls only; it creates no recurring schedules. If a
+recurring or batched variant is added later, it must list existing jobs before
+creating duplicates and expose a clear cancellation path.
+
+## Boundaries
+
+CALL-E governs live conversation behavior. Keep goals to legitimate business
+calls (appointments, intake, follow-ups). Do not use this skill for medical,
+legal, financial, or emergency content, or to attempt to bypass anyone's
+voicemail or do-not-call preferences. A no-answer is a normal outcome; the goal
+may allow a short voicemail but must not harass.
+
+## Rollback / Cancellation
+
+A planned call can be abandoned simply by not calling `run_call`. A running
+call cannot be unsent; the cost is one credit. If a plan needs clarification,
+`ready_to_run` is `false` and no dial happens until details are provided.


### PR DESCRIPTION

## Includes- **App** (`apps/python/calle-hardware-intake/`): FastAPI + `calle` CLI wrapper +
 Gemini tool-calling engine + SQLite. Dry-run path via `--dry-plan` /
 `/api/intake`; no-call by default; live dial is opt-in.
- **Skill** (`skills/calle-hardware-intake/`): `SKILL.md` with integration,
 safety, and examples references.

## Verified- `/api/intake` creates tickets + schedules slots via Gemini function calling.
- A real outbound CALL-E call completed end-to-end (dial → conversation →
 structured result + transcript).

## Notes- CALL-E uses OAuth (`calle auth login`), not an API key.
- Fictional phone numbers only in docs; no secrets committed.
