### PR TITLE
feat(apps): add KinCall trusted-circle check-in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`apps/typescript/kincall`](apps/typescript/kincall/) | TypeScript | Consent-first check-in and trusted-circle coordination: a stated request for help overrides the agent's own judgement, contacts are called one at a time until somebody commits, and the monitored person is called back with the outcome. |
 | [`apps/typescript/verify-contact-claim`](apps/typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |
 | [`apps/typescript/call-neuron`](apps/typescript/call-neuron/) | TypeScript | Functional consent-first scholarship outreach prototype with manual/file intake, identity-first disclosure, neutral voicemail, one-recipient CALL-E planning and confirmation, live status, human dispositions, and browser-local campaign data. |
 | [`apps/typescript/phone-approval-gate`](apps/typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`typescript/kincall`](typescript/kincall/) | TypeScript | Consent-first check-in and trusted-circle coordination: a stated request for help overrides the agent's own judgement, contacts are called one at a time until somebody commits, and the monitored person is called back with the outcome. |
 | [`typescript/verify-contact-claim`](typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |
 | [`typescript/call-neuron`](typescript/call-neuron/) | TypeScript | Functional consent-first scholarship outreach prototype with manual/file intake, identity-first disclosure, neutral voicemail, one-recipient CALL-E planning and confirmation, live status, human dispositions, and browser-local campaign data. |
 | [`typescript/phone-approval-gate`](typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |

--- a/apps/typescript/kincall/.gitignore
+++ b/apps/typescript/kincall/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/apps/typescript/kincall/README.md
+++ b/apps/typescript/kincall/README.md
@@ -1,0 +1,108 @@
+# KinCall
+
+Consent-first phone check-ins that end with a named human, not a notification.
+
+A voice agent calls someone who lives alone, has an ordinary conversation, and reports what
+was said. What happens next is decided here — by pure functions, not by the agent. When the
+check-in warrants it, the trusted circle is called one contact at a time until somebody
+commits, and the monitored person is called back to be told who is coming.
+
+**The agent interprets the conversation. This layer decides what happens.**
+
+## Why the split matters
+
+A voice model can hallucinate, underrate a risk, or behave differently after a version
+bump. So it never decides who gets phoned. It fills a closed structured result, and every
+subsequent step is a deterministic function of that result:
+
+- a stated request for help **overrides** the agent's own "nothing seems wrong";
+- uncertainty is never read as reassurance — an unclear check-in reaches the family;
+- a check-in closes quietly only when *every* signal agrees;
+- a vague "maybe, I'll try" is never recorded as a commitment;
+- an exhausted circle ends **visibly** as "no confirmed support", never silently.
+
+Every function is pure: no clock, no socket, no database. The same result always decides the
+same way, on a first run and on a replay after a crash.
+
+## What is in this directory
+
+A self-contained, runnable extract of the decision layer, with tests and a local
+walkthrough. There is no HTTP client anywhere in it, so **it cannot place a call**.
+
+| File | Purpose |
+| --- | --- |
+| `src/types.ts` | The closed structured vocabulary a conversation is reduced to |
+| `src/decision-tree.ts` | Should anyone be contacted at all — the ordered rules |
+| `src/context-brief.ts` | What a trusted contact is told, in the person's own words |
+| `src/cascade.ts` | Eligibility, ordering, and when the cascade stops |
+| `src/outcome-message.ts` | What the monitored person hears at the end |
+| `demo/run-local.ts` | One complete check-in, decided end to end |
+| `test/workflow.test.ts` | 17 tests over all four stages |
+
+The **full application** — Next.js interface, CALL-E integration, Postgres persistence,
+crash recovery, dashboard and event timeline — lives at
+<https://github.com/JuriSOK/kincall> (MIT).
+
+## Setup
+
+Requires Node.js >= 20. No credentials, no account, no database.
+
+```bash
+npm install
+npm test        # 17 tests
+npm run check   # tsc --noEmit
+npm run demo    # a full check-in, decided locally
+```
+
+`npm run demo` prints a complete walkthrough: a person who asks for help with an
+administrative document, a first contact who declines, a second who confirms, and the
+sentence the person hears at the end. It reaches no network.
+
+## Side effects
+
+**This directory places no calls and creates no jobs.** It performs no I/O at all.
+
+The full application can place real outbound CALL-E calls, and only then:
+
+- calls happen **only** after `CALLE_MODE=live` is set explicitly *and* a CALL-E API key is
+  supplied; the default mode places no call;
+- live calls consume CALL-E credit;
+- retries are bounded — at most two attempts to the monitored person, and at most two per
+  trusted contact. A contact who answered and declined is never called again;
+- the cascade stops immediately on an explicit confirmation;
+- the closing callback to the monitored person is attempted **exactly once** and is never
+  retried;
+- there is **no recurring scheduler**. Schedule preferences are stored and displayed, but
+  nothing runs unattended — a check-in is started by a person.
+
+## Cancellation
+
+There is no recurring job to cancel. In the full application, stopping the local process
+stops all local execution, and a terminal event (`CASE_CLOSED` or `ATTENTION_UNRESOLVED`)
+can never create another call.
+
+## Credentials and phone data
+
+- No credential is needed for anything in this directory.
+- In the full application, phone numbers are read from the operator's own database — never
+  from source. There is no hardcoded real-number fallback.
+- Numbers are validated as E.164 and masked wherever they are displayed or logged.
+- Numbers reserved for fiction are refused before any request leaves the process, so a
+  half-configured profile fails loudly instead of dialling a stranger.
+- Consent must be `confirmed` or no call is placed, in any mode.
+- The fixtures here use no phone numbers at all.
+
+## Boundaries
+
+KinCall is not an emergency service and never contacts one. It does not diagnose, assess
+severity, or give medical, legal or financial advice. A confirmed intervention is a
+**recorded commitment**, not a verified action — it records that somebody said they would
+help, and never claims that they did.
+
+## Known limitations
+
+- Voicemail cannot be reliably detected, so an unanswered callback and a voicemail are
+  indistinguishable; delivery is reported as unconfirmed rather than guessed.
+- The delay between a provider accepting a call and the phone ringing is external.
+- This extract covers the decision layer only. Persistence, idempotency, leases and crash
+  recovery live in the full application.

--- a/apps/typescript/kincall/demo/run-local.ts
+++ b/apps/typescript/kincall/demo/run-local.ts
@@ -1,0 +1,123 @@
+// A complete check-in, decided end to end, with no network and no credentials.
+//
+//   node --import tsx demo/run-local.ts
+//
+// Nothing here can place a call: this app contains no HTTP client at all. It
+// prints the decisions a real deployment would then hand to CALL-E.
+
+import {
+  buildFamilyContextBrief,
+  buildPersonNotificationBrief,
+  decideCompanionAction,
+  eligibleContacts,
+  handleFamilyResult,
+  type FamilyStructuredResult,
+  type NormalizedCompanionResult,
+  type TrustedContact,
+} from "../src/index.js";
+
+const PERSON = "Alice";
+
+// What the voice agent reported after the check-in call. Note that the agent
+// itself judged attentionRequired "no" — nothing sounded alarming.
+const checkIn: NormalizedCompanionResult = {
+  neutralSummary: "they would like help completing an administrative document",
+  personReached: "yes",
+  explicitHelpRequested: "yes",
+  fallMentioned: "no",
+  mobilityDifficulty: "no",
+  painOrInjuryMentioned: "no",
+  unusualConfusion: "no",
+  distressExpressed: "no",
+  conversationEndedNormally: "yes",
+  doesNotWantToDisturbFamily: "yes",
+  otherAttentionSignal: "no",
+  attentionRequired: "no",
+  attentionReasons: ["explicit_help_request"],
+  confidence: "high",
+};
+
+const circle: TrustedContact[] = [
+  { id: "contact_bob", firstName: "Bob", priority: 1, consentStatus: "confirmed", enabled: true },
+  { id: "contact_chloe", firstName: "Chloé", priority: 2, consentStatus: "confirmed", enabled: true },
+  { id: "contact_eve", firstName: "Eve", priority: 3, consentStatus: "pending", enabled: true },
+];
+
+function declined(contactId: string): FamilyStructuredResult {
+  return {
+    contact_id: contactId,
+    answered: "yes",
+    situation_understood: "yes",
+    can_intervene: "no",
+    intervention_type: "other",
+    estimated_time: "",
+    contact_next_person: "yes",
+    summary: "Cannot help today.",
+  };
+}
+
+function confirmed(contactId: string): FamilyStructuredResult {
+  return {
+    contact_id: contactId,
+    answered: "yes",
+    situation_understood: "yes",
+    can_intervene: "yes",
+    intervention_type: "visit",
+    estimated_time: "this afternoon",
+    contact_next_person: "no",
+    summary: "Confirmed a visit this afternoon.",
+  };
+}
+
+console.log("KinCall — local decision walkthrough (no calls, no credentials)\n");
+
+const decision = decideCompanionAction(checkIn, { attemptNumber: 1 });
+console.log("1. Check-in decided");
+console.log(`   agent judged attention required: ${checkIn.attentionRequired}`);
+console.log(`   decision: ${decision.decision}`);
+console.log(`   because:  ${decision.reason}\n`);
+
+if (decision.decision !== "CONTACT_TRUSTED_PERSON") {
+  console.log("Nothing further to do.");
+  process.exit(0);
+}
+
+const brief = buildFamilyContextBrief(checkIn, PERSON);
+console.log("2. What every trusted contact is told");
+console.log(`   "${brief.sentence}"\n`);
+
+const eligible = eligibleContacts(circle);
+console.log("3. Cascade, one contact at a time");
+console.log(
+  `   eligible, in order: ${eligible.map((c) => c.firstName).join(" → ")}` +
+    `   (skipped: ${circle
+      .filter((c) => !eligible.includes(c))
+      .map((c) => `${c.firstName} — consent not confirmed`)
+      .join(", ") || "none"})`
+);
+
+let acceptedBy: TrustedContact | null = null;
+for (const [index, current] of eligible.entries()) {
+  const remaining = eligible.slice(index + 1);
+  const result = index === 0 ? declined(current.id) : confirmed(current.id);
+  const outcome = handleFamilyResult(result, remaining);
+  console.log(`   called ${current.firstName} → ${outcome.kind}`);
+  if (outcome.kind === "confirmed") {
+    acceptedBy = current;
+    break;
+  }
+}
+console.log();
+
+console.log("4. What Alice hears at the end");
+const outcomeMessage = acceptedBy
+  ? buildPersonNotificationBrief({
+      kind: "confirmed",
+      personName: PERSON,
+      contactName: acceptedBy.firstName,
+      estimatedTime: "this afternoon",
+      interventionType: "visit",
+      contactSummary: "",
+    })
+  : buildPersonNotificationBrief({ kind: "unresolved", personName: PERSON });
+console.log(`   "${outcomeMessage.message}"`);

--- a/apps/typescript/kincall/package-lock.json
+++ b/apps/typescript/kincall/package-lock.json
@@ -1,0 +1,569 @@
+{
+  "name": "calle-kincall",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calle-kincall",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "22.20.1",
+        "tsx": "4.23.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/typescript/kincall/package.json
+++ b/apps/typescript/kincall/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "calle-kincall",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Consent-first check-in and trusted-circle coordination: deterministic escalation, bounded retries and a single outcome callback.",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "demo": "node --import tsx demo/run-local.ts"
+  },
+  "devDependencies": {
+    "@types/node": "22.20.1",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/apps/typescript/kincall/src/cascade.ts
+++ b/apps/typescript/kincall/src/cascade.ts
@@ -1,0 +1,58 @@
+import type { FamilyStructuredResult, TrustedContact } from "./types.js";
+export type FamilyOutcome =
+  | { kind: "confirmed" }
+  | { kind: "declined"; nextContactId: string }
+  | { kind: "no_answer"; nextContactId: string }
+  | { kind: "declined_no_contacts_remaining" }
+  | { kind: "no_answer_no_contacts_remaining" };
+
+// Implements the cascade-failure behaviour of the full application.
+// remainingContacts must already exclude the contact this result is for.
+export function handleFamilyResult(
+  result: FamilyStructuredResult,
+  remainingContacts: TrustedContact[]
+): FamilyOutcome {
+  // Only an explicit "yes" stops the cascade (decision record DEC-005). "unknown" means the
+  // contact was vague or non-committal, and KinCall must never record a
+  // hesitant answer as a confirmed intervention (a safety rule of the full application) — it keeps looking for
+  // someone who will actually commit.
+  if (result.can_intervene === "yes") {
+    return { kind: "confirmed" };
+  }
+
+  const nextContact = remainingContacts[0];
+
+  if (result.answered === "yes") {
+    if (!nextContact) return { kind: "declined_no_contacts_remaining" };
+    return { kind: "declined", nextContactId: nextContact.id };
+  }
+
+  if (!nextContact) return { kind: "no_answer_no_contacts_remaining" };
+  return { kind: "no_answer", nextContactId: nextContact.id };
+}
+
+// Who may be called at all, in the order they will be tried.
+//
+// Consent is absolute and checked here rather than at dialling time, so an
+// unconsented contact is never reached even by a caller that forgot to ask.
+// A disabled contact is skipped the same way. Nobody is excluded for being
+// outside a preferred time window — availability only ever REORDERS an
+// eligible circle, so a quiet hour can never leave a person with nobody.
+export function eligibleContacts(contacts: TrustedContact[]): TrustedContact[] {
+  return contacts
+    .filter((contact) => contact.consentStatus === "confirmed" && contact.enabled)
+    .slice()
+    .sort((a, b) => a.priority - b.priority);
+}
+
+// Why a contact was skipped, for the event timeline. Returns null when the
+// contact is callable.
+export function contactBlockedReason(contact: TrustedContact): string | null {
+  if (contact.consentStatus !== "confirmed") {
+    return `${contact.firstName} has not confirmed consent to be called`;
+  }
+  if (!contact.enabled) {
+    return `${contact.firstName} is currently switched off`;
+  }
+  return null;
+}

--- a/apps/typescript/kincall/src/context-brief.ts
+++ b/apps/typescript/kincall/src/context-brief.ts
@@ -1,0 +1,152 @@
+import type { NormalizedCompanionResult } from "./types.js";
+
+// The factual brief a trusted contact is told when KinCall calls them
+// (decision record DEC-022 in https://github.com/JuriSOK/kincall).
+//
+// WHY THIS EXISTS
+//
+// `collectInformationToShare` (engine.ts) derives a closed vocabulary of short
+// canned facts — "asked for help", "mentioned a fall" — from the Companion
+// result's yes/no/unknown fields. That vocabulary is deliberately closed
+// (transmit only what is necessary; a free-text reason can never smuggle
+// in a medical interpretation), and it stays exactly as it is.
+//
+// But it cannot express WHAT the help was about. A live test found the real
+// consequence: a person asked for help completing an administrative document,
+// and every contact was told only that she "asked for help" — true, and
+// useless. The specific context was never lost or unpersisted; it was sitting
+// in `neutral_summary`, which the cascade simply never read.
+//
+// This module turns that already-validated, already-persisted free text into
+// ONE sentence a relative can act on, WITHOUT enumerating situations. There is
+// no list of known contexts here and there must never be one: an administrative
+// document, a broken boiler and a lost set of keys all work through the same
+// single path, because the sentence is the person's own reported words rather
+// than a lookup.
+//
+// WHAT IT IS NOT
+//
+// It never decides anything. `decideCompanionAction` alone decides whether
+// attention is required, from the categorical fields only, exactly as before —
+// this brief is downstream of that decision and informs the conversation only.
+// It is never a diagnosis, never a claim KinCall verified anything, never a
+// transcript (no transcript is stored anywhere — see the decision log in https://github.com/JuriSOK/kincall), and never raw
+// JSON or an internal enum.
+
+export interface FamilyContextBrief {
+  // One sentence, already attributed ("<Name> told KinCall that …" / "KinCall
+  // could not reach <Name> …"), ready to drop into the prompt verbatim.
+  sentence: string;
+  // Which source produced it. Carried so tests and callers can assert the
+  // precedence without re-deriving it, and so a future caller can tell a
+  // specific report apart from a generic fallback.
+  source: "companion_summary" | "explicit_help" | "not_reached" | "unavailable";
+  // False when no specific context existed and the sentence is a safe generic
+  // fallback. Lets the prompt avoid implying detail it does not have.
+  specific: boolean;
+}
+
+// A free-text summary is only usable if it actually says something. CALL-E's
+// own schema requires the field but an empty string passes validation
+// (isCompanionStructuredResult only checks `typeof === "string"`), and a
+// legacy v1 row's `conversation_summary` may be empty too.
+//
+// The length floor is deliberately tiny: it rejects "", " ", "n/a" and other
+// non-summaries without ever second-guessing a genuinely terse but real
+// summary. It is NOT a confidence threshold and must not become one — the
+// product does not rank how good a summary is, it only checks that one exists.
+const MIN_USABLE_SUMMARY_LENGTH = 12;
+
+function usableSummary(raw: string | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length < MIN_USABLE_SUMMARY_LENGTH) return null;
+  // A summary that is really a serialized object is a malformed result, not
+  // context — it must never reach a phone call. Cheap structural check only;
+  // this is not a sanitiser and does not try to parse.
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return null;
+  return trimmed;
+}
+
+// Ensures the sentence ends cleanly when it is pasted into the prompt, without
+// rewriting the person's reported words in any other way.
+function terminated(sentence: string): string {
+  return /[.!?]$/.test(sentence) ? sentence : `${sentence}.`;
+}
+
+// Turns "Claire said she would like help completing an administrative form"
+// into a sentence explicitly attributed to the check-in, so a relative can
+// never mistake it for something KinCall concluded or verified.
+//
+// Already-attributed summaries are left alone: CALL-E's own schema instructs
+// it to write "Report it as something they said or indicated", so most
+// summaries already start with the person's name, and prefixing again would
+// produce "Claire told KinCall that Claire said …".
+function attribute(summary: string, personName: string): string {
+  const startsWithName = summary.toLowerCase().startsWith(personName.toLowerCase());
+  return terminated(startsWithName ? summary : `${personName} told KinCall that ${summary}`);
+}
+
+// Builds the brief from an already-validated, already-normalized Companion
+// result. `null` means the stored result could not be read at all (a malformed
+// or entirely unrecognised shape) — the cascade still runs, because it was
+// triggered precisely because nothing could be validated, and the contact is
+// told plainly that the check-in could not be completed.
+//
+// Source precedence, highest first. Each step is a strictly weaker claim than
+// the one above it, so the brief degrades safely rather than inventing detail:
+//
+//   1. A usable `neutral_summary` — the person's own reported words. Works for
+//      any situation, including ones nobody anticipated.
+//   2. `person_reached === "no"` — no conversation happened, so there is no
+//      summary worth trusting; say exactly that.
+//   3. `explicit_help_requested === "yes"` with no usable summary — we know
+//      they asked for help but not what for; say only that.
+//   4. Nothing specific — a generic sentence naming no situation at all.
+//
+// Note 2 sits ABOVE 3 on purpose: if nobody was reached, an "asked for help"
+// flag cannot be trusted either, and claiming a request that was never heard
+// would be fabricating context.
+export function buildFamilyContextBrief(
+  result: NormalizedCompanionResult | null,
+  personName: string
+): FamilyContextBrief {
+  if (!result) {
+    return {
+      sentence: `KinCall could not complete a check-in with ${personName} and could not record what was said.`,
+      source: "unavailable",
+      specific: false,
+    };
+  }
+
+  if (result.personReached === "no") {
+    return {
+      sentence: `KinCall could not reach ${personName} during the scheduled check-in.`,
+      source: "not_reached",
+      specific: true,
+    };
+  }
+
+  const summary = usableSummary(result.neutralSummary);
+  if (summary) {
+    return {
+      sentence: attribute(summary, personName),
+      source: "companion_summary",
+      specific: true,
+    };
+  }
+
+  if (result.explicitHelpRequested === "yes") {
+    return {
+      sentence: `${personName} asked KinCall to contact someone in their trusted circle for help.`,
+      source: "explicit_help",
+      specific: false,
+    };
+  }
+
+  return {
+    sentence: `KinCall's check-in with ${personName} raised something that should be looked into, but no further detail was recorded.`,
+    source: "unavailable",
+    specific: false,
+  };
+}

--- a/apps/typescript/kincall/src/decision-tree.ts
+++ b/apps/typescript/kincall/src/decision-tree.ts
@@ -1,0 +1,145 @@
+import type { NormalizedCompanionResult, OrchestrationDecision } from "./types.js";
+export interface CompanionDecisionResult {
+  decision: OrchestrationDecision;
+  reason: string;
+}
+
+// Exactly one retry of the vulnerable person, then the trusted circle (decision record DEC-011).
+// The full application's specification always required this shape — "programmer une
+// nouvelle tentative ; si le nombre maximal de tentatives est atteint :
+// contacter le premier proche" — and an earlier decision deferred only the "how many"
+// half of it. This is that bound, and it is a bound, not a policy knob: an
+// unbounded retry loop would call a vulnerable person forever and never reach
+// anyone who could actually help.
+export const MAX_COMPANION_ATTEMPTS = 2;
+
+export interface CompanionDecisionContext {
+  // Which check-in attempt produced this result: 1 for the first call, 2 for
+  // the retry. Read from the persisted call event, never from a counter in
+  // memory, so a restart resumes at the correct attempt.
+  attemptNumber: number;
+}
+
+// Every signal that, stated explicitly by the person, warrants someone checking
+// in. Each is a fact the person reported, not an interpretation of their
+// condition, and each alone is enough to cascade — there is no priority tier
+// left to weigh them against (DEC-011, "Priority removed").
+function statedConcerningSignals(result: NormalizedCompanionResult): string[] {
+  const signals: Array<[boolean, string]> = [
+    [result.fallMentioned === "yes", "a fall"],
+    [result.mobilityDifficulty === "yes", "difficulty moving around"],
+    [result.painOrInjuryMentioned === "yes", "pain or an injury"],
+    [result.unusualConfusion === "yes", "unusual confusion"],
+    [result.distressExpressed === "yes", "distress"],
+    [result.conversationEndedNormally === "no", "a conversation that ended abnormally"],
+    [result.otherAttentionSignal === "yes", "another unusual signal"],
+  ];
+  return signals.filter(([present]) => present).map(([, label]) => label);
+}
+
+// The deterministic rule order
+// established (and later simplified to a binary outcome — see
+// decision record DEC-011). CALL-E may interpret the
+// conversation; it does not control the workflow.
+//
+// KinCall makes exactly one operational decision — close, or contact the
+// trusted circle. There is no priority tier: the original high/medium/low
+// distinction never changed what the cascade did, since every escalation ran
+// the identical contact sequence. Keeping a label with no behavioural
+// consequence would have implied a graded response that does not exist, which
+// is closer to false reassurance than to precision. This is an operational
+// decision, not a medical triage — KinCall does not assess severity, only
+// whether someone should check in.
+//
+// Two rules deliberately OVERRIDE whatever attention_required the model
+// reported — an explicit request for help, and a failure to reach the person —
+// because those are operational facts, not judgements, and a model that
+// underrates them must not be able to talk KinCall out of acting.
+//
+// The only path to a closure is the last rule, and it requires positive
+// evidence on every axis. Everything else — including attention_required
+// "unknown", unknown reachability, and a result that failed validation
+// entirely (handled by the caller) — reaches the trusted circle instead, by
+// precaution. Ambiguity is never reported as "nothing unusual" (KinCall
+// must not assert that someone is safe).
+//
+// Assumes an already-normalized, well-formed result; a malformed one never
+// reaches this function.
+export function decideCompanionAction(
+  result: NormalizedCompanionResult,
+  context: CompanionDecisionContext
+): CompanionDecisionResult {
+  // ── 1 / 2. Reachability, before anything the model reported ───────────────
+  // With no conversation there is nothing to read signals from, so a reported
+  // signal here would not be trustworthy either way.
+  if (result.personReached === "no") {
+    if (context.attemptNumber < MAX_COMPANION_ATTEMPTS) {
+      return {
+        decision: "RETRY_CHECK_IN",
+        reason: "The check-in call did not reach the person — one more attempt is owed.",
+      };
+    }
+    // Bounded: never a third call to the person. Nobody has spoken to them
+    // across every attempt, which is exactly when the trusted circle matters.
+    return {
+      decision: "CONTACT_TRUSTED_PERSON",
+      reason: `The person could not be reached in ${MAX_COMPANION_ATTEMPTS} attempts.`,
+    };
+  }
+
+  // ── 3. An explicit request for help outranks every model judgement ────────
+  // "yes" means the person actually asked (the schema's own instruction to the
+  // extraction model), never inferred from silence — which is why "unknown"
+  // does not land here and falls through to the ordinary rules below.
+  if (result.explicitHelpRequested === "yes") {
+    return {
+      decision: "CONTACT_TRUSTED_PERSON",
+      reason: "Person explicitly asked for help.",
+    };
+  }
+
+  // ── 4. Any explicitly stated concerning signal ─────────────────────────────
+  // Reported as something the person said, never as a diagnosis (a safety rule of the full application).
+  const stated = statedConcerningSignals(result);
+  if (stated.length > 0) {
+    return {
+      decision: "CONTACT_TRUSTED_PERSON",
+      reason: `The person mentioned ${stated.join(", ")}.`,
+    };
+  }
+
+  // ── 5. The model's own judgement that attention is needed ─────────────────
+  if (result.attentionRequired === "yes") {
+    return {
+      decision: "CONTACT_TRUSTED_PERSON",
+      reason: "The check-in indicated that attention is needed.",
+    };
+  }
+
+  // ── 6. An unjudged result cascades by precaution ───────────────────────────
+  if (result.attentionRequired === "unknown") {
+    return {
+      decision: "CONTACT_TRUSTED_PERSON",
+      reason: "The check-in could not be judged either way.",
+    };
+  }
+
+  // ── 7. The ONLY closure path: positive evidence on every axis ─────────────
+  if (
+    result.personReached === "yes" &&
+    result.conversationEndedNormally === "yes" &&
+    result.attentionRequired === "no"
+  ) {
+    return {
+      decision: "LOG_AND_CLOSE",
+      reason: "No attention signal detected.",
+    };
+  }
+
+  // Anything left is ambiguous — most often an ending that could not be
+  // confirmed. It must reach a person, not a reassuring close.
+  return {
+    decision: "CONTACT_TRUSTED_PERSON",
+    reason: "The check-in could not be confirmed as unremarkable.",
+  };
+}

--- a/apps/typescript/kincall/src/index.ts
+++ b/apps/typescript/kincall/src/index.ts
@@ -1,0 +1,56 @@
+// KinCall — the decision layer of a consent-first phone check-in workflow.
+//
+// Everything exported here is a PURE function of already-validated facts. No
+// module in this app opens a socket, reads a clock, touches a database or
+// places a call: given the same structured result, each returns the same
+// answer, on a first run and on a replay after a crash.
+//
+// That is the whole point of the pattern. A voice agent interprets a
+// conversation; these functions decide what happens next. Swapping the agent,
+// the provider or the model cannot change who gets called.
+//
+// The full application — Next.js interface, CALL-E integration, Postgres
+// persistence, crash recovery, dashboard and event timeline — lives at
+// https://github.com/JuriSOK/kincall
+
+export type {
+  AttentionReason,
+  Confidence,
+  FamilyStructuredResult,
+  NormalizedCompanionResult,
+  OrchestrationDecision,
+  TrustedContact,
+  YesNoUnknown,
+} from "./types.js";
+export { ATTENTION_REASONS } from "./types.js";
+
+// Step 1 — should anyone be contacted at all?
+export {
+  decideCompanionAction,
+  MAX_COMPANION_ATTEMPTS,
+  type CompanionDecisionContext,
+  type CompanionDecisionResult,
+} from "./decision-tree.js";
+
+// Step 2 — what the trusted contact is told, in the person's own words.
+export {
+  buildFamilyContextBrief,
+  type FamilyContextBrief,
+} from "./context-brief.js";
+
+// Step 3 — who is called next, and when the cascade stops.
+export {
+  contactBlockedReason,
+  eligibleContacts,
+  handleFamilyResult,
+  type FamilyOutcome,
+} from "./cascade.js";
+
+// Step 4 — what the monitored person hears at the end.
+export {
+  buildPersonNotificationBrief,
+  type ConfirmedNotificationFacts,
+  type NotificationFacts,
+  type PersonNotificationBrief,
+  type UnresolvedNotificationFacts,
+} from "./outcome-message.js";

--- a/apps/typescript/kincall/src/outcome-message.ts
+++ b/apps/typescript/kincall/src/outcome-message.ts
@@ -1,0 +1,172 @@
+import type { FamilyStructuredResult } from "./types.js";
+
+// What KinCall tells the monitored person once the trusted-circle outcome is
+// settled (decision record DEC-023 in https://github.com/JuriSOK/kincall).
+//
+// Pure and total: it takes already-persisted, already-validated facts and
+// returns sentences. It reads no clock, no database and no environment, so a
+// replaying worker produces byte-identical wording — which matters, because
+// this text is what a real person hears.
+//
+// SPOKEN DIRECTLY TO THE MONITORED PERSON.
+//
+// This is the one KinCall message addressed TO the person the check-in was
+// about, and it must sound like it. A live test produced "Marc confirmed that
+// he will visit Claire this afternoon" — spoken to Claire herself — because the
+// Family calls' third-person context brief was appended here. That brief is
+// written FOR a trusted contact ("Claire told KinCall that…"), so reusing it
+// made KinCall talk about its own listener in front of her, and restated a
+// problem she already knew she had.
+//
+// So this message now carries the OUTCOME ONLY. The original reason for the
+// call is never repeated: the Family calls still receive the full factual
+// context (family/context-brief.ts, unchanged), and this callback says only who
+// committed to what, or that nobody did.
+//
+// WHAT IT MAY NEVER SAY
+//
+//   * the recipient's own name in a third-person sentence — she is listening;
+//   * the original Companion context, in any form;
+//   * that the contact has ALREADY visited or called — the commitment is a
+//     future intention KinCall recorded, never an action it observed (a safety rule of the full application);
+//   * that KinCall verified anything, or that the person is safe or fine;
+//   * "nobody answered" on the unresolved path — contacts may well have
+//     answered and declined, and saying otherwise would be false;
+//   * any diagnosis, severity, or medical framing;
+//   * an internal enum, field name, contact id, or phone number.
+//
+// PRONOUNS. The contact is always "they". KinCall stores no pronouns for a
+// trusted contact, and a relationship label ("daughter", "trusted neighbour")
+// is not one — guessing from it would misgender a real person on a real call.
+// "They" is correct for everyone and needs no data KinCall does not have.
+
+export interface ConfirmedNotificationFacts {
+  kind: "confirmed";
+  // The recipient. Deliberately NEVER spoken — used only to detect and reject a
+  // persisted sentence that refers to her in the third person.
+  personName: string;
+  contactName: string;
+  // Free text as the contact said it ("this afternoon", "17:30"), never parsed
+  // into a time and never compared against a clock. Empty means not stated.
+  estimatedTime: string;
+  interventionType: FamilyStructuredResult["intervention_type"];
+  // The contact's own persisted summary. Used only for the "other" action, and
+  // only when it passes the safety gate below — never quoted verbatim.
+  contactSummary: string;
+}
+
+export interface UnresolvedNotificationFacts {
+  kind: "unresolved";
+  personName: string;
+}
+
+export type NotificationFacts = ConfirmedNotificationFacts | UnresolvedNotificationFacts;
+
+export interface PersonNotificationBrief {
+  // The outcome, in one sentence. This is the thing being communicated.
+  outcome: string;
+  // What the person can do next. Present only on the unresolved path, where
+  // there IS something for them to do — never on the confirmed path, where
+  // suggesting an action would undercut the commitment just reported.
+  guidance: string | null;
+  // What the prompt actually renders: outcome only, plus guidance where it
+  // applies. There is deliberately no context field any more.
+  message: string;
+}
+
+// Adds "at" only in front of something that reads as a clock time ("17:30",
+// "6pm", "18h00") and does not already carry its own preposition or qualifier.
+// "this afternoon" and "dans l'après-midi" are already adverbial and must not
+// become "at this afternoon". Grammar only — nothing here parses a time or
+// reasons about when it is.
+const CLOCK_LIKE = /^\d{1,2}\s*(?:[:h.]\s*\d{2})?\s*(?:am|pm)?$/i;
+
+function withTimePreposition(estimatedTime: string): string {
+  const trimmed = estimatedTime.trim();
+  if (trimmed.length === 0) return "";
+  return CLOCK_LIKE.test(trimmed) ? ` at ${trimmed}` : ` ${trimmed}`;
+}
+
+function terminated(sentence: string): string {
+  return /[.!?]$/.test(sentence) ? sentence : `${sentence}.`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// The ONLY shape of persisted Family summary this will speak back to the
+// monitored person, for an `other` intervention where there is no verb to state.
+//
+// Deliberately narrow. `intervention_type: "other"` means the contact committed
+// to neither a visit nor a call, and `summary` is free text a model wrote FOR A
+// THIRD PARTY ("One or two neutral sentences describing what this contact said
+// and what they agreed to do" — family/prompt.ts). Rewriting arbitrary prose
+// into safe second-person speech is exactly the invention the safety rules forbid, so this
+// accepts only an unambiguous "<Contact> will <action>" and rejects everything
+// else — including anything that might be referring to the listener:
+//
+//   * a sentence naming the recipient — she is on the line;
+//   * a third-person pronoun, which in these summaries usually means HER;
+//   * anything long enough to be narrative rather than a commitment;
+//   * anything carrying JSON punctuation or an internal field name.
+//
+// Returns the bare action phrase, or null to use the safe fallback.
+function safeOtherAction(
+  contactSummary: string,
+  contactName: string,
+  personName: string
+): string | null {
+  const summary = contactSummary.trim().replace(/[.!?]+$/, "");
+  if (summary.length === 0 || summary.length > 100) return null;
+
+  const match = new RegExp(`^${escapeRegExp(contactName)}\\s+will\\s+(.+)$`, "i").exec(summary);
+  if (!match) return null;
+
+  const action = match[1].trim();
+  if (action.length === 0) return null;
+  if (new RegExp(`\\b${escapeRegExp(personName)}\\b`, "i").test(action)) return null;
+  if (/\b(he|him|his|she|her|hers)\b/i.test(action)) return null;
+  if (/[{}[\]"]|_/.test(action)) return null;
+
+  return action;
+}
+
+// Second person throughout: the listener is "you", never her own name.
+function confirmedOutcome(facts: ConfirmedNotificationFacts): string {
+  const when = withTimePreposition(facts.estimatedTime);
+
+  switch (facts.interventionType) {
+    case "visit":
+      return when
+        ? `${facts.contactName} confirmed that they will visit you${when}.`
+        : `${facts.contactName} confirmed that they will come and see you.`;
+    case "call":
+      return when
+        ? `${facts.contactName} confirmed that they will call you${when}.`
+        : `${facts.contactName} confirmed that they will call you.`;
+    case "other":
+    default: {
+      const action = safeOtherAction(facts.contactSummary, facts.contactName, facts.personName);
+      return action
+        ? `${facts.contactName} confirmed that they will ${action} for you.`
+        : `${facts.contactName} confirmed that they can help you.`;
+    }
+  }
+}
+
+// Outcome only — no Companion context, no Family context brief. See the header.
+export function buildPersonNotificationBrief(facts: NotificationFacts): PersonNotificationBrief {
+  if (facts.kind === "unresolved") {
+    // Deliberately "confirmed that they were available", never "nobody
+    // answered": on this path some contacts may have answered and declined,
+    // and some may not have answered at all. The only thing true of all of
+    // them is that none committed.
+    const outcome = "Nobody in your trusted circle confirmed that they were available.";
+    const guidance = "If you still need help, please contact another person you trust directly.";
+    return { outcome, guidance, message: `${outcome} ${guidance}` };
+  }
+
+  const outcome = terminated(confirmedOutcome(facts));
+  return { outcome, guidance: null, message: outcome };
+}

--- a/apps/typescript/kincall/src/types.ts
+++ b/apps/typescript/kincall/src/types.ts
@@ -1,0 +1,92 @@
+// The structured vocabulary a CALL-E conversation is reduced to before any
+// decision is taken.
+//
+// Every field a voice agent may fill is a closed enum or a plain sentence.
+// Nothing here is free-form enough for an interpretation to reach the decision
+// layer: the agent reports what was said, and the pure functions in this app
+// decide what happens next.
+
+export type YesNoUnknown = "yes" | "no" | "unknown";
+
+export type Confidence = "low" | "medium" | "high";
+
+// A closed list, so a free-text reason can never smuggle a medical
+// interpretation into the record, and so an interface can label each one in
+// plain language without parsing prose.
+export const ATTENTION_REASONS = [
+  "explicit_help_request",
+  "fall",
+  "mobility_difficulty",
+  "pain_or_injury",
+  "unusual_confusion",
+  "distress",
+  "abnormal_conversation_end",
+  "person_not_reached",
+  "other_attention_signal",
+] as const;
+
+export type AttentionReason = (typeof ATTENTION_REASONS)[number];
+
+// The check-in call's result, normalised to camelCase.
+export interface NormalizedCompanionResult {
+  // One or two neutral sentences describing what the person actually said,
+  // reported as something they said rather than as a diagnosis.
+  neutralSummary: string;
+  // Whether a two-way conversation actually happened. A voicemail is a
+  // completed call with no concerning signals, which without this field reads
+  // identically to "the person is fine".
+  personReached: YesNoUnknown;
+  // "yes" only when the person explicitly asked — never inferred from silence.
+  explicitHelpRequested: YesNoUnknown;
+  fallMentioned: YesNoUnknown;
+  mobilityDifficulty: YesNoUnknown;
+  painOrInjuryMentioned: YesNoUnknown;
+  unusualConfusion: YesNoUnknown;
+  distressExpressed: YesNoUnknown;
+  conversationEndedNormally: YesNoUnknown;
+  doesNotWantToDisturbFamily: YesNoUnknown;
+  otherAttentionSignal: YesNoUnknown;
+  // The agent's own judgement. Deliberately only ONE input among several — see
+  // decision-tree.ts for the two rules that override it.
+  attentionRequired: YesNoUnknown;
+  attentionReasons: AttentionReason[];
+  confidence: Confidence;
+}
+
+// One trusted-contact call's result.
+export interface FamilyStructuredResult {
+  contact_id: string;
+  answered: YesNoUnknown;
+  situation_understood: YesNoUnknown;
+  // Only an explicit "yes" stops the cascade. "unknown" means the contact was
+  // vague or non-committal, which must never be recorded as a commitment.
+  can_intervene: YesNoUnknown;
+  intervention_type: "visit" | "call" | "other";
+  // Free text as the contact said it ("this afternoon", "17:30"). Never parsed
+  // into a time and never compared against a clock.
+  estimated_time: string;
+  contact_next_person: YesNoUnknown;
+  summary: string;
+  // Optional and only ever a model self-report: a provider that cannot confirm
+  // a voicemail must not have one inferred on its behalf.
+  voicemail_left?: YesNoUnknown;
+}
+
+// The minimum a trusted contact needs for ordering and eligibility. A real
+// deployment carries more; nothing else is needed to decide who is called next.
+export interface TrustedContact {
+  id: string;
+  firstName: string;
+  // 1-based cascade order. Contacts are called one at a time, lowest first.
+  priority: number;
+  // No call is placed to anyone whose consent is not confirmed, in any mode.
+  consentStatus: "pending" | "confirmed" | "declined";
+  // A contact temporarily switched off by the family.
+  enabled: boolean;
+}
+
+// The two decisions this app produces from a check-in.
+export type OrchestrationDecision =
+  | "LOG_AND_CLOSE"
+  | "RETRY_CHECK_IN"
+  | "CONTACT_TRUSTED_PERSON";

--- a/apps/typescript/kincall/test/workflow.test.ts
+++ b/apps/typescript/kincall/test/workflow.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildFamilyContextBrief,
+  buildPersonNotificationBrief,
+  contactBlockedReason,
+  decideCompanionAction,
+  eligibleContacts,
+  handleFamilyResult,
+  MAX_COMPANION_ATTEMPTS,
+  type FamilyStructuredResult,
+  type NormalizedCompanionResult,
+  type TrustedContact,
+} from "../src/index.js";
+
+function checkIn(
+  overrides: Partial<NormalizedCompanionResult> = {}
+): NormalizedCompanionResult {
+  return {
+    neutralSummary: "they had a quiet morning",
+    personReached: "yes",
+    explicitHelpRequested: "no",
+    fallMentioned: "no",
+    mobilityDifficulty: "no",
+    painOrInjuryMentioned: "no",
+    unusualConfusion: "no",
+    distressExpressed: "no",
+    conversationEndedNormally: "yes",
+    doesNotWantToDisturbFamily: "no",
+    otherAttentionSignal: "no",
+    attentionRequired: "no",
+    attentionReasons: [],
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function contact(overrides: Partial<TrustedContact> = {}): TrustedContact {
+  return {
+    id: "contact_1",
+    firstName: "Bob",
+    priority: 1,
+    consentStatus: "confirmed",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function familyResult(
+  overrides: Partial<FamilyStructuredResult> = {}
+): FamilyStructuredResult {
+  return {
+    contact_id: "contact_1",
+    answered: "no",
+    situation_understood: "unknown",
+    can_intervene: "no",
+    intervention_type: "other",
+    estimated_time: "",
+    contact_next_person: "yes",
+    summary: "No answer.",
+    ...overrides,
+  };
+}
+
+const FIRST_ATTEMPT = { attemptNumber: 1 };
+const FINAL_ATTEMPT = { attemptNumber: MAX_COMPANION_ATTEMPTS };
+
+describe("decision tree", () => {
+  it("closes only when every signal is positive", () => {
+    const decision = decideCompanionAction(checkIn(), FIRST_ATTEMPT);
+    assert.equal(decision.decision, "LOG_AND_CLOSE");
+  });
+
+  it("acts on an explicit request for help even when the agent saw nothing wrong", () => {
+    // The agent judged attentionRequired "no". A stated request outranks that:
+    // an agent that underrates a request must not be able to talk the workflow
+    // out of acting.
+    const decision = decideCompanionAction(
+      checkIn({ explicitHelpRequested: "yes", attentionRequired: "no" }),
+      FIRST_ATTEMPT
+    );
+    assert.equal(decision.decision, "CONTACT_TRUSTED_PERSON");
+  });
+
+  it("acts on any single stated signal", () => {
+    for (const signal of [
+      "fallMentioned",
+      "mobilityDifficulty",
+      "painOrInjuryMentioned",
+      "unusualConfusion",
+      "distressExpressed",
+      "otherAttentionSignal",
+    ] as const) {
+      const decision = decideCompanionAction(
+        checkIn({ [signal]: "yes" }),
+        FIRST_ATTEMPT
+      );
+      assert.equal(decision.decision, "CONTACT_TRUSTED_PERSON", signal);
+    }
+  });
+
+  it("never reads uncertainty as reassurance", () => {
+    const decision = decideCompanionAction(
+      checkIn({ attentionRequired: "unknown" }),
+      FIRST_ATTEMPT
+    );
+    assert.equal(decision.decision, "CONTACT_TRUSTED_PERSON");
+  });
+
+  it("retries an unreached person once, then reaches the circle", () => {
+    const first = decideCompanionAction(
+      checkIn({ personReached: "no" }),
+      FIRST_ATTEMPT
+    );
+    assert.equal(first.decision, "RETRY_CHECK_IN");
+
+    const last = decideCompanionAction(
+      checkIn({ personReached: "no" }),
+      FINAL_ATTEMPT
+    );
+    assert.equal(last.decision, "CONTACT_TRUSTED_PERSON");
+  });
+
+  it("is deterministic — the same result always decides the same way", () => {
+    const result = checkIn({ distressExpressed: "yes" });
+    const decisions = Array.from({ length: 20 }, () =>
+      decideCompanionAction(result, FIRST_ATTEMPT).decision
+    );
+    assert.equal(new Set(decisions).size, 1);
+  });
+});
+
+describe("what a trusted contact is told", () => {
+  it("carries the person's own words, whatever the situation is", () => {
+    for (const summary of [
+      "they would like help completing an administrative document",
+      "their boiler has stopped working",
+      "they cannot find their house keys",
+    ]) {
+      const brief = buildFamilyContextBrief(
+        checkIn({ neutralSummary: summary, explicitHelpRequested: "yes" }),
+        "Alice"
+      );
+      assert.ok(brief.sentence.includes(summary), summary);
+      assert.ok(brief.sentence.startsWith("Alice"));
+    }
+  });
+
+  it("degrades to a safe generic sentence rather than inventing a reason", () => {
+    const brief = buildFamilyContextBrief(
+      checkIn({ neutralSummary: "", explicitHelpRequested: "yes" }),
+      "Alice"
+    );
+    assert.equal(brief.specific, false);
+    assert.ok(brief.sentence.includes("Alice"));
+  });
+
+  it("never claims a help request nobody was there to make", () => {
+    const brief = buildFamilyContextBrief(
+      checkIn({ personReached: "no", explicitHelpRequested: "yes" }),
+      "Alice"
+    );
+    assert.equal(brief.source, "not_reached");
+    assert.ok(!/asked/i.test(brief.sentence));
+  });
+});
+
+describe("trusted-circle cascade", () => {
+  const bob = contact({ id: "contact_bob", firstName: "Bob", priority: 1 });
+  const chloe = contact({ id: "contact_chloe", firstName: "Chloé", priority: 2 });
+  const david = contact({ id: "contact_david", firstName: "David", priority: 3 });
+
+  it("orders by priority and excludes anyone who has not consented", () => {
+    const pending = contact({
+      id: "contact_eve",
+      firstName: "Eve",
+      priority: 2,
+      consentStatus: "pending",
+    });
+    const eligible = eligibleContacts([david, pending, bob]);
+    assert.deepEqual(
+      eligible.map((c) => c.id),
+      ["contact_bob", "contact_david"]
+    );
+  });
+
+  it("excludes a contact the family switched off", () => {
+    const off = contact({ id: "contact_off", enabled: false });
+    assert.deepEqual(eligibleContacts([off]), []);
+    assert.match(String(contactBlockedReason(off)), /switched off/);
+    assert.equal(contactBlockedReason(bob), null);
+  });
+
+  it("stops at the first explicit confirmation", () => {
+    const outcome = handleFamilyResult(
+      familyResult({ answered: "yes", can_intervene: "yes" }),
+      [chloe, david]
+    );
+    assert.equal(outcome.kind, "confirmed");
+  });
+
+  it("never treats a vague answer as a commitment", () => {
+    const outcome = handleFamilyResult(
+      familyResult({ answered: "yes", can_intervene: "unknown" }),
+      [chloe]
+    );
+    assert.equal(outcome.kind, "declined");
+  });
+
+  it("moves to the next contact and ends visibly when the circle runs out", () => {
+    const next = handleFamilyResult(familyResult({ answered: "yes" }), [chloe]);
+    assert.equal(next.kind, "declined");
+    assert.equal(
+      next.kind === "declined" ? next.nextContactId : null,
+      "contact_chloe"
+    );
+
+    const exhausted = handleFamilyResult(familyResult({ answered: "yes" }), []);
+    assert.equal(exhausted.kind, "declined_no_contacts_remaining");
+  });
+});
+
+describe("what the monitored person hears at the end", () => {
+  it("speaks in the second person and names the contact who committed", () => {
+    const brief = buildPersonNotificationBrief({
+      kind: "confirmed",
+      personName: "Alice",
+      contactName: "Chloé",
+      estimatedTime: "this afternoon",
+      interventionType: "visit",
+      contactSummary: "",
+    });
+    assert.equal(
+      brief.message,
+      "Chloé confirmed that they will visit you this afternoon."
+    );
+    // She is the listener — never spoken about in the third person.
+    assert.ok(!brief.message.includes("Alice"));
+  });
+
+  it("never claims the visit already happened or that she is safe", () => {
+    const brief = buildPersonNotificationBrief({
+      kind: "confirmed",
+      personName: "Alice",
+      contactName: "Chloé",
+      estimatedTime: "",
+      interventionType: "call",
+      contactSummary: "",
+    });
+    assert.ok(!/already|has called|safe/i.test(brief.message));
+    assert.ok(brief.message.includes("will call you"));
+  });
+
+  it("says nobody confirmed availability — never that nobody answered", () => {
+    const brief = buildPersonNotificationBrief({
+      kind: "unresolved",
+      personName: "Alice",
+    });
+    assert.ok(brief.message.includes("confirmed that they were available"));
+    assert.ok(!/nobody answered|no answer/i.test(brief.message));
+    assert.ok(brief.guidance !== null);
+  });
+});

--- a/apps/typescript/kincall/tsconfig.json
+++ b/apps/typescript/kincall/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "demo/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds **KinCall**, a consent-first phone check-in and trusted-circle coordination app, as a runnable TypeScript app plus the two Apps table entries.

A voice agent calls someone who lives alone, has an ordinary conversation, and reports what was said as a closed structured result. Every decision after that point is a pure function of that result:

- a **stated request for help overrides** the agent's own "nothing seems wrong";
- **uncertainty is never read as reassurance** — an unclear check-in reaches the family;
- a check-in closes quietly only when *every* signal agrees;
- a vague "maybe, I'll try" is **never recorded as a commitment**;
- the trusted circle is called **one contact at a time** until somebody commits;
- an exhausted circle ends **visibly** as "no confirmed support", never silently;
- the monitored person is **called back once** with the outcome.

Swapping the agent, provider or model cannot change who gets phoned. That separation is the pattern this contribution is offering.

`apps/typescript/kincall/` is a self-contained extract of that decision layer with tests and a local walkthrough. It contains **no HTTP client**, so it cannot place a call. The full Next.js application — CALL-E integration, Postgres persistence, crash recovery, dashboard and event timeline — lives at <https://github.com/JuriSOK/kincall> (MIT).

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Real-world side effects

**Nothing in this directory places a call or creates a job — it performs no I/O at all.**

In the full application:

- a call happens **only** after `CALLE_MODE=live` is set explicitly *and* a CALL-E API key is supplied; the default mode places no call;
- live calls consume CALL-E credit;
- retries are **bounded** — at most two attempts to the monitored person, at most two per trusted contact, and a contact who answered and declined is never called again;
- the cascade **stops immediately** on an explicit confirmation;
- the closing callback is attempted **exactly once** and is never retried;
- there is **no recurring scheduler**. Schedule preferences are stored and displayed, but nothing runs unattended — a check-in is started by a person.

## Safety and data

- **Consent must be `confirmed`** or no call is placed, in any mode.
- Phone numbers are validated as **E.164** and **masked** wherever displayed or logged.
- Live phone data is read from **the operator's own database** — never from source. There is no hardcoded real-number fallback.
- Numbers **reserved for fiction are refused** before any request leaves the process, so a half-configured profile fails loudly instead of dialling a stranger.
- **No credential, private phone number, call recording, transcript or personal data is included.** The fixtures here contain no phone numbers at all.
- KinCall is **not an emergency service** and never contacts one. It does not diagnose, assess severity, or give medical, legal or financial advice.
- A confirmed intervention is a **recorded commitment, not a verified action** — it records that somebody said they would help, and never claims that they did.

## Cancellation

There is no recurring job to cancel. Stopping the local process stops all local execution, and a terminal event (`CASE_CLOSED` or `ATTENTION_UNRESOLVED`) can never create another call.

## Verification

Run from `apps/typescript/kincall/`, with no credentials and no network:

```
$ npm install
$ npm run check     # tsc --noEmit — clean
$ npm test          # ℹ tests 17 / ℹ pass 17 / ℹ fail 0
$ npm run demo      # full check-in decided locally, no calls
```

Repository validation, from the root:

```
$ python3 scripts/check_branch_name.py --branch feat/kincall-app
Branch name follows docs/git-naming-conventions.md: feat/kincall-app

$ python3 scripts/validate_repository.py
Repository validation passed.

$ git diff --check     # clean
```

The upstream application it is extracted from passes 982 tests on the same commit.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## AI assistance

Claude Code assisted with preparing this contribution. I reviewed and verified the content, ran every command shown above, and confirmed the described behaviour.
