### PR TITLE
feat(apps): add access route caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/call-on-behalf`](apps/typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
 | [`apps/python/freshchain-resolver`](apps/python/freshchain-resolver/) | Python | Resolve delayed cold-chain receiving exceptions by phone and return a safe dispatch decision. |
 | [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
+| [`apps/python/access-route-caller`](apps/python/access-route-caller/) | Python | Consent-bound caller that asks an organization which accessible communication routes it supports and returns the public instructions in writing. |
 | [`apps/python/batch-runner`](apps/python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`apps/python/broker-login-client`](apps/python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |
 | [`apps/typescript/broker-login-client`](apps/typescript/broker-login-client/) | TypeScript | CALL-E brokered login client using `@call-e/core`. |

--- a/apps/python/access-route-caller/README.md
+++ b/apps/python/access-route-caller/README.md
@@ -1,0 +1,105 @@
+# Access Route Caller
+
+Some organizations still make the phone line the only visible door. That door can be difficult or impossible for somebody who is Deaf or hard of hearing, uses a relay service, needs extra processing time, relies on a support person, or cannot manage an unplanned live call.
+
+Access Route Caller makes one narrow CALL-E call to ask which communication routes the organization supports. It returns the public instructions in writing. It does not conduct the person's underlying business.
+
+## What makes this different
+
+This app does not book, buy, negotiate, access an account, or speak about why somebody needs another route. It asks only how a person can communicate:
+
+- email or secure messaging;
+- text messaging;
+- a scheduled callback window;
+- telecommunications relay support;
+- participation by a support person; or
+- a slower-paced future conversation.
+
+The useful outcome may be that no alternative exists or that the organization refuses automated callers. The app reports that plainly instead of pretending the access problem was solved.
+
+## Safety model
+
+The workflow has three separate gates:
+
+1. The request must state that the owner authorized the call and must point to the organization's published HTTPS contact page.
+2. Preview mode shows the exact CALL-E task, a masked destination, the requested routes, and a SHA-256 receipt. It places no call.
+3. Live mode requires the unchanged request, the matching preview receipt, `--execute`, and a separate `--confirm-owner-authorized` flag.
+
+The task explicitly forbids names, disability or health reasons, account access, identity verification, appointments, purchases, fees, commitments, passwords, codes, and medical, legal, or financial facts. Unknown request fields and unsupported route types fail closed.
+
+## Setup
+
+Python 3.11 or later and `uv` are recommended:
+
+```bash
+cd apps/python/access-route-caller
+uv sync
+```
+
+Copy `example_request.json`. Use one organization or public-serving business, an E.164 number it publishes, and the HTTPS page where the number appears. The included number is a fictional reserved example and must not be called.
+
+## Preview without a call
+
+Preview is the default. It needs no account, credential, or network access:
+
+```bash
+uv run python access_route.py --request example_request.json
+```
+
+The output contains a `receipt` bound to the complete normalized request. Editing the destination or any requested route changes the receipt.
+
+## Run one live call
+
+Use a CALL-E account and a destination you are legally permitted to call. Keep the API key in an environment variable or secret manager, never in the request file:
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+
+uv run python access_route.py \
+  --request your-authorized-request.json \
+  --execute \
+  --confirm-owner-authorized \
+  --receipt <receipt-from-preview> \
+  --output private-result.json
+```
+
+Live mode creates exactly one CALL-E call task and waits for its terminal result. The stable `accessroute-<workflow_id>` idempotency key prevents a retry of the same workflow from creating a duplicate call. Use a new `workflow_id` for a materially different authorized call.
+
+## Input contract
+
+- `workflow_id`: stable non-secret identifier.
+- `owner_authorized`: must be literal `true`.
+- `organization.display_name`: public organization or business name.
+- `organization.phone`: one E.164 number.
+- `organization.published_source`: public HTTPS page where the contact route is published.
+- `requested_routes`: one to six supported route names.
+- `locale`: optional locale such as `en-US`.
+- `allow_neutral_voicemail`: optional boolean, false by default.
+
+No free-text personal narrative belongs in this request. Unknown fields are rejected so a disability reason, case number, or other detail cannot silently enter the provider task.
+
+## Side effects and boundaries
+
+- Live mode places one outbound call. There is no schedule and no background worker.
+- The caller identifies itself as AI in its first sentence.
+- The call gathers public communication-access instructions only.
+- It is not for emergencies, crisis response, medical advice, legal advice, financial activity, collections, political outreach, marketing, or calls to private individuals.
+- It cannot establish that an offered route is legally sufficient, accessible in practice, or available to a specific person or account.
+- A result is a report of what was said, not proof that the organization will honor the route later.
+- CALL-E and its telephony providers necessarily process the call and may retain audio, transcripts, or metadata under their policies. Review those policies before live use.
+- Numbers are masked in previews and phone-like text is removed from returned structured results. A private result can still contain public contact instructions and should not be committed.
+
+## Cancellation and rollback
+
+Preview mode has no side effect. Before execution, cancel by omitting `--execute`, the confirmation flag, or the matching receipt. Once CALL-E accepts the task, this app cannot guarantee cancellation; use CALL-E's dashboard or provider controls if they expose it. The workflow creates no recurring job to remove and makes no external change to roll back.
+
+## Validation
+
+Tests inject a fake CALL-E client and never place a real call:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 ../../../scripts/validate_repository.py
+```
+
+Live verification is opt-in. Use a number you own or a public organization you are authorized to contact, preserve only a redacted result, and never commit the live request, result, credential, transcript, or recording.

--- a/apps/python/access-route-caller/README.md
+++ b/apps/python/access-route-caller/README.md
@@ -89,7 +89,7 @@ No free-text personal narrative belongs in this request. Unknown fields are reje
 - It cannot establish that an offered route is legally sufficient, accessible in practice, or available to a specific person or account.
 - A result is a report of what was said, not proof that the organization will honor the route later.
 - CALL-E and its telephony providers necessarily process the call and may retain audio, transcripts, or metadata under their policies. Review those policies before live use.
-- Numbers are masked in previews and phone-like text is removed from returned structured results. A private result can still contain public contact instructions and should not be committed.
+- Numbers are masked in previews and phone-like text is removed from returned structured results. Live output also includes `consistency_warnings` for missing or duplicate route results and possible cross-route contradictions. These warnings require human review; they do not silently rewrite what the organization said. A private result can still contain public contact instructions and should not be committed.
 
 ## Cancellation and rollback
 

--- a/apps/python/access-route-caller/README.md
+++ b/apps/python/access-route-caller/README.md
@@ -21,7 +21,7 @@ The useful outcome may be that no alternative exists or that the organization re
 
 The workflow has three separate gates:
 
-1. The request must state that the owner authorized the call and must point to the organization's published HTTPS contact page.
+1. The request must state that the owner authorized the call. Public-contact mode requires the organization's published HTTPS contact page; controlled-demo mode instead requires explicit recipient consent and forbids a source-page claim.
 2. Preview mode shows the exact CALL-E task, a masked destination, the requested routes, and a SHA-256 receipt. It places no call.
 3. Live mode requires the unchanged request, the matching preview receipt, `--execute`, and a separate `--confirm-owner-authorized` flag.
 
@@ -69,9 +69,11 @@ Live mode creates exactly one CALL-E call task and waits for its terminal result
 
 - `workflow_id`: stable non-secret identifier.
 - `owner_authorized`: must be literal `true`.
-- `organization.display_name`: public organization or business name.
+- `recipient_mode`: `public_contact` (default) or `consenting_demo`.
+- `recipient_consent_confirmed`: must be literal `true` only for a controlled demo; false otherwise.
+- `organization.display_name`: public organization or business name, or a non-personal scenario label for a controlled demo.
 - `organization.phone`: one E.164 number.
-- `organization.published_source`: public HTTPS page where the contact route is published.
+- `organization.published_source`: required in `public_contact` mode and must be the public HTTPS page where the contact route is published. It must be omitted in `consenting_demo` mode.
 - `requested_routes`: one to six supported route names.
 - `locale`: optional locale such as `en-US`.
 - `allow_neutral_voicemail`: optional boolean, false by default.
@@ -82,8 +84,8 @@ No free-text personal narrative belongs in this request. Unknown fields are reje
 
 - Live mode places one outbound call. There is no schedule and no background worker.
 - The caller identifies itself as AI in its first sentence.
-- The call gathers public communication-access instructions only.
-- It is not for emergencies, crisis response, medical advice, legal advice, financial activity, collections, political outreach, marketing, or calls to private individuals.
+- The call gathers public communication-access instructions, or clearly labeled demonstration instructions in controlled-demo mode, only.
+- It is not for emergencies, crisis response, medical advice, legal advice, financial activity, collections, political outreach, marketing, or unsolicited calls to private individuals. Controlled-demo mode may call a number the user owns or a recipient who explicitly agreed, and it reconfirms consent at the start of the call.
 - It cannot establish that an offered route is legally sufficient, accessible in practice, or available to a specific person or account.
 - A result is a report of what was said, not proof that the organization will honor the route later.
 - CALL-E and its telephony providers necessarily process the call and may retain audio, transcripts, or metadata under their policies. Review those policies before live use.
@@ -102,4 +104,4 @@ python3 -m unittest discover -s tests -v
 python3 ../../../scripts/validate_repository.py
 ```
 
-Live verification is opt-in. Use a number you own or a public organization you are authorized to contact, preserve only a redacted result, and never commit the live request, result, credential, transcript, or recording.
+Live verification is opt-in. Use a number you own, a consenting demo participant, or a public organization you are authorized to contact. Preserve only a redacted result, and never commit the live request, result, credential, transcript, or recording.

--- a/apps/python/access-route-caller/access_route.py
+++ b/apps/python/access-route-caller/access_route.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+E164_PATTERN = re.compile(r"^\+[1-9]\d{7,14}$")
+SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{2,63}$")
+LOCALE_PATTERN = re.compile(r"^[a-z]{2,3}(?:-[A-Z]{2})?$")
+PHONE_LIKE_PATTERN = re.compile(r"(?<!\w)\+?[1-9]\d{7,14}(?!\w)")
+
+ROUTE_LABELS = {
+    "email": "an email address or secure message route",
+    "text": "a text-message route",
+    "scheduled_callback": "a scheduled callback window instead of an unplanned call",
+    "relay_support": "support for a telecommunications relay service",
+    "support_person": "permission for a support person to join or handle a future call",
+    "slower_pace": "a slower-paced future phone conversation with time to process",
+}
+
+ALLOWED_TOP_LEVEL_KEYS = {
+    "workflow_id",
+    "owner_authorized",
+    "organization",
+    "requested_routes",
+    "locale",
+    "allow_neutral_voicemail",
+}
+ALLOWED_ORGANIZATION_KEYS = {"display_name", "phone", "published_source"}
+
+
+@dataclass(frozen=True)
+class Organization:
+    display_name: str
+    phone: str
+    published_source: str
+
+
+@dataclass(frozen=True)
+class AccessRouteRequest:
+    workflow_id: str
+    owner_authorized: bool
+    organization: Organization
+    requested_routes: tuple[str, ...]
+    locale: str
+    allow_neutral_voicemail: bool
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Preview or place one CALL-E call that asks an organization which "
+            "accessible communication routes it supports."
+        )
+    )
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional new JSON output path; existing files are never overwritten.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Place exactly one CALL-E call. Without this flag, only a preview is created.",
+    )
+    parser.add_argument(
+        "--confirm-owner-authorized",
+        action="store_true",
+        help="Required for live mode; confirms the person requesting the call approved it.",
+    )
+    parser.add_argument(
+        "--receipt",
+        help="Preview receipt for the unchanged request; required for live mode.",
+    )
+    parser.add_argument(
+        "--base-url", default=os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL)
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    return parser.parse_args(argv)
+
+
+def clean_text(value: Any, field: str, *, minimum: int, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = " ".join(value.split())
+    if not minimum <= len(cleaned) <= maximum:
+        raise ValueError(f"{field} must contain {minimum}-{maximum} characters")
+    return cleaned
+
+
+def _reject_unknown_keys(raw: dict[str, Any], allowed: set[str], field: str) -> None:
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ValueError(f"{field} contains unsupported fields: {', '.join(unknown)}")
+
+
+def _validate_published_source(value: Any) -> str:
+    source = clean_text(value, "organization.published_source", minimum=12, maximum=300)
+    parsed = urlparse(source)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError(
+            "organization.published_source must be a public HTTPS URL without credentials"
+        )
+    return source
+
+
+def parse_request(raw: Any) -> AccessRouteRequest:
+    if not isinstance(raw, dict):
+        raise ValueError("request must be a JSON object")
+    _reject_unknown_keys(raw, ALLOWED_TOP_LEVEL_KEYS, "request")
+
+    workflow_id = clean_text(raw.get("workflow_id"), "workflow_id", minimum=3, maximum=64)
+    if not SAFE_ID_PATTERN.fullmatch(workflow_id):
+        raise ValueError(
+            "workflow_id may contain only letters, numbers, dot, underscore, and hyphen"
+        )
+
+    if raw.get("owner_authorized") is not True:
+        raise ValueError("owner_authorized must be true")
+
+    organization_raw = raw.get("organization")
+    if not isinstance(organization_raw, dict):
+        raise ValueError("organization must be an object")
+    _reject_unknown_keys(
+        organization_raw, ALLOWED_ORGANIZATION_KEYS, "organization"
+    )
+    phone = clean_text(
+        organization_raw.get("phone"), "organization.phone", minimum=8, maximum=16
+    )
+    if not E164_PATTERN.fullmatch(phone):
+        raise ValueError("organization.phone must use E.164 format")
+    organization = Organization(
+        display_name=clean_text(
+            organization_raw.get("display_name"),
+            "organization.display_name",
+            minimum=2,
+            maximum=100,
+        ),
+        phone=phone,
+        published_source=_validate_published_source(
+            organization_raw.get("published_source")
+        ),
+    )
+
+    route_values = raw.get("requested_routes")
+    if not isinstance(route_values, list) or not 1 <= len(route_values) <= 6:
+        raise ValueError("requested_routes must contain 1-6 route names")
+    if any(not isinstance(route, str) for route in route_values):
+        raise ValueError("requested_routes must contain strings")
+    if len(set(route_values)) != len(route_values):
+        raise ValueError("requested_routes must not contain duplicates")
+    unsupported = sorted(set(route_values) - set(ROUTE_LABELS))
+    if unsupported:
+        raise ValueError(f"unsupported requested route: {', '.join(unsupported)}")
+
+    locale = clean_text(raw.get("locale", "en-US"), "locale", minimum=2, maximum=16)
+    if not LOCALE_PATTERN.fullmatch(locale):
+        raise ValueError("locale must look like en-US or ko-KR")
+
+    voicemail = raw.get("allow_neutral_voicemail", False)
+    if not isinstance(voicemail, bool):
+        raise ValueError("allow_neutral_voicemail must be true or false")
+
+    return AccessRouteRequest(
+        workflow_id=workflow_id,
+        owner_authorized=True,
+        organization=organization,
+        requested_routes=tuple(route_values),
+        locale=locale,
+        allow_neutral_voicemail=voicemail,
+    )
+
+
+def load_request(path: Path) -> AccessRouteRequest:
+    with path.expanduser().open(encoding="utf-8") as handle:
+        return parse_request(json.load(handle))
+
+
+def request_document(request: AccessRouteRequest) -> dict[str, Any]:
+    return {
+        "workflow_id": request.workflow_id,
+        "owner_authorized": request.owner_authorized,
+        "organization": {
+            "display_name": request.organization.display_name,
+            "phone": request.organization.phone,
+            "published_source": request.organization.published_source,
+        },
+        "requested_routes": list(request.requested_routes),
+        "locale": request.locale,
+        "allow_neutral_voicemail": request.allow_neutral_voicemail,
+    }
+
+
+def preview_receipt(request: AccessRouteRequest) -> str:
+    canonical = json.dumps(
+        request_document(request), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(b"access-route-caller-v1\0" + canonical).hexdigest()
+
+
+def mask_phone(phone: str) -> str:
+    return f"{phone[:3]}{'*' * max(4, len(phone) - 6)}{phone[-3:]}"
+
+
+def route_questions(request: AccessRouteRequest) -> str:
+    return "; ".join(
+        f"{route}: {ROUTE_LABELS[route]}" for route in request.requested_routes
+    )
+
+
+def build_task(request: AccessRouteRequest) -> str:
+    voicemail_instruction = (
+        "If a person does not answer, leave only a neutral message saying an automated assistant called to ask about communication options; include no other details."
+        if request.allow_neutral_voicemail
+        else "If a person does not answer, do not leave a voicemail."
+    )
+    return (
+        f"Place one accessibility-information call to {request.organization.display_name}. "
+        "In the first sentence, disclose that you are an AI calling assistant. Say that a person asked you to find a communication route they can use instead of an unplanned live phone conversation. "
+        "Do not state or ask why they need another route. Ask whether the organization supports each requested option and what a person must do to use it. "
+        f"The requested options are: {route_questions(request)}. "
+        "This call may gather public access instructions only. Do not access or change an account, verify identity, make or change an appointment, buy anything, accept terms or fees, transfer the call into a service interaction, or make any commitment. "
+        "Do not request or disclose a name, date of birth, address, account or case number, diagnosis, insurance information, payment information, legal facts, financial facts, password, code, or other personal information. "
+        "If the organization will not speak with an automated caller, record that and end politely. If asked for personal or service-specific information, explain that you are only collecting public communication-access instructions, then end if the public instructions cannot be provided. "
+        f"{voicemail_instruction} Summarize the available routes, conditions, and the safest next step, then end the call."
+    )
+
+
+def build_result_schema(request: AccessRouteRequest) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": [
+            "organization_reached",
+            "automated_caller_accepted",
+            "route_results",
+            "next_step",
+            "evidence_summary",
+        ],
+        "properties": {
+            "organization_reached": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+            },
+            "automated_caller_accepted": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+            },
+            "route_results": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["route", "availability", "instructions"],
+                    "properties": {
+                        "route": {
+                            "type": "string",
+                            "enum": list(request.requested_routes),
+                        },
+                        "availability": {
+                            "type": "string",
+                            "enum": ["yes", "no", "conditional", "unknown"],
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "description": "Public instructions only; omit personal information.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            },
+            "next_step": {
+                "type": "string",
+                "enum": [
+                    "use_available_route",
+                    "human_follow_up_needed",
+                    "no_route_found",
+                    "outcome_unknown",
+                ],
+            },
+            "evidence_summary": {
+                "type": "string",
+                "description": "Short paraphrase of what the organization said, with no personal information.",
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def idempotency_key(request: AccessRouteRequest) -> str:
+    return f"accessroute-{request.workflow_id}"
+
+
+def build_call_arguments(request: AccessRouteRequest) -> dict[str, Any]:
+    return {
+        "task": build_task(request),
+        "recipients": [
+            {"phones": [request.organization.phone], "locale": request.locale}
+        ],
+        "result_schema": build_result_schema(request),
+        "metadata": {
+            "workflow_id": request.workflow_id,
+            "workflow_type": "accessible_communication_route_discovery",
+        },
+        "idempotency_key": idempotency_key(request),
+    }
+
+
+def preview(request: AccessRouteRequest) -> dict[str, Any]:
+    arguments = build_call_arguments(request)
+    arguments["recipients"] = [
+        {"phones": [mask_phone(request.organization.phone)], "locale": request.locale}
+    ]
+    return {
+        "mode": "preview",
+        "creates_phone_call": False,
+        "workflow_id": request.workflow_id,
+        "organization": request.organization.display_name,
+        "published_source": request.organization.published_source,
+        "requested_routes": list(request.requested_routes),
+        "call_arguments": arguments,
+        "receipt": preview_receipt(request),
+        "live_command_note": (
+            "Live mode requires the unchanged request, --execute, "
+            "--confirm-owner-authorized, this receipt, and CALLE_API_KEY."
+        ),
+    }
+
+
+def redact_phone_like_text(value: Any) -> Any:
+    if isinstance(value, str):
+        return PHONE_LIKE_PATTERN.sub("[phone-redacted]", value)
+    if isinstance(value, list):
+        return [redact_phone_like_text(item) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_phone_like_text(item) for key, item in value.items()}
+    return value
+
+
+def execute(
+    request: AccessRouteRequest,
+    client: Any,
+    *,
+    receipt: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    expected_receipt = preview_receipt(request)
+    if receipt != expected_receipt:
+        raise ValueError(
+            "receipt does not match the current request; preview it again before calling"
+        )
+    created = client.calls.create(**build_call_arguments(request))
+    call_id = created.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        raise RuntimeError("CALL-E create response did not contain a call id")
+    completed = client.calls.wait_for_result(
+        call_id, timeout_seconds=timeout_seconds, interval_seconds=2
+    )
+    return {
+        "mode": "execute",
+        "creates_phone_call": True,
+        "workflow_id": request.workflow_id,
+        "organization": request.organization.display_name,
+        "phone": mask_phone(request.organization.phone),
+        "idempotency_key": idempotency_key(request),
+        "call_id": call_id,
+        "status": completed.get("status"),
+        "task_completed": completed.get("task_completed"),
+        "completion_confidence": completed.get("completion_confidence"),
+        "structured_result": redact_phone_like_text(
+            completed.get("structured_result")
+        ),
+    }
+
+
+def write_output(path: Path | None, payload: dict[str, Any]) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if path is None:
+        sys.stdout.write(rendered)
+        return
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("x", encoding="utf-8") as handle:
+        handle.write(rendered)
+    destination.chmod(0o600)
+    sys.stdout.write(f"Wrote {destination}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        request = load_request(args.request)
+        if not args.execute:
+            write_output(args.output, preview(request))
+            return 0
+        if not args.confirm_owner_authorized:
+            raise ValueError("--execute requires --confirm-owner-authorized")
+        if not args.receipt:
+            raise ValueError("--execute requires the receipt from preview mode")
+        if args.timeout_seconds <= 0:
+            raise ValueError("--timeout-seconds must be positive")
+        api_key = os.environ.get("CALLE_API_KEY")
+        if not api_key:
+            raise ValueError("CALLE_API_KEY is required for --execute")
+
+        from calle import CalleClient
+
+        client = CalleClient(api_key=api_key, base_url=args.base_url)
+        write_output(
+            args.output,
+            execute(
+                request,
+                client,
+                receipt=args.receipt,
+                timeout_seconds=args.timeout_seconds,
+            ),
+        )
+        return 0
+    except (
+        FileExistsError,
+        OSError,
+        ValueError,
+        RuntimeError,
+        json.JSONDecodeError,
+    ) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/access-route-caller/access_route.py
+++ b/apps/python/access-route-caller/access_route.py
@@ -26,10 +26,13 @@ ROUTE_LABELS = {
     "support_person": "permission for a support person to join or handle a future call",
     "slower_pace": "a slower-paced future phone conversation with time to process",
 }
+RECIPIENT_MODES = {"public_contact", "consenting_demo"}
 
 ALLOWED_TOP_LEVEL_KEYS = {
     "workflow_id",
     "owner_authorized",
+    "recipient_mode",
+    "recipient_consent_confirmed",
     "organization",
     "requested_routes",
     "locale",
@@ -42,13 +45,15 @@ ALLOWED_ORGANIZATION_KEYS = {"display_name", "phone", "published_source"}
 class Organization:
     display_name: str
     phone: str
-    published_source: str
+    published_source: str | None
 
 
 @dataclass(frozen=True)
 class AccessRouteRequest:
     workflow_id: str
     owner_authorized: bool
+    recipient_mode: str
+    recipient_consent_confirmed: bool
     organization: Organization
     requested_routes: tuple[str, ...]
     locale: str
@@ -128,6 +133,13 @@ def parse_request(raw: Any) -> AccessRouteRequest:
     if raw.get("owner_authorized") is not True:
         raise ValueError("owner_authorized must be true")
 
+    recipient_mode = raw.get("recipient_mode", "public_contact")
+    if recipient_mode not in RECIPIENT_MODES:
+        raise ValueError("recipient_mode must be public_contact or consenting_demo")
+    recipient_consent_confirmed = raw.get("recipient_consent_confirmed", False)
+    if not isinstance(recipient_consent_confirmed, bool):
+        raise ValueError("recipient_consent_confirmed must be true or false")
+
     organization_raw = raw.get("organization")
     if not isinstance(organization_raw, dict):
         raise ValueError("organization must be an object")
@@ -139,6 +151,24 @@ def parse_request(raw: Any) -> AccessRouteRequest:
     )
     if not E164_PATTERN.fullmatch(phone):
         raise ValueError("organization.phone must use E.164 format")
+    published_source_raw = organization_raw.get("published_source")
+    if recipient_mode == "public_contact":
+        published_source = _validate_published_source(published_source_raw)
+        if recipient_consent_confirmed:
+            raise ValueError(
+                "recipient_consent_confirmed must be false for public_contact mode"
+            )
+    else:
+        if recipient_consent_confirmed is not True:
+            raise ValueError(
+                "consenting_demo mode requires recipient_consent_confirmed true"
+            )
+        if published_source_raw is not None:
+            raise ValueError(
+                "consenting_demo mode must not include organization.published_source"
+            )
+        published_source = None
+
     organization = Organization(
         display_name=clean_text(
             organization_raw.get("display_name"),
@@ -147,9 +177,7 @@ def parse_request(raw: Any) -> AccessRouteRequest:
             maximum=100,
         ),
         phone=phone,
-        published_source=_validate_published_source(
-            organization_raw.get("published_source")
-        ),
+        published_source=published_source,
     )
 
     route_values = raw.get("requested_routes")
@@ -174,6 +202,8 @@ def parse_request(raw: Any) -> AccessRouteRequest:
     return AccessRouteRequest(
         workflow_id=workflow_id,
         owner_authorized=True,
+        recipient_mode=recipient_mode,
+        recipient_consent_confirmed=recipient_consent_confirmed,
         organization=organization,
         requested_routes=tuple(route_values),
         locale=locale,
@@ -187,14 +217,18 @@ def load_request(path: Path) -> AccessRouteRequest:
 
 
 def request_document(request: AccessRouteRequest) -> dict[str, Any]:
+    organization = {
+        "display_name": request.organization.display_name,
+        "phone": request.organization.phone,
+    }
+    if request.organization.published_source is not None:
+        organization["published_source"] = request.organization.published_source
     return {
         "workflow_id": request.workflow_id,
         "owner_authorized": request.owner_authorized,
-        "organization": {
-            "display_name": request.organization.display_name,
-            "phone": request.organization.phone,
-            "published_source": request.organization.published_source,
-        },
+        "recipient_mode": request.recipient_mode,
+        "recipient_consent_confirmed": request.recipient_consent_confirmed,
+        "organization": organization,
         "requested_routes": list(request.requested_routes),
         "locale": request.locale,
         "allow_neutral_voicemail": request.allow_neutral_voicemail,
@@ -224,14 +258,36 @@ def build_task(request: AccessRouteRequest) -> str:
         if request.allow_neutral_voicemail
         else "If a person does not answer, do not leave a voicemail."
     )
+    opening = (
+        f"Place one controlled accessibility-information demo call to {request.organization.display_name}. "
+        "The recipient explicitly agreed to receive this demo call and may role-play an organization. In the first sentence, disclose that you are an AI calling assistant making a demonstration call and confirm that they still agree to continue. If they do not confirm, end immediately. Treat every answer as demonstration data, not verified public instructions. "
+        if request.recipient_mode == "consenting_demo"
+        else f"Place one accessibility-information call to {request.organization.display_name}. "
+    )
+    disclosure = (
+        ""
+        if request.recipient_mode == "consenting_demo"
+        else "In the first sentence, disclose that you are an AI calling assistant. "
+    )
+    information_boundary = (
+        "This call may gather demonstration communication-access instructions only. "
+        if request.recipient_mode == "consenting_demo"
+        else "This call may gather public access instructions only. "
+    )
+    stop_boundary = (
+        "If the demo participant withdraws consent or stops role-playing, end politely. If asked for personal or service-specific information, explain that this is only a controlled demonstration and do not collect it. "
+        if request.recipient_mode == "consenting_demo"
+        else "If the organization will not speak with an automated caller, record that and end politely. If asked for personal or service-specific information, explain that you are only collecting public communication-access instructions, then end if the public instructions cannot be provided. "
+    )
     return (
-        f"Place one accessibility-information call to {request.organization.display_name}. "
-        "In the first sentence, disclose that you are an AI calling assistant. Say that a person asked you to find a communication route they can use instead of an unplanned live phone conversation. "
+        opening
+        + disclosure
+        + "Say that a person asked you to find a communication route they can use instead of an unplanned live phone conversation. "
         "Do not state or ask why they need another route. Ask whether the organization supports each requested option and what a person must do to use it. "
         f"The requested options are: {route_questions(request)}. "
-        "This call may gather public access instructions only. Do not access or change an account, verify identity, make or change an appointment, buy anything, accept terms or fees, transfer the call into a service interaction, or make any commitment. "
+        f"{information_boundary}Do not access or change an account, verify identity, make or change an appointment, buy anything, accept terms or fees, transfer the call into a service interaction, or make any commitment. "
         "Do not request or disclose a name, date of birth, address, account or case number, diagnosis, insurance information, payment information, legal facts, financial facts, password, code, or other personal information. "
-        "If the organization will not speak with an automated caller, record that and end politely. If asked for personal or service-specific information, explain that you are only collecting public communication-access instructions, then end if the public instructions cannot be provided. "
+        f"{stop_boundary}"
         f"{voicemail_instruction} Summarize the available routes, conditions, and the safest next step, then end the call."
     )
 
@@ -271,7 +327,11 @@ def build_result_schema(request: AccessRouteRequest) -> dict[str, Any]:
                         },
                         "instructions": {
                             "type": "string",
-                            "description": "Public instructions only; omit personal information.",
+                            "description": (
+                                "Demonstration instructions only; omit personal information."
+                                if request.recipient_mode == "consenting_demo"
+                                else "Public instructions only; omit personal information."
+                            ),
                         },
                     },
                     "additionalProperties": False,
@@ -288,7 +348,11 @@ def build_result_schema(request: AccessRouteRequest) -> dict[str, Any]:
             },
             "evidence_summary": {
                 "type": "string",
-                "description": "Short paraphrase of what the organization said, with no personal information.",
+                "description": (
+                    "Short paraphrase of the controlled demonstration, with no personal information."
+                    if request.recipient_mode == "consenting_demo"
+                    else "Short paraphrase of what the organization said, with no personal information."
+                ),
             },
         },
         "additionalProperties": False,
@@ -309,6 +373,7 @@ def build_call_arguments(request: AccessRouteRequest) -> dict[str, Any]:
         "metadata": {
             "workflow_id": request.workflow_id,
             "workflow_type": "accessible_communication_route_discovery",
+            "recipient_mode": request.recipient_mode,
         },
         "idempotency_key": idempotency_key(request),
     }
@@ -324,6 +389,8 @@ def preview(request: AccessRouteRequest) -> dict[str, Any]:
         "creates_phone_call": False,
         "workflow_id": request.workflow_id,
         "organization": request.organization.display_name,
+        "recipient_mode": request.recipient_mode,
+        "recipient_consent_confirmed": request.recipient_consent_confirmed,
         "published_source": request.organization.published_source,
         "requested_routes": list(request.requested_routes),
         "call_arguments": arguments,

--- a/apps/python/access-route-caller/access_route.py
+++ b/apps/python/access-route-caller/access_route.py
@@ -26,6 +26,16 @@ ROUTE_LABELS = {
     "support_person": "permission for a support person to join or handle a future call",
     "slower_pace": "a slower-paced future phone conversation with time to process",
 }
+ROUTE_MENTION_PATTERNS = {
+    "email": re.compile(r"\be-?mail\b", re.IGNORECASE),
+    "text": re.compile(r"\b(?:text|sms)\b", re.IGNORECASE),
+    "scheduled_callback": re.compile(
+        r"\b(?:scheduled[ -])?call[ -]?back\b", re.IGNORECASE
+    ),
+    "relay_support": re.compile(r"\brelay\b", re.IGNORECASE),
+    "support_person": re.compile(r"\bsupport person\b", re.IGNORECASE),
+    "slower_pace": re.compile(r"\bslower[ -]paced?\b", re.IGNORECASE),
+}
 RECIPIENT_MODES = {"public_contact", "consenting_demo"}
 
 ALLOWED_TOP_LEVEL_KEYS = {
@@ -412,6 +422,62 @@ def redact_phone_like_text(value: Any) -> Any:
     return value
 
 
+def result_consistency_warnings(
+    request: AccessRouteRequest, structured_result: Any
+) -> list[str]:
+    if not isinstance(structured_result, dict):
+        return ["Structured result is unavailable or malformed; review provider output."]
+    route_results = structured_result.get("route_results")
+    if not isinstance(route_results, list):
+        return ["route_results is missing or malformed; review provider output."]
+
+    counts: dict[str, int] = {}
+    valid_results: list[dict[str, Any]] = []
+    for item in route_results:
+        if not isinstance(item, dict):
+            continue
+        route = item.get("route")
+        if not isinstance(route, str):
+            continue
+        counts[route] = counts.get(route, 0) + 1
+        valid_results.append(item)
+
+    warnings = [
+        f"Missing requested route result: {route}."
+        for route in request.requested_routes
+        if counts.get(route, 0) == 0
+    ]
+    warnings.extend(
+        f"Duplicate route result: {route}."
+        for route in request.requested_routes
+        if counts.get(route, 0) > 1
+    )
+
+    unavailable = {
+        item.get("route")
+        for item in valid_results
+        if item.get("availability") == "no"
+    }
+    for item in valid_results:
+        source_route = item.get("route")
+        instructions = item.get("instructions")
+        if item.get("availability") not in {"yes", "conditional"}:
+            continue
+        if not isinstance(source_route, str) or not isinstance(instructions, str):
+            continue
+        for unavailable_route in request.requested_routes:
+            if unavailable_route == source_route or unavailable_route not in unavailable:
+                continue
+            pattern = ROUTE_MENTION_PATTERNS[unavailable_route]
+            if pattern.search(instructions):
+                warnings.append(
+                    "Possible contradiction: "
+                    f"{source_route} instructions reference {unavailable_route}, "
+                    f"but {unavailable_route} is marked unavailable."
+                )
+    return warnings
+
+
 def execute(
     request: AccessRouteRequest,
     client: Any,
@@ -431,6 +497,7 @@ def execute(
     completed = client.calls.wait_for_result(
         call_id, timeout_seconds=timeout_seconds, interval_seconds=2
     )
+    structured_result = redact_phone_like_text(completed.get("structured_result"))
     return {
         "mode": "execute",
         "creates_phone_call": True,
@@ -442,8 +509,9 @@ def execute(
         "status": completed.get("status"),
         "task_completed": completed.get("task_completed"),
         "completion_confidence": completed.get("completion_confidence"),
-        "structured_result": redact_phone_like_text(
-            completed.get("structured_result")
+        "structured_result": structured_result,
+        "consistency_warnings": result_consistency_warnings(
+            request, structured_result
         ),
     }
 

--- a/apps/python/access-route-caller/example_request.json
+++ b/apps/python/access-route-caller/example_request.json
@@ -1,0 +1,18 @@
+{
+  "workflow_id": "cedar-library-access-001",
+  "owner_authorized": true,
+  "organization": {
+    "display_name": "Cedar Public Library",
+    "phone": "+12025550123",
+    "published_source": "https://example.org/contact"
+  },
+  "requested_routes": [
+    "email",
+    "text",
+    "scheduled_callback",
+    "relay_support",
+    "support_person"
+  ],
+  "locale": "en-US",
+  "allow_neutral_voicemail": false
+}

--- a/apps/python/access-route-caller/pyproject.toml
+++ b/apps/python/access-route-caller/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "calle-access-route-caller"
+version = "0.1.0"
+description = "Consent-bound CALL-E workflow for discovering accessible communication routes."
+requires-python = ">=3.11"
+dependencies = [
+  "calle-ai==0.2.0",
+]

--- a/apps/python/access-route-caller/tests/test_access_route.py
+++ b/apps/python/access-route-caller/tests/test_access_route.py
@@ -55,7 +55,22 @@ class FakeCalls:
                         "route": "email",
                         "availability": "yes",
                         "instructions": "Use access@example.org or call +12025550177.",
-                    }
+                    },
+                    {
+                        "route": "text",
+                        "availability": "no",
+                        "instructions": "Text messaging is unavailable.",
+                    },
+                    {
+                        "route": "scheduled_callback",
+                        "availability": "no",
+                        "instructions": "Scheduled callbacks are unavailable.",
+                    },
+                    {
+                        "route": "relay_support",
+                        "availability": "no",
+                        "instructions": "Relay support is unavailable.",
+                    },
                 ],
                 "next_step": "use_available_route",
                 "evidence_summary": "Staff confirmed the public access route.",
@@ -201,6 +216,43 @@ class AccessRouteTests(unittest.TestCase):
         rendered = json.dumps(result)
         self.assertNotIn("+12025550177", rendered)
         self.assertIn("[phone-redacted]", rendered)
+        self.assertEqual(result["consistency_warnings"], [])
+
+    def test_result_consistency_warnings_flag_provider_conflicts(self) -> None:
+        structured_result = {
+            "route_results": [
+                {
+                    "route": "email",
+                    "availability": "no",
+                    "instructions": "Email is unavailable.",
+                },
+                {
+                    "route": "text",
+                    "availability": "yes",
+                    "instructions": "Send a text to the published number.",
+                },
+                {
+                    "route": "text",
+                    "availability": "yes",
+                    "instructions": "SMS is also supported.",
+                },
+                {
+                    "route": "scheduled_callback",
+                    "availability": "yes",
+                    "instructions": "Request the callback by email.",
+                },
+            ]
+        }
+        warnings = access_route.result_consistency_warnings(
+            request(), structured_result
+        )
+        self.assertIn("Missing requested route result: relay_support.", warnings)
+        self.assertIn("Duplicate route result: text.", warnings)
+        self.assertIn(
+            "Possible contradiction: scheduled_callback instructions reference "
+            "email, but email is marked unavailable.",
+            warnings,
+        )
 
     def test_write_output_does_not_overwrite(self) -> None:
         destination = Path(__file__).parent / ".write-output-test.json"

--- a/apps/python/access-route-caller/tests/test_access_route.py
+++ b/apps/python/access-route-caller/tests/test_access_route.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import access_route
+
+
+def valid_raw() -> dict:
+    return {
+        "workflow_id": "cedar-library-access-001",
+        "owner_authorized": True,
+        "organization": {
+            "display_name": "Cedar Public Library",
+            "phone": "+12025550123",
+            "published_source": "https://example.org/contact",
+        },
+        "requested_routes": [
+            "email",
+            "text",
+            "scheduled_callback",
+            "relay_support",
+        ],
+        "locale": "en-US",
+        "allow_neutral_voicemail": False,
+    }
+
+
+def request() -> access_route.AccessRouteRequest:
+    return access_route.parse_request(valid_raw())
+
+
+class FakeCalls:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return {"id": "call_demo_001"}
+
+    def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+        assert call_id == "call_demo_001"
+        assert timeout_seconds == 30
+        assert interval_seconds == 2
+        return {
+            "status": "completed",
+            "task_completed": True,
+            "completion_confidence": 0.91,
+            "structured_result": {
+                "organization_reached": "yes",
+                "automated_caller_accepted": "yes",
+                "route_results": [
+                    {
+                        "route": "email",
+                        "availability": "yes",
+                        "instructions": "Use access@example.org or call +12025550177.",
+                    }
+                ],
+                "next_step": "use_available_route",
+                "evidence_summary": "Staff confirmed the public access route.",
+            },
+        }
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls = FakeCalls()
+
+
+class AccessRouteTests(unittest.TestCase):
+    def test_valid_request_parses(self) -> None:
+        parsed = request()
+        self.assertEqual(parsed.organization.display_name, "Cedar Public Library")
+        self.assertEqual(
+            parsed.requested_routes,
+            ("email", "text", "scheduled_callback", "relay_support"),
+        )
+
+    def test_invalid_request_fields_fail_closed(self) -> None:
+        cases = [
+            (("owner_authorized",), False, "owner_authorized must be true"),
+            (("organization", "phone"), "202-555-0123", "E.164"),
+            (
+                ("organization", "published_source"),
+                "http://example.org/contact",
+                "public HTTPS URL",
+            ),
+            (("locale",), "english", "locale must look like"),
+        ]
+        for path, value, message in cases:
+            with self.subTest(path=path):
+                raw = valid_raw()
+                target = raw
+                for key in path[:-1]:
+                    target = target[key]
+                target[path[-1]] = value
+                with self.assertRaisesRegex(ValueError, message):
+                    access_route.parse_request(raw)
+
+    def test_unknown_fields_are_rejected(self) -> None:
+        raw = valid_raw()
+        raw["reason_for_disability"] = "not allowed"
+        with self.assertRaisesRegex(ValueError, "unsupported fields"):
+            access_route.parse_request(raw)
+
+    def test_duplicate_and_unknown_routes_are_rejected(self) -> None:
+        raw = valid_raw()
+        raw["requested_routes"] = ["email", "email"]
+        with self.assertRaisesRegex(ValueError, "duplicates"):
+            access_route.parse_request(raw)
+        raw["requested_routes"] = ["telepathy"]
+        with self.assertRaisesRegex(ValueError, "unsupported requested route"):
+            access_route.parse_request(raw)
+
+    def test_preview_masks_number_and_creates_no_call(self) -> None:
+        payload = access_route.preview(request())
+        self.assertIs(payload["creates_phone_call"], False)
+        rendered = json.dumps(payload)
+        self.assertNotIn("+12025550123", rendered)
+        self.assertIn("+12******123", rendered)
+
+    def test_preview_receipt_is_stable_and_bound_to_request(self) -> None:
+        first = request()
+        self.assertEqual(
+            access_route.preview_receipt(first), access_route.preview_receipt(first)
+        )
+        raw = valid_raw()
+        raw["requested_routes"] = ["email"]
+        second = access_route.parse_request(raw)
+        self.assertNotEqual(
+            access_route.preview_receipt(first), access_route.preview_receipt(second)
+        )
+
+    def test_task_carries_no_personal_reason_or_commitment_authority(self) -> None:
+        task = access_route.build_task(request())
+        self.assertIn("Do not state or ask why", task)
+        self.assertIn("Do not access or change an account", task)
+        self.assertIn("make or change an appointment", task)
+
+    def test_result_schema_is_closed_and_route_bounded(self) -> None:
+        schema = access_route.build_result_schema(request())
+        self.assertIs(schema["additionalProperties"], False)
+        item = schema["properties"]["route_results"]["items"]
+        self.assertIs(item["additionalProperties"], False)
+        self.assertEqual(
+            item["properties"]["route"]["enum"],
+            ["email", "text", "scheduled_callback", "relay_support"],
+        )
+
+    def test_execute_requires_matching_receipt_before_call(self) -> None:
+        client = FakeClient()
+        with self.assertRaisesRegex(ValueError, "receipt does not match"):
+            access_route.execute(
+                request(), client, receipt="0" * 64, timeout_seconds=30
+            )
+        self.assertEqual(client.calls.created, [])
+
+    def test_execute_places_one_call_and_redacts_phone_like_results(self) -> None:
+        parsed = request()
+        client = FakeClient()
+        result = access_route.execute(
+            parsed,
+            client,
+            receipt=access_route.preview_receipt(parsed),
+            timeout_seconds=30,
+        )
+        self.assertEqual(len(client.calls.created), 1)
+        self.assertEqual(
+            result["idempotency_key"], "accessroute-cedar-library-access-001"
+        )
+        rendered = json.dumps(result)
+        self.assertNotIn("+12025550177", rendered)
+        self.assertIn("[phone-redacted]", rendered)
+
+    def test_write_output_does_not_overwrite(self) -> None:
+        destination = Path(__file__).parent / ".write-output-test.json"
+        if destination.exists():
+            destination.unlink()
+        try:
+            access_route.write_output(destination, {"ok": True})
+            with self.assertRaises(FileExistsError):
+                access_route.write_output(destination, {"ok": False})
+            self.assertEqual(
+                json.loads(destination.read_text(encoding="utf-8")), {"ok": True}
+            )
+        finally:
+            if destination.exists():
+                destination.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/access-route-caller/tests/test_access_route.py
+++ b/apps/python/access-route-caller/tests/test_access_route.py
@@ -77,6 +77,24 @@ class AccessRouteTests(unittest.TestCase):
             ("email", "text", "scheduled_callback", "relay_support"),
         )
 
+    def test_consenting_demo_requires_consent_and_no_source_claim(self) -> None:
+        raw = valid_raw()
+        raw["recipient_mode"] = "consenting_demo"
+        raw["recipient_consent_confirmed"] = True
+        del raw["organization"]["published_source"]
+        parsed = access_route.parse_request(raw)
+        self.assertEqual(parsed.recipient_mode, "consenting_demo")
+        self.assertIsNone(parsed.organization.published_source)
+
+        raw["recipient_consent_confirmed"] = False
+        with self.assertRaisesRegex(ValueError, "requires recipient_consent_confirmed"):
+            access_route.parse_request(raw)
+
+        raw["recipient_consent_confirmed"] = True
+        raw["organization"]["published_source"] = "https://example.org/contact"
+        with self.assertRaisesRegex(ValueError, "must not include"):
+            access_route.parse_request(raw)
+
     def test_invalid_request_fields_fail_closed(self) -> None:
         cases = [
             (("owner_authorized",), False, "owner_authorized must be true"),
@@ -137,6 +155,17 @@ class AccessRouteTests(unittest.TestCase):
         self.assertIn("Do not state or ask why", task)
         self.assertIn("Do not access or change an account", task)
         self.assertIn("make or change an appointment", task)
+
+    def test_demo_task_reconfirms_consent_and_labels_demo_data(self) -> None:
+        raw = valid_raw()
+        raw["recipient_mode"] = "consenting_demo"
+        raw["recipient_consent_confirmed"] = True
+        del raw["organization"]["published_source"]
+        task = access_route.build_task(access_route.parse_request(raw))
+        self.assertIn("still agree to continue", task)
+        self.assertIn("demonstration data", task)
+        self.assertIn("withdraws consent", task)
+        self.assertEqual(task.count("first sentence"), 1)
 
     def test_result_schema_is_closed_and_route_bounded(self) -> None:
         schema = access_route.build_result_schema(request())


### PR DESCRIPTION
## Summary

Adds a Python example that uses CALL-E to discover an organization's public accessible-communication routes without conducting the caller's underlying business.

The app can ask about email, text, scheduled callbacks, relay support, support-person participation, and slower-paced future calls. It returns a constrained structured result. This belongs in the repository as a narrow phone-agent example with explicit authority and side-effect boundaries.

For live verification, a separate `consenting_demo` mode can call a number the user owns or an explicitly consenting participant without pretending the number came from a public organization page. It reconfirms consent at the start of the call and labels every answer as demonstration data.

Preview is the default and places no call. Live mode requires owner authorization, an unchanged-request receipt, an explicit execute flag, a second confirmation flag, and a CALL-E credential. The task forbids account access, identity verification, appointments, purchases, terms, fees, commitments, and personal, medical, legal, or financial facts.

Controlled-demo mode requires literal recipient consent, forbids a published-source claim, reconfirms consent on the call, and stops if consent is withdrawn.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. This app creates no recurring workflow and documents pre-execution cancellation and post-acceptance limits.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Validation

- `python -B -m unittest discover -s tests -v` — 13 tests passed using an injected fake CALL-E client; no call was placed.
- `python -B scripts/validate_repository.py` — repository validation passed.
- The client method signatures were checked against `calle-ai==0.2.0`.
