### PR TITLE
docs(apps): point hungrycall-cascade and ringedingeding at their new organization home

### DIFF
--- a/apps/python/hungrycall-cascade/README.md
+++ b/apps/python/hungrycall-cascade/README.md
@@ -116,4 +116,4 @@ untouched, and no full number reaching any output.
 
 This is a focused, self-contained proof of the orchestration. The complete application —
 restaurant lookup, a second branch for table reservations, ordering chains, web interface
-and the live CALL-E transport — lives at <https://github.com/lukisch/hungrycall>.
+and the live CALL-E transport — lives at <https://github.com/ellmos-ai/hungrycall>.

--- a/apps/python/hungrycall-cascade/cascade.py
+++ b/apps/python/hungrycall-cascade/cascade.py
@@ -19,7 +19,7 @@ yes does not count.
 
 This is the collection edition: fixture-driven, no network, no telephone, no
 credentials, no scheduler. The full application lives at
-https://github.com/lukisch/hungrycall
+https://github.com/ellmos-ai/hungrycall
 """
 
 from __future__ import annotations

--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -146,4 +146,4 @@ number reaching an output.
 
 This is a focused, self-contained proof of the aggregation. The complete application —
 call orchestration, the hash-chained record, web interface and the live CALL-E transport —
-lives at <https://github.com/lukisch/ringedingeding>.
+lives at <https://github.com/ellmos-ai/ringedingeding>.

--- a/apps/python/ringedingeding/aggregate.py
+++ b/apps/python/ringedingeding/aggregate.py
@@ -24,7 +24,7 @@ Three rules follow from that, and they are what the tests defend:
 
 This is the collection edition: fixture-driven, no network, no telephone, no
 credentials, no scheduler. The full application lives at
-https://github.com/lukisch/ringedingeding
+https://github.com/ellmos-ai/ringedingeding
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The two full applications behind the merged contributions #73 and #77 moved from personal namespaces to their organization: https://github.com/ellmos-ai/hungrycall and https://github.com/ellmos-ai/ringedingeding. GitHub redirects keep the old links working; this PR updates the four references (module docstrings and READMEs) to the canonical URLs.

- No code changes beyond the URL strings.
- Package tests re-run on this branch: hungrycall-cascade 24 passed, ringedingeding 23 passed.
- `python scripts/validate_repository.py`: Repository validation passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7n5jEhvuZKWUhUDEUScsq