### PR TITLE
feat(apps): add multi-recipient response aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/phone-approval-gate`](apps/typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |
 | [`apps/typescript/call-on-behalf`](apps/typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
 | [`apps/python/freshchain-resolver`](apps/python/freshchain-resolver/) | Python | Resolve delayed cold-chain receiving exceptions by phone and return a safe dispatch decision. |
+| [`apps/python/ringedingeding`](apps/python/ringedingeding/) | Python | Multi-recipient response aggregator that keeps answered, refused and unreached apart, reports every share against those who answered, and never reads silence as consent. |
 | [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`apps/python/batch-runner`](apps/python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`apps/python/broker-login-client`](apps/python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |

--- a/apps/README.md
+++ b/apps/README.md
@@ -14,6 +14,7 @@ Current apps:
 | [`typescript/call-neuron`](typescript/call-neuron/) | TypeScript | Functional consent-first scholarship outreach prototype with manual/file intake, identity-first disclosure, neutral voicemail, one-recipient CALL-E planning and confirmation, live status, human dispositions, and browser-local campaign data. |
 | [`typescript/phone-approval-gate`](typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |
 | [`typescript/call-on-behalf`](typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
+| [`python/ringedingeding`](python/ringedingeding/) | Python | Multi-recipient response aggregator that keeps answered, refused and unreached apart, reports every share against those who answered, and never reads silence as consent. |
 | [`python/callback-window-coordinator`](python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`python/batch-runner`](python/batch-runner/) | Python | JSONL batch runner using CALL-E CLI auth state, FastMCP, Rich output, and MCP tool-call metadata. |
 | [`python/broker-login-client`](python/broker-login-client/) | Python | CALL-E brokered login client with local token cache and MCP HTTP calls. |

--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -1,0 +1,149 @@
+# Multi-recipient response aggregator
+
+Call several people, then say what they answered — without inventing a majority.
+
+Calling twenty people is the easy part. The hard part is the sentence afterwards:
+*"eleven of them prefer Tuesday."* Eleven of how many? Of those who answered, or of those
+who were invited? And if four never picked up, do they count as indifferent?
+
+They do not. This app keeps the groups apart and names the denominator every time.
+
+| Group | Meaning |
+| --- | --- |
+| `answered` | said something |
+| `refused` | picked up and declined to take part |
+| `unreached` | nobody answered, or the line was busy |
+| `pending` | not called yet |
+| `unknown` | the call ended in a state nobody can interpret |
+
+Three rules follow, and they are what the regressions defend:
+
+- **Every share is reported against those who answered** — never against those who were
+  invited — and the report says so in words.
+- **Silence about one option is unknown, not a no.** Someone who answered but never
+  mentioned Thursday has not ruled Thursday out.
+- **A tie stays a tie.** Nothing breaks the draw, because the caller was not asked to decide
+  anything.
+
+## Setup
+
+Python 3.11 or newer. No dependencies.
+
+```bash
+cd apps/python/ringedingeding
+python aggregate.py --fixture example-schedule.json
+python aggregate.py --fixture example-opinions.json
+```
+
+## Finding a date
+
+```text
+FIXTURE RUN -- SIMULATED, NO CALL PLACED
+No network, no telephone, no credentials. Answers come from the fixture file.
+
+Question: Which evening works for the club meeting?
+Basis: 4 answered / 6 invited
+Incomplete: 1 refused, 1 unreached. These people are not in the figures below and are not counted as indifferent.
+
+Tue 19:00  [works for all respondents]
+     works:  Ana, Ben, Cleo, Dara
+     cannot: -
+     silent (unknown, not a no): -
+Wed 19:00  [-]
+     works:  Ana, Ben, Dara
+     cannot: -
+     silent (unknown, not a no): Cleo
+Thu 19:00  [-]
+     works:  -
+     cannot: Ana
+     silent (unknown, not a no): Ben, Cleo, Dara
+
+Slots that work for everyone who answered: Tue 19:00 -- among respondents only.
+```
+
+**Wednesday is the point of this fixture.** Nobody objected to it — `cannot` is empty — and
+a naive tally would call it a match. Cleo simply never mentioned it. The slot is not
+confirmed, and the report says which of the two it is.
+
+## Merging opinions
+
+```text
+Question: Which caterer should we book for the summer party?
+Basis: 5 answered / 6 invited
+Incomplete: 1 unreached. These people are not in the figures below and are not counted as indifferent.
+
+  Green Table: 2 of 5 who answered
+  Hearth and Co: 2 of 5 who answered
+  abstained: Emil
+
+Tie between Green Table and Hearth and Co. It is not broken here.
+
+Conditions attached:
+  - Ana: only if the vegan option is included
+  - Dara: only if they can set up before six
+
+Reasons given (raw alongside):
+  - Ana: They did the spring event and it went well.
+      raw: "Green Table, definitely -- as long as they do the vegan option."
+  - Ben: Prices are more predictable.
+      raw: "I would say Hearth and Co. Their prices are more predictable."
+```
+
+A tally alone would have lost three things: that the vote is tied, that two of the votes
+carry conditions, and that Emil abstained rather than being unreachable. Each is kept
+separately, and the raw sentence travels beside its interpretation so a reader can check
+the reading instead of trusting it.
+
+## Catch-up rounds
+
+A second round calls the `pending` and the `unreached` — nobody else. Someone who answered
+is done, and someone who refused has given their answer; calling them again is not a
+catch-up, it is pestering. Folding fresh answers in never overwrites an existing one.
+
+## Safety
+
+- **No calls.** There is no live transport and no `--live` flag in this edition. Every
+  answer comes from the fixture file.
+- **No credentials.** No account, no API key, no network request of any kind.
+- **No scheduler, no retry.** A catch-up round is something a person starts, not something
+  that happens by itself.
+- **Numbers are validated as E.164 before processing** and masked in every output path. A
+  regression asserts that no full number appears in either the report or the structured
+  result, for both fixtures.
+- **Fictional data only.** The fixtures use the `+1 555-0100…555-0199` range, reserved for
+  fiction and belonging to nobody.
+- **Cancellation.** Stopping the process stops it. Nothing was dispatched, so nothing needs
+  recalling.
+
+## Deliberate limits
+
+- **`no_answer`, `busy` and `declined` never collapse into one group.** They mean different
+  things for a follow-up: two are worth another call, one is not.
+- **An uninterpretable call lands in `unknown`**, not in `unreached`. Not knowing what
+  happened is not the same as knowing nobody picked up.
+- **An incomplete result always carries its caveat**, generated from the coverage rather
+  than written by hand, so it cannot fall out of step with the figures.
+- Not for medical, legal, financial or emergency workflows.
+
+## Tests
+
+```bash
+cd apps/python/ringedingeding
+python -m pytest -q
+```
+
+```text
+.......................                                                  [100%]
+23 passed in 0.08s
+```
+
+The regressions guard the ways a summary could lie: unreached people counted as
+indifferent, statuses collapsing into one another, silence read as consent, a tie quietly
+broken, conditions or reasons dropped, a catch-up round overwriting an answer, and a full
+number reaching an output.
+
+## The full application
+
+This is a focused, self-contained proof of the aggregation. The complete application —
+call orchestration, the hash-chained record, web interface and the live CALL-E transport —
+lives at <https://github.com/lukisch/ringedingeding>.

--- a/apps/python/ringedingeding/aggregate.py
+++ b/apps/python/ringedingeding/aggregate.py
@@ -1,0 +1,489 @@
+"""Aggregate what several people said on the phone -- without inventing a majority.
+
+Calling twenty people is the easy part. The hard part is the sentence afterwards:
+"eleven of them prefer Tuesday." Eleven of how many? Of those who answered, or of
+those who were invited? If four never picked up, do they count as indifferent?
+
+They do not. This module keeps the groups apart and names the denominator every
+time:
+
+    answered    said something
+    refused     picked up and declined to take part
+    unreached   nobody answered, or the line was busy
+    pending     not called yet
+    unknown     the call ended in a state nobody can interpret
+
+Three rules follow from that, and they are what the tests defend:
+
+* Every share is reported against those who **answered**, never against those who
+  were invited -- and the report says so in words.
+* Silence about one option is **unknown**, not a no. Someone who answered but said
+  nothing about Thursday has not ruled Thursday out.
+* A tie stays a tie. There is no tie-break, because the caller was not asked to
+  decide anything.
+
+This is the collection edition: fixture-driven, no network, no telephone, no
+credentials, no scheduler. The full application lives at
+https://github.com/lukisch/ringedingeding
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Sequence
+
+# --------------------------------------------------------------------------------------
+# Phone numbers
+# --------------------------------------------------------------------------------------
+
+E164 = re.compile(r"^\+[1-9]\d{6,14}$")
+
+
+class NumberRejected(ValueError):
+    """Raised before any processing when a participant number is not valid E.164."""
+
+
+def validate_number(raw: str) -> str:
+    number = (raw or "").strip()
+    if not E164.match(number):
+        raise NumberRejected(f"not a valid E.164 number: {mask(number) or '<empty>'}")
+    return number
+
+
+def mask(number: str) -> str:
+    """Country prefix and last two digits. Everything else is hidden, everywhere."""
+    if not number:
+        return ""
+    keep_tail = 2
+    if len(number) <= keep_tail + 3:
+        return "*" * len(number)
+    return f"{number[:3]}{'*' * (len(number) - 3 - keep_tail)}{number[-keep_tail:]}"
+
+
+# --------------------------------------------------------------------------------------
+# Who is where
+# --------------------------------------------------------------------------------------
+
+
+class Bucket(str, Enum):
+    ANSWERED = "answered"
+    REFUSED = "refused"
+    UNREACHED = "unreached"
+    PENDING = "pending"
+    UNKNOWN = "unknown"
+
+
+class Status(str, Enum):
+    """Call statuses stay distinct. NO_ANSWER, BUSY and DECLINED are not the same thing."""
+
+    COMPLETED = "completed"
+    DECLINED = "declined"
+    NO_ANSWER = "no_answer"
+    BUSY = "busy"
+    NOT_CALLED = "not_called"
+    UNKNOWN = "unknown"
+
+    @property
+    def bucket(self) -> Bucket:
+        return {
+            Status.COMPLETED: Bucket.ANSWERED,
+            Status.DECLINED: Bucket.REFUSED,
+            Status.NO_ANSWER: Bucket.UNREACHED,
+            Status.BUSY: Bucket.UNREACHED,
+            Status.NOT_CALLED: Bucket.PENDING,
+            Status.UNKNOWN: Bucket.UNKNOWN,
+        }[self]
+
+
+@dataclass(frozen=True)
+class Participant:
+    id: str
+    name: str
+    phone: str
+
+    def __post_init__(self) -> None:
+        validate_number(self.phone)
+
+    @property
+    def phone_masked(self) -> str:
+        return mask(self.phone)
+
+
+class Stance(str, Enum):
+    """Where one person stands on one option."""
+
+    WORKS = "works"
+    CANNOT = "cannot"
+    SILENT = "silent"  # answered the call, said nothing about this option
+
+
+@dataclass(frozen=True)
+class Answer:
+    """One person's response, raw text and interpretation side by side.
+
+    `raw` is what was said. `stances`, `choice` and `conditions` are readings of it.
+    The raw line travels with the result so a reader can check the interpretation
+    instead of trusting it.
+    """
+
+    participant_id: str
+    status: Status
+    raw: str = ""
+    stances: dict[str, Stance] = field(default_factory=dict)
+    choice: str | None = None
+    abstained: bool = False
+    conditions: tuple[str, ...] = ()
+    reason: str = ""
+
+    @property
+    def bucket(self) -> Bucket:
+        return self.status.bucket
+
+
+# --------------------------------------------------------------------------------------
+# Coverage: who is behind the numbers, and who is not
+# --------------------------------------------------------------------------------------
+
+
+@dataclass
+class Coverage:
+    invited: list[Participant]
+    by_bucket: dict[Bucket, list[Participant]]
+
+    @property
+    def answered(self) -> list[Participant]:
+        return self.by_bucket[Bucket.ANSWERED]
+
+    @property
+    def basis(self) -> str:
+        """The denominator, spelled out. This string goes into every report."""
+        return f"{len(self.answered)} answered / {len(self.invited)} invited"
+
+    @property
+    def is_complete(self) -> bool:
+        return len(self.answered) == len(self.invited)
+
+    @property
+    def caveat(self) -> str | None:
+        """The sentence that must appear beside any incomplete result."""
+        if self.is_complete:
+            return None
+        missing = {
+            bucket.value: len(people)
+            for bucket, people in self.by_bucket.items()
+            if bucket is not Bucket.ANSWERED and people
+        }
+        parts = ", ".join(f"{count} {name}" for name, count in sorted(missing.items()))
+        return (
+            f"Incomplete: {parts}. These people are not in the figures below and are "
+            f"not counted as indifferent."
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "basis": self.basis,
+            "complete": self.is_complete,
+            "caveat": self.caveat,
+            "buckets": {
+                bucket.value: [
+                    {"name": p.name, "phone": p.phone_masked} for p in people
+                ]
+                for bucket, people in self.by_bucket.items()
+            },
+        }
+
+
+def classify(participants: Sequence[Participant], answers: dict[str, Answer]) -> Coverage:
+    buckets: dict[Bucket, list[Participant]] = {b: [] for b in Bucket}
+    for person in participants:
+        answer = answers.get(person.id)
+        bucket = answer.bucket if answer is not None else Bucket.PENDING
+        buckets[bucket].append(person)
+    return Coverage(invited=list(participants), by_bucket=buckets)
+
+
+# --------------------------------------------------------------------------------------
+# Scheduling
+# --------------------------------------------------------------------------------------
+
+
+@dataclass
+class SlotRow:
+    slot: str
+    works: list[str]
+    cannot: list[str]
+    silent: list[str]
+
+    @property
+    def works_for_everyone_who_answered(self) -> bool:
+        """True only if nobody said no *and* nobody stayed silent.
+
+        Silence is not agreement. A slot that half the respondents never mentioned
+        is not a slot that works for them.
+        """
+        return not self.cannot and not self.silent and bool(self.works)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slot": self.slot,
+            "works": list(self.works),
+            "cannot": list(self.cannot),
+            "silent_unknown": list(self.silent),
+            "works_for_all_respondents": self.works_for_everyone_who_answered,
+        }
+
+
+def merge_schedule(
+    slots: Sequence[str], participants: Sequence[Participant], answers: dict[str, Answer]
+) -> tuple[Coverage, list[SlotRow]]:
+    coverage = classify(participants, answers)
+    by_id = {p.id: p for p in participants}
+
+    rows: list[SlotRow] = []
+    for slot in slots:
+        works, cannot, silent = [], [], []
+        for person in coverage.answered:
+            stance = answers[person.id].stances.get(slot, Stance.SILENT)
+            name = by_id[person.id].name
+            {Stance.WORKS: works, Stance.CANNOT: cannot, Stance.SILENT: silent}[
+                stance
+            ].append(name)
+        rows.append(SlotRow(slot=slot, works=works, cannot=cannot, silent=silent))
+    return coverage, rows
+
+
+# --------------------------------------------------------------------------------------
+# Opinions
+# --------------------------------------------------------------------------------------
+
+
+@dataclass
+class OpinionResult:
+    tally: dict[str, int]
+    leaders: list[str]
+    abstentions: list[str]
+    conditions: list[dict[str, Any]]
+    reasons: list[dict[str, Any]]
+
+    @property
+    def is_tie(self) -> bool:
+        return len(self.leaders) > 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tally": dict(sorted(self.tally.items())),
+            "leaders": list(self.leaders),
+            "tie": self.is_tie,
+            "abstentions": list(self.abstentions),
+            "conditions": list(self.conditions),
+            "reasons": list(self.reasons),
+        }
+
+
+def merge_opinions(
+    participants: Sequence[Participant], answers: dict[str, Answer]
+) -> tuple[Coverage, OpinionResult]:
+    coverage = classify(participants, answers)
+    by_id = {p.id: p for p in participants}
+
+    tally: Counter[str] = Counter()
+    abstentions: list[str] = []
+    conditions: list[dict[str, Any]] = []
+    reasons: list[dict[str, Any]] = []
+
+    for person in coverage.answered:
+        answer = answers[person.id]
+        name = by_id[person.id].name
+        if answer.abstained or answer.choice is None:
+            abstentions.append(name)
+        else:
+            tally[answer.choice] += 1
+        for condition in answer.conditions:
+            conditions.append({"who": name, "condition": condition})
+        if answer.reason:
+            reasons.append({"who": name, "reason": answer.reason, "raw": answer.raw})
+
+    # A tie is a result, not a problem to be solved. Every option on the highest
+    # count is reported; nothing breaks the draw.
+    top = max(tally.values(), default=0)
+    leaders = sorted(option for option, count in tally.items() if count == top and top > 0)
+
+    return coverage, OpinionResult(
+        tally=dict(tally),
+        leaders=leaders,
+        abstentions=abstentions,
+        conditions=conditions,
+        reasons=reasons,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Catch-up
+# --------------------------------------------------------------------------------------
+
+
+def pending_for_catch_up(
+    participants: Sequence[Participant], answers: dict[str, Answer]
+) -> list[Participant]:
+    """Who a second round would call: the pending and the unreached, nobody else.
+
+    Someone who answered is done, and someone who refused has given their answer.
+    A catch-up round that calls them again is not a catch-up, it is pestering.
+    """
+    coverage = classify(participants, answers)
+    return coverage.by_bucket[Bucket.PENDING] + coverage.by_bucket[Bucket.UNREACHED]
+
+
+def apply_catch_up(
+    answers: dict[str, Answer], fresh: dict[str, Answer], allowed: Sequence[Participant]
+) -> dict[str, Answer]:
+    """Fold new answers in without touching the ones that were already given."""
+    allowed_ids = {p.id for p in allowed}
+    merged = dict(answers)
+    for participant_id, answer in fresh.items():
+        if participant_id in allowed_ids:
+            merged[participant_id] = answer
+    return merged
+
+
+# --------------------------------------------------------------------------------------
+# Fixtures and CLI
+# --------------------------------------------------------------------------------------
+
+
+def load_fixture(path: pathlib.Path):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    kind = data["kind"]
+
+    participants = [
+        Participant(id=p["id"], name=p["name"], phone=p["phone"]) for p in data["participants"]
+    ]
+    answers = {
+        a["participant_id"]: Answer(
+            participant_id=a["participant_id"],
+            status=Status(a["status"]),
+            raw=a.get("raw", ""),
+            stances={k: Stance(v) for k, v in a.get("stances", {}).items()},
+            choice=a.get("choice"),
+            abstained=bool(a.get("abstained", False)),
+            conditions=tuple(a.get("conditions", [])),
+            reason=a.get("reason", ""),
+        )
+        for a in data.get("answers", [])
+    }
+    return kind, data.get("question", ""), data.get("slots", []), participants, answers
+
+
+def render_schedule(question: str, coverage: Coverage, rows: list[SlotRow]) -> str:
+    lines = [
+        "FIXTURE RUN -- SIMULATED, NO CALL PLACED",
+        "No network, no telephone, no credentials. Answers come from the fixture file.",
+        "",
+        f"Question: {question}",
+        f"Basis: {coverage.basis}",
+    ]
+    if coverage.caveat:
+        lines.append(coverage.caveat)
+    lines.append("")
+    for row in rows:
+        verdict = "works for all respondents" if row.works_for_everyone_who_answered else "-"
+        lines.append(f"{row.slot}  [{verdict}]")
+        lines.append(f"     works:  {', '.join(row.works) or '-'}")
+        lines.append(f"     cannot: {', '.join(row.cannot) or '-'}")
+        lines.append(f"     silent (unknown, not a no): {', '.join(row.silent) or '-'}")
+    lines.append("")
+    common = [r.slot for r in rows if r.works_for_everyone_who_answered]
+    lines.append(
+        f"Slots that work for everyone who answered: {', '.join(common) or 'none'}"
+        + (" -- among respondents only." if not coverage.is_complete else "")
+    )
+    return "\n".join(lines)
+
+
+def render_opinions(question: str, coverage: Coverage, result: OpinionResult) -> str:
+    lines = [
+        "FIXTURE RUN -- SIMULATED, NO CALL PLACED",
+        "No network, no telephone, no credentials. Answers come from the fixture file.",
+        "",
+        f"Question: {question}",
+        f"Basis: {coverage.basis}",
+    ]
+    if coverage.caveat:
+        lines.append(coverage.caveat)
+    lines.append("")
+    for option, count in sorted(result.tally.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"  {option}: {count} of {len(coverage.answered)} who answered")
+    if result.abstentions:
+        lines.append(f"  abstained: {', '.join(result.abstentions)}")
+    lines.append("")
+    if result.is_tie:
+        lines.append(f"Tie between {' and '.join(result.leaders)}. It is not broken here.")
+    elif result.leaders:
+        lines.append(f"Ahead: {result.leaders[0]}")
+    else:
+        lines.append("Nobody expressed a preference.")
+    if result.conditions:
+        lines.append("")
+        lines.append("Conditions attached:")
+        for item in result.conditions:
+            lines.append(f"  - {item['who']}: {item['condition']}")
+    if result.reasons:
+        lines.append("")
+        lines.append("Reasons given (raw alongside):")
+        for item in result.reasons:
+            lines.append(f"  - {item['who']}: {item['reason']}")
+            lines.append(f"      raw: \"{item['raw']}\"")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate answers from several people over a fixture. Never places a call."
+    )
+    parser.add_argument("--fixture", required=True, type=pathlib.Path)
+    parser.add_argument("--json", action="store_true", help="emit the structured result")
+    args = parser.parse_args(argv)
+
+    try:
+        kind, question, slots, participants, answers = load_fixture(args.fixture)
+    except NumberRejected as exc:
+        print(f"refused: {exc}", file=sys.stderr)
+        return 2
+
+    if kind == "schedule":
+        coverage, rows = merge_schedule(slots, participants, answers)
+        payload = {
+            "mode": "fixture / simulated / no-call",
+            "kind": kind,
+            "question": question,
+            "coverage": coverage.to_dict(),
+            "slots": [r.to_dict() for r in rows],
+        }
+        text = render_schedule(question, coverage, rows)
+    elif kind == "opinion":
+        coverage, result = merge_opinions(participants, answers)
+        payload = {
+            "mode": "fixture / simulated / no-call",
+            "kind": kind,
+            "question": question,
+            "coverage": coverage.to_dict(),
+            "result": result.to_dict(),
+        }
+        text = render_opinions(question, coverage, result)
+    else:
+        print(f"unknown fixture kind: {kind}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(payload, indent=2) if args.json else text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/ringedingeding/example-opinions.json
+++ b/apps/python/ringedingeding/example-opinions.json
@@ -1,0 +1,82 @@
+{
+  "_note": "Fictional data. The numbers are in the +1 555-0100..555-0199 range, which is reserved for fiction and belongs to nobody.",
+  "kind": "opinion",
+  "question": "Which caterer should we book for the summer party?",
+  "participants": [
+    {
+      "id": "ana",
+      "name": "Ana",
+      "phone": "+15550100101"
+    },
+    {
+      "id": "ben",
+      "name": "Ben",
+      "phone": "+15550100102"
+    },
+    {
+      "id": "cleo",
+      "name": "Cleo",
+      "phone": "+15550100103"
+    },
+    {
+      "id": "dara",
+      "name": "Dara",
+      "phone": "+15550100104"
+    },
+    {
+      "id": "emil",
+      "name": "Emil",
+      "phone": "+15550100105"
+    },
+    {
+      "id": "fay",
+      "name": "Fay",
+      "phone": "+15550100106"
+    }
+  ],
+  "answers": [
+    {
+      "participant_id": "ana",
+      "status": "completed",
+      "raw": "Green Table, definitely -- as long as they do the vegan option.",
+      "choice": "Green Table",
+      "conditions": [
+        "only if the vegan option is included"
+      ],
+      "reason": "They did the spring event and it went well."
+    },
+    {
+      "participant_id": "ben",
+      "status": "completed",
+      "raw": "I would say Hearth and Co. Their prices are more predictable.",
+      "choice": "Hearth and Co",
+      "reason": "Prices are more predictable."
+    },
+    {
+      "participant_id": "cleo",
+      "status": "completed",
+      "raw": "Green Table.",
+      "choice": "Green Table"
+    },
+    {
+      "participant_id": "dara",
+      "status": "completed",
+      "raw": "Hearth and Co, but only if they can come before six.",
+      "choice": "Hearth and Co",
+      "conditions": [
+        "only if they can set up before six"
+      ]
+    },
+    {
+      "participant_id": "emil",
+      "status": "completed",
+      "raw": "Honestly, I do not mind either way. You decide.",
+      "abstained": true
+    },
+    {
+      "participant_id": "fay",
+      "status": "busy",
+      "raw": ""
+    }
+  ]
+}

--- a/apps/python/ringedingeding/example-schedule.json
+++ b/apps/python/ringedingeding/example-schedule.json
@@ -1,0 +1,90 @@
+{
+  "_note": "Fictional data. The numbers are in the +1 555-0100..555-0199 range, which is reserved for fiction and belongs to nobody.",
+  "kind": "schedule",
+  "question": "Which evening works for the club meeting?",
+  "slots": [
+    "Tue 19:00",
+    "Wed 19:00",
+    "Thu 19:00"
+  ],
+  "participants": [
+    {
+      "id": "ana",
+      "name": "Ana",
+      "phone": "+15550100101"
+    },
+    {
+      "id": "ben",
+      "name": "Ben",
+      "phone": "+15550100102"
+    },
+    {
+      "id": "cleo",
+      "name": "Cleo",
+      "phone": "+15550100103"
+    },
+    {
+      "id": "dara",
+      "name": "Dara",
+      "phone": "+15550100104"
+    },
+    {
+      "id": "emil",
+      "name": "Emil",
+      "phone": "+15550100105"
+    },
+    {
+      "id": "fay",
+      "name": "Fay",
+      "phone": "+15550100106"
+    }
+  ],
+  "answers": [
+    {
+      "participant_id": "ana",
+      "status": "completed",
+      "raw": "Tuesday and Wednesday are both fine. Thursday I have choir.",
+      "stances": {
+        "Tue 19:00": "works",
+        "Wed 19:00": "works",
+        "Thu 19:00": "cannot"
+      }
+    },
+    {
+      "participant_id": "ben",
+      "status": "completed",
+      "raw": "Tuesday works. Wednesday too, I think.",
+      "stances": {
+        "Tue 19:00": "works",
+        "Wed 19:00": "works"
+      }
+    },
+    {
+      "participant_id": "cleo",
+      "status": "completed",
+      "raw": "Tuesday is good for me.",
+      "stances": {
+        "Tue 19:00": "works"
+      }
+    },
+    {
+      "participant_id": "dara",
+      "status": "completed",
+      "raw": "Tuesday yes, Wednesday yes, Thursday no idea yet.",
+      "stances": {
+        "Tue 19:00": "works",
+        "Wed 19:00": "works"
+      }
+    },
+    {
+      "participant_id": "emil",
+      "status": "declined",
+      "raw": "Please take me off the list for this one."
+    },
+    {
+      "participant_id": "fay",
+      "status": "no_answer",
+      "raw": ""
+    }
+  ]
+}

--- a/apps/python/ringedingeding/pyproject.toml
+++ b/apps/python/ringedingeding/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "calle-multi-recipient-aggregator-app"
+version = "0.1.0"
+description = "Aggregate answers from several phone calls without inventing a majority."
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "pytest>=9.0.0",
+]

--- a/apps/python/ringedingeding/test_aggregate.py
+++ b/apps/python/ringedingeding/test_aggregate.py
@@ -1,0 +1,330 @@
+"""Regressions for the aggregation. Each one guards a way the summary could lie."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from aggregate import (
+    Answer,
+    Bucket,
+    NumberRejected,
+    Participant,
+    Stance,
+    Status,
+    apply_catch_up,
+    classify,
+    load_fixture,
+    main,
+    mask,
+    merge_opinions,
+    merge_schedule,
+    pending_for_catch_up,
+    render_opinions,
+    render_schedule,
+)
+
+HERE = pathlib.Path(__file__).parent
+SCHEDULE = HERE / "example-schedule.json"
+OPINIONS = HERE / "example-opinions.json"
+
+
+def people(count: int = 4) -> list[Participant]:
+    names = ["Ana", "Ben", "Cleo", "Dara", "Emil", "Fay"]
+    return [
+        Participant(id=names[i].lower(), name=names[i], phone=f"+1555010010{i + 1}")
+        for i in range(count)
+    ]
+
+
+# -- the denominator ---------------------------------------------------------------------
+
+
+def test_basis_names_answered_over_invited():
+    persons = people(4)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED),
+        "ben": Answer("ben", Status.NO_ANSWER),
+        "cleo": Answer("cleo", Status.DECLINED),
+    }
+    coverage = classify(persons, answers)
+    assert coverage.basis == "1 answered / 4 invited"
+    assert coverage.is_complete is False
+
+
+def test_unreached_are_never_counted_as_indifferent():
+    """The people who did not answer must not silently join any group."""
+    persons = people(3)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer("ben", Status.NO_ANSWER),
+        "cleo": Answer("cleo", Status.BUSY),
+    }
+    coverage, result = merge_opinions(persons, answers)
+
+    assert sum(result.tally.values()) == 1
+    assert result.abstentions == []  # not answering is not abstaining
+    assert len(coverage.by_bucket[Bucket.UNREACHED]) == 2
+    assert "not counted as indifferent" in coverage.caveat
+
+
+def test_incomplete_coverage_always_carries_a_caveat():
+    persons = people(2)
+    coverage = classify(persons, {"ana": Answer("ana", Status.COMPLETED)})
+    assert coverage.caveat is not None
+    assert "1 pending" in coverage.caveat
+
+
+def test_complete_coverage_carries_no_caveat():
+    persons = people(2)
+    answers = {p.id: Answer(p.id, Status.COMPLETED) for p in persons}
+    coverage = classify(persons, answers)
+    assert coverage.is_complete is True
+    assert coverage.caveat is None
+
+
+# -- statuses stay apart -----------------------------------------------------------------
+
+
+def test_no_answer_busy_and_declined_do_not_collapse_into_one_group():
+    assert Status.NO_ANSWER.bucket is Bucket.UNREACHED
+    assert Status.BUSY.bucket is Bucket.UNREACHED
+    assert Status.DECLINED.bucket is Bucket.REFUSED
+    assert Status.NOT_CALLED.bucket is Bucket.PENDING
+    assert Status.UNKNOWN.bucket is Bucket.UNKNOWN
+    # Refused and unreached mean different things for a follow-up.
+    assert Status.DECLINED.bucket is not Status.NO_ANSWER.bucket
+
+
+def test_an_uninterpretable_call_lands_in_unknown_not_in_unreached():
+    persons = people(1)
+    coverage = classify(persons, {"ana": Answer("ana", Status.UNKNOWN)})
+    assert coverage.by_bucket[Bucket.UNKNOWN] and not coverage.by_bucket[Bucket.UNREACHED]
+
+
+# -- silence is not a no -----------------------------------------------------------------
+
+
+def test_silence_about_a_slot_is_unknown_not_a_refusal():
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, stances={"Mon": Stance.WORKS}),
+        "ben": Answer("ben", Status.COMPLETED, stances={}),  # answered, said nothing
+    }
+    _, rows = merge_schedule(["Mon"], persons, answers)
+    row = rows[0]
+
+    assert row.works == ["Ana"]
+    assert row.cannot == []
+    assert row.silent == ["Ben"]
+
+
+def test_a_slot_nobody_objected_to_is_not_a_slot_that_works_for_everyone():
+    """The trap: no 'cannot' does not mean consent."""
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, stances={"Mon": Stance.WORKS}),
+        "ben": Answer("ben", Status.COMPLETED, stances={}),
+    }
+    _, rows = merge_schedule(["Mon"], persons, answers)
+    assert rows[0].cannot == []
+    assert rows[0].works_for_everyone_who_answered is False
+
+
+def test_a_slot_everyone_confirmed_does_work():
+    persons = people(2)
+    answers = {
+        p.id: Answer(p.id, Status.COMPLETED, stances={"Mon": Stance.WORKS}) for p in persons
+    }
+    _, rows = merge_schedule(["Mon"], persons, answers)
+    assert rows[0].works_for_everyone_who_answered is True
+
+
+# -- ties --------------------------------------------------------------------------------
+
+
+def test_a_tie_stays_a_tie():
+    persons = people(4)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer("ben", Status.COMPLETED, choice="B"),
+        "cleo": Answer("cleo", Status.COMPLETED, choice="A"),
+        "dara": Answer("dara", Status.COMPLETED, choice="B"),
+    }
+    _, result = merge_opinions(persons, answers)
+
+    assert result.is_tie is True
+    assert result.leaders == ["A", "B"]
+
+
+def test_a_clear_lead_is_reported_as_one():
+    persons = people(3)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer("ben", Status.COMPLETED, choice="A"),
+        "cleo": Answer("cleo", Status.COMPLETED, choice="B"),
+    }
+    _, result = merge_opinions(persons, answers)
+    assert result.is_tie is False
+    assert result.leaders == ["A"]
+
+
+def test_abstention_is_recorded_and_not_turned_into_a_vote():
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer("ben", Status.COMPLETED, abstained=True),
+    }
+    _, result = merge_opinions(persons, answers)
+    assert result.tally == {"A": 1}
+    assert result.abstentions == ["Ben"]
+
+
+# -- conditions and reasons survive ------------------------------------------------------
+
+
+def test_conditions_and_reasons_are_kept_with_the_raw_line():
+    persons = people(1)
+    answers = {
+        "ana": Answer(
+            "ana",
+            Status.COMPLETED,
+            raw="Green Table, but only with the vegan option.",
+            choice="Green Table",
+            conditions=("only with the vegan option",),
+            reason="The spring event went well.",
+        )
+    }
+    _, result = merge_opinions(persons, answers)
+
+    assert result.conditions == [
+        {"who": "Ana", "condition": "only with the vegan option"}
+    ]
+    assert result.reasons[0]["reason"] == "The spring event went well."
+    assert result.reasons[0]["raw"].startswith("Green Table, but only")
+
+
+def test_the_raw_answer_travels_beside_the_interpretation():
+    _, _, _, persons, answers = load_fixture(OPINIONS)
+    _, result = merge_opinions(persons, answers)
+    text = render_opinions("q", *merge_opinions(persons, answers))
+    assert "raw:" in text
+    assert any(item["raw"] for item in result.reasons)
+
+
+# -- catch-up ----------------------------------------------------------------------------
+
+
+def test_catch_up_targets_only_pending_and_unreached():
+    persons = people(4)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED),
+        "ben": Answer("ben", Status.DECLINED),
+        "cleo": Answer("cleo", Status.NO_ANSWER),
+        # dara was never called
+    }
+    targets = [p.id for p in pending_for_catch_up(persons, answers)]
+    assert sorted(targets) == ["cleo", "dara"]
+    assert "ana" not in targets  # already answered
+    assert "ben" not in targets  # refusing is an answer
+
+
+def test_catch_up_does_not_overwrite_an_existing_answer():
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer("ben", Status.NO_ANSWER),
+    }
+    allowed = pending_for_catch_up(persons, answers)
+    fresh = {
+        "ana": Answer("ana", Status.COMPLETED, choice="CHANGED"),
+        "ben": Answer("ben", Status.COMPLETED, choice="B"),
+    }
+    merged = apply_catch_up(answers, fresh, allowed)
+
+    assert merged["ana"].choice == "A"
+    assert merged["ben"].choice == "B"
+
+
+# -- numbers -----------------------------------------------------------------------------
+
+
+def test_invalid_number_is_refused_before_processing():
+    with pytest.raises(NumberRejected):
+        Participant("x", "Bad", "0170 1234567")
+
+
+def test_no_full_number_appears_in_either_output():
+    for path, renderer, merger in (
+        (SCHEDULE, "schedule", merge_schedule),
+        (OPINIONS, "opinion", merge_opinions),
+    ):
+        _, question, slots, persons, answers = load_fixture(path)
+        if renderer == "schedule":
+            coverage, payload = merge_schedule(slots, persons, answers)
+            text = render_schedule(question, coverage, payload)
+            structured = json.dumps(
+                {"c": coverage.to_dict(), "s": [r.to_dict() for r in payload]}
+            )
+        else:
+            coverage, payload = merge_opinions(persons, answers)
+            text = render_opinions(question, coverage, payload)
+            structured = json.dumps({"c": coverage.to_dict(), "r": payload.to_dict()})
+
+        for person in persons:
+            assert person.phone not in text + structured, person.phone
+        assert mask(persons[0].phone) in structured
+
+
+# -- the shipped fixtures ----------------------------------------------------------------
+
+
+def test_schedule_fixture_tells_the_intended_story():
+    _, _, slots, persons, answers = load_fixture(SCHEDULE)
+    coverage, rows = merge_schedule(slots, persons, answers)
+    by_slot = {r.slot: r for r in rows}
+
+    assert coverage.basis == "4 answered / 6 invited"
+    # Tuesday: everyone who answered confirmed it.
+    assert by_slot["Tue 19:00"].works_for_everyone_who_answered is True
+    # Wednesday: nobody objected, but Cleo never mentioned it. Not a match.
+    assert by_slot["Wed 19:00"].cannot == []
+    assert by_slot["Wed 19:00"].silent == ["Cleo"]
+    assert by_slot["Wed 19:00"].works_for_everyone_who_answered is False
+    # Thursday: one refusal, the rest silent.
+    assert by_slot["Thu 19:00"].cannot == ["Ana"]
+
+
+def test_opinion_fixture_ends_in_an_unbroken_tie():
+    _, _, _, persons, answers = load_fixture(OPINIONS)
+    coverage, result = merge_opinions(persons, answers)
+
+    assert coverage.basis == "5 answered / 6 invited"
+    assert result.tally == {"Green Table": 2, "Hearth and Co": 2}
+    assert result.is_tie is True
+    assert result.abstentions == ["Emil"]
+    assert len(result.conditions) == 2
+
+
+def test_cli_schedule_marks_the_run_and_names_the_basis(capsys):
+    assert main(["--fixture", str(SCHEDULE)]) == 0
+    out = capsys.readouterr().out
+    assert "NO CALL PLACED" in out
+    assert "4 answered / 6 invited" in out
+    assert "silent (unknown, not a no)" in out
+
+
+def test_cli_opinions_reports_the_tie_without_breaking_it(capsys):
+    assert main(["--fixture", str(OPINIONS)]) == 0
+    out = capsys.readouterr().out
+    assert "Tie between" in out
+    assert "It is not broken here." in out
+
+
+def test_cli_json_output_is_valid_and_marked(capsys):
+    assert main(["--fixture", str(SCHEDULE), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "fixture / simulated / no-call"
+    assert payload["coverage"]["complete"] is False


### PR DESCRIPTION
## Summary

Calling twenty people is the easy part. The hard part is the sentence afterwards:
*"eleven of them prefer Tuesday."* Eleven of how many? Of those who answered, or of those
who were invited? And if four never picked up, do they count as indifferent?

They do not. This app keeps five groups apart — `answered`, `refused`, `unreached`,
`pending`, `unknown` — and names the denominator in the report itself: `4 answered / 6
invited`, with a generated caveat listing exactly who is missing and stating that they are
not counted as indifferent.

Three rules follow, and they are what the regressions defend:

- **Silence about one option is unknown, not a no.** The shipped schedule fixture makes
  this case on purpose: for Wednesday, `cannot` is empty — nobody objected — and the slot
  still does not count as agreed, because one respondent never mentioned it. A naive tally
  would call that a match.
- **A tie stays a tie.** The opinion fixture ends 2–2 and stays there. Nothing breaks the
  draw, because the caller was not asked to decide anything.
- **Conditions, abstentions and reasons survive the merge**, and every coded reading keeps
  the raw sentence beside it, so a reader can check the interpretation instead of trusting
  it.

A catch-up round calls only the `pending` and the `unreached`. Someone who answered is
done, and someone who refused has given their answer — calling them again is not a
catch-up.

Full application: <https://github.com/lukisch/ringedingeding>

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Verification

```
cd apps/python/ringedingeding && python -m pytest -q
.......................                                                  [100%]
23 passed in 0.08s

python scripts/validate_repository.py
Repository validation passed.
```

Both were run on this branch. The validator was also run on the unmodified upstream
checkout first, so a green result here is a comparison and not just an assertion.

## Real-world side effects

None. There is no live transport and no `--live` flag in this edition. No account, no API
key, no network request of any kind. Every answer comes from the fixture file, and both
runs are labelled `FIXTURE RUN -- SIMULATED, NO CALL PLACED` on their first line.

## Cancellation

There is no scheduler and no retry. A catch-up round is something a person starts, not
something that happens by itself. Stopping the process stops it; nothing was dispatched, so
nothing needs recalling.

## Data

Fictional numbers only, from the `+1 555-0100…555-0199` range reserved for fiction. Numbers
are validated as E.164 before processing and masked in every output path. A regression
asserts that no full number appears in either the report or the structured result, for both
fixtures.

## Limits

Not for medical, legal, financial or emergency workflows.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described — there are none in this edition.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior — there is no recurrence; the catch-up round is operator-started and described above.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default — no-call is the only path.
- [x] `python3 scripts/validate_repository.py` passes.
