### PR TITLE
feat(apps): add wellness-checkin-call demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/broker-login-client-standalone`](apps/typescript/broker-login-client-standalone/) | TypeScript | CALL-E brokered login client without a shared package dependency. |
 | [`apps/python/oauth-login-client`](apps/python/oauth-login-client/) | Python | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`apps/typescript/oauth-login-client`](apps/typescript/oauth-login-client/) | TypeScript | CALL-E OAuth login client for MCP Streamable HTTP. |
+| [`apps/typescript/wellness-checkin-call`](apps/typescript/wellness-checkin-call/) | TypeScript | Consent-gated wellness check-in call for an elderly or at-risk person, with ok/mild_concern/escalate classification and a masked, no-call preview by default. |
 
 The default e2e tests use a local fake broker/OAuth/MCP server or dry-run paths, so they do not require real CALL-E credentials or browser login. Live verification is opt-in in each app README.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -19,6 +19,7 @@ Current apps:
 | [`typescript/broker-login-client-standalone`](typescript/broker-login-client-standalone/) | TypeScript | CALL-E brokered login client without a shared package dependency. |
 | [`python/oauth-login-client`](python/oauth-login-client/) | Python | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`typescript/oauth-login-client`](typescript/oauth-login-client/) | TypeScript | CALL-E OAuth login client for MCP Streamable HTTP. |
+| [`typescript/wellness-checkin-call`](typescript/wellness-checkin-call/) | TypeScript | Consent-gated wellness check-in call for an elderly or at-risk person, with ok/mild_concern/escalate classification and a masked, no-call preview by default. |
 
 Suggested grouping:
 

--- a/apps/typescript/wellness-checkin-call/README.md
+++ b/apps/typescript/wellness-checkin-call/README.md
@@ -1,0 +1,88 @@
+# Wellness Check-in Call
+
+This focused TypeScript app uses the CALL-E server SDK to place a short, consent-gated wellness check-in call to an elderly or at-risk person, ask three simple questions about how they're doing, and classify the answer as `ok`, `mild_concern`, or `escalate` for a caregiver.
+
+The default mode is a masked preview. It does not contact CALL-E or place a call. Live mode requires the request file to record opt-in from the recipient or whoever manages their care, a separate `--confirm-recipient-opt-in` flag, and a server-side API key.
+
+**This is not a medical device.** The call script and this app never give medical advice or a diagnosis — it's a check-in and a classifier, nothing more.
+
+This is a distilled, English-only reference version of a fuller bilingual (English/Japanese) app with a family dashboard, call history, and email notifications. See [Mimamori-Call](https://github.com/atsushiyago/anpi) (source) and the [live demo](https://call-e-anpi.vercel.app) for the complete version.
+
+## Why this workflow
+
+Checking in on someone who lives alone by phone, every day, does not scale for a family or a small care team. This app converts one consented wellness call into a compact, structured result:
+
+- whether the person answered at all;
+- a one-line summary of how they said they're feeling;
+- whether they're eating properly; and
+- whether they reported a concern or a need.
+
+It does not diagnose, prescribe, dispatch emergency services, or contact anyone on the recipient's behalf — it only classifies and reports.
+
+## Setup
+
+Node.js 20 or later:
+
+```bash
+cd apps/typescript/wellness-checkin-call
+npm install
+```
+
+## Preview without a call
+
+Preview is the default and does not need credentials:
+
+```bash
+npm run preview
+```
+
+This prints the masked call plan for [`examples/recipient.example.json`](examples/recipient.example.json), which uses a fictional reserved phone number. Copy that file and replace the number with an E.164 number you own or are authorized to call before running live.
+
+## Run one live call
+
+API keys are server credentials. Keep them in a secret manager or environment variable, never in request files or source control.
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+export CALLE_BASE_URL="https://api.heycall-e.com"
+
+npm run checkin -- --request your-authorized-request.json --execute --confirm-recipient-opt-in --output result.json
+```
+
+Live mode creates exactly one CALL-E call task and waits for its terminal result. A stable `wellness-checkin:<workflow_id>` idempotency key prevents a retry from creating a second call for the same recipient.
+
+## Input contract
+
+The request JSON must contain:
+
+- `workflow_id`: a stable, non-secret identifier for this recipient (not a real name);
+- `phone`: one E.164 phone number; and
+- `recipient_or_caregiver_opted_in`: literal `true` — this app refuses to run without it.
+
+Do not put names, addresses, health history, or other sensitive information in this file. The recipient's name is intentionally not part of the request; the call script never uses one.
+
+## Side effects and safety
+
+- A live run places a real outbound phone call. Use it only after the intended recipient (or whoever manages their care) has explicitly agreed to receive these calls.
+- The call always ends after the third question with a brief, polite close.
+- Phone numbers are masked everywhere this app prints or writes output.
+- The app creates no recurring schedule and checks in on one recipient per run — repeat scheduling is a host/scheduler concern, not this app's.
+- The `ok` / `mild_concern` / `escalate` split is a coarse heuristic over CALL-E's structured result, not a clinical judgment. It only decides how quickly a caregiver should be notified, never what's medically wrong.
+- Not for medical, legal, financial, or emergency use. If the situation is an emergency, contact local emergency services directly — this app does not.
+
+## Cancellation and rollback
+
+Preview mode has no side effect and needs no rollback. Before live execution, stop by omitting `--execute` or `--confirm-recipient-opt-in`. After the provider accepts a live call task, this app cannot guarantee cancellation; use the CALL-E dashboard or provider controls if they expose a cancel action. This app creates no future jobs to remove.
+
+## Validation
+
+Default tests use an injected fake CALL-E client (see [`fake/calle-server.ts`](fake/calle-server.ts)) and never place a phone call:
+
+```bash
+npm run check
+npm test
+npm run demo
+python3 ../../../scripts/validate_repository.py
+```
+
+For opt-in live verification, use a phone you own or are authorized to call, retain only the redacted result, and do not commit the request or result file.

--- a/apps/typescript/wellness-checkin-call/demo/run-local.ts
+++ b/apps/typescript/wellness-checkin-call/demo/run-local.ts
@@ -1,0 +1,67 @@
+/**
+ * Runs three check-ins against a local fake CALL-E, with no credentials and
+ * no phone line: an "ok" result, a "mild_concern" result, and an "escalate"
+ * result from a no-answer.
+ *
+ *   npm run demo
+ */
+import { createSdkPort } from "../src/calle.js";
+import { runCheckin } from "../src/checkin.js";
+import { startFakeCalle, type FakeScript } from "../fake/calle-server.js";
+
+const PHONE = "+12025550142";
+
+function heading(title: string): void {
+  process.stdout.write(`\n${title}\n${"-".repeat(title.length)}\n`);
+}
+
+async function runOne(script: FakeScript) {
+  const fake = await startFakeCalle([script]);
+  const port = await createSdkPort({ apiKey: "calle_demo_key", baseUrl: fake.baseUrl });
+  const report = await runCheckin({
+    request: { workflow_id: "demo", phone: PHONE, recipient_or_caregiver_opted_in: true },
+    port,
+    pollIntervalMs: 5,
+    onProgress: (line) => process.stdout.write(`  ${line}\n`),
+  });
+  await fake.close();
+  return report;
+}
+
+async function main(): Promise<void> {
+  heading("1. Everything is fine");
+  const ok = await runOne({
+    phone: PHONE,
+    structuredResult: {
+      answered: true,
+      condition_summary: "feeling good today",
+      meal_status: "good",
+      concerns_reported: false,
+    },
+  });
+  process.stdout.write(`  level: ${ok.level}\n  reasons: ${ok.reasons.join("; ")}\n`);
+
+  heading("2. A reported concern, on its own");
+  const mild = await runOne({
+    phone: PHONE,
+    structuredResult: {
+      answered: true,
+      condition_summary: "feeling fine",
+      meal_status: "good",
+      concerns_reported: true,
+      concerns_detail: "the porch light bulb burned out",
+    },
+  });
+  process.stdout.write(`  level: ${mild.level}\n  reasons: ${mild.reasons.join("; ")}\n`);
+
+  heading("3. No answer at all");
+  const escalate = await runOne({
+    phone: PHONE,
+    structuredResult: { answered: false },
+  });
+  process.stdout.write(`  level: ${escalate.level}\n  reasons: ${escalate.reasons.join("; ")}\n`);
+
+  process.stdout.write("\nNo real call was placed in any of these three runs.\n");
+}
+
+await main();

--- a/apps/typescript/wellness-checkin-call/examples/recipient.example.json
+++ b/apps/typescript/wellness-checkin-call/examples/recipient.example.json
@@ -1,0 +1,5 @@
+{
+  "workflow_id": "wellness-demo-2026-001",
+  "phone": "+12025550142",
+  "recipient_or_caregiver_opted_in": true
+}

--- a/apps/typescript/wellness-checkin-call/fake/calle-server.ts
+++ b/apps/typescript/wellness-checkin-call/fake/calle-server.ts
@@ -1,0 +1,151 @@
+/**
+ * Local stand-in for the CALL-E Developer API. Speaks the documented wire
+ * contract for create/get, so tests and the demo drive the real
+ * `@call-e/calle` client against it with no credentials and no phone line.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface FakeScript {
+  phone: string;
+  status?: "completed" | "failed" | "canceled";
+  structuredResult?: Record<string, unknown> | null;
+  summary?: string | null;
+  failureCode?: string | null;
+}
+
+export interface CreatedCall {
+  id: string;
+  idempotencyKey: string | null;
+  phone: string;
+}
+
+export interface FakeCalle {
+  baseUrl: string;
+  created: CreatedCall[];
+  close: () => Promise<void>;
+}
+
+interface StoredCall {
+  id: string;
+  phone: string;
+  script: FakeScript;
+  polls: number;
+}
+
+function envelope(code: string, message: string): string {
+  return JSON.stringify({ error: { code, message } });
+}
+
+function snapshot(call: StoredCall, terminal: boolean): string {
+  const script = call.script;
+  const status = terminal ? script.status ?? "completed" : call.polls === 0 ? "queued" : "in_progress";
+  const structuredResult = terminal ? script.structuredResult ?? null : null;
+  return JSON.stringify({
+    id: call.id,
+    object: "call_task",
+    status,
+    task: "wellness check-in",
+    recipients: [
+      {
+        id: `rcp_${call.id.slice(5)}`,
+        phones: [call.phone],
+        locale: "en-US",
+        region: "US",
+        status,
+        structured_result: structuredResult,
+        summary: terminal ? script.summary ?? "Call finished." : null,
+        attempts: [],
+      },
+    ],
+    structured_result: structuredResult,
+    summary: terminal ? script.summary ?? "Call finished." : null,
+    task_completed: terminal ? true : null,
+    completion_confidence: null,
+    evidence: [],
+    metadata: {},
+    failure_code: terminal ? script.failureCode ?? null : null,
+    failure_message: null,
+    created_at: "2026-08-04T17:01:50Z",
+    completed_at: terminal ? "2026-08-04T17:03:40Z" : null,
+  });
+}
+
+export async function startFakeCalle(scripts: FakeScript[]): Promise<FakeCalle> {
+  const created: CreatedCall[] = [];
+  const calls = new Map<string, StoredCall>();
+  const idempotency = new Map<string, string>();
+  let counter = 0;
+
+  const server: Server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("content-type", "application/json");
+
+      if (!(request.headers.authorization ?? "").startsWith("Bearer ")) {
+        response.statusCode = 401;
+        response.end(envelope("unauthorized", "Invalid or missing API key."));
+        return;
+      }
+
+      if (request.method === "POST" && url.pathname === "/v1/calls") {
+        const body = JSON.parse(raw) as {
+          recipients?: { phones?: string[] }[];
+        };
+        const phone = body.recipients?.[0]?.phones?.[0] ?? "";
+        const script = scripts.find((candidate) => candidate.phone === phone);
+        if (script === undefined) {
+          response.statusCode = 400;
+          response.end(envelope("invalid_recipient", `No fake script for this phone number.`));
+          return;
+        }
+
+        const key = (request.headers["idempotency-key"] as string | undefined) ?? null;
+        if (key !== null && idempotency.has(key)) {
+          response.statusCode = 201;
+          response.end(snapshot(calls.get(idempotency.get(key)!)!, false));
+          return;
+        }
+
+        counter += 1;
+        const id = `call_fake${counter}`;
+        const stored: StoredCall = { id, phone, script, polls: 0 };
+        calls.set(id, stored);
+        if (key !== null) idempotency.set(key, id);
+        created.push({ id, idempotencyKey: key, phone });
+
+        response.statusCode = 201;
+        response.end(snapshot(stored, false));
+        return;
+      }
+
+      const single = /^\/v1\/calls\/([^/]+)$/.exec(url.pathname);
+      if (request.method === "GET" && single !== null) {
+        const call = calls.get(single[1]!);
+        if (call === undefined) {
+          response.statusCode = 404;
+          response.end(envelope("not_found", "Unknown call."));
+          return;
+        }
+        call.polls += 1;
+        response.statusCode = 200;
+        response.end(snapshot(call, true));
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end(envelope("not_found", "Unknown route."));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    created,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  };
+}

--- a/apps/typescript/wellness-checkin-call/package-lock.json
+++ b/apps/typescript/wellness-checkin-call/package-lock.json
@@ -1,0 +1,595 @@
+{
+  "name": "calle-wellness-checkin-call",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calle-wellness-checkin-call",
+      "version": "0.1.0",
+      "dependencies": {
+        "@call-e/calle": "^0.6.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.8.0"
+      }
+    },
+    "node_modules/@call-e/calle": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@call-e/calle/-/calle-0.6.0.tgz",
+      "integrity": "sha512-B1Rsj8NAYbhEh4fC05hBEiVn8xxcnfsjeSc9AvcIkyiaG/b8JqYvbiUrK/saYOzy5x+hHAV7TFSQQZNwqWtNow==",
+      "dependencies": {
+        "openapi-fetch": "^0.14.0"
+      },
+      "bin": {
+        "calle": "dist/cli.js"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/typescript/wellness-checkin-call/package.json
+++ b/apps/typescript/wellness-checkin-call/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "calle-wellness-checkin-call",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Three-question wellness check-in call for an elderly or at-risk person, with ok/mild_concern/escalate classification and a masked, consent-gated preview by default.",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "demo": "node --import tsx demo/run-local.ts",
+    "checkin": "node --import tsx src/cli.ts",
+    "preview": "node --import tsx src/cli.ts --request examples/recipient.example.json"
+  },
+  "dependencies": {
+    "@call-e/calle": "^0.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/typescript/wellness-checkin-call/src/calle.ts
+++ b/apps/typescript/wellness-checkin-call/src/calle.ts
@@ -1,0 +1,77 @@
+/**
+ * CALL-E access, ported behind a small interface so tests can point the real
+ * SDK client at a local fake server. The SDK is imported lazily so preview
+ * mode and the demo run with nothing installed beyond dev dependencies.
+ *
+ * The API key goes out on every request, so the base URL is checked before
+ * the client is built: it has to be CALL-E itself or loopback (for the fake
+ * server). Nothing else gets the credential.
+ */
+import type { CallSnapshot } from "./types.js";
+
+export interface CreateCallInput {
+  task: string;
+  phone: string;
+  resultSchema: Record<string, unknown>;
+  metadata: Record<string, string>;
+}
+
+export interface CallePort {
+  createCall(input: CreateCallInput, idempotencyKey: string): Promise<CallSnapshot>;
+  waitForResult(callId: string, options: { timeoutMs: number; intervalMs: number }): Promise<CallSnapshot>;
+}
+
+export class ConfigErrorBaseUrl extends Error {}
+
+export const DEFAULT_BASE_URL = "https://api.heycall-e.com";
+const CALLE_HOSTS = ["api.heycall-e.com"];
+const LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "::1"];
+
+function hostOf(url: URL): string {
+  return url.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+}
+
+/** Refuses to send the API key anywhere it should not go. */
+export function assertTrustedBaseUrl(baseUrl: string): void {
+  const advice = "Set CALLE_BASE_URL to https://api.heycall-e.com. Plain http is allowed only on loopback, for the local fake server.";
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new ConfigErrorBaseUrl(`CALL-E base URL ${baseUrl} is not a URL, so the API key was not sent. ${advice}`);
+  }
+  const host = hostOf(url);
+  const trusted = new Set([...CALLE_HOSTS, ...LOOPBACK_HOSTS]);
+  if (!trusted.has(host)) {
+    throw new ConfigErrorBaseUrl(`CALL-E base URL ${baseUrl} is not a host this app trusts. ${advice}`);
+  }
+  if (url.protocol === "https:") return;
+  if (url.protocol === "http:" && LOOPBACK_HOSTS.includes(host)) return;
+  throw new ConfigErrorBaseUrl(`CALL-E base URL ${baseUrl} does not use https. ${advice}`);
+}
+
+export async function createSdkPort(options: { apiKey: string; baseUrl?: string }): Promise<CallePort> {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  assertTrustedBaseUrl(baseUrl);
+  const { CalleClient } = await import("@call-e/calle");
+  const client = new CalleClient({ apiKey: options.apiKey, baseUrl });
+
+  return {
+    async createCall(input, idempotencyKey) {
+      const call = await client.calls.create(
+        {
+          task: input.task,
+          recipient: { phone: input.phone, locale: "en-US", region: "US" },
+          resultSchema: input.resultSchema,
+          metadata: input.metadata,
+        },
+        { idempotencyKey }
+      );
+      return call as unknown as CallSnapshot;
+    },
+    async waitForResult(callId, waitOptions) {
+      const call = await client.calls.waitForResult(callId, waitOptions);
+      return call as unknown as CallSnapshot;
+    },
+  };
+}

--- a/apps/typescript/wellness-checkin-call/src/checkin.ts
+++ b/apps/typescript/wellness-checkin-call/src/checkin.ts
@@ -1,0 +1,68 @@
+import { classifyWellnessResult } from "./classify.js";
+import { maskPhone } from "./mask.js";
+import { WELLNESS_RESULT_SCHEMA, WELLNESS_TASK } from "./script.js";
+import type { CallePort } from "./calle.js";
+import type { WellnessReport, WellnessRequest } from "./types.js";
+
+export interface PreviewPlan {
+  workflow_id: string;
+  masked_phone: string;
+  task: string;
+  idempotency_key: string;
+}
+
+/** No network call. Safe to run with no credentials, any number of times. */
+export function previewCheckin(request: WellnessRequest): PreviewPlan {
+  return {
+    workflow_id: request.workflow_id,
+    masked_phone: maskPhone(request.phone),
+    task: WELLNESS_TASK,
+    idempotency_key: idempotencyKeyFor(request.workflow_id),
+  };
+}
+
+/**
+ * A stable key per workflow_id, so a retried run reconciles with the
+ * in-flight or completed call instead of dialing a second time.
+ */
+export function idempotencyKeyFor(workflowId: string): string {
+  return `wellness-checkin:${workflowId}`;
+}
+
+export interface RunCheckinOptions {
+  request: WellnessRequest;
+  port: CallePort;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onProgress?: (line: string) => void;
+}
+
+/** Places exactly one call and returns its classified result. */
+export async function runCheckin(options: RunCheckinOptions): Promise<WellnessReport> {
+  const { request, port, pollIntervalMs = 3000, timeoutMs = 10 * 60 * 1000, onProgress } = options;
+  const maskedPhone = maskPhone(request.phone);
+
+  onProgress?.(`placing call to ${maskedPhone}`);
+  const created = await port.createCall(
+    {
+      task: WELLNESS_TASK,
+      phone: request.phone,
+      resultSchema: WELLNESS_RESULT_SCHEMA as unknown as Record<string, unknown>,
+      metadata: { workflow_id: request.workflow_id },
+    },
+    idempotencyKeyFor(request.workflow_id)
+  );
+
+  onProgress?.(`waiting for call ${created.id} to finish`);
+  const finished = await port.waitForResult(created.id, { timeoutMs, intervalMs: pollIntervalMs });
+
+  const { level, reasons } = classifyWellnessResult(finished.structuredResult);
+
+  return {
+    call_id: finished.id,
+    level,
+    reasons,
+    summary: finished.summary,
+    masked_phone: maskedPhone,
+  };
+}

--- a/apps/typescript/wellness-checkin-call/src/classify.ts
+++ b/apps/typescript/wellness-checkin-call/src/classify.ts
@@ -1,0 +1,85 @@
+import type { ClassificationResult, WellnessStructuredResult } from "./types.js";
+
+/**
+ * Keywords in `condition_summary` that suggest the person's condition is
+ * concerning enough to combine with a reported concern and escalate. A coarse
+ * heuristic, not a medical judgment — it only decides how quickly a caregiver
+ * should be notified, never what's medically wrong.
+ */
+const CONCERNING_CONDITION_KEYWORDS = [
+  "pain",
+  "hurts",
+  "hurting",
+  "can't move",
+  "cannot move",
+  "dizzy",
+  "dizziness",
+  "fever",
+  "feverish",
+  "nauseous",
+  "nausea",
+  "unwell",
+  "not well",
+  "not feeling well",
+  "collapsed",
+  "exhausted",
+];
+
+function conditionSoundsConcerning(summary: string | undefined): boolean {
+  if (!summary) return false;
+  const lower = summary.toLowerCase();
+  return CONCERNING_CONDITION_KEYWORDS.some((keyword) => lower.includes(keyword));
+}
+
+/**
+ * Classifies a completed call's structured result into `ok`, `mild_concern`,
+ * or `escalate`.
+ *
+ * Rule: escalate when there's a reported concern *combined with* a concerning
+ * condition or meal status, or when the person didn't answer at all. A
+ * concern or a condition issue alone is a mild concern, not an escalation.
+ */
+export function classifyWellnessResult(
+  result: Record<string, unknown> | null
+): ClassificationResult {
+  if (!result) {
+    return {
+      level: "escalate",
+      reasons: ["No structured result was returned (the call may have failed)."],
+    };
+  }
+
+  const r = result as unknown as WellnessStructuredResult;
+
+  if (r.answered === false) {
+    return { level: "escalate", reasons: ["No answer to the call."] };
+  }
+
+  const reasons: string[] = [];
+  const hasConcern = r.concerns_reported === true;
+  const mealConcerning = r.meal_status === "somewhat_concerning";
+  const conditionConcerning = conditionSoundsConcerning(r.condition_summary);
+
+  if (hasConcern) {
+    reasons.push(`Reported a concern: ${r.concerns_detail ?? "(no detail given)"}`);
+  }
+  if (mealConcerning) {
+    reasons.push("Possible concern with meals.");
+  }
+  if (conditionConcerning) {
+    reasons.push(`Statement suggesting a health concern: "${r.condition_summary}"`);
+  }
+
+  const conditionOrMealConcerning = mealConcerning || conditionConcerning;
+
+  if (hasConcern && conditionOrMealConcerning) {
+    return { level: "escalate", reasons };
+  }
+  if (hasConcern || conditionOrMealConcerning) {
+    return { level: "mild_concern", reasons };
+  }
+  return {
+    level: "ok",
+    reasons: ["Condition, meals, and concerns were all reported as fine."],
+  };
+}

--- a/apps/typescript/wellness-checkin-call/src/cli.ts
+++ b/apps/typescript/wellness-checkin-call/src/cli.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Preview or place one wellness check-in call.
+ *
+ *   node --import tsx src/cli.ts --request examples/recipient.example.json
+ *   node --import tsx src/cli.ts --request my-request.json --execute --confirm-recipient-opt-in
+ */
+import { writeFileSync } from "node:fs";
+import { ConfigError, loadRequest } from "./config.js";
+import { createSdkPort, DEFAULT_BASE_URL } from "./calle.js";
+import { previewCheckin, runCheckin } from "./checkin.js";
+
+interface Args {
+  request: string;
+  execute: boolean;
+  confirmOptIn: boolean;
+  output: string | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { request: "", execute: false, confirmOptIn: false, output: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--request") args.request = argv[++i] ?? "";
+    else if (arg === "--execute") args.execute = true;
+    else if (arg === "--confirm-recipient-opt-in") args.confirmOptIn = true;
+    else if (arg === "--output") args.output = argv[++i] ?? null;
+  }
+  if (!args.request) {
+    throw new ConfigError("--request <path> is required.");
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const request = loadRequest(args.request);
+
+  if (!args.execute) {
+    const plan = previewCheckin(request);
+    process.stdout.write("Preview only — no call was placed.\n\n");
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    process.stdout.write("\nAdd --execute --confirm-recipient-opt-in to place a real call.\n");
+    return;
+  }
+
+  if (!args.confirmOptIn) {
+    throw new ConfigError(
+      "--execute requires --confirm-recipient-opt-in — this app will not place a live call otherwise."
+    );
+  }
+
+  const apiKey = process.env.CALLE_API_KEY;
+  if (!apiKey) {
+    throw new ConfigError("Set CALLE_API_KEY to place a live call.");
+  }
+
+  const port = await createSdkPort({ apiKey, baseUrl: process.env.CALLE_BASE_URL ?? DEFAULT_BASE_URL });
+  const report = await runCheckin({
+    request,
+    port,
+    onProgress: (line) => process.stderr.write(`${line}\n`),
+  });
+
+  const json = JSON.stringify(report, null, 2);
+  process.stdout.write(`${json}\n`);
+  if (args.output) {
+    writeFileSync(args.output, json, { mode: 0o600 });
+    process.stderr.write(`\nReport written to ${args.output} with mode 0600\n`);
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/apps/typescript/wellness-checkin-call/src/config.ts
+++ b/apps/typescript/wellness-checkin-call/src/config.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import type { WellnessRequest } from "./types.js";
+
+export class ConfigError extends Error {}
+
+const E164 = /^\+[1-9]\d{6,14}$/;
+
+export function parseRequest(value: unknown): WellnessRequest {
+  if (typeof value !== "object" || value === null) {
+    throw new ConfigError("Request must be a JSON object.");
+  }
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.workflow_id !== "string" || v.workflow_id.trim() === "") {
+    throw new ConfigError("workflow_id is required and must be a non-empty string.");
+  }
+  if (typeof v.phone !== "string" || !E164.test(v.phone)) {
+    throw new ConfigError("phone is required and must be E.164, e.g. +12025550123.");
+  }
+  if (v.recipient_or_caregiver_opted_in !== true) {
+    throw new ConfigError(
+      "recipient_or_caregiver_opted_in must be literal `true` — this app refuses to run without recorded consent."
+    );
+  }
+
+  return {
+    workflow_id: v.workflow_id,
+    phone: v.phone,
+    recipient_or_caregiver_opted_in: true,
+  };
+}
+
+export function loadRequest(path: string): WellnessRequest {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    throw new ConfigError(`Could not read request file at ${path}: ${(error as Error).message}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new ConfigError(`Request file at ${path} is not valid JSON: ${(error as Error).message}`);
+  }
+  return parseRequest(parsed);
+}

--- a/apps/typescript/wellness-checkin-call/src/mask.ts
+++ b/apps/typescript/wellness-checkin-call/src/mask.ts
@@ -1,0 +1,8 @@
+/** Keeps the country code and last two digits, masks the rest. Never log the full number. */
+export function maskPhone(phone: string): string {
+  const digits = phone.replace(/[^\d+]/g, "");
+  if (digits.length < 6) return "***";
+  const country = digits.slice(0, digits.length > 11 ? 3 : 2);
+  const last = digits.slice(-2);
+  return `${country}${"*".repeat(digits.length - country.length - 2)}${last}`;
+}

--- a/apps/typescript/wellness-checkin-call/src/script.ts
+++ b/apps/typescript/wellness-checkin-call/src/script.ts
@@ -1,0 +1,42 @@
+/**
+ * The three-question wellness check-in script and the structured result CALL-E
+ * should return. Refined against real calls (see the linked full app in the
+ * README) to always move forward rather than loop on an ambiguous or negative
+ * answer.
+ */
+
+export const WELLNESS_TASK =
+  "This is a wellness check-in call. " +
+  "Ask the following 3 questions, in this order, slowly and in a clear, friendly tone. " +
+  '1. "How are you feeling today?" ' +
+  '2. "Have you been eating properly?" ' +
+  '3. "Is there anything you\'re worried about, or anything you need?" ' +
+  "For each question, once you get an answer (whether it's good or bad), move on to the next question. " +
+  "Do not repeat the same question or leave long silences. " +
+  "Once the third question is answered, say a brief kind word, wrap up the conversation politely, and end the call. " +
+  "Never give medical advice or a diagnosis, under any circumstances.";
+
+export const WELLNESS_RESULT_SCHEMA = {
+  type: "object",
+  required: ["answered", "condition_summary", "meal_status", "concerns_reported"],
+  properties: {
+    answered: { type: "boolean", description: "Whether the person answered the call." },
+    condition_summary: {
+      type: "string",
+      description: "One-line summary of their answer about how they're feeling.",
+    },
+    meal_status: {
+      type: "string",
+      enum: ["good", "somewhat_concerning", "unknown"],
+      description: "Rough assessment of whether they're eating properly.",
+    },
+    concerns_reported: {
+      type: "boolean",
+      description: "Whether they reported any concern or thing they need.",
+    },
+    concerns_detail: {
+      type: "string",
+      description: "Details of the reported concern, if any.",
+    },
+  },
+} as const;

--- a/apps/typescript/wellness-checkin-call/src/types.ts
+++ b/apps/typescript/wellness-checkin-call/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * The subset of CALL-E's call-task shape this app reads. Kept narrow on purpose
+ * so the fake server only has to speak the fields this app actually uses.
+ */
+/** Matches the JS shape the `@call-e/calle` SDK returns (camelCase), not the wire JSON. */
+export interface CallSnapshot {
+  id: string;
+  status: "queued" | "in_progress" | "completed" | "failed" | "canceled";
+  structuredResult: Record<string, unknown> | null;
+  summary: string | null;
+  failureCode: string | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+export type WellnessLevel = "ok" | "mild_concern" | "escalate";
+
+export interface WellnessStructuredResult {
+  answered: boolean;
+  condition_summary?: string;
+  meal_status?: "good" | "somewhat_concerning" | "unknown";
+  concerns_reported?: boolean;
+  concerns_detail?: string;
+}
+
+export interface ClassificationResult {
+  level: WellnessLevel;
+  reasons: string[];
+}
+
+export interface WellnessRequest {
+  /** A stable, non-secret identifier for this recipient. Not a real name. */
+  workflow_id: string;
+  /** E.164 phone number. Use a fictional reserved number for examples. */
+  phone: string;
+  /** True only when the recipient (or whoever manages their care) asked for this call to be set up. */
+  recipient_or_caregiver_opted_in: true;
+}
+
+export interface WellnessReport {
+  call_id: string | null;
+  level: WellnessLevel;
+  reasons: string[];
+  summary: string | null;
+  masked_phone: string;
+}

--- a/apps/typescript/wellness-checkin-call/test/checkin.e2e.test.ts
+++ b/apps/typescript/wellness-checkin-call/test/checkin.e2e.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertTrustedBaseUrl, ConfigErrorBaseUrl, createSdkPort } from "../src/calle.js";
+import { previewCheckin, runCheckin } from "../src/checkin.js";
+import { ConfigError, parseRequest } from "../src/config.js";
+import { startFakeCalle } from "../fake/calle-server.js";
+
+const PHONE = "+12025550142";
+const REQUEST = { workflow_id: "test-run", phone: PHONE, recipient_or_caregiver_opted_in: true as const };
+
+test("preview never contacts a network and masks the phone number", () => {
+  const plan = previewCheckin(REQUEST);
+  assert.equal(plan.masked_phone.includes("550142"), false);
+  assert.match(plan.masked_phone, /\*/);
+});
+
+test("a completed call is classified and returned", async (t) => {
+  const fake = await startFakeCalle([
+    {
+      phone: PHONE,
+      structuredResult: {
+        answered: true,
+        condition_summary: "feeling good",
+        meal_status: "good",
+        concerns_reported: false,
+      },
+    },
+  ]);
+  t.after(() => fake.close());
+  const port = await createSdkPort({ apiKey: "calle_demo_key", baseUrl: fake.baseUrl });
+  const report = await runCheckin({ request: REQUEST, port, pollIntervalMs: 5 });
+
+  assert.equal(report.level, "ok");
+  assert.equal(fake.created.length, 1);
+  assert.equal(report.masked_phone.includes("550142"), false);
+});
+
+test("the same workflow_id reuses the call instead of dialing twice", async (t) => {
+  const fake = await startFakeCalle([{ phone: PHONE, structuredResult: { answered: true } }]);
+  t.after(() => fake.close());
+  const port = await createSdkPort({ apiKey: "calle_demo_key", baseUrl: fake.baseUrl });
+
+  await runCheckin({ request: REQUEST, port, pollIntervalMs: 5 });
+  await runCheckin({ request: REQUEST, port, pollIntervalMs: 5 });
+
+  assert.equal(fake.created.length, 1);
+});
+
+test("a request missing recorded opt-in is rejected before any call is placed", () => {
+  assert.throws(
+    () =>
+      parseRequest({
+        workflow_id: "no-consent",
+        phone: PHONE,
+        recipient_or_caregiver_opted_in: false,
+      }),
+    ConfigError
+  );
+});
+
+test("an untrusted base URL is refused before the API key would be sent", () => {
+  assert.throws(() => assertTrustedBaseUrl("https://attacker.example"), ConfigErrorBaseUrl);
+  assert.throws(() => assertTrustedBaseUrl("http://api.heycall-e.com"), ConfigErrorBaseUrl);
+  assert.doesNotThrow(() => assertTrustedBaseUrl("https://api.heycall-e.com"));
+  assert.doesNotThrow(() => assertTrustedBaseUrl("http://127.0.0.1:4000"));
+});

--- a/apps/typescript/wellness-checkin-call/test/classify.test.ts
+++ b/apps/typescript/wellness-checkin-call/test/classify.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyWellnessResult } from "../src/classify.js";
+
+test("no structured result escalates", () => {
+  const result = classifyWellnessResult(null);
+  assert.equal(result.level, "escalate");
+});
+
+test("no answer escalates", () => {
+  const result = classifyWellnessResult({ answered: false });
+  assert.equal(result.level, "escalate");
+});
+
+test("everything fine is ok", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "feeling good",
+    meal_status: "good",
+    concerns_reported: false,
+  });
+  assert.equal(result.level, "ok");
+});
+
+test("a lone reported concern is mild, not escalate", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "feeling fine",
+    meal_status: "good",
+    concerns_reported: true,
+    concerns_detail: "needs more light bulbs",
+  });
+  assert.equal(result.level, "mild_concern");
+});
+
+test("a concerning meal status alone is mild", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "feeling fine",
+    meal_status: "somewhat_concerning",
+    concerns_reported: false,
+  });
+  assert.equal(result.level, "mild_concern");
+});
+
+test("a concerning condition keyword alone is mild", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "a bit dizzy today",
+    meal_status: "good",
+    concerns_reported: false,
+  });
+  assert.equal(result.level, "mild_concern");
+  assert.match(result.reasons[0]!, /dizzy/);
+});
+
+test("a concern plus a concerning condition escalates", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "some pain in my leg",
+    meal_status: "good",
+    concerns_reported: true,
+    concerns_detail: "can't get to the pharmacy",
+  });
+  assert.equal(result.level, "escalate");
+  assert.equal(result.reasons.length, 2);
+});
+
+test("a concern plus a concerning meal status escalates", () => {
+  const result = classifyWellnessResult({
+    answered: true,
+    condition_summary: "feeling fine",
+    meal_status: "somewhat_concerning",
+    concerns_reported: true,
+    concerns_detail: "ran out of groceries",
+  });
+  assert.equal(result.level, "escalate");
+});

--- a/apps/typescript/wellness-checkin-call/tsconfig.json
+++ b/apps/typescript/wellness-checkin-call/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "fake/**/*.ts", "demo/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `apps/typescript/wellness-checkin-call/`: a consent-gated wellness
check-in call for an elderly or at-risk person, using CALL-E to ask three
short questions and classify the result as `ok` / `mild_concern` /
`escalate`.

- Masked, no-call preview by default (no credentials needed)
- Live mode requires an explicit `--execute --confirm-recipient-opt-in`
  and a real API key
- Tests and the demo run against a local fake CALL-E server
  (`fake/calle-server.ts`), speaking the real wire contract

This is a distilled, English-only, self-contained reference version of a
fuller bilingual (English/Japanese) app with a family dashboard, call
history, and email notifications, built for the CALL-E hackathon:
- Source: https://github.com/atsushiyago/anpi
- Live demo: https://call-e-anpi.vercel.app

## Test plan

- [x] `npm run check` (tsc --noEmit)
- [x] `npm test` — 13/13 passing
- [x] `npm run demo` — three scenarios against the local fake server
- [x] `python3 scripts/validate_repository.py` — passes
- [x] `python3 scripts/check_branch_name.py --branch feat/wellness-checkin-call` — passes