### PR TITLE
feat(issues): automate issue type labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,35 @@
+name: Issue
+description: Report a problem, request an improvement, ask a question, or suggest documentation.
+title: "[Issue]: "
+body:
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Select the category that best describes this issue.
+      options:
+        - Bug
+        - Enhancement
+        - Documentation
+        - Question
+    validations:
+      required: true
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Give a concise description of the issue or request.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Explain the problem, request, or question. Include reproduction steps and expected behavior for bugs.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Add relevant links, screenshots, logs, or other context.

--- a/.github/ISSUE_TEMPLATE/workflow_submission.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_submission.yml
@@ -1,7 +1,7 @@
 name: Workflow resource submission
 description: Suggest a phone-call skill, runnable app, workflow plugin, adapter, scheduler recipe, or safety resource.
 title: "[Submission]: "
-labels: [submission]
+labels: [enhancement]
 body:
   - type: input
     id: name

--- a/.github/workflows/label-issue-type.yml
+++ b/.github/workflows/label-issue-type.yml
@@ -1,0 +1,188 @@
+name: Label issue type
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  label-issue-type:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: issue-type-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: false
+    steps:
+      - name: Apply issue type label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const labelsByType = {
+              Bug: 'bug',
+              Enhancement: 'enhancement',
+              Documentation: 'documentation',
+              Question: 'question',
+            };
+            const hintMarker = '<!-- awesome-phone-call-agents-issue-label-bot -->';
+            const selectionMarker = '<!-- awesome-phone-call-agents-issue-label-selection -->';
+            const hintBody = [
+              hintMarker,
+              'This issue is labeled `question` until its type is selected. Edit the issue form and select exactly one issue type, or reply with this checklist after selecting one option:',
+              '',
+              selectionMarker,
+              '- [ ] Bug',
+              '- [ ] Enhancement',
+              '- [ ] Documentation',
+              '- [ ] Question',
+            ].join('\n');
+
+            function readIssueFormType(body) {
+              const issueType = body.match(
+                /^### Issue type\r?\n\r?\n(Bug|Enhancement|Documentation|Question)\s*$/mi
+              );
+              if (issueType) {
+                return issueType[1];
+              }
+
+              const submissionType = body.match(
+                /^### Type\r?\n\r?\n(Agent Skill|Runnable app|Workflow plugin|Provider adapter|Scheduler recipe|Safety pattern|Documentation resource)\s*$/mi
+              );
+              if (!submissionType) {
+                return null;
+              }
+              return submissionType[1] === 'Documentation resource'
+                ? 'Documentation'
+                : 'Enhancement';
+            }
+
+            function readCommentType(body) {
+              if (!body.includes(selectionMarker)) {
+                return null;
+              }
+
+              const selected = Object.keys(labelsByType).filter((type) =>
+                new RegExp(`^- \\[[xX]\\] ${type}\\s*$`, 'mi').test(body)
+              );
+              return selected.length === 1 ? selected[0] : null;
+            }
+
+            async function updateIssue(issue, selectedType) {
+              const { owner, repo } = context.repo;
+              const issueNumber = issue.number;
+              const targetLabel = labelsByType[selectedType] ?? labelsByType.Question;
+              const managedLabels = new Set(Object.values(labelsByType));
+              const { data: currentIssue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issueNumber,
+              });
+
+              const currentLabels = currentIssue.labels.map((label) =>
+                typeof label === 'string' ? label : label.name
+              );
+              for (const label of currentLabels) {
+                if (managedLabels.has(label) && label !== targetLabel) {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    name: label,
+                  });
+                }
+              }
+              if (!currentLabels.includes(targetLabel)) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  labels: [targetLabel],
+                });
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const managedHints = comments.filter(
+                (comment) =>
+                  comment.user?.login === 'github-actions[bot]' &&
+                  comment.body?.includes(hintMarker)
+              );
+
+              if (selectedType) {
+                await Promise.all(
+                  managedHints.map((comment) =>
+                    github.rest.issues.deleteComment({
+                      owner,
+                      repo,
+                      comment_id: comment.id,
+                    })
+                  )
+                );
+                return;
+              }
+
+              if (managedHints.length === 0) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: hintBody,
+                });
+                return;
+              }
+
+              const [firstHint, ...duplicateHints] = managedHints;
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: firstHint.id,
+                body: hintBody,
+              });
+              await Promise.all(
+                duplicateHints.map((comment) =>
+                  github.rest.issues.deleteComment({
+                    owner,
+                    repo,
+                    comment_id: comment.id,
+                  })
+                )
+              );
+            }
+
+            if (context.eventName === 'workflow_dispatch') {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                ...context.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              for (const issue of issues) {
+                if (!issue.pull_request) {
+                  await updateIssue(issue, readIssueFormType(issue.body ?? ''));
+                }
+              }
+              return;
+            }
+
+            const issue = context.payload.issue;
+            if (context.eventName === 'issue_comment') {
+              const comment = context.payload.comment;
+              if (
+                issue.pull_request ||
+                comment.user.login !== issue.user.login ||
+                context.payload.sender.type === 'Bot' ||
+                !comment.body.includes(selectionMarker)
+              ) {
+                return;
+              }
+              await updateIssue(issue, readCommentType(comment.body));
+              return;
+            }
+
+            await updateIssue(issue, readIssueFormType(issue.body ?? ''));


### PR DESCRIPTION
## Summary
- require GitHub Issue Forms instead of blank issues
- label submitted issues as bug, enhancement, documentation, or question
- keep a single correction prompt for unclassified issues and accept the reply checklist

## Validation
- python3 scripts/validate_repository.py
- YAML and embedded GitHub Script syntax checks
- local GitHub API behavior checks for form, fallback, and checklist paths