### PR TITLE
feat(apps): add calle-mcp-result-extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/python/oauth-login-client`](apps/python/oauth-login-client/) | Python | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`apps/typescript/oauth-login-client`](apps/typescript/oauth-login-client/) | TypeScript | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`apps/typescript/vibehub-founder-relay`](apps/typescript/vibehub-founder-relay/) | TypeScript | Consent-first founder-match readiness call with masked preview, stable idempotency, and structured CALL-E results. |
+| [`apps/typescript/calle-mcp-result-extractor`](apps/typescript/calle-mcp-result-extractor/) | TypeScript | Schema-validated structured results from CALL-E calls placed over MCP, which has no `result_schema` parameter of its own — extracts from the transcript instead, with a documented fix for a real Bedrock Converse API tool_use/tool_result retry pitfall. |
 
 The default e2e tests use a local fake broker/OAuth/MCP server or dry-run paths, so they do not require real CALL-E credentials or browser login. Live verification is opt-in in each app README.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -28,6 +28,7 @@ Current apps:
 | [`python/oauth-login-client`](python/oauth-login-client/) | Python | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`typescript/oauth-login-client`](typescript/oauth-login-client/) | TypeScript | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`typescript/vibehub-founder-relay`](typescript/vibehub-founder-relay/) | TypeScript | Consent-first founder-match readiness call with masked preview, stable idempotency, and structured CALL-E results. |
+| [`typescript/calle-mcp-result-extractor`](typescript/calle-mcp-result-extractor/) | TypeScript | Schema-validated structured results from CALL-E calls placed over MCP, which has no `result_schema` parameter of its own — extracts from the transcript instead, with a documented fix for a real Bedrock Converse API tool_use/tool_result retry pitfall. |
 
 Suggested grouping:
 

--- a/apps/typescript/calle-mcp-result-extractor/README.md
+++ b/apps/typescript/calle-mcp-result-extractor/README.md
@@ -62,16 +62,22 @@ needs a flag to make it safe to run:
 npm run cli -- plan --to +12125550123 --region US --goal "Confirm the rescheduled appointment and capture the new date."
 ```
 
-Placing the call is the one command with a real side effect, and it refuses to dial unless you say
-so explicitly:
+`plan_call` returns a `confirm_token` that authorizes the actual call — a secret you should never
+type on a command line (shell history, `ps`, over-the-shoulder) or see printed to a terminal
+(scrollback, screen recordings, copy-pasted logs). `plan` never prints it; instead it saves it to a
+private, owner-only-permission file (`~/.calle-mcp/apps/calle-mcp-result-extractor/pending-plan.json`)
+that `call` reads automatically, so the two-step flow never requires handling the token yourself:
 
 ```bash
-npm run cli -- call --plan-id <id-from-plan> --confirm-token <token-from-plan>
-# → "Preview only (default). Would call run_call with plan_id=... Pass --live to actually place the call."
+npm run cli -- call
+# → "Preview only (default). Would call run_call for plan ... Pass --live to actually place the call."
 
-npm run cli -- call --plan-id <id-from-plan> --confirm-token <token-from-plan> --live
-# → places the real call
+npm run cli -- call --live
+# → places the real call, using the token from the last "plan", then clears it (single-use)
 ```
+
+If you'd rather not touch disk at all, pipe a token on stdin instead and it takes priority over the
+saved plan: `some-vault get token | npm run cli -- call --live`.
 
 ## One live run
 
@@ -123,9 +129,14 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
 
 - **No CALL-E session.** `plan` and `call` fail with a message pointing you at
   `npx @call-e/cli auth login` rather than a raw MCP error.
+- **Numbers that aren't E.164.** `plan --to` is validated locally (`+`, then 7–15 digits) before
+  anything is sent to CALL-E — a malformed number never reaches the network.
+  `+15555550123` passes; `555-0123` or `(555) 0123` don't.
 - **Plan not ready to run.** `plan_call` can come back with `ready_to_run: false` and clarifying
   questions instead of a `confirm_token` — there is no path to `call` without a valid token from a
   plan that was actually ready.
+- **No pending plan (and nothing piped).** `call` needs either a prior `plan` (which saved its
+  token privately) or a token piped on stdin — it never falls back to an empty or fabricated token.
 - **Missing `--live`.** `call` without `--live` never reaches `run_call`.
 - **Extraction never validates.** `BedrockReasoningProvider` retries once with the validation
   error fed back to the model, then throws a `ReasoningValidationError` naming the task and the
@@ -139,12 +150,19 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
 - **Cancellation.** CALL-E's MCP surface exposes no cancel-in-flight operation for a call that's
   already dialing. There is nothing recurring here to disable — every call is a single planned,
   confirmed, one-shot run.
-- **Credentials.** CALL-E auth comes entirely from `@call-e/cli`'s token cache; this tool never
-  reads, stores, or logs a token itself. AWS credentials for Bedrock come from the default SDK
-  credential chain — never a hardcoded key. No secrets appear in any file in this directory.
-- **Phone numbers.** The bundled example uses a NANP-reserved fictional number
-  (`+1 212 555 0123`, the `555-01xx` block set aside for fiction). Mask real phone numbers in any
-  transcript or log you share.
+- **Credentials.** CALL-E *session* auth comes entirely from `@call-e/cli`'s token cache; this tool
+  never reads, stores, or logs that token. It does write one thing locally: `plan_call`'s
+  short-lived, single-use `confirm_token`, saved to an owner-only-permission file under
+  `~/.calle-mcp/apps/calle-mcp-result-extractor/` and deleted the moment `call --live` uses it (see
+  [`src/pending-plan.ts`](src/pending-plan.ts)). That token is never a CLI argument and never
+  printed — see "Placing the call" above. AWS credentials for Bedrock come from the default SDK
+  credential chain — never a hardcoded key.
+- **Phone numbers.** `--to` is validated as E.164 locally before anything is sent (see "What blocks
+  a live call"). Every command's printed output — `plan`, `call`, `status`, `extract` — is passed
+  through [`maskPhoneNumbersInText`](src/phone-safety.ts), which masks every E.164-looking
+  substring, not just a known field, because a callback number can show up inside a transcript or
+  call summary that this tool doesn't otherwise parse. The bundled example still uses a
+  NANP-reserved fictional number (`+1 212 555 0123`, the `555-01xx` block set aside for fiction).
 
 ## Reading further
 
@@ -154,3 +172,7 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
   wrapper over `@call-e/core`.
 - [`src/extract-from-transcript.ts`](src/extract-from-transcript.ts) — the extraction function
   itself, provider-agnostic.
+- [`src/pending-plan.ts`](src/pending-plan.ts) — private, owner-only-permission storage for a
+  plan's `confirm_token` between `plan` and `call`.
+- [`src/phone-safety.ts`](src/phone-safety.ts) — local E.164 validation and the phone-number
+  masking applied to every command's output.

--- a/apps/typescript/calle-mcp-result-extractor/README.md
+++ b/apps/typescript/calle-mcp-result-extractor/README.md
@@ -1,0 +1,156 @@
+# calle-mcp-result-extractor
+
+Schema-validated structured results from CALL-E calls placed over MCP — which has no
+`result_schema` parameter of its own.
+
+## The problem
+
+CALL-E's Developer API supports asking for a structured result by passing a JSON schema alongside
+your call request, and getting back data that matches it. That's a REST-API-only feature.
+
+CALL-E's MCP tool surface (`plan_call`, `run_call`, `get_call_run` — what you get when CALL-E is
+wired up as an MCP server for an agent host) has no equivalent parameter. Every completed run's
+`result.extracted` field is CALL-E's own generic call metadata (duration, disposition, and
+similar) — never output shaped to whatever your agent actually needed to know from the call. You
+do get `result.transcript`, though, every time.
+
+If your agent host only talks to CALL-E over MCP — Claude Code, Cowork-style agents, OpenClaw,
+Hermes, skills.sh-installed agents, or anything else set up as an MCP client rather than calling
+the REST API directly — and you need a typed answer instead of a transcript to read, you have to
+extract it yourself. This is that extraction step: give it a transcript and a Zod schema, get back
+a value that satisfies the schema or a clear error explaining why it doesn't.
+
+## Try it without an account
+
+```bash
+npm install
+npm run demo
+```
+
+This runs the full pipeline — a canned completed call-run standing in for a real one, extracted
+through a deterministic fake reasoning provider — with no CALL-E account, no AWS credentials, and
+no network calls at all. It prints the structured result extracted from
+[`fake/sample-call-run.json`](fake/sample-call-run.json)'s transcript.
+
+## Setup
+
+```bash
+npm install
+npm run check   # tsc --noEmit
+npm test        # runs against the fake provider and a stubbed Bedrock client — no credentials needed
+```
+
+For live extraction you need AWS credentials that can invoke Bedrock (any of the usual chain:
+profile, environment variables, execution role). For live calls you additionally need a CALL-E
+session:
+
+```bash
+npx @call-e/cli auth login
+```
+
+This tool reuses that login's token cache (`~/.calle-mcp/cli` by default) through
+[`@call-e/core`](https://www.npmjs.com/package/@call-e/core) — there's no separate login flow to
+maintain here. Override the cache location or MCP server with `CALLE_MCP_CACHE_ROOT` /
+`CALLE_MCP_SERVER_URL` if you need to.
+
+## Preview, which is the default
+
+Planning a call is always safe — `plan_call` has no side effects, so `npm run cli -- plan` never
+needs a flag to make it safe to run:
+
+```bash
+npm run cli -- plan --to +12125550123 --region US --goal "Confirm the rescheduled appointment and capture the new date."
+```
+
+Placing the call is the one command with a real side effect, and it refuses to dial unless you say
+so explicitly:
+
+```bash
+npm run cli -- call --plan-id <id-from-plan> --confirm-token <token-from-plan>
+# → "Preview only (default). Would call run_call with plan_id=... Pass --live to actually place the call."
+
+npm run cli -- call --plan-id <id-from-plan> --confirm-token <token-from-plan> --live
+# → places the real call
+```
+
+## One live run
+
+Once you have a transcript — from `npm run cli -- status --run-id <id>` after a real call settles,
+or from your own recording pipeline — extract a real structured result through Bedrock instead of
+the fake provider:
+
+```bash
+npm run cli -- extract --transcript-file my-call.txt --schema appointment-confirmation --provider bedrock --region us-east-1
+```
+
+The bundled `appointment-confirmation` schema is there to make the demo and CLI runnable
+end-to-end; for your own use case, import `extractStructuredResult()` and pass your own Zod
+schema and system prompt directly — see [`src/extract-from-transcript.ts`](src/extract-from-transcript.ts).
+This is a reference implementation, not a general-purpose CLI product.
+
+## From an agent
+
+```ts
+import { z } from "zod";
+import { extractStructuredResult, DEFAULT_EXTRACTION_SYSTEM_PROMPT } from "calle-mcp-result-extractor/src/extract-from-transcript.js";
+import { BedrockReasoningProvider } from "calle-mcp-result-extractor/src/reasoning/bedrock.js";
+import { getCallRun, resolveCalleMcpConfig } from "calle-mcp-result-extractor/src/calle-mcp.js";
+
+const config = resolveCalleMcpConfig();
+const run = await getCallRun(config, runId); // however you got runId from your MCP host
+
+const schema = z.object({ confirmed: z.boolean(), newDate: z.string().nullable() });
+const result = await extractStructuredResult(new BedrockReasoningProvider(), {
+  task: "confirm-appointment",
+  systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+  transcript: run.result!.transcript!,
+  questionsToResolve: ["Did they confirm? What's the new date?"],
+  schema,
+});
+```
+
+Swap `BedrockReasoningProvider` for your own `ReasoningProvider` implementation
+(`src/reasoning/types.ts`) if you're not on Bedrock — the extraction logic doesn't care which
+model answered, only that the answer validates against your schema.
+
+## Exit codes
+
+The CLI exits `1` on any error (invalid arguments, an MCP auth failure, a schema that never
+validates after retries) and `0` on success. Errors are printed to stderr; results to stdout, so
+`npm run cli -- extract ... > result.json` works as expected.
+
+## What blocks a live call
+
+- **No CALL-E session.** `plan` and `call` fail with a message pointing you at
+  `npx @call-e/cli auth login` rather than a raw MCP error.
+- **Plan not ready to run.** `plan_call` can come back with `ready_to_run: false` and clarifying
+  questions instead of a `confirm_token` — there is no path to `call` without a valid token from a
+  plan that was actually ready.
+- **Missing `--live`.** `call` without `--live` never reaches `run_call`.
+- **Extraction never validates.** `BedrockReasoningProvider` retries once with the validation
+  error fed back to the model, then throws a `ReasoningValidationError` naming the task and the
+  exact Zod issues — it never silently returns malformed data.
+
+## Side effects, cancellation, credentials
+
+- **Side effects.** `plan_call` and `get_call_run` (via `status`) have none. `run_call` places a
+  real outbound phone call — the one operation in this tool with a real-world effect, and it's
+  gated behind `--live` as described above.
+- **Cancellation.** CALL-E's MCP surface exposes no cancel-in-flight operation for a call that's
+  already dialing. There is nothing recurring here to disable — every call is a single planned,
+  confirmed, one-shot run.
+- **Credentials.** CALL-E auth comes entirely from `@call-e/cli`'s token cache; this tool never
+  reads, stores, or logs a token itself. AWS credentials for Bedrock come from the default SDK
+  credential chain — never a hardcoded key. No secrets appear in any file in this directory.
+- **Phone numbers.** The bundled example uses a NANP-reserved fictional number
+  (`+1 212 555 0123`, the `555-01xx` block set aside for fiction). Mask real phone numbers in any
+  transcript or log you share.
+
+## Reading further
+
+- [`docs/bedrock-tool-result-retry.md`](docs/bedrock-tool-result-retry.md) — the specific Converse
+  API constraint that makes naive retry-with-feedback fail, and the fix.
+- [`src/calle-mcp.ts`](src/calle-mcp.ts) — the typed `plan_call` / `run_call` / `get_call_run`
+  wrapper over `@call-e/core`.
+- [`src/extract-from-transcript.ts`](src/extract-from-transcript.ts) — the extraction function
+  itself, provider-agnostic.

--- a/apps/typescript/calle-mcp-result-extractor/README.md
+++ b/apps/typescript/calle-mcp-result-extractor/README.md
@@ -82,10 +82,11 @@ npm run cli -- call --live
 #   "plan", then clears it (single-use)
 ```
 
-Every `plan` clears whatever was pending before it, unconditionally — before validation, before the
-network call, no matter how the new attempt turns out. Re-planning with a bad number, a plan that
-comes back `ready_to_run: false`, or a network error never leaves an older, already-superseded plan
-sitting there fully authorized for a later `call --live` to execute by mistake. And because the
+Every `plan` clears whatever was pending before it as the very first thing it does — before
+argument parsing, before config resolution, before validation, before the network call, no matter
+how the new attempt turns out. A missing flag, a bad number, a plan that comes back
+`ready_to_run: false`, or any other failure along the way never leaves an older, already-superseded
+plan sitting there fully authorized for a later `call --live` to execute by mistake. And because the
 preview and the live run both show the *actual stored* destination, region, and goal — not just a
 plan id — confirming a call means seeing what it will really do.
 

--- a/apps/typescript/calle-mcp-result-extractor/README.md
+++ b/apps/typescript/calle-mcp-result-extractor/README.md
@@ -70,14 +70,28 @@ that `call` reads automatically, so the two-step flow never requires handling th
 
 ```bash
 npm run cli -- call
-# → "Preview only (default). Would call run_call for plan ... Pass --live to actually place the call."
+# → Preview only (default). Would call run_call for:
+#     plan:   plan_abc123
+#     to:     +155•••••23
+#     region: US
+#     goal:   Confirm the rescheduled appointment and capture the new date.
+#   Pass --live to actually place the call.
 
 npm run cli -- call --live
-# → places the real call, using the token from the last "plan", then clears it (single-use)
+# → prints the same masked summary, places the real call using the token from the last
+#   "plan", then clears it (single-use)
 ```
 
+Every `plan` clears whatever was pending before it, unconditionally — before validation, before the
+network call, no matter how the new attempt turns out. Re-planning with a bad number, a plan that
+comes back `ready_to_run: false`, or a network error never leaves an older, already-superseded plan
+sitting there fully authorized for a later `call --live` to execute by mistake. And because the
+preview and the live run both show the *actual stored* destination, region, and goal — not just a
+plan id — confirming a call means seeing what it will really do.
+
 If you'd rather not touch disk at all, pipe a token on stdin instead and it takes priority over the
-saved plan: `some-vault get token | npm run cli -- call --live`.
+saved plan's token (the plan's other details still come from the saved plan):
+`some-vault get token | npm run cli -- call --live`.
 
 ## One live run
 
@@ -135,8 +149,12 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
 - **Plan not ready to run.** `plan_call` can come back with `ready_to_run: false` and clarifying
   questions instead of a `confirm_token` — there is no path to `call` without a valid token from a
   plan that was actually ready.
-- **No pending plan (and nothing piped).** `call` needs either a prior `plan` (which saved its
-  token privately) or a token piped on stdin — it never falls back to an empty or fabricated token.
+- **No pending plan.** `call` needs a prior `plan` that saved its details privately — it never
+  falls back to an empty or fabricated plan, and a token piped on stdin only substitutes the token
+  itself, not the destination/region/goal, which still come from the saved plan.
+- **A stale plan from before the last `plan` attempt.** Every `plan` call clears the previously
+  saved plan first, regardless of how the new attempt turns out — see "Preview, which is the
+  default" above.
 - **Missing `--live`.** `call` without `--live` never reaches `run_call`.
 - **Extraction never validates.** `BedrockReasoningProvider` retries once with the validation
   error fed back to the model, then throws a `ReasoningValidationError` naming the task and the
@@ -158,11 +176,13 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
   printed — see "Placing the call" above. AWS credentials for Bedrock come from the default SDK
   credential chain — never a hardcoded key.
 - **Phone numbers.** `--to` is validated as E.164 locally before anything is sent (see "What blocks
-  a live call"). Every command's printed output — `plan`, `call`, `status`, `extract` — is passed
-  through [`maskPhoneNumbersInText`](src/phone-safety.ts), which masks every E.164-looking
-  substring, not just a known field, because a callback number can show up inside a transcript or
-  call summary that this tool doesn't otherwise parse. The bundled example still uses a
-  NANP-reserved fictional number (`+1 212 555 0123`, the `555-01xx` block set aside for fiction).
+  a live call"). Every command's printed output — `plan`, `call`, `status`, `extract`, *and any
+  uncaught error* — is passed through [`maskPhoneNumbersInText`](src/phone-safety.ts), which masks
+  every E.164-looking substring, not just a known field, because a callback number can show up
+  inside a transcript, call summary, or error message that this tool doesn't otherwise parse. A
+  rejected `--to` value is never echoed back at all (masking only works on validly-shaped numbers,
+  and a rejected value is by definition not one). The bundled example uses a NANP-reserved fictional
+  number (`+1 212 555 0123`, the `555-01xx` block set aside for fiction).
 
 ## Reading further
 
@@ -173,6 +193,9 @@ validates after retries) and `0` on success. Errors are printed to stderr; resul
 - [`src/extract-from-transcript.ts`](src/extract-from-transcript.ts) — the extraction function
   itself, provider-agnostic.
 - [`src/pending-plan.ts`](src/pending-plan.ts) — private, owner-only-permission storage for a
-  plan's `confirm_token` between `plan` and `call`.
+  plan's `confirm_token` between `plan` and `call`, and the faithful masked summary shown before
+  both the preview and the live dial.
+- [`src/plan-workflow.ts`](src/plan-workflow.ts) — plans and saves a call, always clearing the
+  previous pending plan first regardless of how the new attempt turns out.
 - [`src/phone-safety.ts`](src/phone-safety.ts) — local E.164 validation and the phone-number
-  masking applied to every command's output.
+  masking applied to every command's output, including errors.

--- a/apps/typescript/calle-mcp-result-extractor/demo/run-local.ts
+++ b/apps/typescript/calle-mcp-result-extractor/demo/run-local.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  AppointmentConfirmationResult,
+  EXPECTED_RESULT,
+  QUESTIONS_TO_RESOLVE,
+} from "../examples/appointment-confirmation.js";
+import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "../src/extract-from-transcript.js";
+import { FakeReasoningProvider } from "../src/reasoning/fake.js";
+
+/**
+ * Runs the whole extraction pipeline with zero credentials and zero network
+ * calls: a canned CALL-E call-run result stands in for a real one, and a
+ * deterministic fake reasoning provider stands in for Bedrock. This is what
+ * "no live credentials, no real outbound calls, dry-run by default" looks
+ * like end to end — `npm run demo`.
+ */
+async function main() {
+  const fixturePath = fileURLToPath(new URL("../fake/sample-call-run.json", import.meta.url));
+  const callRun = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+    status: string;
+    result: { transcript: string };
+  };
+
+  if (callRun.status !== "COMPLETED" || !callRun.result.transcript) {
+    throw new Error("Fixture is not a completed call with a transcript.");
+  }
+
+  const reasoning = new FakeReasoningProvider().register(
+    "appointment-confirmation",
+    EXPECTED_RESULT,
+  );
+
+  const result = await extractStructuredResult(reasoning, {
+    task: "appointment-confirmation",
+    systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+    transcript: callRun.result.transcript,
+    questionsToResolve: QUESTIONS_TO_RESOLVE,
+    schema: AppointmentConfirmationResult,
+  });
+
+  console.log("Structured result (schema-validated, zero credentials used):");
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/typescript/calle-mcp-result-extractor/docs/bedrock-tool-result-retry.md
+++ b/apps/typescript/calle-mcp-result-extractor/docs/bedrock-tool-result-retry.md
@@ -1,0 +1,67 @@
+# The Converse API tool_use / tool_result pairing rule
+
+When you force structured output from AWS Bedrock's Converse API by requiring a tool call
+(`toolChoice: { tool: { name } }`), and the model's tool input fails your schema validation, the
+obvious next move is to send it back with feedback: "that wasn't valid, try again." Sending that
+feedback as an ordinary user text message is the wrong move, and it fails in a way that's easy to
+misdiagnose.
+
+## What goes wrong
+
+```ts
+messages.push(
+  { role: "assistant", content: response.output.message.content }, // has a tool_use block
+  { role: "user", content: [{ text: "That was invalid JSON, please retry." }] }, // plain text
+);
+```
+
+The next `ConverseCommand` call throws:
+
+```
+ValidationException: An assistant message with tool_use blocks must be followed by a
+user message with tool_result blocks.
+```
+
+The Converse API enforces this pairing strictly: any assistant turn containing a `tool_use`
+content block must be immediately followed by a user turn containing a `tool_result` block for
+that exact `toolUseId`. A plain-text follow-up breaks the pairing and the whole request is
+rejected — including the retry you were trying to make, which defeats the purpose of retrying at
+all.
+
+## The fix
+
+Send the validation failure as a `toolResult` with `status: "error"`, keyed to the original
+`toolUseId`:
+
+```ts
+messages.push(
+  { role: "assistant", content },
+  {
+    role: "user",
+    content: [
+      {
+        toolResult: {
+          toolUseId: toolUse.toolUseId,
+          status: "error",
+          content: [{ text: `Your input failed validation: ${issues}` }],
+        },
+      },
+    ],
+  },
+);
+```
+
+The model receives this exactly like a tool execution that failed, and correctly retries the tool
+call with corrected input on the next turn.
+
+## The other edge case
+
+Sometimes the model doesn't return a `tool_use` block at all — no forced-tool-choice guarantee
+survives every model/prompt combination. In that case there is no `toolUseId` to pair a
+`tool_result` with, so appending anything is unsafe. The correct move is to drop back to the
+original single-message conversation and retry from scratch, not to keep extending a message list
+that has no valid tool_use/tool_result pairing to build on.
+
+See [`../src/reasoning/bedrock.ts`](../src/reasoning/bedrock.ts) for the full implementation and
+[`../test/bedrock-retry.test.ts`](../test/bedrock-retry.test.ts) for regression tests covering
+both paths against a stubbed client (no AWS credentials needed to run them).

--- a/apps/typescript/calle-mcp-result-extractor/examples/appointment-confirmation.ts
+++ b/apps/typescript/calle-mcp-result-extractor/examples/appointment-confirmation.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * Example schema for the scenario in fake/sample-call-run.json: confirming a
+ * rescheduled appointment by phone. Swap this for whatever your own call
+ * actually needs to determine — the schema is the only domain-specific part
+ * of this tool.
+ */
+export const AppointmentConfirmationResult = z.object({
+  appointmentConfirmed: z.boolean(),
+  newDate: z.string().nullable().describe("ISO-8601 date if stated, otherwise null"),
+  newTime: z.string().nullable().describe("Free-text time as stated, otherwise null"),
+  prepInstructions: z.string().nullable(),
+  requiresCallback: z.boolean().describe("True if the recipient could not confirm on this call"),
+});
+
+export type AppointmentConfirmationResult = z.infer<typeof AppointmentConfirmationResult>;
+
+export const QUESTIONS_TO_RESOLVE = [
+  "Did the recipient confirm the new appointment date and time?",
+  "What is the exact new date and time?",
+  "Is there anything the customer needs to do or bring beforehand?",
+];
+
+/** What extractStructuredResult should return for the fake transcript above. */
+export const EXPECTED_RESULT: AppointmentConfirmationResult = {
+  appointmentConfirmed: true,
+  newDate: "2026-08-12",
+  newTime: "10 AM",
+  prepInstructions: "Arrive 15 minutes early for paperwork.",
+  requiresCallback: false,
+};

--- a/apps/typescript/calle-mcp-result-extractor/fake/sample-call-run.json
+++ b/apps/typescript/calle-mcp-result-extractor/fake/sample-call-run.json
@@ -1,0 +1,18 @@
+{
+  "run_id": "fake-run-a1b2c3",
+  "status": "COMPLETED",
+  "result": {
+    "summary": "Confirmed the rescheduled appointment and captured the new date.",
+    "outcome": {
+      "task_completed": true,
+      "completion_confidence": { "score": 0.94, "label": "high" },
+      "evidence": ["Recipient confirmed the new date aloud", "Recipient repeated the date back correctly"]
+    },
+    "extracted": {
+      "call_duration_seconds": 47,
+      "disposition": "answered"
+    },
+    "transcript": "[00:00:00] BOT: Hi, is this Riverside Dental?\n[00:00:03] USER: Yes, this is Dana speaking.\n[00:00:05] BOT: Hi Dana, I'm an automated assistant calling on behalf of Alex Rivera to confirm the appointment originally scheduled for this Thursday needs to move. Is a reschedule to next Monday at 10 AM available?\n[00:00:14] USER: Let me check... yes, Monday the 12th at 10 AM works.\n[00:00:19] BOT: Great, just to confirm: Monday the 12th at 10 AM. Is there anything Alex needs to bring or do beforehand?\n[00:00:26] USER: Just arrive 15 minutes early for paperwork, nothing else needed.\n[00:00:31] BOT: Understood. To confirm back: the appointment is now Monday the 12th at 10 AM, arrive 15 minutes early, no other prep needed. Is that correct?\n[00:00:40] USER: That's correct.\n[00:00:41] BOT: Thank you for your help, goodbye.",
+    "call_id": "fake-call-a1b2c3"
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/package-lock.json
+++ b/apps/typescript/calle-mcp-result-extractor/package-lock.json
@@ -1,0 +1,593 @@
+{
+  "name": "calle-mcp-result-extractor",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calle-mcp-result-extractor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+        "@call-e/core": "^0.2.5",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.8.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1105.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1105.0.tgz",
+      "integrity": "sha512-ITKOkgdFFzqEgi2D36tvXTzLqK0RhEGp4EDCh9kK417RYLwKXR29KRBC+B7ZdPP1LxqQ35jPf2ZXpKqNCSAuLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/eventstream-handler-node": "^3.972.31",
+        "@aws-sdk/middleware-eventstream": "^3.972.26",
+        "@aws-sdk/middleware-websocket": "^3.972.49",
+        "@aws-sdk/token-providers": "3.1105.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
+      "integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1105.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1105.0.tgz",
+      "integrity": "sha512-NEZNwh8DpYpFnGVdRCXZmW7HTQniLIiryVab9jj0IvrTACWx15Ik8fwi7PNH5R0P9yhykM7T6jgU6QyOKesUOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@call-e/core": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@call-e/core/-/core-0.2.5.tgz",
+      "integrity": "sha512-GK/LQ9/18VYD/gyOueXyJTqoIM9lMiQsngDLhlCTZcSpRhaqM2Xsnw31OFAe1HdpD7DNUULw/E0CETDSZ1TklQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/package.json
+++ b/apps/typescript/calle-mcp-result-extractor/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "calle-mcp-result-extractor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Schema-validated structured results from CALL-E calls placed over MCP, which has no result_schema parameter of its own.",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "demo": "node --import tsx demo/run-local.ts",
+    "cli": "node --import tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+    "@call-e/core": "^0.2.5",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/calle-mcp.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/calle-mcp.ts
@@ -1,0 +1,146 @@
+import { expandHomePath, resolveServerUrl } from "@call-e/core/config";
+import {
+  AuthRequiredError,
+  callMcpTool,
+  isUnauthorizedMcpError,
+  type McpClientConfig,
+} from "@call-e/core/mcp-client";
+
+export { AuthRequiredError, isUnauthorizedMcpError };
+
+/**
+ * Reuses the token cache written by `calle auth login` (the `@call-e/cli`
+ * package) at `~/.calle-mcp/cli` by default, so this tool doesn't need its
+ * own login flow — authenticate once with the CLI and every tool that
+ * builds this config picks it up. Override with CALLE_MCP_CACHE_ROOT /
+ * CALLE_MCP_SERVER_URL if you're pointing at a different channel or a
+ * per-app cache instead.
+ */
+export function resolveCalleMcpConfig(overrides: Partial<McpClientConfig> = {}): McpClientConfig {
+  return {
+    cacheRoot: expandHomePath(
+      overrides.cacheRoot ?? process.env.CALLE_MCP_CACHE_ROOT ?? "~/.calle-mcp/cli",
+    ),
+    serverUrl: resolveServerUrl({
+      serverUrl: overrides.serverUrl ?? process.env.CALLE_MCP_SERVER_URL,
+    }),
+    timeoutSeconds: overrides.timeoutSeconds ?? 30,
+    ...overrides,
+  };
+}
+
+export interface PlanCallInput {
+  toPhones: string[];
+  region: string;
+  goal: string;
+  language?: string;
+  userInput?: string;
+}
+
+export interface PlanCallResult {
+  plan_id: string;
+  ready_to_run: boolean;
+  next_step: string;
+  clarifying_questions?: string[];
+  confirm_summary: string;
+  confirm_token?: string | null;
+}
+
+export interface RunCallResult {
+  run_id: string;
+  status: string;
+  message?: string | null;
+  result?: {
+    summary?: string | null;
+    outcome?: {
+      task_completed: boolean;
+      completion_confidence: { score: number; label: string };
+      evidence?: string[];
+    } | null;
+    /** CALL-E's own generic call metadata — never schema-constrained. See extractStructuredResult. */
+    extracted?: Record<string, unknown>;
+    transcript?: string | null;
+    call_id?: string | null;
+  };
+}
+
+/** Plans a call without dialing. Always safe to call — no side effects. */
+export async function planCall(
+  config: McpClientConfig,
+  input: PlanCallInput,
+): Promise<PlanCallResult> {
+  return callMcpTool<PlanCallResult>({
+    config,
+    toolName: "plan_call",
+    toolArguments: {
+      to_phones: input.toPhones,
+      region: input.region,
+      language: input.language ?? "English",
+      goal: input.goal,
+      user_input: input.userInput ?? "Plan the call exactly as specified in the goal.",
+    },
+  });
+}
+
+/**
+ * Places the real call. Requires a `confirm_token` from a prior `planCall`
+ * that came back `ready_to_run: true` — there is no path to a live call
+ * that skips planning and human-visible confirmation.
+ */
+export async function runCall(
+  config: McpClientConfig,
+  planId: string,
+  confirmToken: string,
+): Promise<RunCallResult> {
+  return callMcpTool<RunCallResult>({
+    config,
+    toolName: "run_call",
+    toolArguments: { plan_id: planId, confirm_token: confirmToken },
+  });
+}
+
+export async function getCallRun(config: McpClientConfig, runId: string): Promise<RunCallResult> {
+  return callMcpTool<RunCallResult>({
+    config,
+    toolName: "get_call_run",
+    toolArguments: { run_id: runId },
+  });
+}
+
+const SETTLED_STATUSES = new Set([
+  "COMPLETED",
+  "NO_ANSWER",
+  "NO ANSWER",
+  "DECLINED",
+  "FAILED",
+  "ERROR",
+  "CANCELLED",
+  "CANCELED",
+]);
+
+export interface WaitForCallRunOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+/** Polls get_call_run until the run reaches a settled status or times out. */
+export async function waitForCallRun(
+  config: McpClientConfig,
+  runId: string,
+  options: WaitForCallRunOptions = {},
+): Promise<RunCallResult> {
+  const pollIntervalMs = options.pollIntervalMs ?? 5000;
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const run = await getCallRun(config, runId);
+    if (SETTLED_STATUSES.has(run.status.toUpperCase())) {
+      return run;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for call run ${runId} to settle (last status: ${run.status}).`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/cli.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   AppointmentConfirmationResult,
   QUESTIONS_TO_RESOLVE,
@@ -8,7 +9,7 @@ import { getCallRun, isUnauthorizedMcpError, resolveCalleMcpConfig, runCall } fr
 import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "./extract-from-transcript.js";
 import { maskPhoneNumbersInText, REDACTED_TOKEN_PLACEHOLDER } from "./phone-safety.js";
 import { clearPendingPlan, formatPendingPlanSummary, loadPendingPlan, readConfirmTokenFromStdin } from "./pending-plan.js";
-import { planAndSave } from "./plan-workflow.js";
+import { planAndSave, type PlanCallFn } from "./plan-workflow.js";
 import { BedrockReasoningProvider } from "./reasoning/bedrock.js";
 import { FakeReasoningProvider } from "./reasoning/fake.js";
 import type { ReasoningProvider } from "./reasoning/types.js";
@@ -17,6 +18,17 @@ const KNOWN_SCHEMAS = {
   "appointment-confirmation": AppointmentConfirmationResult,
 } as const;
 type SchemaName = keyof typeof KNOWN_SCHEMAS;
+
+/**
+ * Thrown by usage() instead of calling process.exit directly, so that
+ * argument-parsing failures go through the same throw/catch path as every
+ * other error in a command — in particular so cmdPlan's "clear the pending
+ * plan first, no matter what" guarantee actually holds for this case too,
+ * and so that guarantee is unit-testable without exiting the test runner.
+ * main()'s catch handler is the only place that turns this into a process
+ * exit; the usage text is already printed by the time it's thrown.
+ */
+export class UsageError extends Error {}
 
 function usage(): never {
   console.error(`calle-mcp-result-extractor — demo CLI, not a supported product API
@@ -43,7 +55,7 @@ Commands:
       output are masked.
 
 Every live command requires a prior "calle auth login" (from @call-e/cli).`);
-  process.exit(1);
+  throw new UsageError();
 }
 
 function flag(args: string[], name: string): string | undefined {
@@ -102,18 +114,34 @@ async function cmdExtract(args: string[]) {
   printSafe(result);
 }
 
-async function cmdPlan(args: string[]) {
+export interface CmdPlanDeps {
+  /** Override for tests only — real CLI usage always resolves the real config. */
+  resolveConfig?: typeof resolveCalleMcpConfig;
+  /** Override for tests only — see plan-workflow.ts. */
+  planCallFn?: PlanCallFn;
+}
+
+export async function cmdPlan(args: string[], deps: CmdPlanDeps = {}): Promise<void> {
+  // Must be the very first thing this function does — strictly before
+  // argument parsing (usage() below can throw) and before config resolution
+  // (resolveConfig() below can throw too) — so that *nothing* about a new
+  // plan attempt, however it fails, can skip invalidating whatever was
+  // authorized before it. planAndSave also clears defensively for its own
+  // direct callers, but cmdPlan cannot rely on reaching that call at all.
+  clearPendingPlan();
+
   const to = flag(args, "to");
   const region = flag(args, "region");
   const goal = flag(args, "goal");
   if (!to || !region || !goal) usage();
 
-  const config = resolveCalleMcpConfig();
+  const resolveConfig = deps.resolveConfig ?? resolveCalleMcpConfig;
+  const config = resolveConfig();
   try {
-    // planAndSave clears any previously pending plan first, unconditionally
+    // planAndSave clears any previously pending plan first too, unconditionally
     // — see its doc comment for why that has to happen before validation or
     // the network call, not just on success.
-    const plan = await planAndSave(config, { to, region, goal });
+    const plan = await planAndSave(config, { to, region, goal }, deps.planCallFn);
     // confirm_token authorizes a real call — never print it, CLI arg it, or
     // let it reach shell history. Everything else about the plan is fine to
     // show (still passed through the phone mask, since to_phones round-trips
@@ -192,11 +220,24 @@ async function main() {
   }
 }
 
-main().catch((error: unknown) => {
-  // Every other path in this file prints through the phone mask; this
-  // catch-all must too, since any thrown error (including ones this file
-  // didn't anticipate) can end up here and still be printed to the user.
-  const rendered = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  console.error(maskPhoneNumbersInText(rendered));
-  process.exitCode = 1;
-});
+// Only run as a real CLI invocation when this file is the actual entry
+// point (`node cli.js ...`) — not when it's imported as a module, which the
+// test suite does to exercise cmdPlan() directly. Without this guard,
+// importing this file for tests would also execute main() for real, against
+// the test runner's own argv, and its failure path would set
+// process.exitCode = 1 regardless of what the tests actually assert.
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error: unknown) => {
+    if (error instanceof UsageError) {
+      // usage() already printed the help text; nothing more to say.
+      process.exitCode = 1;
+      return;
+    }
+    // Every other path in this file prints through the phone mask; this
+    // catch-all must too, since any thrown error (including ones this file
+    // didn't anticipate) can end up here and still be printed to the user.
+    const rendered = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    console.error(maskPhoneNumbersInText(rendered));
+    process.exitCode = 1;
+  });
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/cli.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/cli.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import {
+  AppointmentConfirmationResult,
+  QUESTIONS_TO_RESOLVE,
+} from "../examples/appointment-confirmation.js";
+import { getCallRun, isUnauthorizedMcpError, planCall, resolveCalleMcpConfig, runCall } from "./calle-mcp.js";
+import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "./extract-from-transcript.js";
+import { BedrockReasoningProvider } from "./reasoning/bedrock.js";
+import { FakeReasoningProvider } from "./reasoning/fake.js";
+import type { ReasoningProvider } from "./reasoning/types.js";
+
+const KNOWN_SCHEMAS = {
+  "appointment-confirmation": AppointmentConfirmationResult,
+} as const;
+type SchemaName = keyof typeof KNOWN_SCHEMAS;
+
+function usage(): never {
+  console.error(`calle-mcp-result-extractor — demo CLI, not a supported product API
+
+Commands:
+  extract --transcript-file <path> [--schema appointment-confirmation] [--provider fake|bedrock]
+      Extract a schema-validated structured result from a transcript file.
+      No credentials required with --provider fake (the default).
+
+  plan --to <E.164 phone> --region <region> --goal <text>
+      Plan a call (no dialing, no side effects, safe to run any time).
+
+  call --plan-id <id> --confirm-token <token> [--live]
+      Place the call planCall produced. Without --live this prints what
+      would be sent and exits — it never dials by accident.
+
+  status --run-id <id>
+      Fetch the current status of a call run.
+
+Every live command requires a prior "calle auth login" (from @call-e/cli).`);
+  process.exit(1);
+}
+
+function flag(args: string[], name: string): string | undefined {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+async function cmdExtract(args: string[]) {
+  const transcriptFile = flag(args, "transcript-file");
+  if (!transcriptFile) usage();
+  const schemaName = (flag(args, "schema") ?? "appointment-confirmation") as SchemaName;
+  const schema = KNOWN_SCHEMAS[schemaName];
+  if (!schema) {
+    console.error(`Unknown schema "${schemaName}". Known: ${Object.keys(KNOWN_SCHEMAS).join(", ")}`);
+    console.error("For your own schema, import extractStructuredResult() directly instead of the CLI.");
+    process.exit(1);
+  }
+  const providerName = flag(args, "provider") ?? "fake";
+  const transcript = readFileSync(transcriptFile, "utf8");
+
+  let reasoning: ReasoningProvider;
+  if (providerName === "fake") {
+    console.error(
+      "Using the fake provider — this returns a canned result and does not call any model. " +
+        "Pass --provider bedrock for a real extraction (requires AWS credentials).",
+    );
+    reasoning = new FakeReasoningProvider().register(schemaName, {
+      appointmentConfirmed: true,
+      newDate: null,
+      newTime: null,
+      prepInstructions: null,
+      requiresCallback: true,
+    });
+  } else if (providerName === "bedrock") {
+    reasoning = new BedrockReasoningProvider({ region: flag(args, "region") });
+  } else {
+    console.error(`Unknown provider "${providerName}". Use "fake" or "bedrock".`);
+    process.exit(1);
+  }
+
+  const result = await extractStructuredResult(reasoning, {
+    task: schemaName,
+    systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+    transcript,
+    questionsToResolve: QUESTIONS_TO_RESOLVE,
+    schema,
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function cmdPlan(args: string[]) {
+  const to = flag(args, "to");
+  const region = flag(args, "region");
+  const goal = flag(args, "goal");
+  if (!to || !region || !goal) usage();
+  const config = resolveCalleMcpConfig();
+  try {
+    const plan = await planCall(config, { toPhones: [to], region, goal });
+    console.log(JSON.stringify(plan, null, 2));
+    if (!plan.ready_to_run) {
+      console.error(`Not ready to run: ${plan.next_step}`);
+    }
+  } catch (error) {
+    if (isUnauthorizedMcpError(error)) {
+      console.error('Not authenticated. Run "npx @call-e/cli auth login" first.');
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+async function cmdCall(args: string[]) {
+  const planId = flag(args, "plan-id");
+  const confirmToken = flag(args, "confirm-token");
+  if (!planId || !confirmToken) usage();
+  if (!args.includes("--live")) {
+    console.log(
+      `Preview only (default). Would call run_call with plan_id=${planId}. ` +
+        "Pass --live to actually place the call — this is a genuine outbound phone call.",
+    );
+    return;
+  }
+  const config = resolveCalleMcpConfig();
+  const run = await runCall(config, planId, confirmToken);
+  console.log(JSON.stringify(run, null, 2));
+}
+
+async function cmdStatus(args: string[]) {
+  const runId = flag(args, "run-id");
+  if (!runId) usage();
+  const config = resolveCalleMcpConfig();
+  const run = await getCallRun(config, runId);
+  console.log(JSON.stringify(run, null, 2));
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  switch (command) {
+    case "extract":
+      return cmdExtract(rest);
+    case "plan":
+      return cmdPlan(rest);
+    case "call":
+      return cmdCall(rest);
+    case "status":
+      return cmdStatus(rest);
+    default:
+      usage();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/typescript/calle-mcp-result-extractor/src/cli.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/cli.ts
@@ -4,10 +4,11 @@ import {
   AppointmentConfirmationResult,
   QUESTIONS_TO_RESOLVE,
 } from "../examples/appointment-confirmation.js";
-import { getCallRun, isUnauthorizedMcpError, planCall, resolveCalleMcpConfig, runCall } from "./calle-mcp.js";
+import { getCallRun, isUnauthorizedMcpError, resolveCalleMcpConfig, runCall } from "./calle-mcp.js";
 import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "./extract-from-transcript.js";
-import { assertE164, maskPhoneNumbersInText, REDACTED_TOKEN_PLACEHOLDER } from "./phone-safety.js";
-import { clearPendingPlan, loadPendingPlan, readConfirmTokenFromStdin, savePendingPlan } from "./pending-plan.js";
+import { maskPhoneNumbersInText, REDACTED_TOKEN_PLACEHOLDER } from "./phone-safety.js";
+import { clearPendingPlan, formatPendingPlanSummary, loadPendingPlan, readConfirmTokenFromStdin } from "./pending-plan.js";
+import { planAndSave } from "./plan-workflow.js";
 import { BedrockReasoningProvider } from "./reasoning/bedrock.js";
 import { FakeReasoningProvider } from "./reasoning/fake.js";
 import type { ReasoningProvider } from "./reasoning/types.js";
@@ -106,21 +107,13 @@ async function cmdPlan(args: string[]) {
   const region = flag(args, "region");
   const goal = flag(args, "goal");
   if (!to || !region || !goal) usage();
-  assertE164(to, "--to");
 
   const config = resolveCalleMcpConfig();
   try {
-    const plan = await planCall(config, { toPhones: [to], region, goal });
-    if (plan.ready_to_run && plan.confirm_token) {
-      savePendingPlan({
-        planId: plan.plan_id,
-        confirmToken: plan.confirm_token,
-        toPhones: [to],
-        region,
-        goal,
-        createdAt: new Date().toISOString(),
-      });
-    }
+    // planAndSave clears any previously pending plan first, unconditionally
+    // — see its doc comment for why that has to happen before validation or
+    // the network call, not just on success.
+    const plan = await planAndSave(config, { to, region, goal });
     // confirm_token authorizes a real call — never print it, CLI arg it, or
     // let it reach shell history. Everything else about the plan is fine to
     // show (still passed through the phone mask, since to_phones round-trips
@@ -142,36 +135,35 @@ async function cmdPlan(args: string[]) {
 
 async function cmdCall(args: string[]) {
   const pending = loadPendingPlan();
+  if (!pending) {
+    console.error('No pending plan found. Run "plan" first.');
+    process.exit(1);
+  }
   const isLive = args.includes("--live");
 
-  // Preview never needs the token itself, only proof a plan exists — so it
-  // never touches stdin, which would otherwise risk blocking on it in a
-  // non-interactive environment for a command that has no side effects.
+  // Preview never needs the token itself, only the plan that's actually
+  // stored — so it never touches stdin, which would otherwise risk blocking
+  // on it in a non-interactive environment for a command that has no side
+  // effects. The summary always reflects what's on file, not a plan id
+  // alone, so there's no way to confirm a call you can't actually see.
   if (!isLive) {
-    if (!pending) {
-      console.error('No pending plan found. Run "plan" first.');
-      process.exit(1);
-    }
     console.log(
-      `Preview only (default). Would call run_call for plan ${pending.planId}. ` +
+      `Preview only (default). Would call run_call for:\n${formatPendingPlanSummary(pending)}\n` +
         "Pass --live to actually place the call — this is a genuine outbound phone call.",
     );
     return;
   }
 
   const stdinToken = await readConfirmTokenFromStdin();
-  const confirmToken = stdinToken ?? pending?.confirmToken;
-  const planId = pending?.planId;
-  if (!confirmToken || !planId) {
-    console.error(
-      'No pending plan found and no confirm_token piped on stdin. Run "plan" first, ' +
-        "or pipe a token: some-source | node cli.js call --live",
-    );
-    process.exit(1);
-  }
+  const confirmToken = stdinToken ?? pending.confirmToken;
 
+  // The same faithful, masked summary is shown immediately before the real
+  // dial too — the last checkpoint before an irreversible action, and it can
+  // be a while since "plan" ran, in a different terminal, so this is not
+  // redundant with the preview above.
+  console.error(`About to place a genuine outbound call for:\n${formatPendingPlanSummary(pending)}`);
   const config = resolveCalleMcpConfig();
-  const run = await runCall(config, planId, confirmToken);
+  const run = await runCall(config, pending.planId, confirmToken);
   clearPendingPlan(); // confirm_token is single-use; don't leave it around for accidental reuse.
   printSafe(run);
 }
@@ -201,6 +193,10 @@ async function main() {
 }
 
 main().catch((error: unknown) => {
-  console.error(error);
+  // Every other path in this file prints through the phone mask; this
+  // catch-all must too, since any thrown error (including ones this file
+  // didn't anticipate) can end up here and still be printed to the user.
+  const rendered = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  console.error(maskPhoneNumbersInText(rendered));
   process.exitCode = 1;
 });

--- a/apps/typescript/calle-mcp-result-extractor/src/cli.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/cli.ts
@@ -6,6 +6,8 @@ import {
 } from "../examples/appointment-confirmation.js";
 import { getCallRun, isUnauthorizedMcpError, planCall, resolveCalleMcpConfig, runCall } from "./calle-mcp.js";
 import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "./extract-from-transcript.js";
+import { assertE164, maskPhoneNumbersInText, REDACTED_TOKEN_PLACEHOLDER } from "./phone-safety.js";
+import { clearPendingPlan, loadPendingPlan, readConfirmTokenFromStdin, savePendingPlan } from "./pending-plan.js";
 import { BedrockReasoningProvider } from "./reasoning/bedrock.js";
 import { FakeReasoningProvider } from "./reasoning/fake.js";
 import type { ReasoningProvider } from "./reasoning/types.js";
@@ -25,13 +27,19 @@ Commands:
 
   plan --to <E.164 phone> --region <region> --goal <text>
       Plan a call (no dialing, no side effects, safe to run any time).
+      The number is validated locally before anything is sent to CALL-E.
+      The confirm_token this returns is saved to a private, restricted-
+      permission file — it is never printed and never a CLI argument.
 
-  call --plan-id <id> --confirm-token <token> [--live]
-      Place the call planCall produced. Without --live this prints what
-      would be sent and exits — it never dials by accident.
+  call [--live]
+      Place the call the last "plan" produced, reading its confirm_token
+      from that private file (or from stdin, if piped). Without --live
+      this prints what would be sent and exits — it never dials by
+      accident. Phone numbers in the output are masked.
 
   status --run-id <id>
-      Fetch the current status of a call run.
+      Fetch the current status of a call run. Phone numbers in the
+      output are masked.
 
 Every live command requires a prior "calle auth login" (from @call-e/cli).`);
   process.exit(1);
@@ -40,6 +48,11 @@ Every live command requires a prior "calle auth login" (from @call-e/cli).`);
 function flag(args: string[], name: string): string | undefined {
   const index = args.indexOf(`--${name}`);
   return index === -1 ? undefined : args[index + 1];
+}
+
+/** Prints a value as masked, redacted-safe JSON — the only way this CLI writes CALL-E responses to stdout. */
+function printSafe(value: unknown): void {
+  console.log(maskPhoneNumbersInText(JSON.stringify(value, null, 2)));
 }
 
 async function cmdExtract(args: string[]) {
@@ -82,7 +95,10 @@ async function cmdExtract(args: string[]) {
     questionsToResolve: QUESTIONS_TO_RESOLVE,
     schema,
   });
-  console.log(JSON.stringify(result, null, 2));
+  // Extraction results are structured app data (appointment confirmed?,
+  // reschedule date, …), not raw CALL-E responses, but masking is cheap
+  // insurance if a schema ever captures a callback number verbatim.
+  printSafe(result);
 }
 
 async function cmdPlan(args: string[]) {
@@ -90,11 +106,29 @@ async function cmdPlan(args: string[]) {
   const region = flag(args, "region");
   const goal = flag(args, "goal");
   if (!to || !region || !goal) usage();
+  assertE164(to, "--to");
+
   const config = resolveCalleMcpConfig();
   try {
     const plan = await planCall(config, { toPhones: [to], region, goal });
-    console.log(JSON.stringify(plan, null, 2));
-    if (!plan.ready_to_run) {
+    if (plan.ready_to_run && plan.confirm_token) {
+      savePendingPlan({
+        planId: plan.plan_id,
+        confirmToken: plan.confirm_token,
+        toPhones: [to],
+        region,
+        goal,
+        createdAt: new Date().toISOString(),
+      });
+    }
+    // confirm_token authorizes a real call — never print it, CLI arg it, or
+    // let it reach shell history. Everything else about the plan is fine to
+    // show (still passed through the phone mask, since to_phones round-trips
+    // through the server response).
+    printSafe({ ...plan, confirm_token: plan.confirm_token ? REDACTED_TOKEN_PLACEHOLDER : null });
+    if (plan.ready_to_run) {
+      console.error('Plan saved privately. Run "call --live" to place this call, or "call" to preview it.');
+    } else {
       console.error(`Not ready to run: ${plan.next_step}`);
     }
   } catch (error) {
@@ -107,19 +141,39 @@ async function cmdPlan(args: string[]) {
 }
 
 async function cmdCall(args: string[]) {
-  const planId = flag(args, "plan-id");
-  const confirmToken = flag(args, "confirm-token");
-  if (!planId || !confirmToken) usage();
-  if (!args.includes("--live")) {
+  const pending = loadPendingPlan();
+  const isLive = args.includes("--live");
+
+  // Preview never needs the token itself, only proof a plan exists — so it
+  // never touches stdin, which would otherwise risk blocking on it in a
+  // non-interactive environment for a command that has no side effects.
+  if (!isLive) {
+    if (!pending) {
+      console.error('No pending plan found. Run "plan" first.');
+      process.exit(1);
+    }
     console.log(
-      `Preview only (default). Would call run_call with plan_id=${planId}. ` +
+      `Preview only (default). Would call run_call for plan ${pending.planId}. ` +
         "Pass --live to actually place the call — this is a genuine outbound phone call.",
     );
     return;
   }
+
+  const stdinToken = await readConfirmTokenFromStdin();
+  const confirmToken = stdinToken ?? pending?.confirmToken;
+  const planId = pending?.planId;
+  if (!confirmToken || !planId) {
+    console.error(
+      'No pending plan found and no confirm_token piped on stdin. Run "plan" first, ' +
+        "or pipe a token: some-source | node cli.js call --live",
+    );
+    process.exit(1);
+  }
+
   const config = resolveCalleMcpConfig();
   const run = await runCall(config, planId, confirmToken);
-  console.log(JSON.stringify(run, null, 2));
+  clearPendingPlan(); // confirm_token is single-use; don't leave it around for accidental reuse.
+  printSafe(run);
 }
 
 async function cmdStatus(args: string[]) {
@@ -127,7 +181,7 @@ async function cmdStatus(args: string[]) {
   if (!runId) usage();
   const config = resolveCalleMcpConfig();
   const run = await getCallRun(config, runId);
-  console.log(JSON.stringify(run, null, 2));
+  printSafe(run);
 }
 
 async function main() {

--- a/apps/typescript/calle-mcp-result-extractor/src/extract-from-transcript.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/extract-from-transcript.ts
@@ -1,0 +1,63 @@
+import type { z } from "zod";
+import type { ReasoningProvider } from "./reasoning/types.js";
+
+/**
+ * CALL-E's MCP tool surface (plan_call / run_call / get_call_run) has no
+ * result_schema parameter — that is a REST-API-only feature of the CALL-E
+ * Developer API. Over MCP, the `extracted` field on a completed run is
+ * always CALL-E's own generic call metadata, never output constrained to a
+ * schema you supply. If your agent host talks to CALL-E over MCP (Claude
+ * Code, Cowork-style agents, skills.sh-installed agents, or anything else
+ * wired up as an MCP client) and you need a typed, validated result rather
+ * than a wall of transcript text, you have to extract it yourself from the
+ * transcript CALL-E does return. This function does that: given a
+ * transcript and a Zod schema describing exactly what you need, it runs one
+ * extraction pass through a reasoning provider and returns a value
+ * guaranteed to satisfy the schema (or throws).
+ */
+export interface ExtractStructuredResultOptions<TSchema extends z.ZodTypeAny> {
+  task: string;
+  systemPrompt: string;
+  transcript: string;
+  questionsToResolve: string[];
+  schema: TSchema;
+}
+
+export function buildExtractionPrompt(
+  transcript: string,
+  questionsToResolve: string[],
+): string {
+  return [
+    "QUESTIONS THE CALL WAS SUPPOSED TO ANSWER:",
+    questionsToResolve.map((q, i) => `${i + 1}. ${q}`).join("\n"),
+    "",
+    "TRANSCRIPT:",
+    transcript,
+    "",
+    "Extract the structured result from this transcript.",
+  ].join("\n");
+}
+
+export async function extractStructuredResult<TSchema extends z.ZodTypeAny>(
+  reasoning: ReasoningProvider,
+  options: ExtractStructuredResultOptions<TSchema>,
+): Promise<z.infer<TSchema>> {
+  return reasoning.complete({
+    task: options.task,
+    systemPrompt: options.systemPrompt,
+    userPrompt: buildExtractionPrompt(options.transcript, options.questionsToResolve),
+    schema: options.schema,
+  });
+}
+
+/**
+ * A reasonable default system prompt for transcript extraction: read
+ * literally, never fabricate, unknown stays unknown. Pass your own if your
+ * domain needs different framing — this is a sane starting point, not a
+ * requirement.
+ */
+export const DEFAULT_EXTRACTION_SYSTEM_PROMPT = `You extract structured findings from a real
+phone-call transcript. Read the transcript literally — do not infer facts that were not said.
+Unknown data must remain unknown: use null for any field the transcript does not clearly answer.
+Never fabricate identifiers, reference numbers, dates, or outcomes that were not actually stated
+on the call.`;

--- a/apps/typescript/calle-mcp-result-extractor/src/pending-plan.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/pending-plan.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ensurePrivateDir, readJson, removeFile, writePrivateJson } from "@call-e/core/cache";
+import { maskPhoneNumbersInText } from "./phone-safety.js";
 
 /**
  * `plan_call`'s `confirm_token` authorizes an actual outbound phone call —
@@ -39,6 +40,23 @@ export function loadPendingPlan(): PendingPlan | null {
 
 export function clearPendingPlan(): void {
   removeFile(pendingPlanPath());
+}
+
+/**
+ * A human-readable, phone-masked summary of exactly what a live call would
+ * do — the destination, region, and goal actually on file, not just a plan
+ * id. Shown before both the dry-run preview and the real `--live` dial, so
+ * what gets confirmed is always the plan that's actually stored, not
+ * whatever the operator assumes is still pending.
+ */
+export function formatPendingPlanSummary(pending: PendingPlan): string {
+  const lines = [
+    `plan:   ${pending.planId}`,
+    `to:     ${pending.toPhones.join(", ")}`,
+    `region: ${pending.region}`,
+    `goal:   ${pending.goal}`,
+  ];
+  return maskPhoneNumbersInText(lines.map((line) => `  ${line}`).join("\n"));
 }
 
 /**

--- a/apps/typescript/calle-mcp-result-extractor/src/pending-plan.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/pending-plan.ts
@@ -1,0 +1,60 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ensurePrivateDir, readJson, removeFile, writePrivateJson } from "@call-e/core/cache";
+
+/**
+ * `plan_call`'s `confirm_token` authorizes an actual outbound phone call —
+ * it must never be a CLI argument (shell history, `ps`, shoulder-surfing) or
+ * printed to a terminal (scrollback, screen recordings, copy-pasted logs).
+ * `plan` writes it here instead, using @call-e/core's own private-file
+ * helpers (the same ones the CLI's own token cache uses), and `call` reads
+ * it back — nothing about the token ever needs to be typed or displayed.
+ */
+
+export interface PendingPlan {
+  planId: string;
+  confirmToken: string;
+  toPhones: string[];
+  region: string;
+  goal: string;
+  createdAt: string;
+}
+
+function pendingPlanPath(): string {
+  // Overridable so tests never touch the developer's real ~/.calle-mcp.
+  const dir =
+    process.env.CALLE_MCP_APP_STATE_DIR ??
+    join(homedir(), ".calle-mcp", "apps", "calle-mcp-result-extractor");
+  ensurePrivateDir(dir);
+  return join(dir, "pending-plan.json");
+}
+
+export function savePendingPlan(plan: PendingPlan): void {
+  writePrivateJson(pendingPlanPath(), plan);
+}
+
+export function loadPendingPlan(): PendingPlan | null {
+  return readJson<PendingPlan>(pendingPlanPath());
+}
+
+export function clearPendingPlan(): void {
+  removeFile(pendingPlanPath());
+}
+
+/**
+ * Reads a confirm_token piped on stdin (e.g. `some-vault get token | node
+ * cli.js call --live`), for callers who would rather not touch disk at all.
+ * Returns null immediately if stdin is a TTY (interactive) rather than
+ * blocking on input the user never intended to provide.
+ */
+export async function readConfirmTokenFromStdin(): Promise<string | null> {
+  if (process.stdin.isTTY) {
+    return null;
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const text = Buffer.concat(chunks).toString("utf8").trim();
+  return text.length > 0 ? text : null;
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/phone-safety.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/phone-safety.ts
@@ -1,0 +1,42 @@
+/**
+ * Local, offline safety checks for phone numbers and secrets in this app's
+ * CLI output — nothing here calls the network.
+ */
+
+/** E.164: a leading +, then 7–15 digits, first digit non-zero. */
+const E164_PATTERN = /^\+[1-9]\d{6,14}$/;
+
+export function isE164(value: string): boolean {
+  return E164_PATTERN.test(value);
+}
+
+export function assertE164(value: string, label: string): void {
+  if (!isE164(value)) {
+    throw new Error(
+      `${label} must be an E.164 phone number (e.g. +15555550123), got "${value}". ` +
+        "This is checked locally before anything is sent to CALL-E.",
+    );
+  }
+}
+
+/**
+ * Masks every E.164-looking substring in a block of text (typically a
+ * JSON.stringify'd CALL-E response). The destination number you dialed and
+ * any callback number read aloud during the call and captured in the
+ * transcript both match this pattern — mask unconditionally rather than only
+ * masking known fields, since CALL-E's response shape isn't fully typed and
+ * a phone number can show up in fields this app doesn't explicitly model.
+ */
+export function maskPhoneNumbersInText(text: string): string {
+  return text.replace(/\+[1-9]\d{6,14}/g, (match) => {
+    const digits = match.slice(1);
+    const visibleStart = digits.slice(0, 3);
+    const visibleEnd = digits.slice(-2);
+    const maskedLength = Math.max(digits.length - visibleStart.length - visibleEnd.length, 3);
+    return `+${visibleStart}${"•".repeat(maskedLength)}${visibleEnd}`;
+  });
+}
+
+/** Placeholder shown in place of a real confirm_token in any printed output. */
+export const REDACTED_TOKEN_PLACEHOLDER =
+  "[redacted — stored privately, never printed or passed as a CLI argument]";

--- a/apps/typescript/calle-mcp-result-extractor/src/phone-safety.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/phone-safety.ts
@@ -12,8 +12,14 @@ export function isE164(value: string): boolean {
 
 export function assertE164(value: string, label: string): void {
   if (!isE164(value)) {
+    // Deliberately does not echo `value` back: a rejected value might still
+    // be a real phone number in the wrong format (missing "+", spaces,
+    // parens, a typo'd digit), and it wouldn't reliably match
+    // maskPhoneNumbersInText's E.164 pattern precisely because it's
+    // malformed — so it can't be masked, only omitted.
     throw new Error(
-      `${label} must be an E.164 phone number (e.g. +15555550123), got "${value}". ` +
+      `${label} must be an E.164 phone number (e.g. +15555550123): "+" followed by 7–15 digits, ` +
+        "no spaces, dashes, or parentheses. The value you passed is not shown here for that reason. " +
         "This is checked locally before anything is sent to CALL-E.",
     );
   }

--- a/apps/typescript/calle-mcp-result-extractor/src/plan-workflow.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/plan-workflow.ts
@@ -1,0 +1,52 @@
+import type { McpClientConfig } from "@call-e/core/mcp-client";
+import { planCall as defaultPlanCall, type PlanCallResult } from "./calle-mcp.js";
+import { assertE164 } from "./phone-safety.js";
+import { clearPendingPlan, savePendingPlan } from "./pending-plan.js";
+
+export interface PlanRequest {
+  to: string;
+  region: string;
+  goal: string;
+}
+
+export type PlanCallFn = typeof defaultPlanCall;
+
+/**
+ * Validates and plans a call, saving it as the pending plan only if it came
+ * back ready to run.
+ *
+ * Clears any previously pending plan first, unconditionally — before
+ * validation, before the network call, regardless of how this attempt turns
+ * out. Without that, a re-plan that fails E.164 validation, fails on the
+ * network, or comes back `ready_to_run: false` would leave whatever was
+ * planned *before* it still fully authorized, and "call --live" would
+ * silently execute that stale, already-superseded call instead of the one
+ * just reviewed.
+ */
+export async function planAndSave(
+  config: McpClientConfig,
+  request: PlanRequest,
+  planCallFn: PlanCallFn = defaultPlanCall,
+): Promise<PlanCallResult> {
+  clearPendingPlan();
+  assertE164(request.to, "--to");
+
+  const plan = await planCallFn(config, {
+    toPhones: [request.to],
+    region: request.region,
+    goal: request.goal,
+  });
+
+  if (plan.ready_to_run && plan.confirm_token) {
+    savePendingPlan({
+      planId: plan.plan_id,
+      confirmToken: plan.confirm_token,
+      toPhones: [request.to],
+      region: request.region,
+      goal: request.goal,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  return plan;
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/reasoning/bedrock.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/reasoning/bedrock.ts
@@ -1,0 +1,129 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type Message,
+  type Tool,
+} from "@aws-sdk/client-bedrock-runtime";
+import type { DocumentType } from "@smithy/types";
+import type { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import {
+  ReasoningValidationError,
+  type ReasoningProvider,
+  type StructuredCompletionRequest,
+} from "./types.js";
+
+export interface BedrockReasoningProviderConfig {
+  /** Inference-profile or model id; default from BEDROCK_MODEL_ID env var. */
+  modelId?: string;
+  region?: string;
+  client?: BedrockRuntimeClient;
+  /** One retry with validation feedback is attempted by default. */
+  maxAttempts?: number;
+}
+
+const DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-6";
+
+/**
+ * AWS Bedrock Converse API adapter. Structured output is enforced by forcing
+ * a single tool call whose input schema is the requested Zod schema
+ * (converted to JSON Schema); the tool input is re-validated with Zod before
+ * returning. Auth is whatever the AWS SDK default credential chain resolves
+ * (profile, execution role, etc.) — never a hardcoded key.
+ *
+ * The retry path exists because of a real Converse API constraint that is
+ * easy to get wrong: once the model returns a `tool_use` content block, the
+ * *next* message in the conversation must be a `tool_result` for that same
+ * `toolUseId`, or the API rejects the whole request. Sending a follow-up as
+ * plain user text (e.g. "that wasn't valid JSON, try again") throws
+ * `ValidationException: An assistant message with tool_use blocks must be
+ * followed by a user message with tool_result blocks`. See
+ * ../../docs/bedrock-tool-result-retry.md for the full writeup.
+ */
+export class BedrockReasoningProvider implements ReasoningProvider {
+  readonly name = "bedrock";
+  private readonly client: BedrockRuntimeClient;
+  private readonly modelId: string;
+  private readonly maxAttempts: number;
+
+  constructor(config: BedrockReasoningProviderConfig = {}) {
+    this.modelId = config.modelId ?? process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID;
+    this.maxAttempts = config.maxAttempts ?? 3;
+    this.client =
+      config.client ?? new BedrockRuntimeClient(config.region ? { region: config.region } : {});
+  }
+
+  async complete<TSchema extends z.ZodTypeAny>(
+    request: StructuredCompletionRequest<TSchema>,
+  ): Promise<z.infer<TSchema>> {
+    const toolName = `emit_${request.task.replaceAll(/[^a-zA-Z0-9]+/g, "_")}`;
+    const jsonSchema = zodToJsonSchema(request.schema, { target: "jsonSchema7" });
+    const tool: Tool = {
+      toolSpec: {
+        name: toolName,
+        description: `Return the ${request.task} result in the required structure.`,
+        inputSchema: { json: jsonSchema as DocumentType },
+      },
+    };
+
+    const messages: Message[] = [{ role: "user", content: [{ text: request.userPrompt }] }];
+    let lastIssues = "";
+
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      const response = await this.client.send(
+        new ConverseCommand({
+          modelId: this.modelId,
+          system: [{ text: request.systemPrompt }],
+          messages,
+          toolConfig: { tools: [tool], toolChoice: { tool: { name: toolName } } },
+          inferenceConfig: {
+            maxTokens: request.maxTokens ?? 2048,
+            temperature: request.temperature ?? 0,
+          },
+        }),
+      );
+
+      const content = response.output?.message?.content ?? [];
+      const toolUse = content.find((block) => block.toolUse !== undefined)?.toolUse;
+      const parsed = request.schema.safeParse(toolUse?.input);
+      if (parsed.success) {
+        return parsed.data as z.infer<TSchema>;
+      }
+
+      if (!toolUse?.toolUseId) {
+        // No tool_use block to pair a tool_result with — retry from the
+        // original prompt rather than appending an unpaired assistant turn,
+        // which the Converse API would reject on the next call.
+        lastIssues = "Model did not return a tool_use block for the requested tool.";
+        continue;
+      }
+
+      lastIssues = parsed.error.message;
+      // Feed validation issues back as a tool_result (required immediately
+      // after a tool_use block) for one corrective attempt.
+      messages.push(
+        { role: "assistant", content },
+        {
+          role: "user",
+          content: [
+            {
+              toolResult: {
+                toolUseId: toolUse.toolUseId,
+                status: "error",
+                content: [
+                  {
+                    text:
+                      `Your ${toolName} input failed validation. Fix these issues and call the ` +
+                      `tool again with a corrected, complete input:\n${lastIssues}`,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      );
+    }
+
+    throw new ReasoningValidationError(request.task, lastIssues);
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/reasoning/fake.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/reasoning/fake.ts
@@ -1,0 +1,39 @@
+import type { z } from "zod";
+import {
+  ReasoningValidationError,
+  type ReasoningProvider,
+  type StructuredCompletionRequest,
+} from "./types.js";
+
+/**
+ * Deterministic, zero-network reasoning provider for the demo and the test
+ * suite. Register a canned response per task name; `complete()` validates it
+ * against the requested schema so a mismatched fixture fails loudly instead
+ * of silently returning bad data. No credentials, no outbound HTTP calls.
+ */
+export class FakeReasoningProvider implements ReasoningProvider {
+  readonly name = "fake";
+  private readonly responses = new Map<string, unknown>();
+
+  register(task: string, response: unknown): this {
+    this.responses.set(task, response);
+    return this;
+  }
+
+  async complete<TSchema extends z.ZodTypeAny>(
+    request: StructuredCompletionRequest<TSchema>,
+  ): Promise<z.infer<TSchema>> {
+    if (!this.responses.has(request.task)) {
+      throw new ReasoningValidationError(
+        request.task,
+        `No fake response registered for task "${request.task}". ` +
+          "Call .register(task, response) before using FakeReasoningProvider.",
+      );
+    }
+    const parsed = request.schema.safeParse(this.responses.get(request.task));
+    if (!parsed.success) {
+      throw new ReasoningValidationError(request.task, parsed.error.message);
+    }
+    return parsed.data as z.infer<TSchema>;
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/src/reasoning/types.ts
+++ b/apps/typescript/calle-mcp-result-extractor/src/reasoning/types.ts
@@ -1,0 +1,38 @@
+import type { z } from "zod";
+
+/**
+ * One structured-extraction request: a task label (used in error messages and
+ * as the generated tool name for Bedrock), a system prompt, a user prompt
+ * (typically the transcript plus the questions the call was meant to answer),
+ * and the Zod schema the result must satisfy.
+ */
+export interface StructuredCompletionRequest<TSchema extends z.ZodTypeAny> {
+  task: string;
+  systemPrompt: string;
+  userPrompt: string;
+  schema: TSchema;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/**
+ * Anything that can turn a prompt into a schema-valid object is a reasoning
+ * provider — Bedrock, OpenAI, a local model, or the fake provider used for
+ * offline demos and tests. Swap providers without touching extraction logic.
+ */
+export interface ReasoningProvider {
+  readonly name: string;
+  complete<TSchema extends z.ZodTypeAny>(
+    request: StructuredCompletionRequest<TSchema>,
+  ): Promise<z.infer<TSchema>>;
+}
+
+export class ReasoningValidationError extends Error {
+  constructor(
+    public readonly task: string,
+    public readonly issues: string,
+  ) {
+    super(`Reasoning provider could not produce a valid "${task}" result: ${issues}`);
+    this.name = "ReasoningValidationError";
+  }
+}

--- a/apps/typescript/calle-mcp-result-extractor/test/bedrock-retry.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/bedrock-retry.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { z } from "zod";
+import { BedrockReasoningProvider } from "../src/reasoning/bedrock.js";
+
+/**
+ * Regression coverage for a real Converse API constraint: once the model
+ * returns a tool_use content block, the very next message must be a
+ * tool_result for that same toolUseId, or the API rejects the request with
+ * "An assistant message with tool_use blocks must be followed by a user
+ * message with tool_result blocks." See ../docs/bedrock-tool-result-retry.md.
+ *
+ * These tests stub BedrockRuntimeClient.send() so they run with no AWS
+ * credentials and no network access.
+ */
+
+interface StubResponse {
+  output?: { message?: { content: unknown[] } };
+}
+
+class StubBedrockClient {
+  public readonly sentInputs: unknown[] = [];
+  private readonly responses: StubResponse[];
+
+  constructor(responses: StubResponse[]) {
+    this.responses = responses;
+  }
+
+  async send(command: { input: unknown }): Promise<StubResponse> {
+    this.sentInputs.push(command.input);
+    const next = this.responses.shift();
+    if (!next) {
+      throw new Error("StubBedrockClient ran out of canned responses.");
+    }
+    return next;
+  }
+}
+
+const Schema = z.object({ confirmed: z.boolean() });
+
+function toolUseResponse(toolUseId: string, input: unknown): StubResponse {
+  return { output: { message: { content: [{ toolUse: { toolUseId, input } }] } } };
+}
+
+test("retries an invalid tool input by sending a paired tool_result, not free text", async () => {
+  const client = new StubBedrockClient([
+    toolUseResponse("call-1", { confirmed: "not-a-boolean" }), // fails schema
+    toolUseResponse("call-2", { confirmed: true }), // succeeds
+  ]);
+  const provider = new BedrockReasoningProvider({
+    client: client as never,
+    modelId: "test-model",
+  });
+
+  const result = await provider.complete({
+    task: "confirm",
+    systemPrompt: "system",
+    userPrompt: "user",
+    schema: Schema,
+  });
+
+  assert.deepEqual(result, { confirmed: true });
+  assert.equal(client.sentInputs.length, 2);
+
+  // The second request must append the failed assistant turn immediately
+  // followed by a user turn carrying a toolResult for the SAME toolUseId —
+  // never a plain-text user message after a tool_use block.
+  const secondRequest = client.sentInputs[1] as { messages: Array<Record<string, unknown>> };
+  const appendedMessages = secondRequest.messages.slice(-2);
+  assert.equal(appendedMessages[0]!.role, "assistant");
+  assert.equal(appendedMessages[1]!.role, "user");
+  const toolResultBlock = (appendedMessages[1]!.content as Array<{ toolResult?: { toolUseId: string; status: string } }>)[0]!.toolResult;
+  assert.equal(toolResultBlock?.toolUseId, "call-1");
+  assert.equal(toolResultBlock?.status, "error");
+});
+
+test("retries from the original prompt (no unpaired assistant turn) when no tool_use comes back", async () => {
+  const client = new StubBedrockClient([
+    { output: { message: { content: [{ text: "I'd rather just explain in prose." }] } } },
+    toolUseResponse("call-2", { confirmed: true }),
+  ]);
+  const provider = new BedrockReasoningProvider({
+    client: client as never,
+    modelId: "test-model",
+  });
+
+  const result = await provider.complete({
+    task: "confirm",
+    systemPrompt: "system",
+    userPrompt: "user",
+    schema: Schema,
+  });
+
+  assert.deepEqual(result, { confirmed: true });
+  // No unpaired assistant tool_use turn was appended — both requests carry
+  // only the original single user message.
+  for (const input of client.sentInputs) {
+    const messages = (input as { messages: unknown[] }).messages;
+    assert.equal(messages.length, 1);
+  }
+});
+
+test("throws a labelled validation error after exhausting retries", async () => {
+  const client = new StubBedrockClient([
+    toolUseResponse("call-1", { confirmed: "nope" }),
+    toolUseResponse("call-2", { confirmed: "still-nope" }),
+  ]);
+  const provider = new BedrockReasoningProvider({
+    client: client as never,
+    modelId: "test-model",
+    maxAttempts: 2,
+  });
+
+  await assert.rejects(
+    provider.complete({ task: "confirm", systemPrompt: "s", userPrompt: "u", schema: Schema }),
+    /confirm/,
+  );
+});

--- a/apps/typescript/calle-mcp-result-extractor/test/cmd-plan.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/cmd-plan.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+// See test/pending-plan.test.ts — must be set before pending-plan.js loads.
+const stateDir = mkdtempSync(join(tmpdir(), "calle-mcp-result-extractor-test-"));
+process.env.CALLE_MCP_APP_STATE_DIR = stateDir;
+
+const { loadPendingPlan, savePendingPlan } = await import("../src/pending-plan.js");
+const { cmdPlan, UsageError } = await import("../src/cli.js");
+
+const STALE_PLAN = {
+  planId: "plan_stale",
+  confirmToken: "token_stale",
+  toPhones: ["+15555550123"],
+  region: "US",
+  goal: "An earlier, already-reviewed call.",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  savePendingPlan(STALE_PLAN); // every test starts with a stale plan already on disk
+});
+
+afterEach(() => {
+  rmSync(join(stateDir, "pending-plan.json"), { force: true });
+});
+
+test("a missing required argument still clears the stale pending plan, before usage() throws", async () => {
+  assert.equal(loadPendingPlan()?.planId, "plan_stale"); // sanity check
+
+  await assert.rejects(cmdPlan([]), UsageError); // no --to/--region/--goal at all
+
+  assert.equal(
+    loadPendingPlan(),
+    null,
+    "a plan attempt that never even reaches planCall() must still invalidate the prior authorization",
+  );
+});
+
+test("a missing single required argument (--goal) still clears the stale pending plan", async () => {
+  assert.equal(loadPendingPlan()?.planId, "plan_stale");
+
+  await assert.rejects(cmdPlan(["--to", "+15555550199", "--region", "US"]), UsageError);
+
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("a config-resolution failure still clears the stale pending plan, before the network call", async () => {
+  assert.equal(loadPendingPlan()?.planId, "plan_stale");
+
+  const resolveConfig = () => {
+    throw new Error("simulated config resolution failure");
+  };
+
+  await assert.rejects(
+    cmdPlan(["--to", "+15555550199", "--region", "US", "--goal", "New goal"], { resolveConfig }),
+    /simulated config resolution failure/,
+  );
+
+  assert.equal(
+    loadPendingPlan(),
+    null,
+    "a plan attempt that fails before planCall() is ever invoked must still invalidate the prior authorization",
+  );
+});
+
+test("a fully successful new plan still replaces (not merely clears) the stale plan", async () => {
+  assert.equal(loadPendingPlan()?.planId, "plan_stale");
+
+  const plan = await cmdPlanReturningPlan(["--to", "+15555550199", "--region", "US", "--goal", "New goal"], {
+    resolveConfig: () => ({ cacheRoot: stateDir, serverUrl: "https://example.invalid", timeoutSeconds: 5 }),
+    planCallFn: async () => ({
+      plan_id: "plan_new",
+      ready_to_run: true,
+      next_step: "run_call",
+      confirm_summary: "Call +15555550199 to confirm.",
+      confirm_token: "token_new",
+    }),
+  });
+
+  assert.equal(plan.plan_id, "plan_new");
+  assert.equal(loadPendingPlan()?.planId, "plan_new");
+});
+
+// cmdPlan doesn't return the plan it made (it only prints it) — reach into
+// planAndSave's result the same way cmdPlan does, so this last test can
+// assert on the end state without parsing captured console output.
+async function cmdPlanReturningPlan(
+  args: string[],
+  deps: Parameters<typeof cmdPlan>[1],
+): Promise<{ plan_id: string }> {
+  await cmdPlan(args, deps);
+  const pending = loadPendingPlan();
+  if (!pending) throw new Error("expected a pending plan to have been saved");
+  return { plan_id: pending.planId };
+}
+
+process.on("exit", () => {
+  rmSync(stateDir, { recursive: true, force: true });
+});

--- a/apps/typescript/calle-mcp-result-extractor/test/extract-from-transcript.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/extract-from-transcript.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  AppointmentConfirmationResult,
+  EXPECTED_RESULT,
+  QUESTIONS_TO_RESOLVE,
+} from "../examples/appointment-confirmation.js";
+import { DEFAULT_EXTRACTION_SYSTEM_PROMPT, extractStructuredResult } from "../src/extract-from-transcript.js";
+import { FakeReasoningProvider } from "../src/reasoning/fake.js";
+import { ReasoningValidationError } from "../src/reasoning/types.js";
+
+const FIXTURE_PATH = fileURLToPath(new URL("../fake/sample-call-run.json", import.meta.url));
+
+function loadTranscript(): string {
+  const callRun = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as {
+    result: { transcript: string };
+  };
+  return callRun.result.transcript;
+}
+
+test("extracts a schema-valid result from the bundled fake transcript, no credentials", async () => {
+  const reasoning = new FakeReasoningProvider().register(
+    "appointment-confirmation",
+    EXPECTED_RESULT,
+  );
+
+  const result = await extractStructuredResult(reasoning, {
+    task: "appointment-confirmation",
+    systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+    transcript: loadTranscript(),
+    questionsToResolve: QUESTIONS_TO_RESOLVE,
+    schema: AppointmentConfirmationResult,
+  });
+
+  assert.deepEqual(result, EXPECTED_RESULT);
+});
+
+test("fake provider rejects a response that does not satisfy the schema", async () => {
+  const reasoning = new FakeReasoningProvider().register("appointment-confirmation", {
+    appointmentConfirmed: "yes", // wrong type — should be boolean
+  });
+
+  await assert.rejects(
+    extractStructuredResult(reasoning, {
+      task: "appointment-confirmation",
+      systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+      transcript: loadTranscript(),
+      questionsToResolve: QUESTIONS_TO_RESOLVE,
+      schema: AppointmentConfirmationResult,
+    }),
+    ReasoningValidationError,
+  );
+});
+
+test("fake provider fails clearly when no response was registered for the task", async () => {
+  const reasoning = new FakeReasoningProvider();
+
+  await assert.rejects(
+    extractStructuredResult(reasoning, {
+      task: "appointment-confirmation",
+      systemPrompt: DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+      transcript: loadTranscript(),
+      questionsToResolve: QUESTIONS_TO_RESOLVE,
+      schema: AppointmentConfirmationResult,
+    }),
+    /No fake response registered/,
+  );
+});

--- a/apps/typescript/calle-mcp-result-extractor/test/pending-plan.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/pending-plan.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+// CALLE_MCP_APP_STATE_DIR must be set before pending-plan.js is imported —
+// it reads the env var once, at module load, when computing the state dir.
+const stateDir = mkdtempSync(join(tmpdir(), "calle-mcp-result-extractor-test-"));
+process.env.CALLE_MCP_APP_STATE_DIR = stateDir;
+
+const { clearPendingPlan, loadPendingPlan, savePendingPlan } = await import("../src/pending-plan.js");
+
+const SAMPLE = {
+  planId: "plan_abc123",
+  confirmToken: "super-secret-confirm-token",
+  toPhones: ["+15555550123"],
+  region: "US",
+  goal: "Confirm the appointment.",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  clearPendingPlan();
+});
+
+afterEach(() => {
+  clearPendingPlan();
+});
+
+test("loadPendingPlan returns null when nothing has been saved", () => {
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("savePendingPlan then loadPendingPlan round-trips the plan, including the token", () => {
+  savePendingPlan(SAMPLE);
+  assert.deepEqual(loadPendingPlan(), SAMPLE);
+});
+
+test("clearPendingPlan removes the saved plan", () => {
+  savePendingPlan(SAMPLE);
+  clearPendingPlan();
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("clearPendingPlan on an already-clear state does not throw", () => {
+  assert.doesNotThrow(() => clearPendingPlan());
+});
+
+test("the state file is written with owner-only permissions, never world- or group-readable", () => {
+  savePendingPlan(SAMPLE);
+  const mode = statSync(join(stateDir, "pending-plan.json")).mode & 0o777;
+  assert.equal(mode & 0o077, 0, `expected no group/other permissions, got ${mode.toString(8)}`);
+});
+
+process.on("exit", () => {
+  rmSync(stateDir, { recursive: true, force: true });
+});

--- a/apps/typescript/calle-mcp-result-extractor/test/pending-plan.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/pending-plan.test.ts
@@ -9,7 +9,9 @@ import { afterEach, beforeEach, test } from "node:test";
 const stateDir = mkdtempSync(join(tmpdir(), "calle-mcp-result-extractor-test-"));
 process.env.CALLE_MCP_APP_STATE_DIR = stateDir;
 
-const { clearPendingPlan, loadPendingPlan, savePendingPlan } = await import("../src/pending-plan.js");
+const { clearPendingPlan, formatPendingPlanSummary, loadPendingPlan, savePendingPlan } = await import(
+  "../src/pending-plan.js"
+);
 
 const SAMPLE = {
   planId: "plan_abc123",
@@ -51,6 +53,21 @@ test("the state file is written with owner-only permissions, never world- or gro
   savePendingPlan(SAMPLE);
   const mode = statSync(join(stateDir, "pending-plan.json")).mode & 0o777;
   assert.equal(mode & 0o077, 0, `expected no group/other permissions, got ${mode.toString(8)}`);
+});
+
+test("formatPendingPlanSummary shows the plan id, region, and goal, with the phone number masked", () => {
+  const summary = formatPendingPlanSummary(SAMPLE);
+
+  assert.match(summary, /plan_abc123/);
+  assert.match(summary, /US/);
+  assert.match(summary, /Confirm the appointment\./);
+  assert.doesNotMatch(summary, /\+15555550123/);
+  assert.match(summary, /\+155•+23/); // start and end digits still visible
+});
+
+test("formatPendingPlanSummary never leaks the confirm_token", () => {
+  const summary = formatPendingPlanSummary(SAMPLE);
+  assert.doesNotMatch(summary, /super-secret-confirm-token/);
 });
 
 process.on("exit", () => {

--- a/apps/typescript/calle-mcp-result-extractor/test/phone-safety.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/phone-safety.test.ts
@@ -18,6 +18,22 @@ test("assertE164 throws with a clear, local-only message on a bad number", () =>
   assert.throws(() => assertE164("555-0123", "--to"), /--to must be an E\.164 phone number/);
 });
 
+test("assertE164's error message never echoes the rejected value back", () => {
+  const distinctiveBadValue = "555-0199-not-e164";
+  try {
+    assertE164(distinctiveBadValue, "--to");
+    assert.fail("expected assertE164 to throw");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    assert.doesNotMatch(
+      message,
+      new RegExp(distinctiveBadValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      "the invalid input must never be echoed back, even partially — it may still be a real, " +
+        "just malformed, phone number, and it wouldn't reliably match the phone mask either",
+    );
+  }
+});
+
 test("assertE164 does not throw on a valid number", () => {
   assert.doesNotThrow(() => assertE164("+15555550123", "--to"));
 });

--- a/apps/typescript/calle-mcp-result-extractor/test/phone-safety.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/phone-safety.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { assertE164, isE164, maskPhoneNumbersInText } from "../src/phone-safety.js";
+
+test("isE164 accepts valid E.164 numbers", () => {
+  assert.equal(isE164("+15555550123"), true);
+  assert.equal(isE164("+442071838750"), true);
+});
+
+test("isE164 rejects malformed numbers", () => {
+  assert.equal(isE164("5555550123"), false); // missing +
+  assert.equal(isE164("+0123456789"), false); // leading 0 after +
+  assert.equal(isE164("+1 555 555 0123"), false); // spaces
+  assert.equal(isE164("not-a-phone"), false);
+});
+
+test("assertE164 throws with a clear, local-only message on a bad number", () => {
+  assert.throws(() => assertE164("555-0123", "--to"), /--to must be an E\.164 phone number/);
+});
+
+test("assertE164 does not throw on a valid number", () => {
+  assert.doesNotThrow(() => assertE164("+15555550123", "--to"));
+});
+
+test("maskPhoneNumbersInText masks every E.164 substring and keeps the rest of the text intact", () => {
+  const raw = JSON.stringify({
+    run_id: "run_abc123",
+    result: {
+      summary: "Confirmed. Callback number given as +15555550199 if needed.",
+      to_phones: ["+15555550123"],
+    },
+  });
+
+  const masked = maskPhoneNumbersInText(raw);
+
+  assert.doesNotMatch(masked, /\+15555550199/);
+  assert.doesNotMatch(masked, /\+15555550123/);
+  assert.match(masked, /run_abc123/); // non-phone content untouched
+  // Start and end digits stay visible for correlation, middle is masked.
+  assert.match(masked, /\+155•+99/);
+  assert.match(masked, /\+155•+23/);
+});
+
+test("maskPhoneNumbersInText leaves text with no phone numbers unchanged", () => {
+  const text = JSON.stringify({ plan_id: "plan_xyz", ready_to_run: true });
+  assert.equal(maskPhoneNumbersInText(text), text);
+});

--- a/apps/typescript/calle-mcp-result-extractor/test/plan-workflow.test.ts
+++ b/apps/typescript/calle-mcp-result-extractor/test/plan-workflow.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+// See test/pending-plan.test.ts — must be set before pending-plan.js loads.
+const stateDir = mkdtempSync(join(tmpdir(), "calle-mcp-result-extractor-test-"));
+process.env.CALLE_MCP_APP_STATE_DIR = stateDir;
+
+const { clearPendingPlan, loadPendingPlan } = await import("../src/pending-plan.js");
+const { planAndSave } = await import("../src/plan-workflow.js");
+
+const FAKE_CONFIG = { cacheRoot: stateDir, serverUrl: "https://example.invalid", timeoutSeconds: 5 };
+const VALID_REQUEST = { to: "+15555550123", region: "US", goal: "Confirm the appointment." };
+
+function readyPlan(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    plan_id: "plan_new",
+    ready_to_run: true,
+    next_step: "run_call",
+    confirm_summary: "Call +15555550123 to confirm.",
+    confirm_token: "token_new",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clearPendingPlan();
+});
+
+afterEach(() => {
+  clearPendingPlan();
+});
+
+test("a ready plan is saved as the pending plan", async () => {
+  const plan = await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () => readyPlan());
+
+  assert.equal(plan.ready_to_run, true);
+  const pending = loadPendingPlan();
+  assert.equal(pending?.planId, "plan_new");
+  assert.equal(pending?.confirmToken, "token_new");
+});
+
+test("re-planning after a ready plan clears the old plan even if the new attempt is not ready", async () => {
+  await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () => readyPlan({ plan_id: "plan_A", confirm_token: "token_A" }));
+  assert.equal(loadPendingPlan()?.planId, "plan_A"); // sanity check the first plan really saved
+
+  const plan = await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () =>
+    readyPlan({
+      plan_id: "plan_B",
+      ready_to_run: false,
+      confirm_token: null,
+      next_step: "needs clarification",
+    }),
+  );
+
+  assert.equal(plan.ready_to_run, false);
+  // The critical assertion: plan A must not still be sitting there
+  // authorized just because plan B wasn't ready.
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("re-planning clears the old plan even when the new attempt throws", async () => {
+  await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () => readyPlan({ plan_id: "plan_A", confirm_token: "token_A" }));
+  assert.equal(loadPendingPlan()?.planId, "plan_A");
+
+  await assert.rejects(
+    planAndSave(FAKE_CONFIG, VALID_REQUEST, async () => {
+      throw new Error("simulated network failure");
+    }),
+  );
+
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("re-planning clears the old plan even when the new --to fails local E.164 validation", async () => {
+  await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () => readyPlan({ plan_id: "plan_A", confirm_token: "token_A" }));
+  assert.equal(loadPendingPlan()?.planId, "plan_A");
+
+  await assert.rejects(
+    planAndSave(FAKE_CONFIG, { ...VALID_REQUEST, to: "not-a-phone" }, async () => readyPlan()),
+    /must be an E\.164 phone number/,
+  );
+
+  assert.equal(loadPendingPlan(), null);
+});
+
+test("a plan that is not ready to run is never saved", async () => {
+  const plan = await planAndSave(FAKE_CONFIG, VALID_REQUEST, async () =>
+    readyPlan({ ready_to_run: false, confirm_token: null, next_step: "needs clarification" }),
+  );
+
+  assert.equal(plan.ready_to_run, false);
+  assert.equal(loadPendingPlan(), null);
+});
+
+process.on("exit", () => {
+  rmSync(stateDir, { recursive: true, force: true });
+});

--- a/apps/typescript/calle-mcp-result-extractor/tsconfig.json
+++ b/apps/typescript/calle-mcp-result-extractor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "fake/**/*.ts", "demo/**/*.ts", "examples/**/*.ts"]
+}


### PR DESCRIPTION
CALL-E's MCP tool surface (plan_call/run_call/get_call_run) has no result_schema parameter -- that's a REST-API-only feature of the CALL-E Developer API. Over MCP, a completed run's `extracted` field is always CALL-E's own generic call metadata, never output shaped to a caller's schema, even though the transcript is always available.

This adds a small extraction layer that gets a schema-validated structured result from the transcript instead, with a pluggable reasoning provider (a Bedrock adapter included, plus a deterministic fake provider so the demo and tests need no credentials at all).

It also documents and regression-tests a real Bedrock Converse API pitfall: retrying a failed structured-output attempt by appending a plain-text follow-up after a tool_use block breaks the API's tool_use/tool_result pairing requirement and gets the whole retry rejected. The fix is to send the validation feedback back as a toolResult block instead.

## Test plan
- [x] `npm run demo` -- full pipeline with zero credentials and zero network calls
- [x] `npm test` -- 6/6 passing, including two regression tests against a stubbed Bedrock client covering both the pairing fix and the no-tool_use-returned edge case
- [x] `npm run check` -- `tsc --noEmit` clean
- [x] `python3 scripts/validate_repository.py` -- passes
