### PR TITLE
feat: add quotechaser supplier quote app

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`apps/typescript/quotechaser`](apps/typescript/quotechaser/) | TypeScript | Supplier quote caller that previews an approved buying brief, calls each vendor with CALL-E, and returns comparable structured quote records. |
 | [`apps/typescript/verify-contact-claim`](apps/typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |
 | [`apps/typescript/phone-approval-gate`](apps/typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |
 | [`apps/typescript/call-on-behalf`](apps/typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`typescript/quotechaser`](typescript/quotechaser/) | TypeScript | Supplier quote caller that previews an approved buying brief, calls each vendor with CALL-E, and returns comparable structured quote records. |
 | [`typescript/verify-contact-claim`](typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |
 | [`typescript/phone-approval-gate`](typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |
 | [`typescript/call-on-behalf`](typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |

--- a/apps/typescript/quotechaser/README.md
+++ b/apps/typescript/quotechaser/README.md
@@ -1,0 +1,89 @@
+# QuoteChaser
+
+QuoteChaser turns the most annoying part of procurement into a small, auditable
+phone-call workflow. Give it a buying brief and a short vendor list. It previews
+exactly what CALL-E will ask, refuses secrets or payment details, calls each vendor
+only after a matching receipt is supplied, and returns one comparable quote row per
+vendor.
+
+The narrow use case is intentional: small businesses often need prices from
+suppliers who still answer faster by phone than by web form. A bakery, contractor,
+restaurant, school club or event planner can spend an afternoon chasing unit prices,
+stock status and pickup windows. QuoteChaser makes those calls consistent and leaves
+behind structured results an agent can sort, compare and act on.
+
+## What it collects
+
+| Field | Purpose |
+| --- | --- |
+| outcome | `quote_received`, `not_available`, `callback_needed`, `unreachable` or `outcome_unknown` |
+| unit_price and total_price | Numeric values when the vendor gives them |
+| currency | Currency code or label from the quote |
+| availability | What the vendor said about stock |
+| lead_time | Pickup, delivery or order timing |
+| minimum_order | Any stated minimum |
+| callback_required | Whether a human follow-up is needed |
+| evidence | Short support from CALL-E's result |
+
+## Try it without an account
+
+```bash
+cd apps/typescript/quotechaser
+npm install
+npm run check
+npm test
+npm run demo
+```
+
+The demo uses fake CALL-E results. It places no calls, needs no credentials and
+prints a quote comparison for the example bakery request.
+
+## Preview
+
+```bash
+npm run quotechaser -- preview --request examples/request.example.json
+```
+
+Preview prints the buyer, item, vendor list, allowed disclosure and a receipt. No
+network request is made. The receipt is a SHA-256 hash of the request file as loaded,
+so changing the quantity, vendors or voicemail policy invalidates the approval.
+
+## One live run
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+npm run quotechaser -- preview --request your-request.json
+npm run quotechaser -- call --request your-request.json --live --receipt <hash> --report quote-report.json
+```
+
+`call` refuses to run without `--live`, a matching receipt and `CALLE_API_KEY`.
+The API key is read from the environment only. Reports are written as JSON with file
+mode `0600`.
+
+## Request file
+
+| Field | Notes |
+| --- | --- |
+| request_id | Stable identifier for the buying task |
+| buyer.business_name and buyer.contact_name | Spoken only as part of the authorized business request |
+| item.name, item.quantity, item.must_haves | The quote brief |
+| vendors[] | Up to 8 vendors, with E.164 phone numbers and a source for each number |
+| max_disclosure[] | What the automated caller is allowed to say |
+| policy.locale | Locale passed through the task text |
+| policy.allow_voicemail | If false, the caller does not leave a detailed voicemail |
+
+## Side effects, safety and cancellation
+
+- A live run can place one outbound CALL-E call per vendor.
+- There is no recurring job. Stop the process to stop launching further vendor
+  calls; calls already handed to CALL-E may continue on the provider side.
+- Samples use fictional numbers. Use only numbers a business has published for
+  sales or supplier inquiries.
+- QuoteChaser refuses request files that appear to contain passwords, PINs, payment
+  card numbers, bank details, Social Security numbers or similar regulated
+  identifiers.
+- It does not buy anything, accept a quote or promise payment. It collects
+  information and marks follow-up when a human decision is needed.
+
+This is a demo app for a reusable CALL-E workflow pattern, not a supported SDK or a
+procurement system.

--- a/apps/typescript/quotechaser/demo/run-local.ts
+++ b/apps/typescript/quotechaser/demo/run-local.ts
@@ -1,0 +1,48 @@
+import { loadQuoteRequest } from "../src/config.js";
+import { renderReport } from "../src/format.js";
+import { runQuotes } from "../src/runner.js";
+import type { CalleCallResult } from "../src/types.js";
+
+const request = loadQuoteRequest("examples/request.example.json");
+let index = 0;
+
+const fakeCalls: CalleCallResult[] = [
+  {
+    status: "completed",
+    taskCompleted: true,
+    structuredResult: {
+      outcome: "quote_received",
+      unit_price: 0.84,
+      total_price: 420,
+      currency: "USD",
+      availability: "500 boxes in stock",
+      lead_time: "pickup tomorrow after 2 PM",
+      minimum_order: "250 boxes",
+      callback_required: false
+    },
+    evidence: ["The vendor quoted 84 cents each and said 500 are in stock."]
+  },
+  {
+    status: "completed",
+    taskCompleted: false,
+    structuredResult: {
+      outcome: "callback_needed",
+      unit_price: null,
+      total_price: null,
+      currency: null,
+      availability: "sales desk must check warehouse stock",
+      lead_time: "unknown",
+      minimum_order: "unknown",
+      callback_required: true
+    },
+    evidence: ["The person who answered said sales would need to call back."]
+  }
+];
+
+const report = await runQuotes(request, {
+  async createAndWait() {
+    return fakeCalls[index++] ?? fakeCalls[fakeCalls.length - 1]!;
+  }
+});
+
+process.stdout.write(`${renderReport(report, request)}\n`);

--- a/apps/typescript/quotechaser/examples/request.example.json
+++ b/apps/typescript/quotechaser/examples/request.example.json
@@ -1,0 +1,35 @@
+{
+  "request_id": "bakery-boxes-august",
+  "buyer": {
+    "business_name": "Little River Bakery",
+    "contact_name": "Maya Chen"
+  },
+  "item": {
+    "name": "white cake boxes",
+    "quantity": 500,
+    "must_haves": ["10x10x4 inches", "food-safe", "pickup or delivery this week"]
+  },
+  "vendors": [
+    {
+      "name": "Northside Packaging",
+      "phone": "+14155550100",
+      "source": "published supplier directory listing"
+    },
+    {
+      "name": "Market Street Paper Goods",
+      "phone": "+14155550101",
+      "source": "business website contact page"
+    }
+  ],
+  "max_disclosure": [
+    "business name",
+    "contact first and last name",
+    "item name",
+    "quantity",
+    "must-have requirements"
+  ],
+  "policy": {
+    "locale": "en-US",
+    "allow_voicemail": false
+  }
+}

--- a/apps/typescript/quotechaser/package.json
+++ b/apps/typescript/quotechaser/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "calle-quotechaser",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Supplier quote caller that previews an approved buying brief, places one CALL-E call per vendor, and returns comparable structured quote records.",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "demo": "node --import tsx demo/run-local.ts",
+    "quotechaser": "node --import tsx src/cli.ts",
+    "preview": "node --import tsx src/cli.ts preview --request examples/request.example.json"
+  },
+  "dependencies": {
+    "@call-e/calle": "0.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/typescript/quotechaser/src/cli.ts
+++ b/apps/typescript/quotechaser/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { QuoteRequestError, loadQuoteRequest } from "./config.js";
+import { renderReport } from "./format.js";
+import { previewReceipt, previewText } from "./script.js";
+import { createSdkPort, runQuotes, writeReport } from "./runner.js";
+
+const USAGE = `QuoteChaser
+
+  preview --request <file>
+      Print the approved buying brief and consent receipt. Places no calls.
+
+  call --request <file> --live --receipt <hash> --report <file> [--json]
+      Call every vendor in the request with CALL-E and write a structured report.
+      Needs CALLE_API_KEY. The receipt must match the preview for the same file.
+
+  help
+      Show this message.`;
+
+interface Parsed {
+  command: string;
+  values: Record<string, string>;
+  flags: Set<string>;
+}
+
+function parseArgs(argv: string[]): Parsed {
+  const command = argv[0] ?? "";
+  const values: Record<string, string> = {};
+  const flags = new Set<string>();
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index]!;
+    if (!token.startsWith("--")) {
+      throw new QuoteRequestError(`Unexpected argument: ${token}`);
+    }
+    const name = token.slice(2);
+    if (name === "live" || name === "json") {
+      flags.add(name);
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new QuoteRequestError(`Option --${name} needs a value.`);
+    }
+    values[name] = value;
+    index += 1;
+  }
+  return { command, values, flags };
+}
+
+function required(parsed: Parsed, name: string): string {
+  const value = parsed.values[name];
+  if (value === undefined) {
+    throw new QuoteRequestError(`Option --${name} is required.`);
+  }
+  return value;
+}
+
+async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+  if (parsed.command === "" || parsed.command === "help") {
+    process.stdout.write(`${USAGE}\n`);
+    return parsed.command === "" ? 30 : 0;
+  }
+  if (parsed.command === "preview") {
+    const request = loadQuoteRequest(required(parsed, "request"));
+    process.stdout.write(`${previewText(request)}\n`);
+    return 0;
+  }
+  if (parsed.command === "call") {
+    if (!parsed.flags.has("live")) {
+      throw new QuoteRequestError("Refusing to place calls without --live.");
+    }
+    const request = loadQuoteRequest(required(parsed, "request"));
+    const receipt = required(parsed, "receipt");
+    if (receipt !== previewReceipt(request)) {
+      throw new QuoteRequestError("Receipt does not match this request file. Run preview again and review it.");
+    }
+    const apiKey = process.env.CALLE_API_KEY;
+    if (!apiKey) {
+      throw new QuoteRequestError("CALLE_API_KEY is required for live calls.");
+    }
+    const report = await runQuotes(request, createSdkPort(apiKey));
+    writeReport(required(parsed, "report"), report);
+    process.stdout.write(parsed.flags.has("json") ? `${JSON.stringify(report, null, 2)}\n` : `${renderReport(report, request)}\n`);
+    return 0;
+  }
+  throw new QuoteRequestError(`Unknown command: ${parsed.command}`);
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 30;
+  });

--- a/apps/typescript/quotechaser/src/config.ts
+++ b/apps/typescript/quotechaser/src/config.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import type { QuoteRequest } from "./types.js";
+
+export class QuoteRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QuoteRequestError";
+  }
+}
+
+const E164_RE = /^\+[1-9]\d{7,14}$/;
+const SECRET_RE = /\b(?:\d[ -]*?){13,19}\b|\b(?:password|passcode|pin|ssn|social security|card number|bank account)\b/i;
+
+export function loadQuoteRequest(path: string): QuoteRequest {
+  const parsed = JSON.parse(fs.readFileSync(path, "utf8")) as unknown;
+  return assertQuoteRequest(parsed);
+}
+
+export function assertQuoteRequest(value: unknown): QuoteRequest {
+  const request = value as QuoteRequest;
+  if (!request || typeof request !== "object") {
+    throw new QuoteRequestError("Request must be a JSON object.");
+  }
+  requireString(request.request_id, "request_id");
+  requireString(request.buyer?.business_name, "buyer.business_name");
+  requireString(request.buyer?.contact_name, "buyer.contact_name");
+  requireString(request.item?.name, "item.name");
+  if (!Number.isInteger(request.item?.quantity) || request.item.quantity <= 0) {
+    throw new QuoteRequestError("item.quantity must be a positive integer.");
+  }
+  if (!Array.isArray(request.item.must_haves) || request.item.must_haves.length === 0) {
+    throw new QuoteRequestError("item.must_haves must contain at least one requirement.");
+  }
+  if (!Array.isArray(request.vendors) || request.vendors.length === 0) {
+    throw new QuoteRequestError("vendors must contain at least one vendor.");
+  }
+  if (request.vendors.length > 8) {
+    throw new QuoteRequestError("QuoteChaser caps each run at 8 vendors.");
+  }
+  for (const [index, vendor] of request.vendors.entries()) {
+    requireString(vendor.name, `vendors[${index}].name`);
+    requireString(vendor.source, `vendors[${index}].source`);
+    requireString(vendor.phone, `vendors[${index}].phone`);
+    if (!E164_RE.test(vendor.phone)) {
+      throw new QuoteRequestError(`vendors[${index}].phone must be E.164, for example +14155550100.`);
+    }
+  }
+  if (!Array.isArray(request.max_disclosure) || request.max_disclosure.length === 0) {
+    throw new QuoteRequestError("max_disclosure must name what the caller may say.");
+  }
+  requireString(request.policy?.locale, "policy.locale");
+  if (typeof request.policy.allow_voicemail !== "boolean") {
+    throw new QuoteRequestError("policy.allow_voicemail must be true or false.");
+  }
+  const serialized = JSON.stringify(request);
+  if (SECRET_RE.test(serialized)) {
+    throw new QuoteRequestError("Request appears to contain a secret, payment detail, password, PIN or regulated identifier.");
+  }
+  return request;
+}
+
+export function maskPhone(phone: string): string {
+  return `${phone.slice(0, 3)}${"*".repeat(Math.max(0, phone.length - 5))}${phone.slice(-2)}`;
+}
+
+function requireString(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new QuoteRequestError(`${name} is required.`);
+  }
+}

--- a/apps/typescript/quotechaser/src/format.ts
+++ b/apps/typescript/quotechaser/src/format.ts
@@ -1,0 +1,21 @@
+import { maskPhone } from "./config.js";
+import type { QuoteReport, QuoteRequest } from "./types.js";
+
+export function renderReport(report: QuoteReport, request: QuoteRequest): string {
+  const lines = [`QuoteChaser report for ${report.request_id}`, `Calls placed: ${report.calls_placed}`, ""];
+  for (const quote of report.quotes) {
+    const vendor = request.vendors.find((item) => item.name === quote.vendor_name);
+    const price = quote.total_price === null ? "unknown" : `${quote.currency ?? "currency unknown"} ${quote.total_price}`;
+    lines.push(
+      `${quote.vendor_name}${vendor ? ` ${maskPhone(vendor.phone)}` : ""}`,
+      `  outcome: ${quote.outcome}`,
+      `  total: ${price}`,
+      `  availability: ${quote.availability}`,
+      `  lead time: ${quote.lead_time}`,
+      `  minimum order: ${quote.minimum_order}`,
+      `  callback required: ${quote.callback_required ? "yes" : "no"}`,
+      ""
+    );
+  }
+  return lines.join("\n").trimEnd();
+}

--- a/apps/typescript/quotechaser/src/runner.ts
+++ b/apps/typescript/quotechaser/src/runner.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import { CalleClient } from "@call-e/calle";
+import { buildTask, resultSchema } from "./script.js";
+import type { CalleCallResult, QuoteOutcome, QuoteReport, QuoteRequest, Vendor, VendorQuote } from "./types.js";
+
+interface CallePort {
+  createAndWait(input: {
+    task: string;
+    resultSchema: Record<string, unknown>;
+    metadata: Record<string, string>;
+  }): Promise<CalleCallResult>;
+}
+
+export function createSdkPort(apiKey: string): CallePort {
+  const client = new CalleClient({ apiKey });
+  return {
+    createAndWait(input) {
+      return client.calls.createAndWait(input) as Promise<CalleCallResult>;
+    }
+  };
+}
+
+export async function runQuotes(request: QuoteRequest, port: CallePort): Promise<QuoteReport> {
+  const quotes: VendorQuote[] = [];
+  for (const vendor of request.vendors) {
+    const call = await port.createAndWait({
+      task: buildTask(request, vendor),
+      resultSchema: resultSchema(),
+      metadata: {
+        app: "quotechaser",
+        request_id: request.request_id,
+        vendor_name: vendor.name
+      }
+    });
+    quotes.push(toVendorQuote(vendor, call));
+  }
+  return {
+    request_id: request.request_id,
+    generated_at: new Date().toISOString(),
+    calls_placed: request.vendors.length,
+    quotes
+  };
+}
+
+export function toVendorQuote(vendor: Vendor, call: CalleCallResult): VendorQuote {
+  const structured = objectOrNull(call.structuredResult ?? call.structured_result);
+  const status = typeof call.status === "string" ? call.status : "unknown";
+  const completed = call.taskCompleted ?? call.task_completed ?? false;
+  const outcome = normalizeOutcome(structured?.outcome, status, completed);
+  return {
+    vendor_name: vendor.name,
+    outcome,
+    unit_price: numberOrNull(structured?.unit_price),
+    total_price: numberOrNull(structured?.total_price),
+    currency: stringOrNull(structured?.currency),
+    availability: stringOrDefault(structured?.availability, "unknown"),
+    lead_time: stringOrDefault(structured?.lead_time, "unknown"),
+    minimum_order: stringOrDefault(structured?.minimum_order, "unknown"),
+    callback_required: Boolean(structured?.callback_required ?? outcome === "callback_needed"),
+    evidence: evidenceList(call.evidence)
+  };
+}
+
+export function writeReport(path: string, report: QuoteReport): void {
+  fs.writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+}
+
+function normalizeOutcome(value: unknown, status: string, completed: boolean): QuoteOutcome {
+  if (
+    value === "quote_received" ||
+    value === "not_available" ||
+    value === "callback_needed" ||
+    value === "unreachable" ||
+    value === "outcome_unknown"
+  ) {
+    return value;
+  }
+  if (status === "completed" && completed) {
+    return "quote_received";
+  }
+  if (status === "failed" || status === "canceled") {
+    return "unreachable";
+  }
+  return "outcome_unknown";
+}
+
+function objectOrNull(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function stringOrDefault(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() !== "" ? value : fallback;
+}
+
+function evidenceList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}

--- a/apps/typescript/quotechaser/src/script.ts
+++ b/apps/typescript/quotechaser/src/script.ts
@@ -1,0 +1,73 @@
+import crypto from "node:crypto";
+import type { QuoteRequest, Vendor } from "./types.js";
+
+export function buildTask(request: QuoteRequest, vendor: Vendor): string {
+  const requirements = request.item.must_haves.map((item) => `- ${item}`).join("\n");
+  return [
+    `Call ${vendor.phone} for ${request.buyer.business_name}.`,
+    "Start by saying you are an automated assistant calling with permission for a business purchasing task.",
+    `Ask ${vendor.name} for a quote for ${request.item.quantity} ${request.item.name}.`,
+    "Requirements:",
+    requirements,
+    "Collect unit price, total price, currency, availability, lead time, minimum order, and whether a human callback is needed.",
+    request.policy.allow_voicemail
+      ? "If voicemail answers, leave only the business name, item, quantity, and a request to call back. Do not include private details."
+      : "If voicemail answers, do not leave a detailed message; mark callback_needed.",
+  ].join("\n");
+}
+
+export function resultSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    required: [
+      "outcome",
+      "unit_price",
+      "total_price",
+      "currency",
+      "availability",
+      "lead_time",
+      "minimum_order",
+      "callback_required"
+    ],
+    properties: {
+      outcome: {
+        type: "string",
+        enum: ["quote_received", "not_available", "callback_needed", "unreachable", "outcome_unknown"]
+      },
+      unit_price: { type: ["number", "null"] },
+      total_price: { type: ["number", "null"] },
+      currency: { type: ["string", "null"] },
+      availability: { type: "string" },
+      lead_time: { type: "string" },
+      minimum_order: { type: "string" },
+      callback_required: { type: "boolean" }
+    }
+  };
+}
+
+export function previewText(request: QuoteRequest): string {
+  const vendors = request.vendors
+    .map((vendor, index) => `${index + 1}. ${vendor.name} ${vendor.phone} (${vendor.source})`)
+    .join("\n");
+  return [
+    `QuoteChaser preview for ${request.request_id}`,
+    "",
+    `Buyer: ${request.buyer.business_name} (${request.buyer.contact_name})`,
+    `Item: ${request.item.quantity} ${request.item.name}`,
+    "Must haves:",
+    ...request.item.must_haves.map((item) => `- ${item}`),
+    "",
+    "Vendors:",
+    vendors,
+    "",
+    "Allowed disclosure:",
+    ...request.max_disclosure.map((item) => `- ${item}`),
+    "",
+    `Voicemail: ${request.policy.allow_voicemail ? "limited callback message allowed" : "no detailed voicemail"}`,
+    `Receipt: ${previewReceipt(request)}`
+  ].join("\n");
+}
+
+export function previewReceipt(request: QuoteRequest): string {
+  return crypto.createHash("sha256").update(JSON.stringify(request)).digest("hex");
+}

--- a/apps/typescript/quotechaser/src/types.ts
+++ b/apps/typescript/quotechaser/src/types.ts
@@ -1,0 +1,60 @@
+export interface QuoteRequest {
+  request_id: string;
+  buyer: {
+    business_name: string;
+    contact_name: string;
+  };
+  item: {
+    name: string;
+    quantity: number;
+    must_haves: string[];
+  };
+  vendors: Vendor[];
+  max_disclosure: string[];
+  policy: {
+    locale: string;
+    allow_voicemail: boolean;
+  };
+}
+
+export interface Vendor {
+  name: string;
+  phone: string;
+  source: string;
+}
+
+export type QuoteOutcome =
+  | "quote_received"
+  | "not_available"
+  | "callback_needed"
+  | "unreachable"
+  | "outcome_unknown";
+
+export interface VendorQuote {
+  vendor_name: string;
+  outcome: QuoteOutcome;
+  unit_price: number | null;
+  total_price: number | null;
+  currency: string | null;
+  availability: string;
+  lead_time: string;
+  minimum_order: string;
+  callback_required: boolean;
+  evidence: string[];
+}
+
+export interface QuoteReport {
+  request_id: string;
+  generated_at: string;
+  calls_placed: number;
+  quotes: VendorQuote[];
+}
+
+export interface CalleCallResult {
+  status?: string;
+  taskCompleted?: boolean;
+  task_completed?: boolean;
+  structuredResult?: unknown;
+  structured_result?: unknown;
+  evidence?: unknown;
+}

--- a/apps/typescript/quotechaser/test/quotechaser.test.ts
+++ b/apps/typescript/quotechaser/test/quotechaser.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertQuoteRequest, QuoteRequestError } from "../src/config.js";
+import { toVendorQuote } from "../src/runner.js";
+import { previewReceipt } from "../src/script.js";
+import type { QuoteRequest, Vendor } from "../src/types.js";
+
+const request: QuoteRequest = {
+  request_id: "test-run",
+  buyer: { business_name: "Test Bakery", contact_name: "Maya Chen" },
+  item: { name: "cake boxes", quantity: 500, must_haves: ["food-safe"] },
+  vendors: [{ name: "Vendor A", phone: "+14155550100", source: "business website" }],
+  max_disclosure: ["business name", "item", "quantity"],
+  policy: { locale: "en-US", allow_voicemail: false }
+};
+
+const vendor: Vendor = request.vendors[0]!;
+
+test("validates a safe quote request", () => {
+  assert.equal(assertQuoteRequest(request).request_id, "test-run");
+});
+
+test("refuses non E.164 phone numbers", () => {
+  assert.throws(
+    () => assertQuoteRequest({ ...request, vendors: [{ ...vendor, phone: "555-0100" }] }),
+    QuoteRequestError
+  );
+});
+
+test("refuses secrets and payment-like details", () => {
+  assert.throws(
+    () => assertQuoteRequest({ ...request, item: { ...request.item, must_haves: ["use card 4111 1111 1111 1111"] } }),
+    QuoteRequestError
+  );
+});
+
+test("receipt changes when the request changes", () => {
+  const first = previewReceipt(request);
+  const second = previewReceipt({ ...request, item: { ...request.item, quantity: 600 } });
+  assert.notEqual(first, second);
+});
+
+test("turns CALL-E structured output into a comparable vendor quote", () => {
+  const quote = toVendorQuote(vendor, {
+    status: "completed",
+    taskCompleted: true,
+    structuredResult: {
+      outcome: "quote_received",
+      unit_price: 1.25,
+      total_price: 625,
+      currency: "USD",
+      availability: "in stock",
+      lead_time: "two days",
+      minimum_order: "100",
+      callback_required: false
+    },
+    evidence: ["They quoted one dollar and twenty-five cents each."]
+  });
+  assert.equal(quote.total_price, 625);
+  assert.equal(quote.outcome, "quote_received");
+  assert.equal(quote.evidence.length, 1);
+});

--- a/apps/typescript/quotechaser/tsconfig.json
+++ b/apps/typescript/quotechaser/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "demo/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds QuoteChaser, a TypeScript CALL-E app that calls suppliers for quote details and returns comparable structured vendor records.

QuoteChaser previews an approved buying brief, refuses sensitive details, places one CALL-E call per vendor only after a matching receipt is supplied, and writes a structured quote report.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Testing

- TypeScript check passed.
- Unit tests passed.
- Dry demo passed.
- Repository validation passed.