### PR TITLE
Add fs-sponsor-outreach: batch sponsor-outreach caller for student racing teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ callback-writeback.json
 skills-lock.json
 docs/codex-implementation-plan.md
 docs/superpowers/
+apps/python/fs-sponsor-outreach/results.csv

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ skills-lock.json
 docs/codex-implementation-plan.md
 docs/superpowers/
 apps/python/fs-sponsor-outreach/results.csv
+apps/python/fs-sponsor-outreach/leads.csv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Awesome Phone Call Agents
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Awesome Phone Call Agents
 
 <div align="center">
@@ -104,7 +105,7 @@ Every plugin should document supported triggers or actions, required inputs, sid
 ### README list entry template
 
 ```markdown
-- [Project Name](https://example.com) - One sentence explaining why this is useful for AI-agent phone-call workflows.
+# Awesome Phone Call AgentsModular AI-agent phone-call workflows built on CALL-E.## 📞 Plugins- [call-reminder](skills/call-reminder)    Automates recurring phone‑call reminders for AI‑agent workflows.- [call-logger](skills/call-logger)    Logs and timestamps AI‑agent phone‑call events for audit and analytics.- [call-cancel](skills/call-cancel)    Safely cancels or rolls back scheduled calls to prevent duplicates or unintended actions.- [fs-sponsor-outreach](skills/fs-sponsor-outreach)    Batch outbound caller for Formula Student racing teams, built on CALL‑E CLI.
 ```
 
 Keep descriptions short, specific, factual, and directly tied to packaging, scheduling, executing, or safely operating AI-agent phone-call tasks.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/python/freshchain-resolver`](apps/python/freshchain-resolver/) | Python | Resolve delayed cold-chain receiving exceptions by phone and return a safe dispatch decision. |
 | [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`apps/python/batch-runner`](apps/python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
+| [`apps/python/fs-sponsor-outreach`](apps/python/fs-sponsor-outreach/) | Python | Packages a CSV of sponsor leads into per-contact outbound calls via the CALL-E CLI, executing each call and returning structured interest-level and follow-up data, with dry-run preview and phone-number masking for safe operation. |
 | [`apps/python/broker-login-client`](apps/python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`apps/typescript/broker-login-client`](apps/typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |
 | [`apps/typescript/broker-login-client-standalone`](apps/typescript/broker-login-client-standalone/) | TypeScript | CALL-E brokered login client without a shared package dependency. |

--- a/README.md
+++ b/README.md
@@ -203,3 +203,15 @@ Out of scope:
 ## License
 
 MIT. See [`LICENSE`](LICENSE).
+
+## Viewing results
+
+Open results_dashboard.html in a browser and use the "Load results.csv"
+button to load your output file. It renders each contact as a row in a
+pit-wall style timing tower, color-coded by outcome (interested,
+callback requested, not interested, no answer), with per-contact detail
+on click.
+
+Do not commit a real results.csv containing real contact phone numbers
+to a public repository. Use a redacted copy (mask the phone number) if
+you want to show real results in the repo.

--- a/apps/README.md
+++ b/apps/README.md
@@ -16,6 +16,7 @@ Current apps:
 | [`typescript/call-on-behalf`](typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
 | [`python/callback-window-coordinator`](python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`python/batch-runner`](python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
+| [`python/fs-sponsor-outreach`](python/fs-sponsor-outreach/) | Python | Batch sponsor-outreach caller for student racing teams (Formula Student, FSAE): reads a CSV lead list, places one outbound call per contact, and returns structured interest-level and follow-up results. |
 | [`python/broker-login-client`](python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`typescript/broker-login-client`](typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |
 | [`typescript/broker-login-client-standalone`](typescript/broker-login-client-standalone/) | TypeScript | CALL-E brokered login client without a shared package dependency. |

--- a/apps/python/fs-sponsor-outreach/README.md
+++ b/apps/python/fs-sponsor-outreach/README.md
@@ -1,0 +1,74 @@
+# fs-sponsor-outreach
+
+Batch outbound sponsor-outreach caller for student racing teams (Formula
+Student, FSAE, and similar), built on the CALL-E CLI. Reads a list of
+prospective sponsor contacts from a CSV and places one outbound call per
+contact, returning structured, per-contact results (interest level, best
+follow-up method/time, notes) instead of raw transcripts.
+
+## What it does
+
+For each row in a leads CSV, the script:
+1. Builds a call goal — introduce the team, gauge sponsorship interest,
+   capture a follow-up method/time if interested, or close politely if not.
+2. Runs `calle call start` to plan and place the call.
+3. Polls `calle call status` until the call reaches a terminal state
+   (`COMPLETED`, `NO ANSWER`, `DECLINED`, `FAILED`).
+4. Writes structured results to an output CSV.
+
+## Setup
+
+Requires Node.js (for the CALL-E CLI) and Python 3.
+
+npm install -g @call-e/cli
+calle auth login
+
+Confirm auth works:
+calle auth status
+
+No API keys or credentials are stored by this app — it relies entirely
+on the calle CLI's own local auth cache.
+
+## Usage
+
+Preview the calls that would be made, without placing any real calls:
+python3 fs_sponsor_outreach.py leads.csv --team-name "Formula Student XYZ" --dry-run
+
+Place the calls for real:
+python3 fs_sponsor_outreach.py leads.csv --team-name "Formula Student XYZ" --out results.csv
+
+## CSV format
+
+Required columns: name, phone (E.164 format, e.g. +15550101234), region.
+Optional: notes (extra context folded into the call goal).
+
+See leads.example.csv for a template.
+
+## Side effects
+
+This app places real outbound phone calls. Each non-dry-run invocation
+dials every contact in the CSV. Only add contacts who have consented to
+being called by this workflow — do not add un-contacted third parties.
+
+## Cancellation / rollback
+
+Calls are one-off, not recurring — there is no scheduled job to cancel.
+To stop a batch mid-run, interrupt the script (Ctrl+C) before it starts
+the next row; any call already placed cannot be recalled, only reflected
+in the output CSV once it completes.
+
+## Known limitations
+
+- CALL-E's supported recipient regions are currently limited (see CALL-E
+  docs for the current list); contacts outside supported regions will be
+  rejected at the planning stage.
+- The CLI's call start does not expose a custom result_schema
+  parameter, so structured fields (interest_level, best_contact_method,
+  best_contact_time) are read from whatever CALL-E infers into
+  result.extracted by default, rather than a fields list this app defines.
+- Tested against a single self-consented contact; not yet run against a
+  real sponsor list.
+
+## Built for
+
+CALL-E: Your Code Is Calling hackathon (Devpost, 2026).

--- a/apps/python/fs-sponsor-outreach/fs_sponsor_outreach.py
+++ b/apps/python/fs-sponsor-outreach/fs_sponsor_outreach.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+fs_sponsor_outreach.py
+
+Batch outbound sponsor-outreach caller built on CALL-E, for student
+racing teams (Formula Student, FSAE, etc.) reaching out to prospective
+sponsors from a CSV lead list.
+
+Wraps the `calle` CLI directly (`calle call start` / `calle call status`) -
+no AI agent required. Requires the `calle` CLI installed and authenticated:
+
+    npm install -g @call-e/cli
+    calle auth login
+
+Usage:
+    python3 fs_sponsor_outreach.py leads.csv --team-name "Formula Student XYZ" --out results.csv
+    python3 fs_sponsor_outreach.py leads.csv --team-name "..." --dry-run
+
+CSV columns required: name, phone (E.164, e.g. +15550101234), region
+Optional columns: notes
+
+Safety note: only call numbers of people who have consented to be
+called by this workflow. Do not add real, un-contacted third parties
+to the leads CSV.
+"""
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+TERMINAL_STATUSES = {"COMPLETED", "NO ANSWER", "DECLINED", "FAILED"}
+
+
+def run_calle(args):
+    """Run a calle CLI command and return parsed JSON stdout."""
+    result = subprocess.run(["calle"] + args, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"calle command failed: {' '.join(args)}\n{result.stderr}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise RuntimeError(f"calle did not return JSON for: {' '.join(args)}\n{result.stdout}")
+
+
+def build_goal(team_name, contact_name, notes):
+    goal = (
+        f"Call {contact_name} and briefly introduce {team_name}, a university "
+        f"Formula Student racing team looking for sponsorship. Ask whether they'd "
+        f"be interested in hearing more. If yes, ask for the best way and time to "
+        f"follow up. If not interested, thank them politely and end the call."
+    )
+    if notes:
+        goal += f" Context: {notes}."
+    return goal
+
+
+def place_call(team_name, lead):
+    goal = build_goal(team_name, lead["name"], lead.get("notes", ""))
+    args = ["call", "start", "--to-phone", lead["phone"], "--goal", goal]
+    if lead.get("region"):
+        args += ["--region", lead["region"]]
+    return run_calle(args)
+
+
+def poll_status(run_id, poll_interval=3, max_wait=180):
+    waited = 0
+    status = run_calle(["call", "status", "--run-id", run_id])
+    while status.get("status") not in TERMINAL_STATUSES and waited < max_wait:
+        time.sleep(poll_interval)
+        waited += poll_interval
+        status = run_calle(["call", "status", "--run-id", run_id])
+    return status
+
+
+def extract_result(status):
+    result = status.get("result", {}) or {}
+    extracted = result.get("extracted", {}) or {}
+    return {
+        "status": status.get("status"),
+        "summary": result.get("summary"),
+        "interest_level": extracted.get("interest_level"),
+        "best_contact_method": extracted.get("best_contact_method"),
+        "best_contact_time": extracted.get("best_contact_time"),
+        "notes": extracted.get("notes"),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Batch sponsor-outreach caller using CALL-E.")
+    parser.add_argument("leads_csv", help="CSV file with columns: name, phone, region, notes")
+    parser.add_argument("--team-name", required=True, help="Name of the team pitched on the call")
+    parser.add_argument("--out", default="results.csv", help="Output CSV path for structured results")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned goals without calling")
+    args = parser.parse_args()
+
+    leads_path = Path(args.leads_csv)
+    if not leads_path.exists():
+        sys.exit(f"Leads file not found: {leads_path}")
+
+    with leads_path.open(newline="", encoding="utf-8") as f:
+        leads = list(csv.DictReader(f))
+
+    if not leads:
+        sys.exit("No leads found in CSV.")
+
+    rows_out = []
+    for lead in leads:
+        name = (lead.get("name") or "").strip()
+        phone = (lead.get("phone") or "").strip()
+        if not name or not phone:
+            print(f"Skipping incomplete row: {lead}")
+            continue
+
+        goal = build_goal(args.team_name, name, lead.get("notes", ""))
+
+        if args.dry_run:
+            print(f"[DRY RUN] {name} <{phone}> region={lead.get('region', '-')}\n  goal: {goal}\n")
+            continue
+
+        print(f"Calling {name} <{phone}>...")
+        started = place_call(args.team_name, lead)
+        run_id = started.get("run_id")
+        if not run_id:
+            print(f"  Failed to start call: {started}")
+            rows_out.append({"name": name, "phone": phone, "status": "START_FAILED"})
+            continue
+
+        final_status = poll_status(run_id)
+        row = extract_result(final_status)
+        row.update({"name": name, "phone": phone, "run_id": run_id})
+        rows_out.append(row)
+        print(f"  -> {row['status']} | interest: {row.get('interest_level')}")
+
+    if args.dry_run:
+        return
+
+    fieldnames = [
+        "name", "phone", "run_id", "status", "interest_level",
+        "best_contact_method", "best_contact_time", "notes", "summary",
+    ]
+    with open(args.out, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows_out:
+            writer.writerow({k: row.get(k, "") for k in fieldnames})
+
+    print(f"\nDone. Results written to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/fs-sponsor-outreach/leads.example.csv
+++ b/apps/python/fs-sponsor-outreach/leads.example.csv
@@ -1,0 +1,2 @@
+name,phone,region,notes
+Eddie (self-test),+1XXXXXXXXXX,US,This is a self-test call to verify the workflow before any real sponsor is contacted

--- a/apps/python/fs-sponsor-outreach/results_dashboard.html
+++ b/apps/python/fs-sponsor-outreach/results_dashboard.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Sponsor Outreach — Timing Tower</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0B0E14;
+    --panel: #12161F;
+    --panel-border: #1F2530;
+    --text: #E8ECF2;
+    --text-dim: #7C8494;
+    --interested: #B026FF;
+    --callback: #FFB800;
+    --not-interested: #E63950;
+    --no-answer: #5C6270;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    padding: 32px 24px 80px;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; }
+
+  header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--panel-border);
+    padding-bottom: 20px;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  h1 {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 700;
+    font-size: 34px;
+    letter-spacing: 0.5px;
+    margin: 0;
+    text-transform: uppercase;
+  }
+  h1 span { color: var(--text-dim); font-weight: 500; }
+  .upload-btn {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text-dim);
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    padding: 8px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .upload-btn:hover { color: var(--text); border-color: var(--text-dim); }
+  #file-input { display: none; }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .stat {
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+    padding: 14px 16px;
+  }
+  .stat .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .stat .label {
+    font-family: 'Barlow Condensed', sans-serif;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 1px;
+    color: var(--text-dim);
+    margin-top: 4px;
+  }
+  .stat.interested .num { color: var(--interested); }
+  .stat.callback .num { color: var(--callback); }
+  .stat.conversion .num { color: var(--text); }
+
+  .tower-head {
+    font-family: 'Barlow Condensed', sans-serif;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 1.5px;
+    color: var(--text-dim);
+    padding: 0 16px 8px;
+    display: grid;
+    grid-template-columns: 28px 1fr 130px 200px 90px;
+    gap: 12px;
+  }
+
+  .row {
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+    margin-bottom: 8px;
+    padding: 14px 16px;
+    display: grid;
+    grid-template-columns: 28px 1fr 130px 200px 90px;
+    gap: 12px;
+    align-items: center;
+    cursor: pointer;
+    transition: border-color 0.15s ease;
+  }
+  .row:hover { border-color: var(--text-dim); }
+
+  .pos {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-dim);
+    font-size: 13px;
+  }
+  .name-block .name { font-weight: 500; }
+  .name-block .phone {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+
+  .badge {
+    font-family: 'Barlow Condensed', sans-serif;
+    text-transform: uppercase;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 3px;
+    display: inline-block;
+    width: fit-content;
+  }
+  .badge.interested { color: var(--interested); background: rgba(176,38,255,0.12); }
+  .badge.callback_requested { color: var(--callback); background: rgba(255,184,0,0.12); }
+  .badge.not_interested { color: var(--not-interested); background: rgba(230,57,80,0.12); }
+  .badge.unclear, .badge.no_answer, .badge.failed { color: var(--no-answer); background: rgba(92,98,112,0.15); }
+
+  .sector-track {
+    display: flex;
+    gap: 3px;
+    height: 6px;
+  }
+  .sector-track div {
+    flex: 1;
+    border-radius: 2px;
+    background: var(--panel-border);
+  }
+  .sector-track div.done { background: var(--text-dim); }
+  .sector-track div.final.interested { background: var(--interested); }
+  .sector-track div.final.callback_requested { background: var(--callback); }
+  .sector-track div.final.not_interested { background: var(--not-interested); }
+  .sector-track div.final.unclear,
+  .sector-track div.final.no_answer,
+  .sector-track div.final.failed { background: var(--no-answer); }
+
+  .contact-method {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text-dim);
+  }
+
+  .detail {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--panel-border);
+    margin-top: 12px;
+    padding-top: 12px;
+    font-size: 13px;
+    color: var(--text-dim);
+    display: none;
+    line-height: 1.5;
+  }
+  .row.open .detail { display: block; }
+
+  .empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--text-dim);
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 18px;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Sponsor Outreach <span>/ Timing Tower</span></h1>
+    <label class="upload-btn" for="file-input">LOAD RESULTS.CSV</label>
+    <input id="file-input" type="file" accept=".csv" />
+  </header>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="tower-head">
+    <span>#</span><span>Contact</span><span>Outcome</span><span>Sectors</span><span>Method</span>
+  </div>
+  <div id="tower"></div>
+</div>
+
+<script>
+// Sample data — replace by loading a real results.csv via the button above.
+// Expected columns match fs_sponsor_outreach.py's output:
+// name, phone, run_id, status, interest_level, best_contact_method, best_contact_time, notes, summary
+const SAMPLE_DATA = [
+  { name: "Alex Rennwerk", phone: "+49XXXXXXXXX", status: "COMPLETED", interest_level: "interested", best_contact_method: "email", best_contact_time: "next week", notes: "Asked for a sponsorship pack and team stats.", summary: "Positive call, requested written proposal." },
+  { name: "Jordan Speedline", phone: "+1XXXXXXXXXX", status: "COMPLETED", interest_level: "callback_requested", best_contact_method: "phone", best_contact_time: "Thursday afternoon", notes: "Busy this week, open to a follow-up call.", summary: "Interested but timing was bad." },
+  { name: "Sam Torque", phone: "+44XXXXXXXXXX", status: "COMPLETED", interest_level: "not_interested", best_contact_method: "-", best_contact_time: "-", notes: "Sponsorship budget already committed for the year.", summary: "Polite decline." },
+  { name: "Robin Chassis", phone: "+1XXXXXXXXXX", status: "NO ANSWER", interest_level: "unclear", best_contact_method: "-", best_contact_time: "-", notes: "No pickup, no voicemail left.", summary: "Unreached." },
+];
+
+const STAGES = ["dialing", "connected", "pitch", "outcome"];
+const STAGE_LABELS = ["Dial", "Connect", "Pitch", "Outcome"];
+
+function computeStats(data) {
+  const total = data.length;
+  const interested = data.filter(d => d.interest_level === "interested").length;
+  const callback = data.filter(d => d.interest_level === "callback_requested").length;
+  const conversion = total ? Math.round(((interested + callback) / total) * 100) : 0;
+  return { total, interested, callback, conversion };
+}
+
+function renderStats(data) {
+  const s = computeStats(data);
+  document.getElementById('stats').innerHTML = `
+    <div class="stat"><div class="num">${s.total}</div><div class="label">Contacts Called</div></div>
+    <div class="stat interested"><div class="num">${s.interested}</div><div class="label">Interested</div></div>
+    <div class="stat callback"><div class="num">${s.callback}</div><div class="label">Callback Requested</div></div>
+    <div class="stat conversion"><div class="num">${s.conversion}%</div><div class="label">Positive Rate</div></div>
+  `;
+}
+
+function sectorTrack(level) {
+  const reached = level === "unclear" || level === "no_answer" || level === "failed" ? 1 : 4;
+  return STAGES.map((_, i) => {
+    const isDone = i < reached;
+    const isFinal = i === reached - 1;
+    const cls = ['done', isDone ? 'done' : '', isFinal ? `final ${level}` : ''].filter(Boolean).join(' ');
+    return `<div class="${isDone ? 'done' : ''} ${isFinal ? 'final ' + level : ''}"></div>`;
+  }).join('');
+}
+
+function renderTower(data) {
+  const tower = document.getElementById('tower');
+  if (!data.length) {
+    tower.innerHTML = `<div class="empty-state">No calls yet — load a results.csv to see the timing tower.</div>`;
+    return;
+  }
+  const order = { interested: 0, callback_requested: 1, unclear: 2, not_interested: 3, no_answer: 2, failed: 2 };
+  const sorted = [...data].sort((a, b) => (order[a.interest_level] ?? 9) - (order[b.interest_level] ?? 9));
+
+  tower.innerHTML = sorted.map((d, i) => `
+    <div class="row" onclick="this.classList.toggle('open')">
+      <div class="pos">${String(i + 1).padStart(2, '0')}</div>
+      <div class="name-block">
+        <div class="name">${d.name}</div>
+        <div class="phone">${d.phone || ''}</div>
+      </div>
+      <div class="badge ${d.interest_level}">${(d.interest_level || 'unclear').replace('_', ' ')}</div>
+      <div class="sector-track">${sectorTrack(d.interest_level)}</div>
+      <div class="contact-method">${d.best_contact_method || '—'}</div>
+      <div class="detail">
+        <strong>Status:</strong> ${d.status || '—'}<br>
+        <strong>Best time:</strong> ${d.best_contact_time || '—'}<br>
+        <strong>Notes:</strong> ${d.notes || '—'}<br>
+        <strong>Summary:</strong> ${d.summary || '—'}
+      </div>
+    </div>
+  `).join('');
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split('\n');
+  const headers = lines[0].split(',').map(h => h.trim());
+  return lines.slice(1).map(line => {
+    // naive split — fine for CALL-E's output (no embedded commas expected in these fields)
+    const cells = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => obj[h] = (cells[i] || '').trim());
+    return obj;
+  });
+}
+
+document.getElementById('file-input').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (evt) => {
+    const data = parseCSV(evt.target.result);
+    renderStats(data);
+    renderTower(data);
+  };
+  reader.readAsText(file);
+});
+
+renderStats(SAMPLE_DATA);
+renderTower(SAMPLE_DATA);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a Python CLI app under apps/python/fs-sponsor-outreach/ that reads a CSV of prospective sponsor contacts and places one outbound call per contact via the CALL-E CLI, returning structured interest-level and follow-up results.

Status: script and README complete; validated with `scripts/validate_repository.py`. Live-call testing pending a consenting test contact in a CALL-E-supported region — will update before marking ready for review.