### PR TITLE
fix(call-on-behalf): stop reading a status or a refusal as evidence

### DIFF
--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -65,6 +65,12 @@ The extraction proposes. The transcript decides.
   the first. A refusal aimed elsewhere is quoted as what was actually turned
   down. When one turn agrees and another refuses the same arrangement, the report
   stands behind neither and says a person has to read the transcript and call.
+- Raising the arrangement means asking for it or proposing it. A statement that only
+  carries the word appointment or confirm raises nothing, so an answer to the
+  question before it stays an answer to that question. A time the caller proposes
+  without a question mark does count, because that is a time the callee can say yes
+  to. It is one rule and all three bindings use it: the agreement, the refusal and
+  the confirmation code that belongs to the agreement.
 - A time no callee turn named is not read back as an offer. CALL-E's own note
   is printed with its name on it. Nothing in the report is both unchecked and
   unlabelled.
@@ -158,7 +164,7 @@ Node 20 or later.
 cd apps/typescript/call-on-behalf
 npm install
 npm run check   # tsc --noEmit
-npm test        # 126 tests, no credentials, no outbound calls
+npm test        # 135 tests, no credentials, no outbound calls
 npm run demo    # the six cases against the local fake CALL-E
 ```
 

--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -56,6 +56,13 @@ The extraction proposes. The transcript decides.
   as booked and the note quotes whatever they did say. The confirmation code
   belongs to the agreement, so a code nobody read out is dropped even when the
   agreement stands.
+- A refusal is a claim of the same size, so it is checked the same way. A reported
+  `declined_by_callee` needs a turn that refuses the arrangement, which means a turn
+  answering the arrangement rather than one of the questions: "no, we do not take
+  that plan" turns down a question and says nothing about a booking the same call
+  may have held. A refusal aimed elsewhere is quoted as what was actually turned
+  down. When one turn agrees and another refuses the same arrangement, the report
+  stands behind neither and says a person has to read the transcript and call.
 - A time no callee turn named is not read back as an offer. CALL-E's own note
   is printed with its name on it. Nothing in the report is both unchecked and
   unlabelled.
@@ -149,7 +156,7 @@ Node 20 or later.
 cd apps/typescript/call-on-behalf
 npm install
 npm run check   # tsc --noEmit
-npm test        # 87 tests, no credentials, no outbound calls
+npm test        # 123 tests, no credentials, no outbound calls
 npm run demo    # the six cases against the local fake CALL-E
 ```
 

--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -65,12 +65,14 @@ The extraction proposes. The transcript decides.
   the first. A refusal aimed elsewhere is quoted as what was actually turned
   down. When one turn agrees and another refuses the same arrangement, the report
   stands behind neither and says a person has to read the transcript and call.
-- Raising the arrangement means asking for it or proposing it. A statement that only
-  carries the word appointment or confirm raises nothing, so an answer to the
-  question before it stays an answer to that question. A time the caller proposes
-  without a question mark does count, because that is a time the callee can say yes
-  to. It is one rule and all three bindings use it: the agreement, the refusal and
-  the confirmation code that belongs to the agreement.
+- Raising the arrangement means asking for it or proposing the time itself. A
+  statement that only carries the word appointment or confirm raises nothing, so an
+  answer to the question before it stays an answer to that question. That holds even
+  when the statement also names some unrelated weekday: "our appointment desk is open
+  Monday" offers no slot. A time the caller proposes without a question mark counts
+  only when it is the time the report would print, because that is a time the callee
+  can say yes to. It is one rule and all three bindings use it: the agreement, the
+  refusal and the confirmation code that belongs to the agreement.
 - A time no callee turn named is not read back as an offer. CALL-E's own note
   is printed with its name on it. Nothing in the report is both unchecked and
   unlabelled.
@@ -164,7 +166,7 @@ Node 20 or later.
 cd apps/typescript/call-on-behalf
 npm install
 npm run check   # tsc --noEmit
-npm test        # 135 tests, no credentials, no outbound calls
+npm test        # 138 tests, no credentials, no outbound calls
 npm run demo    # the six cases against the local fake CALL-E
 ```
 

--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -65,14 +65,18 @@ The extraction proposes. The transcript decides.
   the first. A refusal aimed elsewhere is quoted as what was actually turned
   down. When one turn agrees and another refuses the same arrangement, the report
   stands behind neither and says a person has to read the transcript and call.
-- Raising the arrangement means asking for it or proposing the time itself. A
-  statement that only carries the word appointment or confirm raises nothing, so an
-  answer to the question before it stays an answer to that question. That holds even
-  when the statement also names some unrelated weekday: "our appointment desk is open
-  Monday" offers no slot. A time the caller proposes without a question mark counts
-  only when it is the time the report would print, because that is a time the callee
-  can say yes to. It is one rule and all three bindings use it: the agreement, the
-  refusal and the confirmation code that belongs to the agreement.
+- Raising the arrangement means asking for it or proposing the time itself, in one
+  clause. A statement that only carries the word appointment or confirm raises
+  nothing, so an answer to the question before it stays an answer to that question.
+  That holds even when the statement also names some unrelated weekday: "our
+  appointment desk is open Monday" offers no slot. A time the caller proposes without
+  a question mark counts only when it is the time the report would print, because
+  that is a time the callee can say yes to. The request and the booking words have to
+  be in the same clause, so "I am calling to book an appointment. Do you accept
+  Aetna?" asks about insurance and nothing else. Where a turn puts two things to them
+  the answer belongs to the one asked last. It is one rule and all three
+  bindings use it: the agreement, the refusal and the confirmation code that belongs
+  to the agreement.
 - A time no callee turn named is not read back as an offer. CALL-E's own note
   is printed with its name on it. Nothing in the report is both unchecked and
   unlabelled.
@@ -166,7 +170,7 @@ Node 20 or later.
 cd apps/typescript/call-on-behalf
 npm install
 npm run check   # tsc --noEmit
-npm test        # 138 tests, no credentials, no outbound calls
+npm test        # 142 tests, no credentials, no outbound calls
 npm run demo    # the six cases against the local fake CALL-E
 ```
 

--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -64,7 +64,15 @@ The extraction proposes. The transcript decides.
   with: only a terminal status is read as a result. A call still `queued` or
   `in_progress` gets no verdict, no commitment and no privacy finding. Re-running the
   same errand file reads the same call back, because the idempotency key covers the
-  content of the call and has not changed.
+  content of the call and has not changed. A reconciliation that fails proves
+  nothing either, whatever class the second answer was: a definite refusal to it can
+  be decided before the idempotency lookup, so it is no evidence that the first
+  request never landed.
+- A status is not a claim about what was said. A call CALL-E ended as `failed` or
+  `canceled` can still have carried the questions, the answers and the slot, so the
+  report is read from the transcript and the notes name the status. It is not read
+  as everything done either, because a call that ended early may have been cut off
+  partway through.
 
 ## Try it without an account
 

--- a/apps/typescript/call-on-behalf/README.md
+++ b/apps/typescript/call-on-behalf/README.md
@@ -60,7 +60,9 @@ The extraction proposes. The transcript decides.
   `declined_by_callee` needs a turn that refuses the arrangement, which means a turn
   answering the arrangement rather than one of the questions: "no, we do not take
   that plan" turns down a question and says nothing about a booking the same call
-  may have held. A refusal aimed elsewhere is quoted as what was actually turned
+  may have held. It also has to be about the time the extraction reported, when it
+  reported one, so a no to the second slot proposed on a call is not read as a no to
+  the first. A refusal aimed elsewhere is quoted as what was actually turned
   down. When one turn agrees and another refuses the same arrangement, the report
   stands behind neither and says a person has to read the transcript and call.
 - A time no callee turn named is not read back as an offer. CALL-E's own note
@@ -156,7 +158,7 @@ Node 20 or later.
 cd apps/typescript/call-on-behalf
 npm install
 npm run check   # tsc --noEmit
-npm test        # 123 tests, no credentials, no outbound calls
+npm test        # 126 tests, no credentials, no outbound calls
 npm run demo    # the six cases against the local fake CALL-E
 ```
 

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -90,6 +90,20 @@ this one. The cost is a call where the only precise form of the time or the refe
 in a later turn: that reads as not named, so the report gives less than the extraction
 claimed rather than more.
 
+Raising the arrangement takes two things at once and not one word. The turn has to be
+about the arrangement, which is booking language or the time the extraction reported. It
+also has to put that to the callee, which means an ask or an actual proposal: a question,
+a request or a time they could say yes to. A statement that only carries the word
+appointment, confirm or availability raises nothing. "This appointment is for next week",
+said between a question and its answer, would otherwise make that answer a reply to the
+arrangement, so a no to the insurance question would come back as a refused appointment.
+One rule, used by all three bindings, so it cannot hold on the agreement and not on the
+refusal or the confirmation code. A caller who proposes a time without asking a question
+is still proposing, so "Thursday the thirteenth at nine forty would suit her" is an anchor
+and the tightening does not cost real agreements. It fails closed the other way: an ask
+this does not catch leaves the evidence unbound, so the commitment reads
+`unconfirmed`.
+
 The time is matched as a wall clock, in the forms a transcript carries. When a turn
 names a day or a weekday it has to be the claimed one, so the same time on another
 authorized day is not reported as this one. A turn that names no day is taken as the
@@ -116,8 +130,9 @@ nothing on their own. "No, we do not take that plan" refuses a question and says
 nothing about the booking, which may have been held in the same call. So the turn has
 to be answering the arrangement: what the caller last put to the callee before it has
 to be the arrangement rather than one of the questions. Statements do not change the
-subject, so a caller reading out a date of birth between the two leaves the refusal
-answering the appointment it followed. Then the time is bound too. When the extraction
+subject. A caller reading out a date of birth between the two leaves the refusal
+answering the appointment it followed. So does a statement that only mentions the
+appointment. Then the time is bound too. When the extraction
 reports a datetime, that datetime has to have been named by the moment the callee spoke,
 in the refusing turn or in the caller's proposal before it, which is what the agreement
 side already requires. Two times

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -92,17 +92,20 @@ claimed rather than more.
 
 Raising the arrangement takes two things at once and not one word. The turn has to be
 about the arrangement, which is booking language or the time the extraction reported. It
-also has to put that to the callee, which means an ask or an actual proposal: a question,
-a request or a time they could say yes to. A statement that only carries the word
-appointment, confirm or availability raises nothing. "This appointment is for next week",
-said between a question and its answer, would otherwise make that answer a reply to the
-arrangement, so a no to the insurance question would come back as a refused appointment.
-One rule, used by all three bindings, so it cannot hold on the agreement and not on the
-refusal or the confirmation code. A caller who proposes a time without asking a question
-is still proposing, so "Thursday the thirteenth at nine forty would suit her" is an anchor
-and the tightening does not cost real agreements. It fails closed the other way: an ask
-this does not catch leaves the evidence unbound, so the commitment reads
-`unconfirmed`.
+also has to put that to the callee, which is one of two things and not a third: a genuine
+request, meaning a booking turn phrased as a question or a request, or a concrete proposal,
+meaning a turn that names the offered time itself. A statement that only carries the word
+appointment, confirm or availability raises nothing, and neither does one that adds an
+unrelated weekday: "our appointment desk is open Monday", said between a question and its
+answer, offers no slot, so it must not make that answer a reply to the arrangement. That is
+why the proposal half is the offered time and not any weekday, and why a first-person
+purpose statement such as "I am calling to book an appointment" is not an ask: it says why
+the caller rang and puts no question to the callee. A time the caller states rather than
+asks still counts when it is the offered time, so "Thursday the thirteenth at nine forty
+would suit her" is an anchor and the tightening does not cost real proposals. One rule, used
+by all three bindings, so it cannot hold on the agreement and not on the refusal or the
+confirmation code. It fails closed the other way: an ask this does not catch leaves the
+evidence unbound, so the commitment reads `unconfirmed`.
 
 The time is matched as a wall clock, in the forms a transcript carries. When a turn
 names a day or a weekday it has to be the claimed one, so the same time on another

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -93,7 +93,10 @@ next step says "another time" rather than a time nobody said. An agreement with 
 time at all cannot be checked against the windows, so it reads `unconfirmed` too.
 CALL-E's own note is printed with its name on it, because nothing here checked that
 sentence. The one claim left standing on the extraction alone is
-`declined_by_callee`, which says less than the extraction did rather than more.
+`declined_by_callee`, which says less than the extraction did rather than more. It
+is labelled in the notes as CALL-E's reading and it does not settle the errand: a
+booking that was refused is not a goal met, so the outcome is `partially_met` at
+best and the next step says plainly that nothing is booked.
 
 When nothing supports the claim, the report says not answered or `unconfirmed` and
 notes that CALL-E claimed otherwise. It will sometimes be too strict, in two ways.
@@ -110,11 +113,14 @@ lost connection, a timeout, a server error. The call may be ringing right now.
 
 In that case the app reconciles under the same idempotency key first, which returns
 the existing call rather than placing a second one. If it still cannot read the
-call, the outcome is `outcome_unknown` with exit code 40. The report says the
-outcome is not known instead of saying nothing was said. Running the same errand
-file again reads the same call back, because the key covers the content of the
-call. Editing the file first makes it a different call, so the next step says not
-to.
+call, the outcome is `outcome_unknown` with exit code 40. Getting the call back is
+the only thing that settles it. A refusal to the reconciliation, a definite one such
+as 401 or 402 included, can be decided before the idempotency lookup ever happens,
+so it says nothing about the request that went unanswered and the call stays
+unknown. The report says the outcome is not known instead of saying nothing was
+said. Running the same errand file again reads the same call back, because the key
+covers the content of the call. Editing the file first makes it a different call, so
+the next step says not to.
 
 A call CALL-E has not finished with lands in the same place. Only a terminal status
 is read as a result: `completed`, `failed` or `canceled`, which is every terminal
@@ -127,8 +133,18 @@ verdict, no commitment and no privacy finding. Reading a call in flight as a res
 is how a call still ringing gets reported as an errand that is done. The next step
 is the same: run the same errand file again and it reads that same call back.
 
-A refusal is different. When CALL-E declines to create the call at all, nothing was
-placed, the outcome is `api_error` and the report can say so plainly.
+A refusal on the first attempt is different. CALL-E declined to create the call and
+nothing was placed, so the outcome is `api_error` and the report can say so plainly.
+
+A call that ended before the conversation did is the other way round. `failed` and
+`canceled` are terminal, so there is a transcript to read. A line that dropped after
+the slot was held carries the whole errand: the questions, the answers and the
+agreement. That status is not read as nobody having answered. What was said comes
+from the transcript and the notes name the status as `call_failed` or
+`call_canceled` with the failure code beside it. The outcome is never `goal_met`,
+because a call that ended early may have been cut off partway through. A call with
+nobody on its transcript is still read from its failure code, which is where
+`voicemail` and `not_reached` come from.
 
 ## Who you may call
 

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -90,22 +90,39 @@ this one. The cost is a call where the only precise form of the time or the refe
 in a later turn: that reads as not named, so the report gives less than the extraction
 claimed rather than more.
 
-Raising the arrangement takes two things at once and not one word. The turn has to be
-about the arrangement, which is booking language or the time the extraction reported. It
-also has to put that to the callee, which is one of two things and not a third: a genuine
-request, meaning a booking turn phrased as a question or a request, or a concrete proposal,
-meaning a turn that names the offered time itself. A statement that only carries the word
-appointment, confirm or availability raises nothing, and neither does one that adds an
-unrelated weekday: "our appointment desk is open Monday", said between a question and its
-answer, offers no slot, so it must not make that answer a reply to the arrangement. That is
-why the proposal half is the offered time and not any weekday, and why a first-person
-purpose statement such as "I am calling to book an appointment" is not an ask: it says why
-the caller rang and puts no question to the callee. A time the caller states rather than
-asks still counts when it is the offered time, so "Thursday the thirteenth at nine forty
-would suit her" is an anchor and the tightening does not cost real proposals. One rule, used
-by all three bindings, so it cannot hold on the agreement and not on the refusal or the
-confirmation code. It fails closed the other way: an ask this does not catch leaves the
-evidence unbound, so the commitment reads `unconfirmed`.
+Raising the arrangement takes two things at once in one clause, not one word anywhere in
+the turn. The clause has to be about the arrangement, which is booking language or the time the
+extraction reported. It also has to put that to the callee, which is one of two things and
+not a third. A genuine request, meaning booking language phrased as a question or a
+request. Or a concrete proposal, meaning a clause that names the offered time itself. A
+statement that only carries the word appointment, confirm or availability raises nothing,
+and neither does one that adds an unrelated weekday: "our appointment desk is open Monday",
+said between a question and its answer, offers no slot, so it must not make that answer a
+reply to the arrangement. That is why the proposal half is the offered time and not any
+weekday. It is also why a first-person purpose statement such as "I am calling to book an
+appointment" is not an ask: it says why the caller rang and puts no question to the callee.
+
+One clause, because a turn is not one thing put to the callee. "I am calling to book an
+appointment. Do you accept Aetna?" is a purpose statement and then an insurance question,
+and the question mark belongs to the insurance question. Lending it to the booking words in
+front of it reported a refused appointment in a call where no slot had been put to anybody.
+So the request form and the booking language have to be in the same clause. Where one turn
+does put two things to them the answer belongs to whichever was asked last: "could you
+hold Thursday at nine forty? Do you accept Aetna?" then "no, we do not take that plan" is a
+no about insurance and no answer at all about the slot. Clauses are split on a sentence end,
+a semicolon, a colon, a comma, a dash or a line break, because speech splices two
+utterances with a comma as often as it writes a full stop.
+
+A time the caller states rather than asks still counts when it is the offered time, so
+"Thursday the thirteenth at nine forty would suit her" is an anchor and the tightening does
+not cost real proposals. The proposal arm reads the whole turn as well as the clause, so the
+day check still sees every day the turn named and "Wednesday, at nine forty" is not read as
+Thursday at nine forty. One rule, used by all three bindings, so it cannot hold on the
+agreement and not on the refusal or the confirmation code. It fails closed the other way: an
+ask this does not catch leaves the evidence unbound, so the commitment reads `unconfirmed`.
+A request whose booking word sits on the far side of a comma from its question form, "about
+the appointment, could you do Thursday?", is one of those. A turn that names the reported
+time anchors on the proposal arm whatever its punctuation.
 
 The time is matched as a wall clock, in the forms a transcript carries. When a turn
 names a day or a weekday it has to be the claimed one, so the same time on another

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -101,15 +101,30 @@ formatting choice. With one, the note quotes the turn. Either way a refusal does
 settle the errand: a booking that was refused is not a goal met, so the outcome is
 `partially_met` at best.
 
-A refusal is anchored the same way an agreement is, because refusal words prove
+A refusal is bound the same two ways an agreement is, because refusal words prove
 nothing on their own. "No, we do not take that plan" refuses a question and says
 nothing about the booking, which may have been held in the same call. So the turn has
 to be answering the arrangement: what the caller last put to the callee before it has
 to be the arrangement rather than one of the questions. Statements do not change the
 subject, so a caller reading out a date of birth between the two leaves the refusal
-answering the appointment it followed. A refusal aimed somewhere else is quoted in the
+answering the appointment it followed. Then the time is bound too. When the extraction
+reports a datetime, that datetime has to be named around the refusing turn, in it or in
+the turn either side, which is what the agreement side already requires. Two times
+proposed on one call is otherwise a way for a no to the second to be reported as a no
+to the first or as a no to the errand. A refusal aimed somewhere else is quoted in the
 report as what was actually turned down, so `unconfirmed` never reads as nothing
 having been said.
+
+When the extraction reports no time there is nothing to bind to, so the prompt anchor
+stands alone. That is the same asymmetry on the agreement side, where an agreement with
+no time cannot be held against the authorized windows either and reads `unconfirmed`.
+The time binding fails closed. `offered_datetime` is contracted as the time that was
+agreed or offered, so on a refused errand it can name a time that was discussed rather
+than the one that was turned down. Where it does, the refusal reads as being about
+something else, the commitment comes back `unconfirmed` and the note quotes the refusal.
+That says less than the call held, which is the direction to be wrong in: a real refusal
+reported as unsettled costs a phone call to check, a refusal of one option reported as a
+refusal of another costs somebody a slot that still stands.
 
 When both claims have a turn behind them, one agreeing and one refusing the same
 arrangement, the report stands behind neither. The commitment reads `unconfirmed`,

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -93,13 +93,30 @@ next step says "another time" rather than a time nobody said. An agreement with 
 time at all cannot be checked against the windows, so it reads `unconfirmed` too.
 CALL-E's own note is printed with its name on it, because nothing here checked that
 sentence. A reported refusal is held to the same standard as a reported agreement:
-`declined_by_callee` needs a turn that plainly refuses the errand, or the business
+`declined_by_callee` needs either a turn that refuses the arrangement or the business
 refusing to deal with an automated caller at all. Without one the commitment reads
 `unconfirmed` and the next step says nothing is settled either way, because telling
 somebody their errand was turned down is a claim about their errand and not a
 formatting choice. With one, the note quotes the turn. Either way a refusal does not
 settle the errand: a booking that was refused is not a goal met, so the outcome is
 `partially_met` at best.
+
+A refusal is anchored the same way an agreement is, because refusal words prove
+nothing on their own. "No, we do not take that plan" refuses a question and says
+nothing about the booking, which may have been held in the same call. So the turn has
+to be answering the arrangement: what the caller last put to the callee before it has
+to be the arrangement rather than one of the questions. Statements do not change the
+subject, so a caller reading out a date of birth between the two leaves the refusal
+answering the appointment it followed. A refusal aimed somewhere else is quoted in the
+report as what was actually turned down, so `unconfirmed` never reads as nothing
+having been said.
+
+When both claims have a turn behind them, one agreeing and one refusing the same
+arrangement, the report stands behind neither. The commitment reads `unconfirmed`,
+the note quotes both turns and the next step says a person has to read the transcript
+and call, because reporting the agreement would book something the callee took back
+and reporting the refusal would drop a slot they may be holding. A confirmation code
+belongs to an agreement that stands, so it is dropped there too.
 
 The refusal patterns are narrow on purpose. Missing a real refusal costs a softer
 report that says the outcome is unknown. Inventing one costs the person a fact about

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -73,13 +73,22 @@ discussing something else is not an answer to a question nobody asked.
 
 An agreement is reported when the transcript shows somebody agreeing to the thing
 the report would print. It is anchored twice: to the turn where the caller raised
-the arrangement, plus to the time itself, which has to be named in the agreeing turn
-or in the turn either side of it. Booking language on its own proves nothing. An
+the arrangement, plus to the time itself, which has to have been named by the moment
+the callee spoke, either in the agreeing turn or in the caller's proposal before it.
+Booking language on its own proves nothing. An
 agreement about some other time reads `unconfirmed`, not `committed` and not
 `outside_authorized_window`, because both of those would print or act on a time off
 the extraction alone. The note quotes what they did say, so nobody reads
 `unconfirmed` as nothing having happened. Any confirmation code goes with the
 agreement.
+
+Both bindings look backwards only. A turn is evidence for what it was answering.
+Nothing said after it can be that. A caller who proposes Wednesday, hears no, then
+proposes Thursday has not been refused Thursday. A callee who reads out a second
+reference number after agreeing to the first appointment has not given that number for
+this one. The cost is a call where the only precise form of the time or the reference is
+in a later turn: that reads as not named, so the report gives less than the extraction
+claimed rather than more.
 
 The time is matched as a wall clock, in the forms a transcript carries. When a turn
 names a day or a weekday it has to be the claimed one, so the same time on another
@@ -87,8 +96,9 @@ authorized day is not reported as this one. A turn that names no day is taken as
 day the caller had already established.
 
 Everything else the report prints off the extraction is held to the same standard. A
-confirmation code has to have been read out around the agreement or the report drops
-it and says it did. A time no callee turn named is not read back as an offer, so the
+confirmation code has to have been read out by the time the agreement was made or the
+report drops it and says it did. A time no callee turn named is not read back as an
+offer, so the
 next step says "another time" rather than a time nobody said. An agreement with no
 time at all cannot be checked against the windows, so it reads `unconfirmed` too.
 CALL-E's own note is printed with its name on it, because nothing here checked that
@@ -108,10 +118,13 @@ to be answering the arrangement: what the caller last put to the callee before i
 to be the arrangement rather than one of the questions. Statements do not change the
 subject, so a caller reading out a date of birth between the two leaves the refusal
 answering the appointment it followed. Then the time is bound too. When the extraction
-reports a datetime, that datetime has to be named around the refusing turn, in it or in
-the turn either side, which is what the agreement side already requires. Two times
-proposed on one call is otherwise a way for a no to the second to be reported as a no
-to the first or as a no to the errand. A refusal aimed somewhere else is quoted in the
+reports a datetime, that datetime has to have been named by the moment the callee spoke,
+in the refusing turn or in the caller's proposal before it, which is what the agreement
+side already requires. Two times
+proposed on one call is otherwise a way for a no to one of them to be read as a no
+to the other in either order. It is also a way for either to be read as a no to the
+errand. A refusal aimed
+somewhere else is quoted in the
 report as what was actually turned down, so `unconfirmed` never reads as nothing
 having been said.
 

--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -92,11 +92,18 @@ it and says it did. A time no callee turn named is not read back as an offer, so
 next step says "another time" rather than a time nobody said. An agreement with no
 time at all cannot be checked against the windows, so it reads `unconfirmed` too.
 CALL-E's own note is printed with its name on it, because nothing here checked that
-sentence. The one claim left standing on the extraction alone is
-`declined_by_callee`, which says less than the extraction did rather than more. It
-is labelled in the notes as CALL-E's reading and it does not settle the errand: a
-booking that was refused is not a goal met, so the outcome is `partially_met` at
-best and the next step says plainly that nothing is booked.
+sentence. A reported refusal is held to the same standard as a reported agreement:
+`declined_by_callee` needs a turn that plainly refuses the errand, or the business
+refusing to deal with an automated caller at all. Without one the commitment reads
+`unconfirmed` and the next step says nothing is settled either way, because telling
+somebody their errand was turned down is a claim about their errand and not a
+formatting choice. With one, the note quotes the turn. Either way a refusal does not
+settle the errand: a booking that was refused is not a goal met, so the outcome is
+`partially_met` at best.
+
+The refusal patterns are narrow on purpose. Missing a real refusal costs a softer
+report that says the outcome is unknown. Inventing one costs the person a fact about
+their own errand, so the checks are built to be wrong in the first direction.
 
 When nothing supports the claim, the report says not answered or `unconfirmed` and
 notes that CALL-E claimed otherwise. It will sometimes be too strict, in two ways.

--- a/apps/typescript/call-on-behalf/fake/calle-server.ts
+++ b/apps/typescript/call-on-behalf/fake/calle-server.ts
@@ -17,6 +17,11 @@ export interface FakeScript {
   confidence?: { score: number; label: string } | null;
   failureCode?: string | null;
   apiError?: { status: number; code: string };
+  /**
+   * One answer per create attempt, in order, so a first attempt that leaves the
+   * call unknown can be followed by an answer of another class.
+   */
+  createErrors?: { status: number; code: string }[];
   /** The call is created and the answer to the create is lost, so the caller cannot tell. */
   lostCreateResponse?: boolean;
   /** Reading the call back fails, so the result of a created call cannot be read. */
@@ -124,6 +129,8 @@ export async function startFakeCalle(scripts: FakeScript[]): Promise<FakeCalle> 
   const created: CreatedCall[] = [];
   const calls = new Map<string, StoredCall>();
   const idempotency = new Map<string, { id: string; bodyKey: string }>();
+  /** Create attempts per script, so `createErrors` can answer them one at a time. */
+  const createAttempts = new Map<string, number>();
   let counter = 0;
 
   const server: Server = createServer((request, response) => {
@@ -167,6 +174,14 @@ export async function startFakeCalle(scripts: FakeScript[]): Promise<FakeCalle> 
             response.end(snapshot(calls.get(seen.id)!, false));
             return;
           }
+        }
+        const attempts = (createAttempts.get(script.phone) ?? 0) + 1;
+        createAttempts.set(script.phone, attempts);
+        const sequenced = script.createErrors?.[attempts - 1];
+        if (sequenced !== undefined) {
+          response.statusCode = sequenced.status;
+          response.end(envelope(sequenced.code, `Fake server answered create attempt ${attempts} with an error.`));
+          return;
         }
         if (script.apiError !== undefined) {
           response.statusCode = script.apiError.status;

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -346,8 +346,9 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   let unconfirmedReason: "agreement" | "refusal" | "conflict" = "agreement";
   if (request.goal.commitment !== "none") {
     const agreement = agreementEvidence(turns, request.goal.commitment, offered);
-    // Held to the same standard and anchored the same way: a turn that refuses one
-    // of the questions is not a turn that refuses the arrangement.
+    // Held to the same standard and bound the same way. A turn that refuses one of
+    // the questions does not refuse the arrangement. A turn that refuses another
+    // time does not refuse this one.
     const refusal = refusalEvidence(turns, offered, request.questions);
     if (madeRaw.length > 0 && agreement.quote.length > 0 && refusal.quote.length > 0) {
       // Both claims have a turn behind them, so the transcript does not decide this

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -13,6 +13,13 @@
  * is a claim of its own. Only a call CALL-E has finished with is read at all: a
  * queued, ringing or running call is an unknown outcome too, because its transcript
  * is still being written.
+ *
+ * The other half of that rule is that a status is not a claim either. A call CALL-E
+ * ended as failed or canceled can still have carried the whole errand, so what was
+ * said is read from the transcript and the status goes in the notes. A create
+ * nobody could reconcile stays unknown whatever the second answer was, because a
+ * refusal to the reconciliation can be decided before the idempotency lookup and is
+ * no evidence that the first request never landed.
  */
 
 import { blocking, sensitiveTopicFindings, spokenItems, unauthorizedFindings, withoutKnownNumbers } from "./disclosure.js";
@@ -130,6 +137,11 @@ function nextStep(
   if (commitment === "committed") {
     return "That is arranged. The confirmation, if they gave one, is in the report above.";
   }
+  if (commitment === "declined_by_callee") {
+    // Whatever else came back, the thing the errand asked for did not happen, so
+    // the next step says that instead of reporting the errand as done.
+    return `${request.callee.name} would not arrange it on this call, so nothing is booked. Anything they did answer is above and the transcript is below.`;
+  }
   if (outcome === "goal_met") {
     return "Everything you asked was answered. Nothing was agreed, because this errand did not ask for anything to be agreed.";
   }
@@ -182,12 +194,14 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
         callId = reconciled.id;
         progress(`Reconciled to call ${reconciled.id}.`);
       } catch (secondError) {
+        // Getting the call back is the only thing that resolves this. The first
+        // request may already have been accepted. A definite refusal here can be
+        // decided before the idempotency lookup ever happens, so it is no evidence
+        // that no call exists. Whatever class the second answer is, the call stays
+        // unaccounted for.
         const second = asCallError(secondError);
-        if (second.ambiguous) {
-          unknown = `the call could not be reconciled (${problem.code}, then ${second.code})`;
-        } else {
-          refusal = second;
-        }
+        progress(`Reconciling returned ${second.code}, so a call may be live under that key.`);
+        unknown = `the call could not be reconciled (${problem.code}, then ${second.code})`;
       }
     } else {
       refusal = problem;
@@ -352,27 +366,31 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   const confirmationCode = codeNamedAround(turns, agreedIndex, claimedCode) ? claimedCode : "";
 
   const answered = answers.filter((answer) => answer.answered).length;
+  // Terminal and not completed, so CALL-E ended the call before the conversation
+  // was done. That says the line went, not that nothing was said on it.
+  const endedEarly = call.status !== "completed";
   let outcome: ErrandOutcome;
-  if (call.status !== "completed") {
-    // Terminal and not completed, so the call ended before the conversation did.
-    // The failure code says why when there is one and the status says it otherwise.
-    outcome = failureOutcome(attempt?.failureCode ?? call.failureCode ?? call.status);
-  } else if (reading.declinedAutomated) {
+  if (reading.declinedAutomated) {
     outcome = "callee_declined_automated";
   } else if (reading.machineAnswered) {
     outcome = "voicemail";
+  } else if (endedEarly && !reading.reachedPerson) {
+    // Nobody was on the line and the call is over, so nothing was asked. The
+    // failure code says why when there is one and the status says it otherwise.
+    outcome = failureOutcome(attempt?.failureCode ?? call.failureCode ?? call.status);
   } else if (!reading.reachedPerson) {
     outcome = "not_reached";
   } else {
-    const commitmentSettled =
-      request.goal.commitment === "none" || commitment === "committed" || commitment === "declined_by_callee";
+    const commitmentSettled = request.goal.commitment === "none" || commitment === "committed";
     outcome =
       answered === answers.length && commitmentSettled
         ? "goal_met"
         : answered > 0 || commitment !== "none_sought"
           ? "partially_met"
           : "not_met";
-    if (lowConfidence && outcome === "goal_met") {
+    // A call that ended early may have been cut off partway through the errand, so
+    // what the transcript holds is reported and the errand is not called done.
+    if ((lowConfidence || endedEarly) && outcome === "goal_met") {
       outcome = "partially_met";
     }
   }
@@ -388,6 +406,12 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   const notes = [claimedNote.length > 0 ? `CALL-E's note, unchecked: "${claimedNote}"` : ""];
   if (lowConfidence) {
     notes.push(`CALL-E scored its own completion low (${String(confidence?.score)}), so treat the answers with care.`);
+  }
+  if (endedEarly && reading.reachedPerson) {
+    const why = attempt?.failureCode ?? call.failureCode ?? "";
+    notes.push(
+      `CALL-E ended this call as call_${call.status}${why.length > 0 ? ` (${why})` : ""} and somebody was on the line, so everything above is read from the transcript and not from that status.`,
+    );
   }
   if (unsupported > 0) {
     notes.push(
@@ -407,6 +431,13 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
       unconfirmedNote.length > 0
         ? unconfirmedNote
         : "CALL-E reported an agreement and no turn in the transcript shows anybody agreeing.",
+    );
+  }
+  if (commitment === "declined_by_callee" && !reading.declinedAutomated) {
+    // The one claim the report still stands on the extraction alone, so it says
+    // whose claim it is rather than passing it off as a checked fact.
+    notes.push(
+      "CALL-E reported that they would not arrange it. Nothing in the transcript was checked against that, so it is CALL-E's reading.",
     );
   }
   if (reading.declineQuote.length > 0) {

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -109,6 +109,8 @@ function nextStep(
   request: ErrandRequest,
   offered: string,
   stillOpen = false,
+  /** Which claim the transcript failed to support, when commitment is unconfirmed. */
+  unsupported: "agreement" | "refusal" = "agreement",
 ): string {
   if (outcome === "outcome_unknown") {
     return stillOpen ? UNFINISHED_NEXT_STEP : UNREAD_NEXT_STEP;
@@ -126,6 +128,12 @@ function nextStep(
     return "The call did not connect to a person. Nothing was said on your behalf and nothing was arranged.";
   }
   if (commitment === "unconfirmed") {
+    if (unsupported === "refusal") {
+      // A claimed refusal nobody voiced. The report will not tell somebody their
+      // errand was turned down on the extraction's word alone, so it says the
+      // outcome is unknown rather than picking a side.
+      return "CALL-E reported that they would not arrange it and the transcript does not show anybody refusing, so nothing is settled either way. Read the transcript below, then call to check.";
+    }
     return "Something was reported as agreed and the transcript does not show anybody agreeing to it, so treat nothing as booked. Read the transcript below, then call to check if you need it.";
   }
   if (commitment === "outside_authorized_window") {
@@ -326,6 +334,8 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   let agreedIndex = -1;
   /** Why the report will not stand behind a claimed agreement, for the note. */
   let unconfirmedNote = "";
+  /** Which claim went unsupported, so the next step can say the right thing. */
+  let unsupportedClaim: "agreement" | "refusal" = "agreement";
   if (request.goal.commitment !== "none") {
     if (madeRaw === "accepted") {
       const agreement = agreementEvidence(turns, request.goal.commitment, offered);
@@ -356,7 +366,19 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
     } else if (madeRaw === "other_time_offered") {
       commitment = "proposal_only";
     } else if (madeRaw === "declined_by_callee") {
-      commitment = "declined_by_callee";
+      // A refusal is a claim about the errand's outcome, so it is held to the
+      // same standard as an agreement: somebody has to have said it. Without a
+      // turn behind it the report will not state as fact that they would not
+      // arrange it, because the next step is an instruction and an instruction
+      // built on the extraction alone is the thing this app exists to avoid.
+      if (reading.refusalQuote.length > 0 || reading.declinedAutomated) {
+        commitment = "declined_by_callee";
+      } else {
+        commitment = "unconfirmed";
+        unsupportedClaim = "refusal";
+        unconfirmedNote =
+          "CALL-E reported that they would not arrange it and no turn in the transcript refuses anything, so this report does not treat the errand as turned down.";
+      }
     }
   }
 
@@ -434,10 +456,8 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
     );
   }
   if (commitment === "declined_by_callee" && !reading.declinedAutomated) {
-    // The one claim the report still stands on the extraction alone, so it says
-    // whose claim it is rather than passing it off as a checked fact.
     notes.push(
-      "CALL-E reported that they would not arrange it. Nothing in the transcript was checked against that, so it is CALL-E's reading.",
+      `CALL-E reported that they would not arrange it and the transcript agrees. They said: "${reading.refusalQuote}"`,
     );
   }
   if (reading.declineQuote.length > 0) {
@@ -460,7 +480,14 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
     callee_notes: notes.filter((note) => note.length > 0).join(" "),
     // A time only the extraction knows about is not read back to the person as if
     // they had been offered it.
-    next_step: nextStep(outcome, commitment, request, commitment === "proposal_only" && !offeredSaid ? "" : offeredSpoken),
+    next_step: nextStep(
+      outcome,
+      commitment,
+      request,
+      commitment === "proposal_only" && !offeredSaid ? "" : offeredSpoken,
+      false,
+      unsupportedClaim,
+    ),
     call_id: call.id,
     provider_call_id: attempt?.providerCallId ?? null,
     call_status: call.status,

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -24,7 +24,7 @@
 
 import { blocking, sensitiveTopicFindings, spokenItems, unauthorizedFindings, withoutKnownNumbers } from "./disclosure.js";
 import { CalleCallError, CalleWaitTimeout, isTerminalCallStatus, type CallePort } from "./calle.js";
-import { agreementEvidence, codeNamedAround, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "./read.js";
+import { agreementEvidence, codeNamedBefore, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "./read.js";
 import {
   buildCallInput,
   buildTask,
@@ -406,9 +406,9 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   }
 
   // A reference number belongs to an agreement, so it is held to the same standard:
-  // somebody has to have read it out where the agreement was made.
+  // somebody has to have read it out by the time the agreement was made.
   const claimedCode = readString(structured, "confirmation_code");
-  const confirmationCode = codeNamedAround(turns, agreedIndex, claimedCode) ? claimedCode : "";
+  const confirmationCode = codeNamedBefore(turns, agreedIndex, claimedCode) ? claimedCode : "";
 
   const answered = answers.filter((answer) => answer.answered).length;
   // Terminal and not completed, so CALL-E ended the call before the conversation

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -24,7 +24,7 @@
 
 import { blocking, sensitiveTopicFindings, spokenItems, unauthorizedFindings, withoutKnownNumbers } from "./disclosure.js";
 import { CalleCallError, CalleWaitTimeout, isTerminalCallStatus, type CallePort } from "./calle.js";
-import { agreementEvidence, codeNamedAround, mentionsDatetime, readTranscript, supportingTurn } from "./read.js";
+import { agreementEvidence, codeNamedAround, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "./read.js";
 import {
   buildCallInput,
   buildTask,
@@ -109,8 +109,8 @@ function nextStep(
   request: ErrandRequest,
   offered: string,
   stillOpen = false,
-  /** Which claim the transcript failed to support, when commitment is unconfirmed. */
-  unsupported: "agreement" | "refusal" = "agreement",
+  /** Why the commitment is unconfirmed, so the instruction says the right thing. */
+  reason: "agreement" | "refusal" | "conflict" = "agreement",
 ): string {
   if (outcome === "outcome_unknown") {
     return stillOpen ? UNFINISHED_NEXT_STEP : UNREAD_NEXT_STEP;
@@ -128,11 +128,17 @@ function nextStep(
     return "The call did not connect to a person. Nothing was said on your behalf and nothing was arranged.";
   }
   if (commitment === "unconfirmed") {
-    if (unsupported === "refusal") {
+    if (reason === "conflict") {
+      // Both claims have a turn behind them. Picking either one means telling
+      // somebody their errand went a way the same call contradicts, so this says
+      // what the call holds and hands it to a person.
+      return "This call holds both somebody agreeing to it and somebody refusing it, so nothing here can tell you which one stands. Read the transcript below and call to check before you rely on either.";
+    }
+    if (reason === "refusal") {
       // A claimed refusal nobody voiced. The report will not tell somebody their
       // errand was turned down on the extraction's word alone, so it says the
       // outcome is unknown rather than picking a side.
-      return "CALL-E reported that they would not arrange it and the transcript does not show anybody refusing, so nothing is settled either way. Read the transcript below, then call to check.";
+      return "CALL-E reported that they would not arrange it and no turn in the transcript refuses it, so nothing is settled either way. Read the transcript below, then call to check.";
     }
     return "Something was reported as agreed and the transcript does not show anybody agreeing to it, so treat nothing as booked. Read the transcript below, then call to check if you need it.";
   }
@@ -332,13 +338,25 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   let commitment: CommitmentState = "none_sought";
   let agreedQuote = "";
   let agreedIndex = -1;
+  /** The turn that refuses the arrangement, when one does, for the note. */
+  let refusedQuote = "";
   /** Why the report will not stand behind a claimed agreement, for the note. */
   let unconfirmedNote = "";
-  /** Which claim went unsupported, so the next step can say the right thing. */
-  let unsupportedClaim: "agreement" | "refusal" = "agreement";
+  /** Why the commitment is unconfirmed, so the next step can say the right thing. */
+  let unconfirmedReason: "agreement" | "refusal" | "conflict" = "agreement";
   if (request.goal.commitment !== "none") {
-    if (madeRaw === "accepted") {
-      const agreement = agreementEvidence(turns, request.goal.commitment, offered);
+    const agreement = agreementEvidence(turns, request.goal.commitment, offered);
+    // Held to the same standard and anchored the same way: a turn that refuses one
+    // of the questions is not a turn that refuses the arrangement.
+    const refusal = refusalEvidence(turns, offered, request.questions);
+    if (madeRaw.length > 0 && agreement.quote.length > 0 && refusal.quote.length > 0) {
+      // Both claims have a turn behind them, so the transcript does not decide this
+      // and neither does this app. Reporting either side means stating an outcome
+      // the same call contradicts.
+      commitment = "unconfirmed";
+      unconfirmedReason = "conflict";
+      unconfirmedNote = `This call holds an agreement and a refusal for the same arrangement, so this report stands behind neither. They said: "${agreement.quote}" and also: "${refusal.quote}"`;
+    } else if (madeRaw === "accepted") {
       if (agreement.quote.length === 0) {
         // An agreement about a time nobody said is not an agreement this app can
         // report, so it does not become committed and it does not become an
@@ -367,17 +385,21 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
       commitment = "proposal_only";
     } else if (madeRaw === "declined_by_callee") {
       // A refusal is a claim about the errand's outcome, so it is held to the
-      // same standard as an agreement: somebody has to have said it. Without a
-      // turn behind it the report will not state as fact that they would not
-      // arrange it, because the next step is an instruction and an instruction
-      // built on the extraction alone is the thing this app exists to avoid.
-      if (reading.refusalQuote.length > 0 || reading.declinedAutomated) {
+      // same standard as an agreement: somebody has to have said it, about the
+      // thing the errand asked for. Without such a turn the report will not state
+      // as fact that they would not arrange it, because the next step is an
+      // instruction and an instruction built on the extraction alone is the thing
+      // this app exists to avoid.
+      if (refusal.quote.length > 0 || reading.declinedAutomated) {
         commitment = "declined_by_callee";
+        refusedQuote = refusal.quote;
       } else {
         commitment = "unconfirmed";
-        unsupportedClaim = "refusal";
+        unconfirmedReason = "refusal";
         unconfirmedNote =
-          "CALL-E reported that they would not arrange it and no turn in the transcript refuses anything, so this report does not treat the errand as turned down.";
+          refusal.otherQuote.length > 0
+            ? `CALL-E reported that they would not arrange it and no turn refuses the arrangement the call asked for. What they did turn down was something else: "${refusal.otherQuote}"`
+            : "CALL-E reported that they would not arrange it and no turn in the transcript refuses anything, so this report does not treat the errand as turned down.";
       }
     }
   }
@@ -455,9 +477,9 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
         : "CALL-E reported an agreement and no turn in the transcript shows anybody agreeing.",
     );
   }
-  if (commitment === "declined_by_callee" && !reading.declinedAutomated) {
+  if (commitment === "declined_by_callee" && refusedQuote.length > 0) {
     notes.push(
-      `CALL-E reported that they would not arrange it and the transcript agrees. They said: "${reading.refusalQuote}"`,
+      `CALL-E reported that they would not arrange it and a turn in the transcript refuses it. They said: "${refusedQuote}"`,
     );
   }
   if (reading.declineQuote.length > 0) {
@@ -486,7 +508,7 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
       request,
       commitment === "proposal_only" && !offeredSaid ? "" : offeredSpoken,
       false,
-      unsupportedClaim,
+      unconfirmedReason,
     ),
     call_id: call.id,
     provider_call_id: attempt?.providerCallId ?? null,

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -413,10 +413,11 @@ export interface AgreementEvidence {
  * not an agreement on its own.
  *
  * Two bindings, because booking language on its own proves nothing. The agreement
- * has to come after the caller raised the arrangement. When the extraction
- * claims a datetime that datetime has to be named around the agreement itself: in
- * the turn, in the caller's proposal before it or in the read back after it. An
- * unrelated yes plus a plausible time is not a booking.
+ * has to come after the caller raised the arrangement. When the extraction claims a
+ * datetime that datetime has to have been named by the time the callee spoke: in
+ * their own turn or in the caller's proposal before it. An unrelated yes plus a
+ * plausible time is not a booking. A time the caller only put to them afterwards
+ * is a proposal they have not answered.
  *
  * Booking language that fails either binding is still worth saying out loud, so it
  * comes back as `otherQuote` and the report quotes it as what was said instead.
@@ -443,7 +444,7 @@ export function agreementEvidence(
     if (!patterns.some((pattern) => pattern.test(turn.text))) {
       continue;
     }
-    if (offered.length > 0 && !namedAround(turns, index, offered)) {
+    if (offered.length > 0 && !namedBefore(turns, index, offered)) {
       otherQuote = turn.text;
       continue;
     }
@@ -529,9 +530,9 @@ export interface RefusalEvidence {
  * which may have been accepted in the same call. So the turn has to be answering the
  * arrangement rather than a question. The caller also has to have raised an
  * arrangement at all. Then, when the extraction reports a datetime, that datetime has
- * to be named around the refusing turn: in it, in the caller's proposal before it or
- * in the turn after. Two times proposed on one call is otherwise a way for a no to the
- * second to be reported as a no to the first.
+ * to have been named by the time the callee spoke: in their own turn or in the
+ * caller's proposal before it. Two times proposed on one call is otherwise a way for a
+ * no to one of them to be reported as a no to the other, in either order.
  *
  * With no datetime reported there is nothing to bind to, so the prompt anchor stands
  * alone. That is the same asymmetry the agreement side has.
@@ -564,10 +565,11 @@ export function refusalEvidence(
       }
       continue;
     }
-    if (offered.length > 0 && !namedAround(turns, index, offered)) {
-      // A no to another time is not a no to this one. The same binding the agreement
-      // side uses, so a call where two slots were discussed cannot report the refusal
-      // of one as the refusal of the other.
+    if (offered.length > 0 && !namedBefore(turns, index, offered)) {
+      // A no to another time is not a no to this one. A no given before the caller
+      // had put this time to them is not about it either. The same binding the
+      // agreement side uses, so a call where two slots were discussed cannot report
+      // the refusal of one as the refusal of the other in either order.
       if (otherQuote.length === 0) {
         otherQuote = turn.text;
       }
@@ -578,26 +580,48 @@ export function refusalEvidence(
   return { quote: "", index: -1, otherQuote };
 }
 
-/** How far either side of the agreement the time may have been said. */
-const NEIGHBOURING_TURNS = 1;
+/** How far back from a turn the caller's proposal may be. */
+const PRECEDING_TURNS = 1;
 
-function nearby(turns: TranscriptTurn[], index: number): TranscriptTurn[] {
-  return turns.slice(Math.max(index - NEIGHBOURING_TURNS, 0), index + NEIGHBOURING_TURNS + 1);
+/**
+ * The turn itself and the caller's turn before it.
+ *
+ * Those are the only two places the thing a turn was answering can have been said,
+ * which is the rule the rest of this module already runs on. Nothing after the turn
+ * is in here: a turn cannot be an answer to something nobody had said yet.
+ *
+ * This used to reach one turn forward as well, on the grounds that the caller reads
+ * the time back once it is settled and that read back is sometimes the first precise
+ * form of it in the call. A read back and a fresh proposal are the same shape from one
+ * turn away, so that reach let a later turn decide what an earlier one had meant. The
+ * caller offers Wednesday, the callee refuses, the caller then offers Thursday. The
+ * refusal of Wednesday passed as evidence about Thursday, which the callee had not
+ * answered yet. Two arrangements in one call did the same thing to a reference number.
+ *
+ * The cost is a call where the only precise form of the time is in the caller's read
+ * back. That now reads as not named, so the commitment comes back unconfirmed and the
+ * report says less than the extraction claimed, which is the direction to be wrong in.
+ */
+function upTo(turns: TranscriptTurn[], index: number): TranscriptTurn[] {
+  return turns.slice(Math.max(index - PRECEDING_TURNS, 0), index + 1);
 }
 
-function namedAround(turns: TranscriptTurn[], index: number, offered: string): boolean {
-  return nearby(turns, index).some((turn) => mentionsDatetime(turn.text, offered));
+function namedBefore(turns: TranscriptTurn[], index: number, offered: string): boolean {
+  return upTo(turns, index).some((turn) => mentionsDatetime(turn.text, offered));
 }
 
 /**
- * Whether the confirmation code was said around the agreement.
+ * Whether the confirmation code was said at the agreement or in the turn it answered.
  *
  * A reference number is part of the same claim as the booking, so it is held to the
- * same standard. A code the extraction produced and nobody read out is dropped.
+ * same standard and bound the same way. Two bookings in one call is otherwise a way
+ * for the second reference to be printed against the first appointment. A code the
+ * callee only reads out in a later turn is dropped, so the report gives no number
+ * rather than the wrong one.
  */
-export function codeNamedAround(turns: TranscriptTurn[], index: number, code: string): boolean {
+export function codeNamedBefore(turns: TranscriptTurn[], index: number, code: string): boolean {
   if (index < 0 || code.trim().length === 0) {
     return false;
   }
-  return nearby(turns, index).some((turn) => mentionsCode(turn.text, code));
+  return upTo(turns, index).some((turn) => mentionsCode(turn.text, code));
 }

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -457,14 +457,77 @@ export function agreementEvidence(
 const COMMITMENT_PROMPT =
   /\b(?:book|books|booked|booking|hold|holding|reserve|reserving|reserved|schedule|scheduled|scheduling|reschedule|pencil|slot|slots|appointment|appointments|availability|confirm|confirming)\b/i;
 
+/**
+ * Caller turns that put something to the callee rather than tell them something.
+ * A question or a request, in the forms a call script uses. The question mark is
+ * not required on its own, because a transcript of speech does not always carry
+ * one and an asked question is still an asked question without it.
+ */
+const ASK_FORMS: RegExp[] = [
+  /\?/,
+  /\b(?:can|could|would|will|shall|may)\s+(?:you|we|i|she|he|they)\b/i,
+  /\b(?:do|does|is|are|have|has)\s+(?:you|she|he|they|there)\b/i,
+  /\b(?:please|any chance)\b/i,
+  /\bi(?:'?m| am) calling to\b/i,
+  /\b(?:would|'?d) like to\b/i,
+];
+
+const MINUTE_WORDS = [...TEEN_WORDS, ...TEN_WORDS.slice(2), "oh", "zero"].join("|");
+const HOUR_WORD_GROUP = HOUR_WORDS.join("|");
+
+/** A clock time as a transcript writes one, whichever day it belongs to. */
+const CLOCK_TIME: RegExp[] = [
+  /\b\d{1,2}[:.]\d{2}\b/,
+  /\b\d{1,2}\s*(?:a\.?m\.?|p\.?m\.?|o'? ?clock)\b/i,
+  /\b(?:half|quarter)\s+(?:past|to)\b/i,
+  new RegExp(
+    `\\b(?:${HOUR_WORD_GROUP})\\b[^a-z0-9]{1,4}(?:o'? ?clock|a\\.?m\\.?|p\\.?m\\.?|in the (?:morning|afternoon|evening))`,
+    "i",
+  ),
+  new RegExp(`\\b(?:${HOUR_WORD_GROUP})[^a-z0-9]{1,3}(?:${MINUTE_WORDS})\\b`, "i"),
+];
+
+/**
+ * Whether the turn names a time a slot could be: a weekday, a day of the month or
+ * a clock time. "Next week" and "soon" are not times anybody can hold, so a turn
+ * carrying only those has proposed nothing to answer.
+ */
+function namesATime(text: string): boolean {
+  return (
+    weekdaysNamed(text).size > 0 || daysNamed(text).size > 0 || CLOCK_TIME.some((pattern) => pattern.test(text))
+  );
+}
+
+/**
+ * Whether a caller turn puts the arrangement to the callee.
+ *
+ * Two halves, because the words alone are not enough. The turn has to be about the
+ * arrangement, which is booking language or the time the extraction reported. It
+ * also has to be putting it to them, which is an ask or an actual proposal, a time
+ * they could say yes to. A statement that merely carries one of those words is
+ * neither. "This appointment is for next week", told between a question and its
+ * answer, would otherwise make that answer a reply to the arrangement, so a no to
+ * the question would be reported as a no to the booking.
+ *
+ * All three bindings run through here, the agreement, the refusal and the
+ * confirmation code that belongs to the agreement, so the rule cannot hold on one
+ * side and not another.
+ *
+ * It is deliberately lexical and it fails closed. A real ask this misses leaves the
+ * evidence unbound, so the commitment reads unconfirmed and the report says less
+ * than the extraction claimed.
+ */
+function raisesArrangement(text: string, offered: string): boolean {
+  if (!COMMITMENT_PROMPT.test(text) && !mentionsDatetime(text, offered)) {
+    return false;
+  }
+  return ASK_FORMS.some((form) => form.test(text)) || namesATime(text);
+}
+
 /** Where the caller raised the arrangement. -1 when it never did. */
 function commitmentPromptAt(turns: TranscriptTurn[], offered: string): number {
   for (const [index, turn] of turns.entries()) {
-    if (turn.speaker !== "bot") {
-      continue;
-    }
-    // Proposing the time is raising the arrangement as much as the word book is.
-    if (COMMITMENT_PROMPT.test(turn.text) || mentionsDatetime(turn.text, offered)) {
+    if (turn.speaker === "bot" && raisesArrangement(turn.text, offered)) {
       return index;
     }
   }
@@ -480,7 +543,9 @@ type LastAsk = "commitment" | "question" | null;
  * A turn answers the most recent thing asked of it, so this is what decides which
  * claim a callee turn is evidence for. Statements are skipped: the caller reading
  * out a date of birth does not change the subject, so a callee who refuses after
- * that is still refusing whatever was last asked.
+ * that is still refusing whatever was last asked. A statement that names the
+ * arrangement is skipped for the same reason, because mentioning an appointment is
+ * not asking for one and the last real ask still stands.
  *
  * A turn that raises the arrangement counts as the arrangement even when it is also
  * one of the errand's questions, which is the usual case: "what is the earliest
@@ -497,7 +562,7 @@ function lastAskBefore(
     if (turn.speaker !== "bot") {
       continue;
     }
-    if (COMMITMENT_PROMPT.test(turn.text) || mentionsDatetime(turn.text, offered)) {
+    if (raisesArrangement(turn.text, offered)) {
       return "commitment";
     }
     if (questions.some((question) => support(tokens(question.text), turn.text) >= QUESTION_ASKED)) {

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -512,8 +512,9 @@ export interface RefusalEvidence {
   index: number;
   /**
    * A refusal the callee voiced about something else, most often an answer to one of
-   * the questions. It is not evidence about the arrangement and it goes in the report
-   * so a person is not told nothing was said when something was.
+   * the questions or a no to another time. It is not evidence about the arrangement
+   * the extraction reported and it goes in the report so a person is not told nothing
+   * was said when something was.
    */
   otherQuote: string;
 }
@@ -522,15 +523,23 @@ export interface RefusalEvidence {
  * What the transcript shows about a refusal of the arrangement. An extraction saying
  * `declined_by_callee` is not a refusal on its own.
  *
- * Anchored the same way an agreement is, because it is the same size of claim about
- * the errand. Refusal words prove nothing by themselves: "no, we do not take that
- * plan" is a refusal of a question and it says nothing about the booking, which may
- * have been accepted in the same call. So the turn has to be answering the
+ * Two bindings, the same two an agreement is held to, because it is the same size of
+ * claim about the errand. Refusal words prove nothing by themselves: "no, we do not
+ * take that plan" is a refusal of a question and it says nothing about the booking,
+ * which may have been accepted in the same call. So the turn has to be answering the
  * arrangement rather than a question. The caller also has to have raised an
- * arrangement at all.
+ * arrangement at all. Then, when the extraction reports a datetime, that datetime has
+ * to be named around the refusing turn: in it, in the caller's proposal before it or
+ * in the turn after. Two times proposed on one call is otherwise a way for a no to the
+ * second to be reported as a no to the first.
  *
- * A refusal aimed at something else still comes back as `otherQuote`, so the report
- * can quote what was actually turned down.
+ * With no datetime reported there is nothing to bind to, so the prompt anchor stands
+ * alone. That is the same asymmetry the agreement side has.
+ *
+ * A refusal aimed at something else, another time included, still comes back as
+ * `otherQuote`, so the report can quote what was actually turned down. A refused
+ * arrangement that cannot be matched to the reported one fails closed: no evidence,
+ * so the commitment reads `unconfirmed` rather than turned down.
  */
 export function refusalEvidence(
   turns: TranscriptTurn[],
@@ -550,6 +559,15 @@ export function refusalEvidence(
       continue;
     }
     if (lastAskBefore(turns, index, offered, questions) !== "commitment") {
+      if (otherQuote.length === 0) {
+        otherQuote = turn.text;
+      }
+      continue;
+    }
+    if (offered.length > 0 && !namedAround(turns, index, offered)) {
+      // A no to another time is not a no to this one. The same binding the agreement
+      // side uses, so a call where two slots were discussed cannot report the refusal
+      // of one as the refusal of the other.
       if (otherQuote.length === 0) {
         otherQuote = turn.text;
       }

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -37,6 +37,24 @@ const DECLINE_AUTOMATED_PATTERNS: RegExp[] = [
   /\bwe only (?:speak|deal) with the (?:patient|customer|account holder)\b/i,
 ];
 
+/**
+ * A refusal of the errand itself, as opposed to a refusal to deal with a robot.
+ * Deliberately narrow: the point is to find a turn that plainly will not do the
+ * thing, so an extraction that reports a refusal nobody voiced comes back
+ * unsupported. Missing a real refusal costs a softer report, inventing one costs
+ * the person a fact about their own errand.
+ */
+const REFUSAL_PATTERNS: RegExp[] = [
+  /\b(?:we|i)\s*(?:'?re| are| am)?\s*(?:not able|unable)\s+to\b/i,
+  /\b(?:we|i)\s*(?:can'?t|cannot|won'?t)\s+(?:do|book|make|arrange|schedule|take|fit|offer|help with|accommodate)\b/i,
+  /\b(?:we|i)\s+(?:do not|don'?t)\s+(?:do|book|offer|handle|arrange|take)\b/i,
+  /\bthat(?:'?s| is) not something we\b/i,
+  /\b(?:nothing|no (?:slots?|appointments?|openings?|availability|times?))\s+(?:is |are )?available\b/i,
+  /\bwe(?:'?re| are)\s+(?:fully )?booked\b/i,
+  /\bwe have (?:nothing|no availability)\b/i,
+  /\byou(?:'?ll| will) (?:have to|need to) (?:go|call|try) (?:somewhere else|elsewhere|another)\b/i,
+];
+
 export interface TranscriptReading {
   userTurnCount: number;
   machineAnswered: boolean;
@@ -46,6 +64,11 @@ export interface TranscriptReading {
   botText: string;
   /** The turn where the callee declined, for the report. */
   declineQuote: string;
+  /**
+   * The turn where the callee refused the errand itself, empty when no turn
+   * says so. A claimed refusal with nothing here is the extraction's alone.
+   */
+  refusalQuote: string;
 }
 
 export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
@@ -60,6 +83,9 @@ export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
   const declineTurn = userTurns.find((turn) =>
     DECLINE_AUTOMATED_PATTERNS.some((pattern) => pattern.test(turn.text)),
   );
+  const refusalTurn = userTurns.find((turn) =>
+    REFUSAL_PATTERNS.some((pattern) => pattern.test(turn.text)),
+  );
   return {
     userTurnCount: userTurns.length,
     machineAnswered,
@@ -67,6 +93,7 @@ export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
     reachedPerson: userTurns.length > 0 && !machineAnswered,
     botText,
     declineQuote: declineTurn?.text ?? "",
+    refusalQuote: refusalTurn?.text ?? "",
   };
 }
 

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -10,7 +10,9 @@
  * Every one of those is anchored to what the caller had just put to the callee. A
  * sentence is evidence for the thing it was answering and for nothing else, which is
  * what stops a yes to one question standing in for an agreement and a no to another
- * standing in for a refusal of the errand.
+ * standing in for a refusal of the errand. What the caller put to them is read clause
+ * by clause, because a question mark at the end of a turn belongs to the thing it was
+ * asked about and not to everything else in that turn.
  *
  * A business declining to deal with an automated caller is a legitimate answer,
  * not an error to retry around. It is detected, reported and obeyed.
@@ -458,7 +460,7 @@ const COMMITMENT_PROMPT =
   /\b(?:book|books|booked|booking|hold|holding|reserve|reserving|reserved|schedule|scheduled|scheduling|reschedule|pencil|slot|slots|appointment|appointments|availability|confirm|confirming)\b/i;
 
 /**
- * Caller turns that put a question or a request to the callee, rather than tell them
+ * Caller clauses that put a question or a request to the callee, rather than tell them
  * something. The question mark is not required on its own, because a transcript of
  * speech does not always carry one and an asked question is still an asked question
  * without it, so the modal, auxiliary and request shapes a call script uses count too.
@@ -468,7 +470,11 @@ const COMMITMENT_PROMPT =
  * not one of them: it tells the callee why the caller rang and asks them nothing, so
  * it is not the caller putting the arrangement to them. A statement like that raises
  * the arrangement only when it also names the offered time, which is the proposal arm
- * in `raisesArrangement`, not an ask.
+ * in `clauseRaises`, not an ask.
+ *
+ * They are matched against one clause rather than a whole turn, because a question
+ * mark at the end of a turn belongs to the thing it was asked about and to nothing
+ * else in that turn.
  */
 const ASK_FORMS: RegExp[] = [
   /\?/,
@@ -478,15 +484,51 @@ const ASK_FORMS: RegExp[] = [
 ];
 
 /**
- * Whether a caller turn puts the arrangement to the callee.
+ * The clauses of a caller turn, in the order they were said.
  *
- * Two halves, because the words alone are not enough. The turn has to be about the
- * arrangement, which is booking language or the time the extraction reported. It
- * also has to put it to them, which is one of two things and not a third:
+ * A turn is not one thing put to the callee. "I am calling to book an appointment. Do
+ * you accept Aetna?" says why the caller rang and then asks about insurance. The
+ * question mark belongs to the insurance question alone. Classifying a turn whole let a
+ * request form anywhere in it license booking words anywhere else, so a no to the
+ * insurance question came back as a refused appointment in a call where no slot had
+ * been put to anybody.
  *
- * - a genuine request: a booking turn in a question or request form, "could you hold
+ * The split is where one thing said ends and the next begins: a sentence end, a
+ * semicolon, a colon, a comma, a dash or a line break. A comma is in there because a
+ * transcript of speech splices two utterances with one as often as it writes a full
+ * stop. The half carrying the question mark is then the whole turn's only ask. A
+ * coordinator counts as a break when a fresh question opens right after it, as in "do
+ * you accept Aetna and can we book Thursday?", because that is a second thing put to
+ * them inside one sentence.
+ *
+ * The cost is a request whose booking word sits on the far side of a comma from its
+ * question form. "About the appointment, could you do Thursday?" is two clauses and
+ * neither is both halves, so it anchors nothing and the commitment reads
+ * `unconfirmed`. That is the direction to be wrong in. A turn that names the time the
+ * extraction reported still anchors on the proposal arm whatever its punctuation.
+ */
+const CLAUSE_BREAK =
+  /(?<=[.!?])\s+|[;:,\r\n]+|\s+[-\u2013\u2014]{1,2}\s+|\s+(?:and|or|but|so|then)\s+(?=(?:can|could|would|will|shall|may|do|does|did|is|are|was|were|have|has|had)\s+(?:you|we|i|she|he|they|there)\b)/i;
+
+function clausesOf(text: string): string[] {
+  return text
+    .split(CLAUSE_BREAK)
+    .map((clause) => clause.trim())
+    .filter((clause) => clause.length > 0);
+}
+
+/**
+ * Whether one clause puts the arrangement to the callee.
+ *
+ * Two halves and both of them inside this clause, which is what binds the request form
+ * to the booking words rather than to whatever else the turn happened to say. The
+ * clause has to be about the arrangement, which is booking language or the time the
+ * extraction reported. It also has to put that to them, which is one of two things and
+ * not a third:
+ *
+ * - a genuine request: booking language in a question or request form, "could you hold
  *   Thursday at nine forty?"
- * - a concrete proposal: a turn that names the offered time itself, "Thursday the
+ * - a concrete proposal: a clause that names the offered time itself, "Thursday the
  *   thirteenth at nine forty would suit her", which is a time they can say yes to
  *   whether or not it is phrased as a question.
  *
@@ -495,6 +537,60 @@ const ASK_FORMS: RegExp[] = [
  * and its answer, asks nothing and offers no slot, so it must not make that answer a
  * reply to the arrangement. That is why the proposal half is the offered time rather
  * than any weekday: a bare weekday in a statement proposes nothing to answer.
+ *
+ * The proposal arm asks the whole turn as well as the clause, so the day check inside
+ * `mentionsDatetime` still sees every day the turn named. Reading a clause alone would
+ * take "Wednesday, at nine forty" for Thursday at nine forty, because the half holding
+ * the clock names no day at all.
+ */
+function clauseRaises(clause: string, text: string, offered: string): boolean {
+  if (mentionsDatetime(clause, offered) && mentionsDatetime(text, offered)) {
+    return true;
+  }
+  return COMMITMENT_PROMPT.test(clause) && ASK_FORMS.some((form) => form.test(clause));
+}
+
+/**
+ * Which clause of a caller turn last put the arrangement to the callee. -1 when none
+ * of them did.
+ *
+ * Where it happened matters as much as whether it did, because a turn can raise the
+ * arrangement and then ask something else. What a callee answers is the last thing said
+ * to them.
+ */
+function arrangementAt(text: string, offered: string): number {
+  const clauses = clausesOf(text);
+  for (let at = clauses.length - 1; at >= 0; at -= 1) {
+    if (clauseRaises(clauses[at]!, text, offered)) {
+      return at;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Which clause of a caller turn last asked one of the errand's questions. -1 when none
+ * of them did.
+ *
+ * A question whose words run across a clause break is still asked and it ends where
+ * the turn ends, so it counts as the last thing said. Without that, a question the
+ * split happens to cut in half would go missing and hand the turn back to the
+ * arrangement, which is the reading this whole rule exists to stop.
+ */
+function questionAt(text: string, questions: ErrandQuestion[]): number {
+  const asked = (part: string): boolean =>
+    questions.some((question) => support(tokens(question.text), part) >= QUESTION_ASKED);
+  const clauses = clausesOf(text);
+  for (let at = clauses.length - 1; at >= 0; at -= 1) {
+    if (asked(clauses[at]!)) {
+      return at;
+    }
+  }
+  return asked(text) ? clauses.length - 1 : -1;
+}
+
+/**
+ * Whether a caller turn puts the arrangement to the callee anywhere in it.
  *
  * All three bindings run through here, the agreement, the refusal and the
  * confirmation code that belongs to the agreement, so the rule cannot hold on one
@@ -505,11 +601,7 @@ const ASK_FORMS: RegExp[] = [
  * than the extraction claimed.
  */
 function raisesArrangement(text: string, offered: string): boolean {
-  const proposesOffered = mentionsDatetime(text, offered);
-  if (!COMMITMENT_PROMPT.test(text) && !proposesOffered) {
-    return false;
-  }
-  return ASK_FORMS.some((form) => form.test(text)) || proposesOffered;
+  return arrangementAt(text, offered) >= 0;
 }
 
 /** Where the caller raised the arrangement. -1 when it never did. */
@@ -535,9 +627,14 @@ type LastAsk = "commitment" | "question" | null;
  * arrangement is skipped for the same reason, because mentioning an appointment is
  * not asking for one and the last real ask still stands.
  *
- * A turn that raises the arrangement counts as the arrangement even when it is also
- * one of the errand's questions, which is the usual case: "what is the earliest
- * appointment you have" is both.
+ * Inside a turn it is the last clause that counts, for the same reason it is the last
+ * turn. "Could you hold Thursday at nine forty? Do you accept Aetna?" raises the
+ * arrangement and then asks something else, so the no that follows is a no to the
+ * insurance question and the report must not read it as a refused booking.
+ *
+ * A clause that is both counts as the arrangement, which is the usual case: "what is
+ * the earliest appointment you have" is a question on the errand's list and the
+ * arrangement being put to them at the same time.
  */
 function lastAskBefore(
   turns: TranscriptTurn[],
@@ -550,11 +647,13 @@ function lastAskBefore(
     if (turn.speaker !== "bot") {
       continue;
     }
-    if (raisesArrangement(turn.text, offered)) {
-      return "commitment";
-    }
-    if (questions.some((question) => support(tokens(question.text), turn.text) >= QUESTION_ASKED)) {
+    const arrangement = arrangementAt(turn.text, offered);
+    const question = questionAt(turn.text, questions);
+    if (question > arrangement) {
       return "question";
+    }
+    if (arrangement >= 0) {
+      return "commitment";
     }
   }
   return null;

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -458,56 +458,43 @@ const COMMITMENT_PROMPT =
   /\b(?:book|books|booked|booking|hold|holding|reserve|reserving|reserved|schedule|scheduled|scheduling|reschedule|pencil|slot|slots|appointment|appointments|availability|confirm|confirming)\b/i;
 
 /**
- * Caller turns that put something to the callee rather than tell them something.
- * A question or a request, in the forms a call script uses. The question mark is
- * not required on its own, because a transcript of speech does not always carry
- * one and an asked question is still an asked question without it.
+ * Caller turns that put a question or a request to the callee, rather than tell them
+ * something. The question mark is not required on its own, because a transcript of
+ * speech does not always carry one and an asked question is still an asked question
+ * without it, so the modal, auxiliary and request shapes a call script uses count too.
+ *
+ * These are interrogative and request forms only. A first-person purpose statement
+ * ("I am calling to book an appointment", "I would like to book an appointment") is
+ * not one of them: it tells the callee why the caller rang and asks them nothing, so
+ * it is not the caller putting the arrangement to them. A statement like that raises
+ * the arrangement only when it also names the offered time, which is the proposal arm
+ * in `raisesArrangement`, not an ask.
  */
 const ASK_FORMS: RegExp[] = [
   /\?/,
   /\b(?:can|could|would|will|shall|may)\s+(?:you|we|i|she|he|they)\b/i,
   /\b(?:do|does|is|are|have|has)\s+(?:you|she|he|they|there)\b/i,
   /\b(?:please|any chance)\b/i,
-  /\bi(?:'?m| am) calling to\b/i,
-  /\b(?:would|'?d) like to\b/i,
 ];
-
-const MINUTE_WORDS = [...TEEN_WORDS, ...TEN_WORDS.slice(2), "oh", "zero"].join("|");
-const HOUR_WORD_GROUP = HOUR_WORDS.join("|");
-
-/** A clock time as a transcript writes one, whichever day it belongs to. */
-const CLOCK_TIME: RegExp[] = [
-  /\b\d{1,2}[:.]\d{2}\b/,
-  /\b\d{1,2}\s*(?:a\.?m\.?|p\.?m\.?|o'? ?clock)\b/i,
-  /\b(?:half|quarter)\s+(?:past|to)\b/i,
-  new RegExp(
-    `\\b(?:${HOUR_WORD_GROUP})\\b[^a-z0-9]{1,4}(?:o'? ?clock|a\\.?m\\.?|p\\.?m\\.?|in the (?:morning|afternoon|evening))`,
-    "i",
-  ),
-  new RegExp(`\\b(?:${HOUR_WORD_GROUP})[^a-z0-9]{1,3}(?:${MINUTE_WORDS})\\b`, "i"),
-];
-
-/**
- * Whether the turn names a time a slot could be: a weekday, a day of the month or
- * a clock time. "Next week" and "soon" are not times anybody can hold, so a turn
- * carrying only those has proposed nothing to answer.
- */
-function namesATime(text: string): boolean {
-  return (
-    weekdaysNamed(text).size > 0 || daysNamed(text).size > 0 || CLOCK_TIME.some((pattern) => pattern.test(text))
-  );
-}
 
 /**
  * Whether a caller turn puts the arrangement to the callee.
  *
  * Two halves, because the words alone are not enough. The turn has to be about the
  * arrangement, which is booking language or the time the extraction reported. It
- * also has to be putting it to them, which is an ask or an actual proposal, a time
- * they could say yes to. A statement that merely carries one of those words is
- * neither. "This appointment is for next week", told between a question and its
- * answer, would otherwise make that answer a reply to the arrangement, so a no to
- * the question would be reported as a no to the booking.
+ * also has to put it to them, which is one of two things and not a third:
+ *
+ * - a genuine request: a booking turn in a question or request form, "could you hold
+ *   Thursday at nine forty?"
+ * - a concrete proposal: a turn that names the offered time itself, "Thursday the
+ *   thirteenth at nine forty would suit her", which is a time they can say yes to
+ *   whether or not it is phrased as a question.
+ *
+ * A declarative that only carries a booking word is neither, even when it also names
+ * some unrelated day. "Our appointment desk is open Monday", told between a question
+ * and its answer, asks nothing and offers no slot, so it must not make that answer a
+ * reply to the arrangement. That is why the proposal half is the offered time rather
+ * than any weekday: a bare weekday in a statement proposes nothing to answer.
  *
  * All three bindings run through here, the agreement, the refusal and the
  * confirmation code that belongs to the agreement, so the rule cannot hold on one
@@ -518,10 +505,11 @@ function namesATime(text: string): boolean {
  * than the extraction claimed.
  */
 function raisesArrangement(text: string, offered: string): boolean {
-  if (!COMMITMENT_PROMPT.test(text) && !mentionsDatetime(text, offered)) {
+  const proposesOffered = mentionsDatetime(text, offered);
+  if (!COMMITMENT_PROMPT.test(text) && !proposesOffered) {
     return false;
   }
-  return ASK_FORMS.some((form) => form.test(text)) || namesATime(text);
+  return ASK_FORMS.some((form) => form.test(text)) || proposesOffered;
 }
 
 /** Where the caller raised the arrangement. -1 when it never did. */

--- a/apps/typescript/call-on-behalf/src/read.ts
+++ b/apps/typescript/call-on-behalf/src/read.ts
@@ -5,7 +5,12 @@
  * contract is for. This module reads the things a structured result must never be
  * the only source of: whether a person was actually there, whether that person
  * told the caller to go away, whether anything the callee said supports a claimed
- * answer and whether anybody agreed to anything.
+ * answer and whether anybody agreed to or refused the arrangement.
+ *
+ * Every one of those is anchored to what the caller had just put to the callee. A
+ * sentence is evidence for the thing it was answering and for nothing else, which is
+ * what stops a yes to one question standing in for an agreement and a no to another
+ * standing in for a refusal of the errand.
  *
  * A business declining to deal with an automated caller is a legitimate answer,
  * not an error to retry around. It is detected, reported and obeyed.
@@ -43,6 +48,10 @@ const DECLINE_AUTOMATED_PATTERNS: RegExp[] = [
  * thing, so an extraction that reports a refusal nobody voiced comes back
  * unsupported. Missing a real refusal costs a softer report, inventing one costs
  * the person a fact about their own errand.
+ *
+ * Matching one of these is not enough on its own. The same words refuse a question
+ * ("we do not take that plan") as easily as they refuse the arrangement, so
+ * `refusalEvidence` decides what a matching turn was actually answering.
  */
 const REFUSAL_PATTERNS: RegExp[] = [
   /\b(?:we|i)\s*(?:'?re| are| am)?\s*(?:not able|unable)\s+to\b/i,
@@ -64,11 +73,6 @@ export interface TranscriptReading {
   botText: string;
   /** The turn where the callee declined, for the report. */
   declineQuote: string;
-  /**
-   * The turn where the callee refused the errand itself, empty when no turn
-   * says so. A claimed refusal with nothing here is the extraction's alone.
-   */
-  refusalQuote: string;
 }
 
 export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
@@ -83,9 +87,6 @@ export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
   const declineTurn = userTurns.find((turn) =>
     DECLINE_AUTOMATED_PATTERNS.some((pattern) => pattern.test(turn.text)),
   );
-  const refusalTurn = userTurns.find((turn) =>
-    REFUSAL_PATTERNS.some((pattern) => pattern.test(turn.text)),
-  );
   return {
     userTurnCount: userTurns.length,
     machineAnswered,
@@ -93,7 +94,6 @@ export function readTranscript(turns: TranscriptTurn[]): TranscriptReading {
     reachedPerson: userTurns.length > 0 && !machineAnswered,
     botText,
     declineQuote: declineTurn?.text ?? "",
-    refusalQuote: refusalTurn?.text ?? "",
   };
 }
 
@@ -148,12 +148,15 @@ function polarity(text: string): "yes" | "no" | null {
   return yesAt < noAt ? "yes" : "no";
 }
 
+/** How much of a question a caller turn has to carry before it counts as asked. */
+const QUESTION_ASKED = 0.7;
+
 /** The last turn where the caller asked this question. -1 when it never did. */
 function askedAt(question: string, turns: TranscriptTurn[]): number {
   const wanted = tokens(question);
   let found = -1;
   for (const [index, turn] of turns.entries()) {
-    if (turn.speaker === "bot" && support(wanted, turn.text) >= 0.7) {
+    if (turn.speaker === "bot" && support(wanted, turn.text) >= QUESTION_ASKED) {
       found = index;
     }
   }
@@ -465,6 +468,96 @@ function commitmentPromptAt(turns: TranscriptTurn[], offered: string): number {
     }
   }
   return -1;
+}
+
+/** What the caller last put to the callee, which is what their next turn answers. */
+type LastAsk = "commitment" | "question" | null;
+
+/**
+ * What the caller had last put to the callee before this turn.
+ *
+ * A turn answers the most recent thing asked of it, so this is what decides which
+ * claim a callee turn is evidence for. Statements are skipped: the caller reading
+ * out a date of birth does not change the subject, so a callee who refuses after
+ * that is still refusing whatever was last asked.
+ *
+ * A turn that raises the arrangement counts as the arrangement even when it is also
+ * one of the errand's questions, which is the usual case: "what is the earliest
+ * appointment you have" is both.
+ */
+function lastAskBefore(
+  turns: TranscriptTurn[],
+  index: number,
+  offered: string,
+  questions: ErrandQuestion[],
+): LastAsk {
+  for (let at = index - 1; at >= 0; at -= 1) {
+    const turn = turns[at]!;
+    if (turn.speaker !== "bot") {
+      continue;
+    }
+    if (COMMITMENT_PROMPT.test(turn.text) || mentionsDatetime(turn.text, offered)) {
+      return "commitment";
+    }
+    if (questions.some((question) => support(tokens(question.text), turn.text) >= QUESTION_ASKED)) {
+      return "question";
+    }
+  }
+  return null;
+}
+
+export interface RefusalEvidence {
+  /** The callee turn that refuses the arrangement. Empty when no turn does. */
+  quote: string;
+  index: number;
+  /**
+   * A refusal the callee voiced about something else, most often an answer to one of
+   * the questions. It is not evidence about the arrangement and it goes in the report
+   * so a person is not told nothing was said when something was.
+   */
+  otherQuote: string;
+}
+
+/**
+ * What the transcript shows about a refusal of the arrangement. An extraction saying
+ * `declined_by_callee` is not a refusal on its own.
+ *
+ * Anchored the same way an agreement is, because it is the same size of claim about
+ * the errand. Refusal words prove nothing by themselves: "no, we do not take that
+ * plan" is a refusal of a question and it says nothing about the booking, which may
+ * have been accepted in the same call. So the turn has to be answering the
+ * arrangement rather than a question. The caller also has to have raised an
+ * arrangement at all.
+ *
+ * A refusal aimed at something else still comes back as `otherQuote`, so the report
+ * can quote what was actually turned down.
+ */
+export function refusalEvidence(
+  turns: TranscriptTurn[],
+  offered = "",
+  questions: ErrandQuestion[] = [],
+): RefusalEvidence {
+  let otherQuote = "";
+  if (commitmentPromptAt(turns, offered) === -1) {
+    // The caller never raised an arrangement, so nothing here can be a refusal of one.
+    const loose = turns.find(
+      (turn) => turn.speaker === "user" && REFUSAL_PATTERNS.some((pattern) => pattern.test(turn.text)),
+    );
+    return { quote: "", index: -1, otherQuote: loose?.text ?? "" };
+  }
+  for (const [index, turn] of turns.entries()) {
+    if (turn.speaker !== "user" || !REFUSAL_PATTERNS.some((pattern) => pattern.test(turn.text))) {
+      continue;
+    }
+    if (lastAskBefore(turns, index, offered, questions) !== "commitment") {
+      if (otherQuote.length === 0) {
+        otherQuote = turn.text;
+      }
+      continue;
+    }
+    return { quote: turn.text, index, otherQuote: "" };
+  }
+  return { quote: "", index: -1, otherQuote };
 }
 
 /** How far either side of the agreement the time may have been said. */

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -410,3 +410,142 @@ test("an errand that cannot be created at all is unknown, not a refusal", async 
     },
   );
 });
+
+/**
+ * The three claims below are the same kind of mistake: a fact stated on evidence
+ * that does not carry it. A definite answer to a reconciliation is read as proof
+ * that no call was ever placed. A status CALL-E ended a call with is read as proof
+ * that nothing was said on it. An extraction saying the callee refused is read as
+ * the errand being done.
+ */
+
+test("a definite refusal on the reconcile is not proof the call was never made", async () => {
+  // 401, 403, 400 and 402 can each be decided before the idempotency lookup ever
+  // happens, so none of them says anything about the create that went unanswered.
+  // Only getting the call back settles that.
+  const definite = [
+    { status: 401, code: "unauthorized" },
+    { status: 403, code: "forbidden" },
+    { status: 400, code: "bad_request" },
+    { status: 402, code: "insufficient_balance" },
+  ];
+  for (const second of definite) {
+    await withFake(
+      [{ phone: CLINIC, createErrors: [{ status: 503, code: "service_unavailable" }, second] }],
+      async (port, fake) => {
+        const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+        assert.equal(report.outcome, "outcome_unknown", `${second.code} was read as proof of no call`);
+        assert.equal(report.call_status, "unknown", second.code);
+        assert.equal(report.call_id, null, "no answer ever named the call");
+        assert.equal(
+          report.callee_notes,
+          `the call could not be reconciled (service_unavailable, then ${second.code})`,
+        );
+        assert.equal(report.commitment, "unconfirmed", "a call nobody can account for may have agreed something");
+        assert.deepEqual(report.authorized_but_unused, [], "what the caller said is not known either");
+        assert.match(report.next_step, /nobody knows yet whether the call was made/);
+        assert.equal(report.next_step.includes("Nothing was said"), false, second.code);
+        assert.equal(report.next_step.includes("refused to create the call"), false, second.code);
+        assert.equal(fake.created.length, 0, "no second call was ever placed");
+      },
+    );
+  }
+});
+
+test("a call that ended early still reports the conversation it carried", async () => {
+  // A line that drops after the booking comes back as `failed`, sometimes with a
+  // code that reads like nobody answered. The transcript holds the questions, the
+  // answers and the slot, so the status cannot unsay any of it.
+  const cases: [string, string | null][] = [
+    ["failed", "line_dropped"],
+    ["failed", "no_answer"],
+    ["canceled", null],
+  ];
+  for (const [status, failureCode] of cases) {
+    await withFake(
+      [
+        {
+          phone: CLINIC,
+          status: status as "failed" | "canceled",
+          failureCode,
+          botLines: BOT_LINES,
+          userLines: USER_LINES,
+          structuredResult: goodResult(),
+        },
+      ],
+      async (port) => {
+        const label = `${status}/${String(failureCode)}`;
+        const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+        assert.equal(report.call_status, status, label);
+        assert.equal(report.reached_person, true, `${label} was read as nobody on the line`);
+        assert.equal(report.outcome, "partially_met", label);
+        assert.equal(report.answers.every((answer) => answer.answered), true, `${label} lost the answers`);
+        assert.equal(report.commitment, "committed", label);
+        assert.equal(report.committed_datetime, "2026-08-13T09:40:00-07:00", label);
+        assert.equal(report.confirmation_code, "4471", label);
+        assert.match(report.callee_notes, new RegExp(`call_${status}`), label);
+        assert.match(report.next_step, /That is arranged/, label);
+        assert.equal(report.next_step.includes("Nothing was said on your behalf"), false, label);
+        assert.equal(report.next_step.includes("did not connect to a person"), false, label);
+      },
+    );
+  }
+});
+
+test("the transcript says who was on the line, not the failure code beside it", async () => {
+  // A machine on the transcript is a machine, whatever code CALL-E filed the call
+  // under. The ordering is the point here: the transcript is read before the code.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        status: "failed",
+        failureCode: "busy",
+        botLines: ["Hello, I am an automated assistant."],
+        userLines: ["You have reached Bayview Family Clinic. Please leave a message after the tone."],
+        structuredResult: null,
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.outcome, "voicemail");
+      assert.equal(report.reached_person, false);
+      assert.match(report.next_step, /went to a machine/);
+    },
+  );
+});
+
+test("a refusal CALL-E reported does not make the errand done", async () => {
+  // Nobody agreed to anything, so the appointment the errand asked for was not
+  // made. Every question was answered, which is partly met and not met in full.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: BOT_LINES,
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look. Can I take the date of birth?",
+          "Earliest is Thursday the thirteenth at nine forty in the morning.",
+          "Yes, we take Blue Shield PPO.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: {
+          ...goodResult(),
+          commitment_made: "declined_by_callee",
+          offered_datetime: "",
+          confirmation_code: "",
+        },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "declined_by_callee");
+      assert.equal(report.answers.every((answer) => answer.answered), true);
+      assert.equal(report.outcome, "partially_met");
+      assert.match(report.next_step, /would not arrange it/);
+      assert.equal(report.next_step.includes("did not ask for anything to be agreed"), false);
+      assert.match(report.callee_notes, /CALL-E reported that they would not arrange it/);
+    },
+  );
+});

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -664,3 +664,83 @@ test("an agreement and a refusal in the same call settle nothing", async () => {
     },
   );
 });
+
+test("a refusal of another proposed time is not a refusal of the one reported", async () => {
+  // Two times go across this call. The caller asks for Thursday at nine forty and the
+  // callee goes away to check it, then the caller offers Wednesday instead and that is
+  // the one the callee turns down. The extraction files declined_by_callee with
+  // Thursday in offered_datetime. Reading the Wednesday refusal as evidence for
+  // Thursday tells somebody the slot they asked for was turned down when nobody said
+  // that about it.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [
+          BOT_LINES[0]!,
+          BOT_LINES[1]!,
+          "Could you hold Thursday the thirteenth at nine forty?",
+          "If that one is hard to hold, could you do Wednesday the twelfth at two in the afternoon?",
+          BOT_LINES[3]!,
+          BOT_LINES[4]!,
+        ],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Earliest is Thursday the thirteenth at nine forty in the morning.",
+          "Let me look at Thursday and come back to you.",
+          "No, we are fully booked on Wednesday. I cannot fit that in.",
+          "Yes, we take Blue Shield PPO.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: { ...goodResult(), commitment_made: "declined_by_callee", confirmation_code: "" },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.equal(report.committed_datetime, null);
+      assert.match(report.next_step, /nothing is settled either way/);
+      assert.equal(report.next_step.includes("would not arrange it on this call"), false);
+      assert.match(report.callee_notes, /no turn refuses the arrangement/);
+      assert.match(report.callee_notes, /fully booked on Wednesday/);
+      // What the callee did answer is still answered, out of the same call.
+      assert.equal(report.answers.every((answer) => answer.answered), true);
+      assert.equal(report.outcome, "partially_met");
+    },
+  );
+});
+
+test("a refusal of the time the extraction reported is still a refusal", async () => {
+  // The other side of the time binding. This turn refuses the slot the extraction
+  // named, so the report stands behind the refusal and quotes it.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [
+          BOT_LINES[0]!,
+          BOT_LINES[1]!,
+          "Could you hold Thursday the thirteenth at nine forty?",
+          BOT_LINES[3]!,
+          BOT_LINES[4]!,
+        ],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Earliest is Thursday the thirteenth at nine forty in the morning.",
+          "I am afraid we cannot book Thursday at nine forty, that slot has just gone.",
+          "Yes, we take Blue Shield PPO.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: { ...goodResult(), commitment_made: "declined_by_callee", confirmation_code: "" },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "declined_by_callee");
+      assert.match(report.next_step, /would not arrange it on this call/);
+      assert.match(report.callee_notes, /a turn in the transcript refuses it/);
+      assert.match(report.callee_notes, /cannot book Thursday at nine forty/);
+      assert.equal(report.outcome, "partially_met");
+    },
+  );
+});

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -540,12 +540,47 @@ test("a refusal CALL-E reported does not make the errand done", async () => {
     ],
     async (port) => {
       const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
-      assert.equal(report.commitment, "declined_by_callee");
+      // Nobody refused anything in this transcript, they offered a slot. So the
+      // refusal is the extraction's claim alone and the report will not state it.
+      assert.equal(report.commitment, "unconfirmed");
       assert.equal(report.answers.every((answer) => answer.answered), true);
       assert.equal(report.outcome, "partially_met");
-      assert.match(report.next_step, /would not arrange it/);
+      assert.match(report.next_step, /nothing is settled either way/);
       assert.equal(report.next_step.includes("did not ask for anything to be agreed"), false);
-      assert.match(report.callee_notes, /CALL-E reported that they would not arrange it/);
+      assert.match(report.callee_notes, /no turn in the transcript refuses anything/);
+    },
+  );
+});
+
+test("a refusal the callee actually voiced is reported as a refusal", async () => {
+  // The other side of the same coin. When a turn plainly refuses, the report
+  // stands behind it, names the quote and stops calling the errand done.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: BOT_LINES,
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look. Can I take the date of birth?",
+          "I am afraid we cannot book that over the phone for somebody else.",
+          "Yes, we take Blue Shield PPO.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: {
+          ...goodResult(),
+          commitment_made: "declined_by_callee",
+          offered_datetime: "",
+          confirmation_code: "",
+        },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "declined_by_callee");
+      assert.match(report.next_step, /would not arrange it/);
+      assert.match(report.callee_notes, /the transcript agrees/);
+      assert.match(report.callee_notes, /cannot book that over the phone/);
     },
   );
 });

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -553,8 +553,8 @@ test("a refusal CALL-E reported does not make the errand done", async () => {
 });
 
 test("a refusal the callee actually voiced is reported as a refusal", async () => {
-  // The other side of the same coin. When a turn plainly refuses, the report
-  // stands behind it, names the quote and stops calling the errand done.
+  // The other side of the same coin. When a turn plainly refuses the arrangement,
+  // the report stands behind it, names the quote and stops calling the errand done.
   await withFake(
     [
       {
@@ -579,8 +579,88 @@ test("a refusal the callee actually voiced is reported as a refusal", async () =
       const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
       assert.equal(report.commitment, "declined_by_callee");
       assert.match(report.next_step, /would not arrange it/);
-      assert.match(report.callee_notes, /the transcript agrees/);
+      assert.match(report.callee_notes, /a turn in the transcript refuses it/);
       assert.match(report.callee_notes, /cannot book that over the phone/);
+    },
+  );
+});
+
+test("a refusal of one of the questions is not a refusal of the errand", async () => {
+  // The arrangement was accepted on this call and what the callee turned down was
+  // the insurance question. CALL-E still reported declined_by_callee, so the only
+  // thing that could stand behind that claim is a turn refusing the arrangement,
+  // and there is not one. Reading the insurance refusal as corroboration would tell
+  // somebody their appointment was turned down in a call where it was held.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: BOT_LINES,
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look. Can I take the date of birth?",
+          "Earliest is Thursday the thirteenth at nine forty in the morning. I can hold that slot, reference four four seven one.",
+          "No, we do not take Blue Shield PPO.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: {
+          ...goodResult(),
+          answer_accepts_plan: "no",
+          commitment_made: "declined_by_callee",
+        },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.equal(report.committed_datetime, null);
+      assert.match(report.next_step, /nothing is settled either way/);
+      assert.equal(report.next_step.includes("would not arrange it on this call"), false);
+      assert.match(report.callee_notes, /no turn refuses the arrangement/);
+      assert.match(report.callee_notes, /we do not take Blue Shield PPO/);
+      // The question they did turn down is still answered, out of that same turn.
+      assert.equal(report.answers[1]!.answered, true);
+      assert.equal(report.answers[1]!.answer, "no");
+    },
+  );
+});
+
+test("an agreement and a refusal in the same call settle nothing", async () => {
+  // Both claims have a turn behind them, so the transcript contradicts itself and
+  // this app does not pick a side. Reporting the agreement would book something the
+  // callee took back, reporting the refusal would drop a slot they may be holding.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [
+          BOT_LINES[0]!,
+          BOT_LINES[1]!,
+          BOT_LINES[2]!,
+          "Can you hold that slot on Thursday at nine forty?",
+          BOT_LINES[4]!,
+        ],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look. Can I take the date of birth?",
+          "Earliest is Thursday the thirteenth at nine forty in the morning. I can hold that slot, reference four four seven one.",
+          "Sorry, I am not able to hold that after all.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: goodResult(),
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.equal(report.committed_datetime, null);
+      // A reference number belongs to an agreement that stands. This one does not.
+      assert.equal(report.confirmation_code, "");
+      assert.match(report.next_step, /both somebody agreeing to it and somebody refusing it/);
+      assert.match(report.next_step, /call to check/);
+      assert.match(report.callee_notes, /an agreement and a refusal for the same arrangement/);
+      assert.match(report.callee_notes, /I can hold that slot/);
+      assert.match(report.callee_notes, /not able to hold that after all/);
     },
   );
 });

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -744,3 +744,76 @@ test("a refusal of the time the extraction reported is still a refusal", async (
     },
   );
 });
+
+test("a statement about the appointment does not turn a refused question into a refused errand", async () => {
+  // The caller asks about the plan, tells them what the appointment is for and the
+  // callee turns down the plan. Nothing was ever put to them about holding a slot,
+  // so a statement carrying the word appointment is not the thing that refusal
+  // answered. Reading it that way tells somebody an appointment was refused in a
+  // call where nobody was asked for one.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [BOT_LINES[0]!, "Do you take Blue Shield PPO?", "This appointment is for next week.", BOT_LINES[4]!],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look that up for you.",
+          "No, we do not take that plan.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: {
+          ...goodResult(),
+          answer_earliest: "",
+          answer_accepts_plan: "no",
+          commitment_made: "declined_by_callee",
+          offered_datetime: "",
+          confirmation_code: "",
+        },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.equal(report.outcome, "partially_met");
+      assert.match(report.next_step, /nothing is settled either way/);
+      assert.equal(report.next_step.includes("would not arrange it on this call"), false);
+      assert.match(report.callee_notes, /no turn refuses the arrangement/);
+      assert.match(report.callee_notes, /we do not take that plan/);
+      // The question they did turn down is still answered, out of that same turn.
+      assert.equal(report.answers[1]!.answered, true);
+      assert.equal(report.answers[1]!.answer, "no");
+    },
+  );
+});
+
+test("a booking nobody asked for is not agreed and its reference number is dropped", async () => {
+  // The same statement on the other two bindings. The callee volunteers a slot and a
+  // reference in a call where the caller only asked about the plan. Reporting that as
+  // agreed books something on the callee's word alone. The reference number goes with
+  // the agreement it belongs to, so it goes nowhere here.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [BOT_LINES[0]!, "Do you take Blue Shield PPO?", "This appointment is for next week.", BOT_LINES[4]!],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "Let me look that up for you.",
+          "Yes, we take Blue Shield PPO. I have put her in for Thursday the thirteenth at nine forty, reference four four seven one.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: { ...goodResult(), answer_earliest: "" },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.equal(report.committed_datetime, null);
+      assert.equal(report.confirmation_code, "");
+      assert.match(report.callee_notes, /no turn in the transcript agrees to that/);
+      assert.match(report.callee_notes, /I have put her in for Thursday/);
+      assert.match(report.next_step, /treat nothing as booked/);
+    },
+  );
+});

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -787,6 +787,50 @@ test("a statement about the appointment does not turn a refused question into a 
   );
 });
 
+test("a question asked in the same turn as a booking line is what the answer answers", async () => {
+  // One caller turn says why the call is happening and then asks about the plan. The
+  // callee turns down the plan. Nothing was ever put to them about holding a slot, so
+  // the question mark on the insurance question is not an ask for the booking words in
+  // front of it. Reading it that way tells somebody an appointment was refused in a
+  // call where nobody was asked for one.
+  await withFake(
+    [
+      {
+        phone: CLINIC,
+        botLines: [
+          BOT_LINES[0]!,
+          "I am calling to book an appointment. Do you take Blue Shield PPO?",
+          BOT_LINES[4]!,
+        ],
+        userLines: [
+          "Bayview Family Clinic, how can I help?",
+          "No, we do not take that plan.",
+          "Photo identification and the insurance card.",
+        ],
+        structuredResult: {
+          ...goodResult(),
+          answer_earliest: "",
+          answer_accepts_plan: "no",
+          commitment_made: "declined_by_callee",
+          offered_datetime: "",
+          confirmation_code: "",
+        },
+      },
+    ],
+    async (port) => {
+      const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+      assert.equal(report.commitment, "unconfirmed");
+      assert.match(report.next_step, /nothing is settled either way/);
+      assert.equal(report.next_step.includes("would not arrange it on this call"), false);
+      assert.match(report.callee_notes, /no turn refuses the arrangement/);
+      assert.match(report.callee_notes, /we do not take that plan/);
+      // The question they did turn down is still answered, out of that same turn.
+      assert.equal(report.answers[1]!.answered, true);
+      assert.equal(report.answers[1]!.answer, "no");
+    },
+  );
+});
+
 test("a booking nobody asked for is not agreed and its reference number is dropped", async () => {
   // The same statement on the other two bindings. The callee volunteers a slot and a
   // reference in a call where the caller only asked about the plan. Reporting that as

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { agreementEvidence, mentionsCode, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "../src/read.js";
+import { agreementEvidence, codeNamedBefore, mentionsCode, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "../src/read.js";
 import type { ErrandQuestion, TranscriptTurn } from "../src/types.js";
 
 const EARLIEST: ErrandQuestion = {
@@ -114,6 +114,24 @@ test("an agreement has to be about the time the extraction claims", () => {
   assert.match(agreementEvidence(elsewhere, "slot_within_windows", "2026-08-18T14:00:00-07:00").quote, /^I have booked/);
 });
 
+test("an agreement is not evidence about a time the caller raised after it", () => {
+  const call = turns([
+    ["bot", "Could you hold Wednesday the twelfth at two in the afternoon?"],
+    ["user", "Yes, I have booked her in."],
+    ["bot", "And could you do Thursday the thirteenth at nine forty as well?"],
+  ]);
+  // They agreed to the time that had been put to them. Thursday came after, so the
+  // turn before it cannot be an agreement to Thursday, whatever the extraction says.
+  const claimed = agreementEvidence(call, "slot_within_windows", "2026-08-13T09:40:00-07:00");
+  assert.equal(claimed.quote, "");
+  assert.match(claimed.otherQuote, /^Yes, I have booked/);
+  // The same turn is evidence for the time it was answering.
+  assert.match(
+    agreementEvidence(call, "slot_within_windows", "2026-08-12T14:00:00-07:00").quote,
+    /^Yes, I have booked/,
+  );
+});
+
 test("an agreement the caller never asked for is not an agreement with the caller", () => {
   const volunteered = turns([
     ["bot", "Do you take Blue Shield PPO?"],
@@ -202,6 +220,41 @@ test("a refusal has to be about the time the extraction claims", () => {
   assert.match(refusalEvidence(call, "2026-08-12T14:00:00-07:00", [EARLIEST, PLAN]).quote, /^No, we are fully booked/);
   // No time reported, so there is nothing to bind to and the prompt anchor stands alone.
   assert.match(refusalEvidence(call, "", [EARLIEST, PLAN]).quote, /^No, we are fully booked/);
+});
+
+test("a refusal is not evidence about a time the caller raised after it", () => {
+  const call = turns([
+    ["bot", "Could you hold Wednesday the twelfth at two in the afternoon?"],
+    ["user", "No, we are fully booked. I cannot fit that in."],
+    ["bot", "Then could you do Thursday the thirteenth at nine forty?"],
+    ["user", "Let me look and call you back."],
+  ]);
+  // The refusal answered Wednesday. Thursday was put to them in the next turn, so the
+  // refusal cannot be about it: the report would say Thursday was turned down before
+  // anybody had been asked about Thursday.
+  const claimed = refusalEvidence(call, "2026-08-13T09:40:00-07:00", [EARLIEST, PLAN]);
+  assert.equal(claimed.quote, "");
+  assert.match(claimed.otherQuote, /^No, we are fully booked/);
+  // The option it does answer is the one the caller had put to them.
+  assert.match(
+    refusalEvidence(call, "2026-08-12T14:00:00-07:00", [EARLIEST, PLAN]).quote,
+    /^No, we are fully booked/,
+  );
+});
+
+test("a confirmation code counts where it was read out, not in a later booking", () => {
+  const call = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty?"],
+    ["user", "Held, reference four four seven one."],
+    ["user", "And the follow up we spoke about is reference nine nine one two."],
+  ]);
+  assert.equal(codeNamedBefore(call, 1, "4471"), true);
+  // The second reference belongs to the second booking. Reading it back onto the
+  // first agreement prints a number that is not that appointment's. A code the
+  // callee only reads out after the agreement is dropped, which is the report
+  // saying less than the extraction claimed rather than more.
+  assert.equal(codeNamedBefore(call, 1, "9912"), false);
+  assert.equal(codeNamedBefore(call, -1, "4471"), false, "no agreement, so no code");
 });
 
 test("a refusal in a call that never raised an arrangement refuses no arrangement", () => {

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -148,8 +148,11 @@ test("confirming an existing appointment reads different from booking one", () =
     ["bot", "I am calling to confirm the appointment on Thursday."],
     ["user", "Yes, that is right, it is still on."],
   ]);
-  assert.equal(agreementEvidence(confirmed, "slot_within_windows").quote, "");
-  assert.match(agreementEvidence(confirmed, "confirm_existing").quote, /still on/);
+  // The appointment being confirmed is on Thursday, so that is the offered time the
+  // real flow passes here. The turn names it, so it anchors on the concrete-proposal
+  // arm rather than on the caller stating why they rang.
+  assert.equal(agreementEvidence(confirmed, "slot_within_windows", "Thursday").quote, "");
+  assert.match(agreementEvidence(confirmed, "confirm_existing", "Thursday").quote, /still on/);
 });
 
 test("a time is not named when the turn names another day", () => {
@@ -355,4 +358,53 @@ test("booking language after a statement about the arrangement is not an agreeme
   const supported = agreementEvidence(asked, "slot_within_windows", "2026-08-13T09:40:00-07:00");
   assert.match(supported.quote, /^I have put her in/);
   assert.equal(codeNamedBefore(asked, supported.index, "4471"), true);
+});
+
+test("a booking-keyword statement with an unrelated weekday is not a proposal", () => {
+  const call = turns([
+    ["bot", "Do you accept Aetna?"],
+    ["bot", "Our appointment desk is open Monday."],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // No slot was offered. "Our appointment desk is open Monday" carries a booking word
+  // and a weekday, but the weekday is not the offered time, so it proposes nothing.
+  // The refusal after it still answers the insurance question.
+  const evidence = refusalEvidence(call, "", [AETNA]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+});
+
+test("a caller purpose statement is not a question put to the callee", () => {
+  const call = turns([
+    ["bot", "Do you accept Aetna?"],
+    ["bot", "I am calling to book an appointment."],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // "I am calling to book an appointment" states why the caller rang. It asks nothing
+  // and names no offered time, so it is not the caller putting the arrangement to them
+  // and the refusal still answers the insurance question.
+  const evidence = refusalEvidence(call, "", [AETNA]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+});
+
+test("a concrete proposal of the offered time anchors, and so does a real question", () => {
+  const proposed = turns([
+    ["bot", "Our appointment desk is open Thursday the thirteenth at nine forty."],
+    ["user", "I am afraid we cannot book that, we are full that day."],
+  ]);
+  // The same declarative shape as the unrelated-weekday case, but this one names the
+  // offered time itself, so it is a concrete proposal of the arrangement and the
+  // refusal answers it.
+  assert.match(
+    refusalEvidence(proposed, "2026-08-13T09:40:00-07:00", [EARLIEST, AETNA]).quote,
+    /^I am afraid we cannot book/,
+  );
+  const asked = turns([
+    ["bot", "Could you book her in for an appointment?"],
+    ["user", "I am afraid we cannot book that over the phone for somebody else."],
+  ]);
+  // A genuine request with no time. "Could you" is a real ask, so it anchors even with
+  // no offered time to lean on.
+  assert.match(refusalEvidence(asked, "", [EARLIEST, AETNA]).quote, /^I am afraid we cannot book/);
 });

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -186,6 +186,24 @@ test("a refusal after the caller raised the arrangement is a refusal of it", () 
   assert.match(refusalEvidence(call, "", [EARLIEST, PLAN]).quote, /^I am afraid we cannot book/);
 });
 
+test("a refusal has to be about the time the extraction claims", () => {
+  const call = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty?"],
+    ["user", "Let me look at Thursday and come back to you."],
+    ["bot", "If that one is hard to hold, could you do Wednesday the twelfth at two in the afternoon?"],
+    ["user", "No, we are fully booked on Wednesday. I cannot fit that in."],
+  ]);
+  // The refusal answers the second option the caller put. Reading it as evidence for
+  // the first tells somebody a slot was turned down that nobody turned down.
+  const claimed = refusalEvidence(call, "2026-08-13T09:40:00-07:00", [EARLIEST, PLAN]);
+  assert.equal(claimed.quote, "");
+  assert.match(claimed.otherQuote, /^No, we are fully booked/);
+  // The same turn is evidence about the option it does answer.
+  assert.match(refusalEvidence(call, "2026-08-12T14:00:00-07:00", [EARLIEST, PLAN]).quote, /^No, we are fully booked/);
+  // No time reported, so there is nothing to bind to and the prompt anchor stands alone.
+  assert.match(refusalEvidence(call, "", [EARLIEST, PLAN]).quote, /^No, we are fully booked/);
+});
+
 test("a refusal in a call that never raised an arrangement refuses no arrangement", () => {
   const call = turns([
     ["bot", "Do you take Blue Shield PPO?"],

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { agreementEvidence, mentionsCode, mentionsDatetime, readTranscript, supportingTurn } from "../src/read.js";
+import { agreementEvidence, mentionsCode, mentionsDatetime, readTranscript, refusalEvidence, supportingTurn } from "../src/read.js";
 import type { ErrandQuestion, TranscriptTurn } from "../src/types.js";
 
 const EARLIEST: ErrandQuestion = {
@@ -159,4 +159,39 @@ test("reading the transcript still finds the machine and the refusal", () => {
   const refused = readTranscript(turns([["user", "We do not deal with automated callers."]]));
   assert.equal(refused.declinedAutomated, true);
   assert.equal(refused.declineQuote, "We do not deal with automated callers.");
+});
+
+test("a refusal has to be answering the arrangement", () => {
+  const call = turns([
+    ["bot", "What is the earliest appointment you have for a routine check-up?"],
+    ["user", "Earliest is Thursday the thirteenth at nine forty. I can hold that slot."],
+    ["bot", "Do you take Blue Shield PPO?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // The only refusal in this call answers the insurance question, so it says nothing
+  // about the booking, which the turn before it held.
+  const evidence = refusalEvidence(call, "2026-08-13T09:40:00-07:00", [EARLIEST, PLAN]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+});
+
+test("a refusal after the caller raised the arrangement is a refusal of it", () => {
+  const call = turns([
+    ["bot", "What is the earliest appointment you have for a routine check-up?"],
+    ["bot", "Her date of birth is 12 April 1990."],
+    ["user", "I am afraid we cannot book that over the phone for somebody else."],
+  ]);
+  // The date of birth is a statement and not a new question, so the refusal is still
+  // answering the appointment the caller asked about.
+  assert.match(refusalEvidence(call, "", [EARLIEST, PLAN]).quote, /^I am afraid we cannot book/);
+});
+
+test("a refusal in a call that never raised an arrangement refuses no arrangement", () => {
+  const call = turns([
+    ["bot", "Do you take Blue Shield PPO?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  const evidence = refusalEvidence(call, "", [PLAN]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /do not take that plan/);
 });

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -408,3 +408,80 @@ test("a concrete proposal of the offered time anchors, and so does a real questi
   // no offered time to lean on.
   assert.match(refusalEvidence(asked, "", [EARLIEST, AETNA]).quote, /^I am afraid we cannot book/);
 });
+
+test("a question in one clause does not make booking words in another an ask", () => {
+  const call = turns([
+    ["bot", "I am calling to book an appointment. Do you accept Aetna?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // One turn, two things said. The first states why the caller rang and the second asks
+  // about insurance, so the question mark belongs to the insurance question. Lending it
+  // to the booking words in the sentence before reports a refused appointment in a call
+  // where no slot was ever put to them.
+  const evidence = refusalEvidence(call, "", [AETNA]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+  // The same turn spliced with a comma instead of a full stop, which is how a
+  // transcript of speech writes it half the time.
+  const spliced = turns([
+    ["bot", "I am calling to book an appointment, do you accept Aetna?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  assert.equal(refusalEvidence(spliced, "", [AETNA]).quote, "");
+  // The agreement side of the same turn. Booking language the callee volunteers after
+  // it has no ask to answer either.
+  const volunteered = turns([
+    ["bot", "I am calling to book an appointment. Do you accept Aetna?"],
+    ["user", "Yes, we do. I have put her in for Thursday the thirteenth at nine forty."],
+  ]);
+  const agreement = agreementEvidence(volunteered, "slot_within_windows", "2026-08-13T09:40:00-07:00");
+  assert.equal(agreement.quote, "");
+  assert.match(agreement.otherQuote, /^Yes, we do/);
+});
+
+test("a request and its booking words in one clause still anchor", () => {
+  const call = turns([
+    [
+      "bot",
+      "Hello, I am an automated assistant calling on behalf of Fatima Haddad. Could you hold an appointment for her?",
+    ],
+    ["user", "I am afraid we cannot book that over the phone for somebody else."],
+  ]);
+  // Reading clause by clause must not cost the calls where the caller does ask. The
+  // request and the booking words are in the same sentence here, so the turn puts the
+  // arrangement to them and the refusal answers it.
+  assert.match(refusalEvidence(call, "", [EARLIEST, AETNA]).quote, /^I am afraid we cannot book/);
+});
+
+test("the last thing a turn puts to them is what the next turn answers", () => {
+  const call = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty? Do you accept Aetna?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // A real request for the slot and then a second question in the same turn. The no
+  // answers the question that was asked last, so it is not a refusal of the slot, which
+  // they have not answered at all.
+  const evidence = refusalEvidence(call, "2026-08-13T09:40:00-07:00", [AETNA]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+  // The other order, so the rule is about which came last and not about which kind of
+  // ask wins. Here the arrangement is the last thing put to them.
+  const arrangementLast = turns([
+    ["bot", "Do you accept Aetna? Could you hold Thursday the thirteenth at nine forty?"],
+    ["user", "No, we cannot book that, we are full that day."],
+  ]);
+  assert.match(
+    refusalEvidence(arrangementLast, "2026-08-13T09:40:00-07:00", [AETNA]).quote,
+    /^No, we cannot book/,
+  );
+  // The same two things in one sentence, joined instead of stopped. A coordinator with a
+  // fresh question after it opens a second thing put to them, so the insurance question
+  // is still the last one and the refusal is still an answer to it.
+  const joined = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty and do you accept Aetna?"],
+    ["user", "No, we do not take that plan."],
+  ]);
+  const insurance = refusalEvidence(joined, "2026-08-13T09:40:00-07:00", [AETNA]);
+  assert.equal(insurance.quote, "");
+  assert.match(insurance.otherQuote, /^No, we do not take that plan/);
+});

--- a/apps/typescript/call-on-behalf/test/read.test.ts
+++ b/apps/typescript/call-on-behalf/test/read.test.ts
@@ -14,6 +14,7 @@ const BRING: ErrandQuestion = {
   text: "What should she bring to a first appointment?",
   answer: "text",
 };
+const AETNA: ErrandQuestion = { id: "aetna", text: "Do you accept Aetna?", answer: "yes_no" };
 
 function turns(lines: [TranscriptTurn["speaker"], string][]): TranscriptTurn[] {
   return lines.map(([speaker, text], index) => ({ offset_seconds: index * 6, speaker, text }));
@@ -265,4 +266,93 @@ test("a refusal in a call that never raised an arrangement refuses no arrangemen
   const evidence = refusalEvidence(call, "", [PLAN]);
   assert.equal(evidence.quote, "");
   assert.match(evidence.otherQuote, /do not take that plan/);
+});
+
+test("a statement that mentions the arrangement is not the caller raising it", () => {
+  const call = turns([
+    ["bot", "Do you accept Aetna?"],
+    ["bot", "This appointment is for next week."],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // The middle turn tells them something. It asks for nothing and it names no time
+  // anybody could hold, so the refusal after it still answers the insurance
+  // question. Reading it as the arrangement reports a refused appointment in a call
+  // where no appointment was ever put to them.
+  const evidence = refusalEvidence(call, "", [AETNA]);
+  assert.equal(evidence.quote, "");
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+});
+
+test("a statement about the arrangement does not displace the last real ask", () => {
+  const answered = turns([
+    ["bot", "What is the earliest appointment you have for a routine check-up?"],
+    ["user", "Earliest is Thursday the thirteenth at nine forty. I can hold that slot."],
+    ["bot", "Do you accept Aetna?"],
+    ["bot", "This appointment is for next week."],
+    ["user", "No, we do not take that plan."],
+  ]);
+  // The arrangement was raised and answered four turns back. The statement in
+  // between is not a second ask, so the insurance question is still the last thing
+  // put to them and the refusal is an answer to that.
+  const insurance = refusalEvidence(answered, "", [EARLIEST, AETNA]);
+  assert.equal(insurance.quote, "");
+  assert.match(insurance.otherQuote, /^No, we do not take that plan/);
+  // The other direction, with the same sentence. The arrangement is the last thing
+  // asked, so a statement after it does not take that away either.
+  const arrangement = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty?"],
+    ["bot", "This appointment is for next week."],
+    ["user", "I am afraid we cannot book that over the phone for somebody else."],
+  ]);
+  assert.match(refusalEvidence(arrangement, "", [EARLIEST, AETNA]).quote, /^I am afraid we cannot book/);
+});
+
+test("a time the caller states rather than asks is still an arrangement proposal", () => {
+  const refused = turns([
+    ["bot", "Thursday the thirteenth at nine forty would suit her for the appointment."],
+    ["user", "I am afraid we cannot book that, we are full on Thursday."],
+  ]);
+  // No question mark and no request. It puts a time on the table, which is what a
+  // proposal is, so the turn that answers it is evidence about it. Tightening what
+  // counts as raising the arrangement must not cost the calls where the caller
+  // proposes instead of asking.
+  assert.match(
+    refusalEvidence(refused, "2026-08-13T09:40:00-07:00", [EARLIEST, AETNA]).quote,
+    /^I am afraid we cannot book/,
+  );
+  const agreed = turns([
+    ["bot", "Thursday the thirteenth at nine forty would suit her for the appointment."],
+    ["user", "I have booked her in for then."],
+  ]);
+  assert.match(
+    agreementEvidence(agreed, "slot_within_windows", "2026-08-13T09:40:00-07:00").quote,
+    /^I have booked/,
+  );
+});
+
+test("booking language after a statement about the arrangement is not an agreement", () => {
+  const call = turns([
+    ["bot", "Do you accept Aetna?"],
+    ["bot", "This appointment is for next week."],
+    [
+      "user",
+      "No, we do not take that plan. I have put her in for Thursday the thirteenth at nine forty, reference four four seven one.",
+    ],
+  ]);
+  // The same statement, the other two bindings. The caller asked for nothing to be
+  // held, so a booking the callee volunteered is not an agreement with the caller
+  // and the reference number that came with it has no agreement to belong to.
+  const evidence = agreementEvidence(call, "slot_within_windows", "2026-08-13T09:40:00-07:00");
+  assert.equal(evidence.quote, "");
+  assert.equal(evidence.index, -1);
+  assert.match(evidence.otherQuote, /^No, we do not take that plan/);
+  assert.equal(codeNamedBefore(call, evidence.index, "4471"), false);
+  // The same turn after an actual ask is evidence for both.
+  const asked = turns([
+    ["bot", "Could you hold Thursday the thirteenth at nine forty?"],
+    ["user", "I have put her in for Thursday the thirteenth at nine forty, reference four four seven one."],
+  ]);
+  const supported = agreementEvidence(asked, "slot_within_windows", "2026-08-13T09:40:00-07:00");
+  assert.match(supported.quote, /^I have put her in/);
+  assert.equal(codeNamedBefore(asked, supported.index, "4471"), true);
 });


### PR DESCRIPTION
## Summary

`apps/typescript/call-on-behalf` treats a definite error on a retried create as
proof that no call was ever created. It is not proof. This fixes that, plus two
more of the same shape in the same file.

When a create leaves the call unknown (no reply, a timeout, a 429, a 5xx) the app
re-issues the same idempotency key. That part is right: it returns the call CALL-E
already holds for that key and can never ring a second time. The bug is what
happened to a second failure. `src/errand.ts` branched on the class of that second
answer, and a definite 4xx was filed as a refusal, which the report renders as
outcome `api_error` with the next step "CALL-E refused to create the call, so no
call was placed and nothing was said on your behalf."

A refusal to the reconciliation can be decided before the idempotency lookup ever
happens. A rejected key answers 401, a spent balance answers 402, a payload the
gateway will not take answers 400, and none of those looked at whether a call
already exists under that key. So the app told somebody nothing was said on their
behalf while a call may have been live on a clinic's line, giving their name and
their date of birth. Any second failure now leaves the call `outcome_unknown` with
the whole chain recorded as `service_unavailable, then unauthorized`. The report
says the outcome is not known, keeps the commitment `unconfirmed`, claims neither
disclosure list and tells the person that running the same errand file again reads
that same call back rather than ringing anybody.

Found while hardening #42 against `Ray-56`'s round-four review, which rejected this
exact inference there. The same reasoning was already merged here in #43, so it is
in shipped code. The blast radius is smaller than #42's: one call, no release duty,
and nobody else gets called on the strength of the wrong answer. It is still a
report telling somebody nothing was said when something may have been.

### Two more of the same shape, in the same file

Found by sweeping `errand.ts` for anything that reads a provider status or an
extraction as an assertion about what happened.

**A call that ended early was read as a call nobody answered.** `failed` and
`canceled` are terminal, so there is a transcript to read, and a line that drops
after the slot was held carries the whole errand. The status was read first, so
that call came back `call_failed` or `not_reached` with "The call did not connect
to a person. Nothing was said on your behalf and nothing was arranged." next to a
transcript holding the questions, the answers and the booking, and next to
`reached_person: true` in the same report. A `no_answer` failure code on a call
somebody plainly answered did the same thing. The transcript is read first now.
The notes name the status as `call_failed` or `call_canceled` with the failure code
beside it, and a call that ended early is never `goal_met`, because it may have
been cut off partway through. A call with nobody on its transcript is still read
from its failure code, so `voicemail` and `not_reached` are unchanged for the case
they are for.

**A refusal CALL-E reported closed the errand.** `declined_by_callee` comes from
the extraction alone, which `docs/scope-and-limits.md` documents and defends as
saying less than the extraction did. It was also settling the commitment, so an
errand whose booking was refused came back `goal_met` with the next step
"Everything you asked was answered. Nothing was agreed, because this errand did
not ask for anything to be agreed.", which is false for every errand that asked
for a booking. A booking that was refused is not a goal met. It now reads
`partially_met` at best and the next step says plainly that nothing is booked.

Review then took that further, six times. It was right every time. A reported
refusal now needs a turn behind it rather than a label in the notes, because the next step is an
instruction and an instruction built on the extraction alone is the thing this app
exists to avoid. That turn has to be answering the arrangement: refusal words are
not specific to it, so "no, we do not take that plan" turns down a question and says
nothing about a booking the same call may have held. It also has to be about the time the
extraction reported, when it reported one, because two times proposed on one call is
otherwise a way for a no to the second to be read as a no to the first. That is the same
offered-time binding the agreement side uses, so a refused arrangement nobody can match to
the reported one fails closed to `unconfirmed` with the refusal quoted as what was actually
turned down. When one turn agrees and another
refuses the same arrangement the report stands behind neither and says a person has
to read the transcript and call. All three bindings look backwards only, because a turn
cannot be an answer to something nobody had said yet. And what counts as the caller
raising the arrangement is a genuine request or a proposal that names the offered time,
not a keyword and not a bare weekday in a statement, so "our appointment desk is open
Monday" cannot make an answer to another question look like a refused booking. The
request and its booking words also have to sit in the same clause of the turn, because a
turn is not one thing put to the callee: the question mark at the end of "I am calling to
book an appointment. Do you accept Aetna?" is an ask about insurance and nothing else.
Where one turn does put two things to them the answer belongs to whichever was asked
last.

### The shape is copied, not invented

`src/gate.ts` in the merged phone-approval-gate keeps a second create failure
unresolved whatever its class, and `placeCall` in #42 does the same and records the
chain `<first>, then <second>`. This app now matches both, including the chain and
the `call_<status>` reason name #42 uses in its notes.

## Verification

Node 22.22.2, from `apps/typescript/call-on-behalf`, no credentials and no
outbound calls:

```text
npx tsc --noEmit                        exit 0, no output
npm test                                142 pass, 0 fail, 0 skipped (113 before)
npm run demo                            exit 0, output byte identical to before
python3 scripts/validate_repository.py  Repository validation passed.
```

Twenty-nine new tests. The twelve report-level ones run end to end over the real
`@call-e/calle` client against the local fake server in `fake/calle-server.ts`.
Each one that changes a behaviour was run against the source it fixes and fails there:

| Test | Before | After |
| --- | --- | --- |
| a definite refusal on the reconcile is not proof the call was never made | `api_error` | `outcome_unknown` |
| a call that ended early still reports the conversation it carried | `call_failed` | `partially_met`, booking kept |
| the transcript says who was on the line, not the failure code beside it | `not_reached` | `voicemail` |
| a refusal CALL-E reported does not make the errand done | `goal_met` | `partially_met`, `unconfirmed` with nothing behind the claim |
| a refusal the callee actually voiced is reported as a refusal | not checked | `declined_by_callee`, the turn quoted |
| a refusal of one of the questions is not a refusal of the errand | `declined_by_callee` | `unconfirmed`, what was turned down quoted |
| an agreement and a refusal in the same call settle nothing | `committed` | `unconfirmed`, both turns quoted, no code |
| a refusal of another proposed time is not a refusal of the one reported | `declined_by_callee` | `unconfirmed`, the option they did turn down quoted |
| a statement about the appointment does not turn a refused question into a refused errand | `declined_by_callee` | `unconfirmed`, the plan refusal quoted |
| a question asked in the same turn as a booking line is what the answer answers | `declined_by_callee` | `unconfirmed`, the plan refusal quoted |
| a booking nobody asked for is not agreed and its reference number is dropped | `committed`, code 4471 | `unconfirmed`, the booking quoted, code dropped |

One report-level test passes on both trees on purpose. "a refusal of the time the
extraction reported is still a refusal" pins the other direction of the offered-time
binding, so nobody can later tighten it into dropping a refusal of the reported slot.

The first runs 401, 403, 400 and 402 through the reconcile path and asserts the
unknown outcome, the recorded chain, no call id, `unconfirmed`, a next step that
does not say nothing was said and no second call placed. No assertion in any of
them accepts either outcome. The fake server gained one knob, `createErrors`, so
one create attempt can be answered differently from the next. No existing test was
weakened, deleted or made tolerant and the demo output did not move. Seventeen unit tests
in `test/read.test.ts` pin the bindings themselves: which claim a turn is evidence for,
the time it has to be about, that nothing said after a turn can be the thing it was
answering and what counts as the caller raising the arrangement at all.

AI assistance (Claude, Anthropic) was used in developing this change. The design,
review and verification were done by the author. Verified locally before
submitting: the four commands above, plus each report-level test that changes a
behaviour run against the source it fixes to confirm it fails there.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

No box says bug fix in a merged app, so that is the closest one. The change is
behavioral, in `src/errand.ts`, with the README and `docs/scope-and-limits.md`
updated to match.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.



