### PR TITLE
feat(apps): add quoterunner candidate discovery app

### DIFF
--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -1,34 +1,50 @@
 # QuoteRunner
 
-Build a vetted call list before anyone dials.
+Find out who is worth calling, call them, and put the answers in one table.
 
 Every call app in this repository starts from a list somebody already had — a
 fixture, a CSV, a study file, a hand-written plan. None of them answer the
 question that comes first: **who should I even call?**
 
-QuoteRunner answers it. Give it a job and a set of candidates; it returns the
-ones that publish a number, are open right now, and can be reached — each with
-the calling window taken from their published opening hours rather than
-configured by hand.
+QuoteRunner answers it, then acts on the answer. Give it a job and a set of
+candidates; it keeps the ones that publish a number, are open right now, and can
+be reached — each with the calling window taken from their published opening
+hours rather than configured by hand — calls them through CALL-E with a typed
+`result_schema`, and sorts what they said by price.
 
 The example is a windscreen quote. The pattern is not: three plumbers with a
-free slot this week, five suppliers who stock the part, the clinics within
-range that are open on a Saturday. Same mechanism, different subject.
+free slot this week, five suppliers who stock the part, the clinics within range
+that are open on a Saturday. Same mechanism, different subject.
 
 ## Setup
 
-Python 3.11 or newer. No dependencies.
+Python 3.11 or newer.
 
 ```bash
 cd apps/python/quoterunner
 python quoterunner.py --fixture example-candidates.json
 ```
 
-## What it prints
+That runs the preview, which needs no dependencies and no credentials. Only
+`--execute` needs the SDK:
+
+```bash
+pip install calle-ai
+```
+
+## Three modes, and only one of them dials
+
+| | places calls | needs credentials | what it is for |
+|---|---|---|---|
+| preview *(default)* | no | no | see who would be called, and why the rest would not |
+| `--simulate` | no | no | the whole pipeline against canned answers |
+| `--execute` | **yes** | yes | the real thing |
+
+### Preview
 
 ```text
-FIXTURE RUN -- NO CALL PLACED
-No transport, no telephone, no credentials. This edition cannot dial.
+PREVIEW -- NO CALL PLACED
+Nothing was dialed. No credentials were read and no request was sent.
 
 Job: Replace the windscreen on a 2019 Honda Civic
 Callable now: 4    Excluded: 3
@@ -46,23 +62,109 @@ Not called:
    - Bellweather Garage  +15****04  ->  closed today
    - Corner Tyre & Glass  +15****05  ->  no published opening hours -- we do not call blind
    - Old Forge Repairs  555**06  ->  Not a valid E.164 number: 555**06
+
+Read that list. If it is who you meant to call:
+
+    --simulate                    see the comparison, no calls
+    --execute --confirm cd284eb519d6   place the calls
 ```
 
 Three exclusions, three different reasons: a business whose opening hours do not
 cover today, one that publishes no hours at all, and one whose number is local
-rather than E.164. `--json` emits the same result as structured output, with a
-ready-to-use script per call.
+rather than E.164.
 
-## Why opening hours are the interesting part
+### Simulate
 
-`opening_hours` is an ordinary OpenStreetMap tag. Treated as decoration it tells
-you when a shop is open. Treated as a control it decides whether a call may be
-placed at all — and it is already published, for millions of businesses, in a
-machine-readable format nobody has to fill in.
+```bash
+python quoterunner.py --fixture example-candidates.json --simulate
+```
 
-That matters here because it removes a manual step from the safety layer.
-[`consent-gate`](../consent-gate/) requires the caller to supply "a recipient
-timezone and permitted calling window" in the plan. QuoteRunner derives that
+```text
+SIMULATED -- no call was placed
+
+Job: Replace the windscreen on a 2019 Honda Civic
+
+       price  available    warranty   business
+------------  ------------ ---------- ----------------------------
+  199.50 USD  2026-08-14   6 mo       Riverside Motors
+     245 USD  2026-08-11   12 mo      Northgate Auto Glass
+ 280-320 USD  2026-08-10   24 mo      Halloran & Sons Bodyshop
+
+Cheapest: Riverside Motors
+
+Answered, no price given:
+   - Quickfit Windscreens  ->  Service manager was out; asked to be called back tomorrow morning.
+```
+
+That is the output the whole app exists to produce. `--simulate` runs the real
+code path — create, wait, validate against the schema, sanitise, compare — with
+the transport swapped for canned answers, so the pipeline is demonstrable and
+testable without a telephone.
+
+### Execute
+
+```bash
+export CALLE_LIVE_CALLS_ENABLED=true
+export CALLE_API_KEY=...
+python quoterunner.py --fixture example-candidates.json \
+    --execute --confirm cd284eb519d6
+```
+
+**This dials real businesses.** Four independent gates stand in front of it, and
+any one of them alone stops the call:
+
+1. `CALLE_LIVE_CALLS_ENABLED=true` in the environment
+2. `CALLE_API_KEY` in the environment
+3. `--confirm <token>` — a token bound to this exact candidate list
+4. every candidate is re-checked against its opening hours **at dial time**
+
+## The confirmation token
+
+Gate 3 is the one worth explaining.
+
+The token is a hash of the job plus the sorted list of numbers. A token you got
+by reviewing one list will not authorise a different list. Re-run the plan an
+hour later, get different candidates because a shop closed, and the old token
+stops working:
+
+```text
+The confirmation token does not match this batch.
+That happens when the candidate list changed after you reviewed it -- a shop
+closed, the search returned something else. Review the plan again.
+Token for the batch above: 7f2a91c04e13
+```
+
+A confirmation that survives a change in what it confirms is not a
+confirmation. This is the same gap we reported through the hackathon's feedback
+form: `call start` has no machine-enforced confirmation, so the only thing
+between an agent and a live call is a sentence in a markdown file that a model
+is free to skip. A hash the operator has to paste back cannot be skipped by a
+model that is feeling confident.
+
+## What comes back
+
+`result_schema` asks for nine fields, every one of them a string with an
+explicit `unknown`, including the price. A receptionist who says *"depends on
+the glass, call back Tuesday"* is a normal outcome, not an error — and a numeric
+price field would force the model to invent a number to satisfy the type.
+
+`does_this_job`, `quoted_price`, `currency`, `price_covers`, `earliest_date`,
+`job_duration`, `warranty_months`, `callback_required`, `evidence_summary`.
+
+Answers are constrained before they are stored. The narrow fields have to match
+their shape — an ISO date, digits, a three-letter currency — or they become
+`unknown`. The two free-text fields are redacted for numbers and emails, because
+`evidence_summary` is model-written prose repeating what a person said out loud,
+and it can contain whatever they read out.
+
+Sorting is by the low end of the price, and quotes in different currencies are
+**not** ranked against each other. Converting them here would invent an exchange
+rate nobody quoted.
+
+## Relationship to consent-gate
+
+[`consent-gate`](../consent-gate/) requires the caller to supply *"a recipient
+timezone and permitted calling window"* in the plan. QuoteRunner derives that
 window from open data instead. The two compose: QuoteRunner decides who is
 callable and when; ConsentGate decides whether this particular call is
 permitted. This app does not duplicate its consent, do-not-call or idempotency
@@ -70,53 +172,74 @@ machinery, and is not a substitute for it.
 
 ## Safety
 
-- **No calls.** There is no live transport and no `--live` flag in this
-  edition. It cannot dial even if configured to.
-- **No credentials.** No account, no API key, no network request of any kind.
-- **No scheduler, no retry.** One pass. Nothing runs later or repeats by itself.
+- **Preview is the default.** Nothing dials unless `--execute` is passed and all
+  four gates open.
 - **Numbers are validated as E.164 before processing** and masked in every
   output path — report, JSON and error message alike. A test asserts that no
   full number from the fixture appears in any of them.
 - **A local or ambiguous number is rejected, never reformatted.** Guessing a
   country code is how you call a stranger in another country.
-- **Fictional data only.** The fixture uses the `+1 555-0100..555-0199` range,
-  reserved for fiction and belonging to nobody.
-- **Cancellation.** Stopping the process stops it. Nothing was dispatched, so
-  nothing needs recalling.
+- **One call per business per job.** The idempotency key is derived from the
+  number and the job, not from a timestamp, so re-running the same batch
+  collapses into the same call rather than dialling twice.
+- **Nothing is redialled automatically.** Busy, no answer and voicemail are
+  recorded and left alone. A redial the operator did not ask for is a second
+  call to a real business.
+- **Calls go out one at a time.** Twelve simultaneous calls from one number is
+  what an autodialer looks like from the receiving end.
+- **The base URL is pinned** to the official origin, or an explicit loopback
+  address for a fake server in tests. A base URL read from the environment is a
+  place where a live call can be silently redirected.
+- **The script forbids the agent from agreeing to anything.** It gathers
+  answers. Booking, buying and negotiating are out of scope by construction, and
+  it must say plainly that it is an AI if asked.
+- **Fictional data only in the fixture.** The `+1 555-0100..555-0199` range is
+  reserved for fiction and belongs to nobody.
+- **Cancellation.** Stopping the process stops it. Calls already placed are
+  listed with their call id; nothing is scheduled to run later.
 - Not for medical, legal, financial or emergency workflows.
 
 ## Deliberate limits
 
 - **Opening hours that cannot be parsed read as closed**, not open. An
-  optimistic parse here calls a real person at an hour nobody agreed to. A test
-  covers the unparseable case explicitly.
+  optimistic parse here calls a real person at an hour nobody agreed to.
 - **A business with no published hours is excluded**, even when it publishes a
   number. Reachable is not the same as callable.
-- **Exclusions are output, not a silent filter.** Every excluded candidate is
-  listed with its reason. A run that quietly dropped half its candidates looks
-  identical to one that found nothing worth calling, and the difference matters
-  to whoever reads the result.
+- **Exclusions are output, not a silent filter.** A run that quietly dropped
+  half its candidates looks identical to one that found nothing worth calling,
+  and the difference matters to whoever reads the result.
 - **Twelve candidates per run, and the cap is not a flag.** A limit the caller
   can raise mid-run is not a limit. The overflow is reported, not dropped.
-- **The script forbids the agent from agreeing to anything.** It gathers
-  answers. Booking, buying and negotiating are out of scope by construction, and
-  it must say plainly that it is an AI if asked.
+- **A create that returns no call id is never retried.** The call may be live
+  and there is nothing to reconcile it by, so it is recorded loudly instead.
+- **An unparseable price does not become zero.** It sorts last as "no price
+  given", rather than winning the comparison.
 
 ## Tests
 
 ```bash
 cd apps/python/quoterunner
-python -m unittest test_quoterunner -v
+python -m unittest discover -p "test_*.py"
 ```
 
 ```text
-Ran 34 tests in 0.005s
+Ran 91 tests in 0.011s
 OK
 ```
 
-The regressions guard the ways a call list goes wrong: a weekday range that
-does not include today, a split-hours gap at lunchtime, hours that cannot be
-parsed, a missing `opening_hours` value, a local number that must not be
-reformatted into a different country, the per-run cap, every candidate landing
-in exactly one bucket, and no full number reaching the report, the JSON or an
-error string.
+No test places a call or reads a credential. The CallsAPI is a fake, which is
+the point: the gates that stop a real call have to be testable without placing
+one.
+
+`test_quoterunner.py` covers the screening layer — a weekday range that does not
+include today, a split-hours gap at lunchtime, hours that cannot be parsed, a
+missing `opening_hours` value, a local number that must not be reformatted into
+a different country, the per-run cap, every candidate landing in exactly one
+bucket, and no full number reaching the report, the JSON or an error string.
+
+`test_execution.py` covers the calling layer — each of the four gates
+independently, a base URL pointing at somebody else's host, a shop that closed
+between planning and dialling, a create that raises, a create with no id, a lost
+result, a no-answer that must not be redialled, a result that does not match the
+schema, a phone number smuggled into a date field, and a price range ranked on
+its low end.

--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -1,0 +1,122 @@
+# QuoteRunner
+
+Build a vetted call list before anyone dials.
+
+Every call app in this repository starts from a list somebody already had — a
+fixture, a CSV, a study file, a hand-written plan. None of them answer the
+question that comes first: **who should I even call?**
+
+QuoteRunner answers it. Give it a job and a set of candidates; it returns the
+ones that publish a number, are open right now, and can be reached — each with
+the calling window taken from their published opening hours rather than
+configured by hand.
+
+The example is a windscreen quote. The pattern is not: three plumbers with a
+free slot this week, five suppliers who stock the part, the clinics within
+range that are open on a Saturday. Same mechanism, different subject.
+
+## Setup
+
+Python 3.11 or newer. No dependencies.
+
+```bash
+cd apps/python/quoterunner
+python quoterunner.py --fixture example-candidates.json
+```
+
+## What it prints
+
+```text
+FIXTURE RUN -- NO CALL PLACED
+No transport, no telephone, no credentials. This edition cannot dial.
+
+Job: Replace the windscreen on a 2019 Honda Civic
+Callable now: 4    Excluded: 3
+
+1. Northgate Auto Glass  +15****00
+     open today: 08:00-18:00
+2. Riverside Motors  +15****01
+     open today: 07:30-19:00
+3. Halloran & Sons Bodyshop  +15****02
+     open today: 09:00-13:00, 15:00-19:00
+4. Quickfit Windscreens  +15****03
+     open today: 00:00-23:59
+
+Not called:
+   - Bellweather Garage  +15****04  ->  closed today
+   - Corner Tyre & Glass  +15****05  ->  no published opening hours -- we do not call blind
+   - Old Forge Repairs  555**06  ->  Not a valid E.164 number: 555**06
+```
+
+Three exclusions, three different reasons: a business whose opening hours do not
+cover today, one that publishes no hours at all, and one whose number is local
+rather than E.164. `--json` emits the same result as structured output, with a
+ready-to-use script per call.
+
+## Why opening hours are the interesting part
+
+`opening_hours` is an ordinary OpenStreetMap tag. Treated as decoration it tells
+you when a shop is open. Treated as a control it decides whether a call may be
+placed at all — and it is already published, for millions of businesses, in a
+machine-readable format nobody has to fill in.
+
+That matters here because it removes a manual step from the safety layer.
+[`consent-gate`](../consent-gate/) requires the caller to supply "a recipient
+timezone and permitted calling window" in the plan. QuoteRunner derives that
+window from open data instead. The two compose: QuoteRunner decides who is
+callable and when; ConsentGate decides whether this particular call is
+permitted. This app does not duplicate its consent, do-not-call or idempotency
+machinery, and is not a substitute for it.
+
+## Safety
+
+- **No calls.** There is no live transport and no `--live` flag in this
+  edition. It cannot dial even if configured to.
+- **No credentials.** No account, no API key, no network request of any kind.
+- **No scheduler, no retry.** One pass. Nothing runs later or repeats by itself.
+- **Numbers are validated as E.164 before processing** and masked in every
+  output path — report, JSON and error message alike. A test asserts that no
+  full number from the fixture appears in any of them.
+- **A local or ambiguous number is rejected, never reformatted.** Guessing a
+  country code is how you call a stranger in another country.
+- **Fictional data only.** The fixture uses the `+1 555-0100..555-0199` range,
+  reserved for fiction and belonging to nobody.
+- **Cancellation.** Stopping the process stops it. Nothing was dispatched, so
+  nothing needs recalling.
+- Not for medical, legal, financial or emergency workflows.
+
+## Deliberate limits
+
+- **Opening hours that cannot be parsed read as closed**, not open. An
+  optimistic parse here calls a real person at an hour nobody agreed to. A test
+  covers the unparseable case explicitly.
+- **A business with no published hours is excluded**, even when it publishes a
+  number. Reachable is not the same as callable.
+- **Exclusions are output, not a silent filter.** Every excluded candidate is
+  listed with its reason. A run that quietly dropped half its candidates looks
+  identical to one that found nothing worth calling, and the difference matters
+  to whoever reads the result.
+- **Twelve candidates per run, and the cap is not a flag.** A limit the caller
+  can raise mid-run is not a limit. The overflow is reported, not dropped.
+- **The script forbids the agent from agreeing to anything.** It gathers
+  answers. Booking, buying and negotiating are out of scope by construction, and
+  it must say plainly that it is an AI if asked.
+
+## Tests
+
+```bash
+cd apps/python/quoterunner
+python -m unittest test_quoterunner -v
+```
+
+```text
+Ran 34 tests in 0.005s
+OK
+```
+
+The regressions guard the ways a call list goes wrong: a weekday range that
+does not include today, a split-hours gap at lunchtime, hours that cannot be
+parsed, a missing `opening_hours` value, a local number that must not be
+reformatted into a different country, the per-run cap, every candidate landing
+in exactly one bucket, and no full number reaching the report, the JSON or an
+error string.

--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -116,7 +116,8 @@ any one of them alone stops the call:
 1. `CALLE_LIVE_CALLS_ENABLED=true` in the environment
 2. `CALLE_API_KEY` in the environment
 3. `--confirm <token>` — a token bound to this exact candidate list
-4. every candidate is re-checked against its opening hours **at dial time**
+4. every candidate is re-checked against its opening hours **at dial time, in
+   its own timezone**, and one that publishes no timezone is not dialled
 
 ## The confirmation token
 
@@ -140,6 +141,26 @@ form: `call start` has no machine-enforced confirmation, so the only thing
 between an agent and a live call is a sentence in a markdown file that a model
 is free to skip. A hash the operator has to paste back cannot be skipped by a
 model that is feeling confident.
+
+## Timezones
+
+Opening hours are published in the shop's own local time, so they are read on
+the shop's own clock. A host in Mexico City reading hours for a shop in Austin
+is an hour out; one in Europe is seven — which is how you ring a closed shop, or
+a person asleep.
+
+Each candidate carries an IANA `timezone`. It is **never** derived from the
+phone number, the country code or the locale: those are guesses, and a guess
+here calls a stranger at three in the morning. A candidate with no timezone is
+excluded from the live path for the same reason one with no published hours is —
+we cannot tell whether it is open there.
+
+`--timezone America/Chicago` lets the operator state the zone for a batch they
+know is single-region. Stating it is not guessing it.
+
+```bash
+python quoterunner.py --fixture example-candidates.json     --timezone America/Chicago --execute --confirm <token>
+```
 
 ## What comes back
 
@@ -179,9 +200,16 @@ machinery, and is not a substitute for it.
   full number from the fixture appears in any of them.
 - **A local or ambiguous number is rejected, never reformatted.** Guessing a
   country code is how you call a stranger in another country.
-- **One call per business per job.** The idempotency key is derived from the
-  number and the job, not from a timestamp, so re-running the same batch
-  collapses into the same call rather than dialling twice.
+- **One call per business per script.** The idempotency key is derived from the
+  number, the whole spoken script and the locale — not from a timestamp — so
+  re-running the same batch collapses into the same call rather than dialling
+  twice. Keying on the job alone would have made a call in a different language,
+  or on behalf of a different person, replay the earlier result instead of
+  happening.
+- **A finished call is not a successful one.** `failed` and `canceled` are
+  terminal, and their `structured_result` can still satisfy the schema. Only a
+  `completed` call that CALL-E did not flag as unfinished produces a quote; the
+  rest are listed with what actually happened.
 - **Nothing is redialled automatically.** Busy, no answer and voicemail are
   recorded and left alone. A redial the operator did not ask for is a second
   call to a real business.
@@ -223,7 +251,7 @@ python -m unittest discover -p "test_*.py"
 ```
 
 ```text
-Ran 96 tests in 0.116s
+Ran 111 tests in 0.122s
 OK
 ```
 
@@ -242,7 +270,10 @@ independently, a base URL pointing at somebody else's host, a shop that closed
 between planning and dialling, a create that raises, a create with no id, a lost
 result, a no-answer that must not be redialled, a result that does not match the
 schema, a phone number smuggled into a date field, and a price range ranked on
-its low end.
+its low end. Three of them come from the review of this pull request: a failed
+call must not produce a rankable quote, the same instant must give a different
+answer in New York and in Los Angeles, and changing who the call is on behalf of
+must change the idempotency key.
 
 It also checks our payload against the **real published SDK**: that `calls.create`
 still accepts every field we send, that `recipients` is still the plural list

--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -211,10 +211,12 @@ machinery, and is not a substitute for it.
   rang anybody. A timeout or a 5xx may have been accepted, with the phone
   ringing while we read the exception — so it is recorded as `unknown`, carries
   its idempotency key for reconciliation, and is never quietly retried.
-- **A finished call is not a successful one.** `failed` and `canceled` are
-  terminal, and their `structured_result` can still satisfy the schema. Only a
-  `completed` call that CALL-E did not flag as unfinished produces a quote; the
-  rest are listed with what actually happened.
+- **A finished call is not a successful one, and silence is not consent.**
+  `failed` and `canceled` are terminal, and their `structured_result` can still
+  satisfy the schema. A quote requires a `completed` status **and** an explicit
+  `task_completed: true`. A missing or null attestation is not treated as
+  success: nobody said the call finished, and an unattested call is exactly the
+  one whose answers you should not put a price on.
 - **Nothing is redialled automatically.** Busy, no answer and voicemail are
   recorded and left alone. A redial the operator did not ask for is a second
   call to a real business.
@@ -228,8 +230,14 @@ machinery, and is not a substitute for it.
   it must say plainly that it is an AI if asked.
 - **Fictional data only in the fixture.** The `+1 555-0100..555-0199` range is
   reserved for fiction and belongs to nobody.
-- **Cancellation.** Stopping the process stops it. Calls already placed are
-  listed with their call id; nothing is scheduled to run later.
+- **Cancellation, stated accurately.** Stopping the process stops *this batch
+  from starting more calls*. It does **not** stop a call CALL-E has already
+  accepted — that call lives on the provider's side and will run to its end.
+  Because of that, every accepted call is written into the results with its
+  call id and idempotency key **before** the wait begins, and `on_accepted`
+  fires at the same moment so a caller can persist it somewhere durable.
+  Killing the process mid-call therefore leaves a record of what is still in
+  flight instead of erasing it. Nothing is scheduled to run later.
 - Not for medical, legal, financial or emergency workflows.
 
 ## Deliberate limits
@@ -256,7 +264,7 @@ python -m unittest discover -p "test_*.py"
 ```
 
 ```text
-Ran 119 tests in 0.138s
+Ran 127 tests in 0.140s
 OK
 ```
 

--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -115,7 +115,8 @@ any one of them alone stops the call:
 
 1. `CALLE_LIVE_CALLS_ENABLED=true` in the environment
 2. `CALLE_API_KEY` in the environment
-3. `--confirm <token>` — a token bound to this exact candidate list
+3. `--confirm <token>` — a token bound to this exact batch: the numbers, the
+   job, who the call is on behalf of, and the language it is made in
 4. every candidate is re-checked against its opening hours **at dial time, in
    its own timezone**, and one that publishes no timezone is not dialled
 
@@ -206,6 +207,10 @@ machinery, and is not a substitute for it.
   twice. Keying on the job alone would have made a call in a different language,
   or on behalf of a different person, replay the earlier result instead of
   happening.
+- **A refusal and a lost answer are different facts.** A rejected request never
+  rang anybody. A timeout or a 5xx may have been accepted, with the phone
+  ringing while we read the exception — so it is recorded as `unknown`, carries
+  its idempotency key for reconciliation, and is never quietly retried.
 - **A finished call is not a successful one.** `failed` and `canceled` are
   terminal, and their `structured_result` can still satisfy the schema. Only a
   `completed` call that CALL-E did not flag as unfinished produces a quote; the
@@ -251,7 +256,7 @@ python -m unittest discover -p "test_*.py"
 ```
 
 ```text
-Ran 111 tests in 0.122s
+Ran 119 tests in 0.138s
 OK
 ```
 
@@ -272,8 +277,9 @@ result, a no-answer that must not be redialled, a result that does not match the
 schema, a phone number smuggled into a date field, and a price range ranked on
 its low end. Three of them come from the review of this pull request: a failed
 call must not produce a rankable quote, the same instant must give a different
-answer in New York and in Los Angeles, and changing who the call is on behalf of
-must change the idempotency key.
+answer in New York and in Los Angeles, changing who the call is on behalf of
+must change both the idempotency key and the confirmation token, and a timeout
+must not be filed as a refusal.
 
 It also checks our payload against the **real published SDK**: that `calls.create`
 still accepts every field we send, that `recipients` is still the plural list

--- a/apps/python/quoterunner/README.md
+++ b/apps/python/quoterunner/README.md
@@ -223,7 +223,7 @@ python -m unittest discover -p "test_*.py"
 ```
 
 ```text
-Ran 91 tests in 0.011s
+Ran 96 tests in 0.116s
 OK
 ```
 
@@ -237,9 +237,16 @@ missing `opening_hours` value, a local number that must not be reformatted into
 a different country, the per-run cap, every candidate landing in exactly one
 bucket, and no full number reaching the report, the JSON or an error string.
 
-`test_execution.py` covers the calling layer — each of the four gates
+`test_execution.py` covers the calling layer and the SDK contract — each of the four gates
 independently, a base URL pointing at somebody else's host, a shop that closed
 between planning and dialling, a create that raises, a create with no id, a lost
 result, a no-answer that must not be redialled, a result that does not match the
 schema, a phone number smuggled into a date field, and a price range ranked on
 its low end.
+
+It also checks our payload against the **real published SDK**: that `calls.create`
+still accepts every field we send, that `recipients` is still the plural list
+form, and that `wait_for_result` still takes the keywords we pass. A signature
+change in `calle-ai` would otherwise stay invisible until a call fails live —
+and the only times this app runs live are in front of a camera or in front of a
+real business.

--- a/apps/python/quoterunner/example-candidates.json
+++ b/apps/python/quoterunner/example-candidates.json
@@ -9,7 +9,8 @@
       "opening_hours": "Mo-Fr 08:00-18:00; Sa 09:00-13:00",
       "address": "12 Northgate Road",
       "locality": "Springfield",
-      "source_id": "fixture/1"
+      "source_id": "fixture/1",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Riverside Motors",
@@ -17,7 +18,8 @@
       "opening_hours": "Mo-Sa 07:30-19:00",
       "address": "88 Riverside Drive",
       "locality": "Springfield",
-      "source_id": "fixture/2"
+      "source_id": "fixture/2",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Halloran & Sons Bodyshop",
@@ -25,7 +27,8 @@
       "opening_hours": "Mo-Fr 09:00-13:00,15:00-19:00",
       "address": "3 Mill Lane",
       "locality": "Springfield",
-      "source_id": "fixture/3"
+      "source_id": "fixture/3",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Quickfit Windscreens",
@@ -33,7 +36,8 @@
       "opening_hours": "24/7",
       "address": "The Retail Park",
       "locality": "Springfield",
-      "source_id": "fixture/4"
+      "source_id": "fixture/4",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Bellweather Garage",
@@ -41,7 +45,8 @@
       "opening_hours": "Sa-Su 10:00-16:00",
       "address": "5 Bell Street",
       "locality": "Springfield",
-      "source_id": "fixture/5"
+      "source_id": "fixture/5",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Corner Tyre & Glass",
@@ -49,7 +54,8 @@
       "opening_hours": "",
       "address": "1 Market Square",
       "locality": "Springfield",
-      "source_id": "fixture/6"
+      "source_id": "fixture/6",
+      "timezone": "America/Chicago"
     },
     {
       "name": "Old Forge Repairs",
@@ -57,7 +63,8 @@
       "opening_hours": "Mo-Fr 09:00-17:00",
       "address": "Forge Yard",
       "locality": "Springfield",
-      "source_id": "fixture/7"
+      "source_id": "fixture/7",
+      "timezone": "America/Chicago"
     }
   ]
 }

--- a/apps/python/quoterunner/example-candidates.json
+++ b/apps/python/quoterunner/example-candidates.json
@@ -1,0 +1,63 @@
+{
+  "job": "Replace the windscreen on a 2019 Honda Civic",
+  "requester": "Sam",
+  "note": "All numbers are from the +1 555-0100..555-0199 range, reserved for fiction and belonging to nobody.",
+  "candidates": [
+    {
+      "name": "Northgate Auto Glass",
+      "phone": "+15550100",
+      "opening_hours": "Mo-Fr 08:00-18:00; Sa 09:00-13:00",
+      "address": "12 Northgate Road",
+      "locality": "Springfield",
+      "source_id": "fixture/1"
+    },
+    {
+      "name": "Riverside Motors",
+      "phone": "+15550101",
+      "opening_hours": "Mo-Sa 07:30-19:00",
+      "address": "88 Riverside Drive",
+      "locality": "Springfield",
+      "source_id": "fixture/2"
+    },
+    {
+      "name": "Halloran & Sons Bodyshop",
+      "phone": "+15550102",
+      "opening_hours": "Mo-Fr 09:00-13:00,15:00-19:00",
+      "address": "3 Mill Lane",
+      "locality": "Springfield",
+      "source_id": "fixture/3"
+    },
+    {
+      "name": "Quickfit Windscreens",
+      "phone": "+15550103",
+      "opening_hours": "24/7",
+      "address": "The Retail Park",
+      "locality": "Springfield",
+      "source_id": "fixture/4"
+    },
+    {
+      "name": "Bellweather Garage",
+      "phone": "+15550104",
+      "opening_hours": "Sa-Su 10:00-16:00",
+      "address": "5 Bell Street",
+      "locality": "Springfield",
+      "source_id": "fixture/5"
+    },
+    {
+      "name": "Corner Tyre & Glass",
+      "phone": "+15550105",
+      "opening_hours": "",
+      "address": "1 Market Square",
+      "locality": "Springfield",
+      "source_id": "fixture/6"
+    },
+    {
+      "name": "Old Forge Repairs",
+      "phone": "555 0106",
+      "opening_hours": "Mo-Fr 09:00-17:00",
+      "address": "Forge Yard",
+      "locality": "Springfield",
+      "source_id": "fixture/7"
+    }
+  ]
+}

--- a/apps/python/quoterunner/execution.py
+++ b/apps/python/quoterunner/execution.py
@@ -40,6 +40,7 @@ from quoterunner import (
     PlanError,
     build_script,
     is_open,
+    local_now,
     mask,
     window_text,
 )
@@ -48,8 +49,15 @@ DEFAULT_BASE_URL = "https://api.heycall-e.com"
 
 # What CALL-E reports when a call is over. Nothing is retried automatically:
 # a redial the operator did not ask for is a second call to a real business.
-TERMINAL = {"completed", "failed", "canceled", "cancelled"}
+TERMINAL = {"completed", "failed", "canceled", "cancelled", "succeeded"}
 NO_ANSWER = {"busy", "no_answer", "voicemail"}
+
+# Terminal is not the same as successful. A `failed` or `canceled` call is over,
+# but whatever it returned is the wreckage of a call that did not happen the way
+# it was meant to -- and a partially populated structured_result from one of
+# those can still satisfy the schema. Ranking it next to a real quote puts a
+# price in the table that nobody actually said.
+EXITOSO = {"completed", "succeeded"}
 
 MAX_WAIT_SECONDS = 900
 POLL_SECONDS = 5
@@ -237,14 +245,26 @@ def check_confirmation(candidates: list[Candidate], job: str, token: str | None)
 # ---------------------------------------------------------------------------
 # Call arguments
 # ---------------------------------------------------------------------------
-def idempotency_key(candidate: Candidate, job: str) -> str:
-    """Stable per business and job, so a re-run cannot dial the same shop twice.
+def idempotency_key(
+    candidate: Candidate, job: str, requester: str = "", locale: str = "en-US"
+) -> str:
+    """Stable per business and per *script*, so a re-run cannot dial twice.
 
-    Derived from the number and the job rather than from a timestamp: two runs
-    of the same batch are the same intent and must collapse into one call.
+    Derived from the call content rather than from a timestamp: two runs of the
+    same batch are the same intent and must collapse into one call.
+
+    It covers the whole spoken script, not just the job line. Keying on the job
+    alone meant that changing the requester's name, or the language the call is
+    made in, still produced the same key -- so a genuinely different call would
+    be deduplicated against the earlier one and CALL-E would replay the old
+    result instead of placing the new call.
     """
     seed = json.dumps(
-        {"phone": candidate.phone, "job": job.strip()},
+        {
+            "phone": candidate.phone,
+            "task": build_script(candidate, job, requester),
+            "locale": locale,
+        },
         ensure_ascii=False,
         sort_keys=True,
     )
@@ -264,7 +284,7 @@ def call_arguments(
                 "source_id": candidate.source_id or "",
             }
         },
-        "idempotency_key": idempotency_key(candidate, job),
+        "idempotency_key": idempotency_key(candidate, job, requester, locale),
     }
 
 
@@ -365,14 +385,40 @@ def run_batch(
         # Re-checked here rather than trusted from planning time. A batch of
         # twelve calls takes minutes, and a shop that closes at 18:00 must not
         # be dialled at 18:04 because it was open when the plan was written.
-        now = moment or datetime.now()
-        if not is_open(candidate.opening_hours, now):
+        #
+        # And checked in the shop's own zone, not the host's. This loop is the
+        # last thing that runs before a real telephone rings, so it is the one
+        # place that must not be reading a Texas shop's hours off a clock in
+        # Mexico City.
+        if not candidate.timezone:
+            say(f"[{index}/{len(candidates)}] {candidate.name}: no timezone, skipped")
+            results.append({
+                "name": candidate.name,
+                "phone_masked": candidate.masked,
+                "status": "not_called",
+                "reason": "no timezone published -- cannot tell what time it is there",
+                "quote": None,
+            })
+            continue
+
+        try:
+            here = local_now(candidate, moment)
+        except PlanError as error:
+            say(f"[{index}/{len(candidates)}] {candidate.name}: {error}")
+            results.append({
+                "name": candidate.name, "phone_masked": candidate.masked,
+                "status": "not_called", "reason": str(error), "quote": None,
+            })
+            continue
+
+        if not is_open(candidate.opening_hours, here):
             say(f"[{index}/{len(candidates)}] {candidate.name}: closed now, skipped")
             results.append({
                 "name": candidate.name,
                 "phone_masked": candidate.masked,
                 "status": "not_called",
-                "reason": f"closed at dial time (today {window_text(candidate.opening_hours, now)})",
+                "reason": (f"closed at dial time in {candidate.timezone} "
+                           f"(today {window_text(candidate.opening_hours, here)})"),
                 "quote": None,
             })
             continue
@@ -434,12 +480,23 @@ def run_batch(
             })
             continue
 
-        if status not in TERMINAL or not _valid_result(structured):
+        # `task_completed` is CALL-E saying whether the agent actually finished
+        # what it was sent to do. Absent means the provider did not report it;
+        # an explicit False means it did not, and that is not a quote.
+        completado = (final or {}).get("task_completed")
+
+        if status not in EXITOSO or completado is False or not _valid_result(structured):
+            if status not in EXITOSO:
+                motivo = f"the call ended as {status}, not as a completed call"
+            elif completado is False:
+                motivo = "CALL-E reported the task was not completed"
+            else:
+                motivo = "the call did not return the full quote schema"
             say(f"      {status}, no usable answer")
             results.append({
                 "name": candidate.name, "phone_masked": candidate.masked,
                 "call_id": call_id, "status": status,
-                "reason": "the call did not return the full quote schema",
+                "reason": motivo,
                 "quote": None,
             })
             continue

--- a/apps/python/quoterunner/execution.py
+++ b/apps/python/quoterunner/execution.py
@@ -1,0 +1,609 @@
+"""QuoteRunner execution layer — place the planned calls through CALL-E.
+
+`quoterunner.py` decides *who* is callable. This module places the calls and
+turns what the businesses said into one comparable table.
+
+Three modes, and only the third one dials:
+
+    preview     the plan, masked, no credentials, no network      (default)
+    simulate    the full pipeline against canned answers          (--simulate)
+    execute     real calls through CALL-E                         (--execute)
+
+`--execute` is gated four ways, deliberately:
+
+    1. CALLE_LIVE_CALLS_ENABLED=true   in the environment
+    2. CALLE_API_KEY                   in the environment
+    3. --confirm <token>               a token bound to this exact batch
+    4. every candidate still open      re-checked at dial time, not at plan time
+
+Gate 3 is the interesting one. The token is a hash of the job plus the sorted
+list of numbers, so a token you obtained by reviewing one list will not
+authorise a different list. Re-run the plan an hour later, get different
+candidates because a shop closed, and the old token stops working. That is the
+point: a confirmation that survives a change in what it confirms is not a
+confirmation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time as _time
+from datetime import datetime
+from typing import Any, Callable, Protocol
+
+from quoterunner import (
+    Candidate,
+    PlanError,
+    build_script,
+    is_open,
+    mask,
+    window_text,
+)
+
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+
+# What CALL-E reports when a call is over. Nothing is retried automatically:
+# a redial the operator did not ask for is a second call to a real business.
+TERMINAL = {"completed", "failed", "canceled", "cancelled"}
+NO_ANSWER = {"busy", "no_answer", "voicemail"}
+
+MAX_WAIT_SECONDS = 900
+POLL_SECONDS = 5
+
+
+class QuoteError(Exception):
+    """Never carries a full phone number. Tests assert this."""
+
+
+class CallsAPI(Protocol):
+    def create(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    def wait_for_result(
+        self, call_id: str, *, timeout_seconds: int, interval_seconds: int
+    ) -> dict[str, Any]: ...
+
+
+# ---------------------------------------------------------------------------
+# What we ask CALL-E to bring back
+# ---------------------------------------------------------------------------
+# Every field is a string with an explicit "unknown", including the price. A
+# receptionist who says "depends on the glass, call back Tuesday" is a normal
+# outcome, not an error, and a numeric field would force the model to invent a
+# number to satisfy the type.
+QUOTE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "does_this_job",
+        "quoted_price",
+        "currency",
+        "price_covers",
+        "earliest_date",
+        "job_duration",
+        "warranty_months",
+        "callback_required",
+        "evidence_summary",
+    ],
+    "properties": {
+        "does_this_job": {
+            "type": "string",
+            "enum": ["yes", "no", "unknown"],
+            "description": "Whether this business does the job at all.",
+        },
+        "quoted_price": {
+            "type": "string",
+            "description": (
+                "The amount only, digits and an optional decimal point, e.g. "
+                "'245' or '245.50'. A range becomes 'low-high', e.g. '200-260'. "
+                "Use 'unknown' if no price was given. Never guess a price."
+            ),
+        },
+        "currency": {
+            "type": "string",
+            "description": "ISO 4217 code such as USD, EUR, MXN, or 'unknown'.",
+        },
+        "price_covers": {
+            "type": "string",
+            "enum": ["parts_and_labour", "labour_only", "parts_only", "unknown"],
+        },
+        "earliest_date": {
+            "type": "string",
+            "description": "YYYY-MM-DD if a date was given, otherwise 'unknown'.",
+        },
+        "job_duration": {
+            "type": "string",
+            "description": "How long the work takes, in their words, or 'unknown'.",
+        },
+        "warranty_months": {
+            "type": "string",
+            "description": "Number of months as digits, '0' if none, or 'unknown'.",
+        },
+        "callback_required": {
+            "type": "string",
+            "enum": ["yes", "no", "unknown"],
+            "description": "Whether they asked to be called back to quote properly.",
+        },
+        "evidence_summary": {
+            "type": "string",
+            "description": (
+                "One or two sentences on what was actually said. No phone "
+                "numbers, no names of individuals, no personal data."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+REQUIRED_FIELDS = tuple(QUOTE_SCHEMA["required"])
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+# `evidence_summary` is model-written prose repeating what a person said out
+# loud, so it can contain anything they read out: a mobile number, an email, an
+# order reference. Masking the phone column and then writing that sentence
+# verbatim leaks the same class of data one field over.
+_PHONE_IN_TEXT = re.compile(r"\+?\d[\d\s\-().]{7,}\d")
+_EMAIL_IN_TEXT = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, str):
+        out = _EMAIL_IN_TEXT.sub("[email redacted]", value)
+        return _PHONE_IN_TEXT.sub("[number redacted]", out)
+    if isinstance(value, dict):
+        return {k: redact(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact(v) for v in value]
+    return value
+
+
+# The narrow fields are not prose and must not go through `redact`: an ISO date
+# like 2026-08-11 is eight digits with separators, which is exactly what a
+# phone-number pattern matches, and the first version of this file quietly
+# turned every availability date into "[number redacted]".
+#
+# So each narrow field is checked against the shape it is supposed to have, and
+# anything else becomes "unknown". That covers the leak too -- a phone number
+# smuggled into `earliest_date` does not match a date and never survives.
+_SHAPES = {
+    "quoted_price": re.compile(r"^\d+(?:\.\d+)?(?:\s*-\s*\d+(?:\.\d+)?)?$"),
+    "currency": re.compile(r"^[A-Za-z]{3}$"),
+    "earliest_date": re.compile(r"^\d{4}-\d{2}-\d{2}$"),
+    "warranty_months": re.compile(r"^\d{1,3}$"),
+}
+
+# Free text. Whatever the person said out loud can end up in here.
+_PROSE = ("evidence_summary", "job_duration")
+
+
+def sanitise_quote(quote: dict[str, Any]) -> dict[str, Any]:
+    """Constrain the narrow fields, redact the prose ones."""
+    clean: dict[str, Any] = {}
+    for field, value in quote.items():
+        if field in _SHAPES:
+            clean[field] = value if _SHAPES[field].match(str(value).strip()) else "unknown"
+        elif field in _PROSE:
+            clean[field] = redact(value)
+        else:
+            clean[field] = value
+    return clean
+
+
+# ---------------------------------------------------------------------------
+# The confirmation token
+# ---------------------------------------------------------------------------
+def confirmation_token(candidates: list[Candidate], job: str) -> str:
+    """Fingerprint of this exact batch. One different number, different token.
+
+    This implements the gap we reported to CALL-E in the Most Valuable Feedback
+    submission: `call start` has no machine-enforced confirmation, so the only
+    thing between an agent and a live call is a sentence in a markdown file that
+    a model is free to skip. A hash the operator has to paste back cannot be
+    skipped by a model that is feeling confident.
+    """
+    payload = json.dumps(
+        {
+            "job": job.strip(),
+            "phones": sorted(c.phone for c in candidates),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def check_confirmation(candidates: list[Candidate], job: str, token: str | None) -> None:
+    expected = confirmation_token(candidates, job)
+    if not token:
+        raise QuoteError(
+            "--execute needs --confirm. Read the plan above, then re-run with:\n"
+            f"    --confirm {expected}"
+        )
+    if token.strip().lower() != expected:
+        raise QuoteError(
+            "The confirmation token does not match this batch.\n"
+            "That happens when the candidate list changed after you reviewed "
+            "it -- a shop closed, the search returned something else. Review "
+            "the plan again.\n"
+            f"Token for the batch above: {expected}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Call arguments
+# ---------------------------------------------------------------------------
+def idempotency_key(candidate: Candidate, job: str) -> str:
+    """Stable per business and job, so a re-run cannot dial the same shop twice.
+
+    Derived from the number and the job rather than from a timestamp: two runs
+    of the same batch are the same intent and must collapse into one call.
+    """
+    seed = json.dumps(
+        {"phone": candidate.phone, "job": job.strip()},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return "quoterunner-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
+
+
+def call_arguments(
+    candidate: Candidate, job: str, requester: str, locale: str = "en-US"
+) -> dict[str, Any]:
+    return {
+        "task": build_script(candidate, job, requester),
+        "recipients": [{"phones": [candidate.phone], "locale": locale}],
+        "result_schema": QUOTE_SCHEMA,
+        "metadata": {
+            "call-e/customerMetadata": {
+                "app": "quoterunner",
+                "source_id": candidate.source_id or "",
+            }
+        },
+        "idempotency_key": idempotency_key(candidate, job),
+    }
+
+
+def validate_base_url(value: str) -> str:
+    """Only the official origin, or an explicit loopback test server.
+
+    A base URL read from the environment is a place where a live call can be
+    silently redirected to somebody else's server, so it is pinned rather than
+    trusted.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(value)
+    official = (
+        parsed.scheme == "https"
+        and parsed.hostname == "api.heycall-e.com"
+        and parsed.port in (None, 443)
+    )
+    loopback = (
+        parsed.scheme == "http"
+        and parsed.hostname in ("127.0.0.1", "localhost")
+        and parsed.port is not None
+    )
+    clean = (
+        parsed.path in ("", "/")
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
+    if official and clean:
+        return DEFAULT_BASE_URL
+    if loopback and clean:
+        return value.rstrip("/")
+    raise QuoteError(
+        "CALLE_BASE_URL must be https://api.heycall-e.com, or an exact "
+        "loopback address with a port for a fake server in tests"
+    )
+
+
+def build_calls_api(base_url: str | None = None) -> CallsAPI:
+    """Import and construct the SDK client. Only ever called by --execute."""
+    if os.environ.get("CALLE_LIVE_CALLS_ENABLED", "").strip().lower() != "true":
+        raise QuoteError("--execute requires CALLE_LIVE_CALLS_ENABLED=true")
+
+    api_key = os.environ.get("CALLE_API_KEY", "").strip()
+    if not api_key:
+        raise QuoteError("--execute requires CALLE_API_KEY")
+
+    try:
+        from calle import CalleClient
+    except ImportError:  # pragma: no cover - dependency guidance
+        raise QuoteError(
+            "Missing dependency. Install with:  pip install calle-ai"
+        ) from None
+
+    url = validate_base_url(base_url or os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))
+    return CalleClient(api_key=api_key, base_url=url).calls
+
+
+# ---------------------------------------------------------------------------
+# Running the batch
+# ---------------------------------------------------------------------------
+def _valid_result(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    for field in REQUIRED_FIELDS:
+        item = value.get(field)
+        if not isinstance(item, str):
+            return False
+        allowed = QUOTE_SCHEMA["properties"][field].get("enum")
+        if allowed is not None and item not in allowed:
+            return False
+    return True
+
+
+def run_batch(
+    candidates: list[Candidate],
+    job: str,
+    requester: str,
+    calls: CallsAPI,
+    *,
+    moment: datetime | None = None,
+    locale: str = "en-US",
+    timeout_seconds: int = MAX_WAIT_SECONDS,
+    on_event: Callable[[str], None] | None = None,
+) -> list[dict[str, Any]]:
+    """Place one call per candidate, in sequence, and collect the answers.
+
+    Sequential on purpose. Twelve simultaneous calls from one number is what an
+    autodialer looks like from the receiving end, and the whole premise here is
+    that these are calls the business wants: a customer asking for a price.
+    """
+    say = on_event or (lambda _m: None)
+    results: list[dict[str, Any]] = []
+
+    for index, candidate in enumerate(candidates, 1):
+        # Re-checked here rather than trusted from planning time. A batch of
+        # twelve calls takes minutes, and a shop that closes at 18:00 must not
+        # be dialled at 18:04 because it was open when the plan was written.
+        now = moment or datetime.now()
+        if not is_open(candidate.opening_hours, now):
+            say(f"[{index}/{len(candidates)}] {candidate.name}: closed now, skipped")
+            results.append({
+                "name": candidate.name,
+                "phone_masked": candidate.masked,
+                "status": "not_called",
+                "reason": f"closed at dial time (today {window_text(candidate.opening_hours, now)})",
+                "quote": None,
+            })
+            continue
+
+        say(f"[{index}/{len(candidates)}] {candidate.name}  {candidate.masked}  calling")
+        try:
+            created = calls.create(**call_arguments(candidate, job, requester, locale))
+        except Exception as error:  # noqa: BLE001 - one refusal must not kill the batch
+            say(f"      create failed: {type(error).__name__}")
+            results.append({
+                "name": candidate.name,
+                "phone_masked": candidate.masked,
+                "status": "error",
+                "reason": f"CALL-E refused the call ({type(error).__name__})",
+                "quote": None,
+            })
+            continue
+
+        call_id = created.get("id") if isinstance(created, dict) else None
+        if not isinstance(call_id, str) or not call_id:
+            # The dangerous case: the call may have been accepted but there is
+            # no id to reconcile it by. Recorded loudly, never retried.
+            say("      no call id returned -- not retrying")
+            results.append({
+                "name": candidate.name,
+                "phone_masked": candidate.masked,
+                "status": "unknown",
+                "reason": "CALL-E accepted the request without returning a call id",
+                "quote": None,
+            })
+            continue
+
+        try:
+            final = calls.wait_for_result(
+                call_id, timeout_seconds=timeout_seconds, interval_seconds=POLL_SECONDS
+            )
+        except Exception as error:  # noqa: BLE001
+            say(f"      result unavailable: {type(error).__name__}")
+            results.append({
+                "name": candidate.name,
+                "phone_masked": candidate.masked,
+                "call_id": call_id,
+                "status": "unknown",
+                "reason": f"call placed, outcome not retrieved ({type(error).__name__})",
+                "quote": None,
+            })
+            continue
+
+        status = str((final or {}).get("status", "unknown")).strip().lower() or "unknown"
+        structured = (final or {}).get("structured_result")
+
+        if status in NO_ANSWER:
+            say(f"      {status}")
+            results.append({
+                "name": candidate.name, "phone_masked": candidate.masked,
+                "call_id": call_id, "status": status,
+                "reason": "nobody picked up; not redialled automatically",
+                "quote": None,
+            })
+            continue
+
+        if status not in TERMINAL or not _valid_result(structured):
+            say(f"      {status}, no usable answer")
+            results.append({
+                "name": candidate.name, "phone_masked": candidate.masked,
+                "call_id": call_id, "status": status,
+                "reason": "the call did not return the full quote schema",
+                "quote": None,
+            })
+            continue
+
+        quote = sanitise_quote(structured)
+        say(f"      {quote['quoted_price']} {quote['currency']}")
+        results.append({
+            "name": candidate.name, "phone_masked": candidate.masked,
+            "call_id": call_id, "status": status,
+            "reason": "", "quote": quote,
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+# ---------------------------------------------------------------------------
+class SimulatedCalls:
+    """A CallsAPI that answers without a telephone.
+
+    Deterministic: the same candidate always produces the same answer, so the
+    comparison table in the README is reproducible and a test can assert on it.
+    The point is to exercise the real code path -- create, wait, validate,
+    redact, compare -- with the transport removed.
+    """
+
+    SCENARIOS = [
+        {
+            "does_this_job": "yes", "quoted_price": "245", "currency": "USD",
+            "price_covers": "parts_and_labour", "earliest_date": "2026-08-11",
+            "job_duration": "about 2 hours", "warranty_months": "12",
+            "callback_required": "no",
+            "evidence_summary": "Quoted for an OEM-equivalent screen, fitted in the workshop.",
+        },
+        {
+            "does_this_job": "yes", "quoted_price": "199.50", "currency": "USD",
+            "price_covers": "parts_and_labour", "earliest_date": "2026-08-14",
+            "job_duration": "half a day", "warranty_months": "6",
+            "callback_required": "no",
+            "evidence_summary": "Cheaper aftermarket glass, next available slot is Friday.",
+        },
+        {
+            "does_this_job": "yes", "quoted_price": "280-320", "currency": "USD",
+            "price_covers": "parts_and_labour", "earliest_date": "2026-08-10",
+            "job_duration": "90 minutes", "warranty_months": "24",
+            "callback_required": "no",
+            "evidence_summary": "Range depends on whether the rain sensor needs recalibrating.",
+        },
+        {
+            "does_this_job": "yes", "quoted_price": "unknown", "currency": "unknown",
+            "price_covers": "unknown", "earliest_date": "unknown",
+            "job_duration": "unknown", "warranty_months": "unknown",
+            "callback_required": "yes",
+            "evidence_summary": "Service manager was out; asked to be called back tomorrow morning.",
+        },
+    ]
+
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+        self._by_id: dict[str, dict[str, Any]] = {}
+
+    def create(self, **kwargs: Any) -> dict[str, Any]:
+        self.created.append(kwargs)
+        index = len(self.created) - 1
+        call_id = f"sim-{index:04d}"
+        self._by_id[call_id] = self.SCENARIOS[index % len(self.SCENARIOS)]
+        return {"id": call_id, "status": "queued"}
+
+    def wait_for_result(
+        self, call_id: str, *, timeout_seconds: int, interval_seconds: int
+    ) -> dict[str, Any]:
+        return {
+            "id": call_id,
+            "status": "completed",
+            "task_completed": True,
+            "structured_result": dict(self._by_id[call_id]),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+def parse_amount(quoted_price: str) -> float | None:
+    """Lowest number in the string, or None. '280-320' sorts as 280.
+
+    Defensive on purpose: this value came out of a spoken sentence through a
+    language model. Anything that is not clearly a number becomes None and
+    sorts last, rather than becoming a zero that wins the comparison.
+    """
+    if not isinstance(quoted_price, str):
+        return None
+    found = re.findall(r"\d+(?:\.\d+)?", quoted_price.replace(",", ""))
+    if not found:
+        return None
+    try:
+        return min(float(n) for n in found)
+    except ValueError:  # pragma: no cover - findall already guarantees digits
+        return None
+
+
+def compare(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Sort the answers into a table. Never compares across currencies."""
+    quoted, no_price, not_reached = [], [], []
+    for row in results:
+        quote = row.get("quote")
+        if not quote:
+            not_reached.append(row)
+        elif parse_amount(quote.get("quoted_price", "")) is None:
+            no_price.append(row)
+        else:
+            quoted.append(row)
+
+    currencies = {r["quote"]["currency"] for r in quoted}
+    quoted.sort(key=lambda r: parse_amount(r["quote"]["quoted_price"]) or 0.0)
+
+    return {
+        "quoted": quoted,
+        "no_price": no_price,
+        "not_reached": not_reached,
+        "currencies": sorted(currencies),
+        "mixed_currencies": len(currencies) > 1,
+        "cheapest": quoted[0]["name"] if quoted and len(currencies) <= 1 else None,
+    }
+
+
+def render_comparison(job: str, table: dict[str, Any], simulated: bool) -> str:
+    head = "SIMULATED -- no call was placed" if simulated else "LIVE CALL RESULTS"
+    lines = [head, "", f"Job: {job}", ""]
+
+    if table["quoted"]:
+        lines.append(f"{'price':>12}  {'available':<12} {'warranty':<10} business")
+        lines.append(f"{'-' * 12}  {'-' * 12} {'-' * 10} {'-' * 28}")
+        for row in table["quoted"]:
+            q = row["quote"]
+            warranty = q["warranty_months"]
+            warranty = f"{warranty} mo" if warranty.isdigit() and warranty != "0" else (
+                "none" if warranty == "0" else "unknown"
+            )
+            lines.append(
+                f"{q['quoted_price']:>8} {q['currency']:<3}  "
+                f"{q['earliest_date']:<12} {warranty:<10} {row['name']}"
+            )
+
+    if table["mixed_currencies"]:
+        lines += ["", "Quotes came back in more than one currency "
+                  f"({', '.join(table['currencies'])}). Not ranked -- converting "
+                  "them here would invent an exchange rate nobody quoted."]
+    elif table["cheapest"]:
+        lines += ["", f"Cheapest: {table['cheapest']}"]
+
+    if table["no_price"]:
+        lines += ["", "Answered, no price given:"]
+        for row in table["no_price"]:
+            lines.append(f"   - {row['name']}  ->  {row['quote']['evidence_summary']}")
+
+    if table["not_reached"]:
+        lines += ["", "No quote:"]
+        for row in table["not_reached"]:
+            lines.append(f"   - {row['name']}  {row['phone_masked']}  ->  {row['reason']}")
+
+    return "\n".join(lines)
+
+
+def progress(message: str) -> None:
+    sys.stdout.write(message + "\n")
+    sys.stdout.flush()

--- a/apps/python/quoterunner/execution.py
+++ b/apps/python/quoterunner/execution.py
@@ -406,6 +406,7 @@ def run_batch(
     locale: str = "en-US",
     timeout_seconds: int = MAX_WAIT_SECONDS,
     on_event: Callable[[str], None] | None = None,
+    on_accepted: Callable[[dict[str, Any]], None] | None = None,
 ) -> list[dict[str, Any]]:
     """Place one call per candidate, in sequence, and collect the answers.
 
@@ -496,16 +497,46 @@ def run_batch(
         call_id = created.get("id") if isinstance(created, dict) else None
         if not isinstance(call_id, str) or not call_id:
             # The dangerous case: the call may have been accepted but there is
-            # no id to reconcile it by. Recorded loudly, never retried.
+            # no id to reconcile it by. The idempotency key is the only handle
+            # left, so it is recorded rather than dropped. Never retried.
             say("      no call id returned -- not retrying")
             results.append({
                 "name": candidate.name,
                 "phone_masked": candidate.masked,
                 "status": "unknown",
                 "reason": "CALL-E accepted the request without returning a call id",
+                "idempotency_key": key,
                 "quote": None,
             })
             continue
+
+        # The call is accepted and the phone is ringing. Everything from here on
+        # can be interrupted -- Ctrl+C, a crash, the machine losing power -- and
+        # the call keeps going regardless, because it lives on CALL-E's side and
+        # not in this loop.
+        #
+        # So the row goes into the results BEFORE the wait, not after. An
+        # interrupted run then still hands back the call id and the idempotency
+        # key of every call it started, which is the only way to reconcile them
+        # afterwards. Writing the row after the wait meant that killing the
+        # process during a five-minute call erased the only record that it had
+        # ever been placed.
+        fila = {
+            "name": candidate.name,
+            "phone_masked": candidate.masked,
+            "call_id": call_id,
+            "idempotency_key": key,
+            "status": "in_flight",
+            "reason": "call accepted by CALL-E; waiting for the outcome",
+            "quote": None,
+        }
+        results.append(fila)
+        say(f"      accepted, call_id={call_id}")
+        if on_accepted is not None:
+            # Hook for a caller that wants to persist this somewhere durable
+            # before the wait. The in-memory list survives an exception; it does
+            # not survive the process dying.
+            on_accepted(dict(fila))
 
         try:
             final = calls.wait_for_result(
@@ -513,57 +544,44 @@ def run_batch(
             )
         except Exception as error:  # noqa: BLE001
             say(f"      result unavailable: {type(error).__name__}")
-            results.append({
-                "name": candidate.name,
-                "phone_masked": candidate.masked,
-                "call_id": call_id,
-                "status": "unknown",
-                "reason": f"call placed, outcome not retrieved ({type(error).__name__})",
-                "quote": None,
-            })
+            fila["status"] = "unknown"
+            fila["reason"] = (
+                f"call placed, outcome not retrieved ({type(error).__name__})")
             continue
 
         status = str((final or {}).get("status", "unknown")).strip().lower() or "unknown"
         structured = (final or {}).get("structured_result")
+        fila["status"] = status
 
         if status in NO_ANSWER:
             say(f"      {status}")
-            results.append({
-                "name": candidate.name, "phone_masked": candidate.masked,
-                "call_id": call_id, "status": status,
-                "reason": "nobody picked up; not redialled automatically",
-                "quote": None,
-            })
+            fila["reason"] = "nobody picked up; not redialled automatically"
             continue
 
-        # `task_completed` is CALL-E saying whether the agent actually finished
-        # what it was sent to do. Absent means the provider did not report it;
-        # an explicit False means it did not, and that is not a quote.
+        # `task_completed` is CALL-E attesting that the agent finished what it
+        # was sent to do. Absent is not the same as true: it means nobody
+        # attested anything, and an unattested call is exactly the one whose
+        # structured_result you should not put a price on. Only an explicit
+        # True passes.
         task_done = (final or {}).get("task_completed")
 
-        if status not in SUCCESSFUL or task_done is False or not _valid_result(structured):
+        if status not in SUCCESSFUL or task_done is not True or not _valid_result(structured):
             if status not in SUCCESSFUL:
-                reason = f"the call ended as {status}, not as a completed call"
+                fila["reason"] = f"the call ended as {status}, not as a completed call"
             elif task_done is False:
-                reason = "CALL-E reported the task was not completed"
+                fila["reason"] = "CALL-E reported the task was not completed"
+            elif task_done is None:
+                fila["reason"] = ("CALL-E did not attest that the task completed; "
+                                  "treated as unfinished")
             else:
-                reason = "the call did not return the full quote schema"
+                fila["reason"] = "the call did not return the full quote schema"
             say(f"      {status}, no usable answer")
-            results.append({
-                "name": candidate.name, "phone_masked": candidate.masked,
-                "call_id": call_id, "status": status,
-                "reason": reason,
-                "quote": None,
-            })
             continue
 
         quote = sanitise_quote(structured)
         say(f"      {quote['quoted_price']} {quote['currency']}")
-        results.append({
-            "name": candidate.name, "phone_masked": candidate.masked,
-            "call_id": call_id, "status": status,
-            "reason": "", "quote": quote,
-        })
+        fila["reason"] = ""
+        fila["quote"] = quote
 
     return results
 

--- a/apps/python/quoterunner/execution.py
+++ b/apps/python/quoterunner/execution.py
@@ -57,7 +57,7 @@ NO_ANSWER = {"busy", "no_answer", "voicemail"}
 # it was meant to -- and a partially populated structured_result from one of
 # those can still satisfy the schema. Ranking it next to a real quote puts a
 # price in the table that nobody actually said.
-EXITOSO = {"completed", "succeeded"}
+SUCCESSFUL = {"completed", "succeeded"}
 
 MAX_WAIT_SECONDS = 900
 POLL_SECONDS = 5
@@ -205,8 +205,17 @@ def sanitise_quote(quote: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # The confirmation token
 # ---------------------------------------------------------------------------
-def confirmation_token(candidates: list[Candidate], job: str) -> str:
+def confirmation_token(
+    candidates: list[Candidate], job: str, requester: str = "", locale: str = "en-US"
+) -> str:
     """Fingerprint of this exact batch. One different number, different token.
+
+    It covers everything that changes what will actually be said or dialled:
+    the numbers, the job, who the call is on behalf of, and the language it is
+    made in. Binding it to the numbers and the job alone left an approval valid
+    across a rewritten script -- you could review a batch of English calls on
+    behalf of one person and use that same token to place Spanish calls on
+    behalf of another.
 
     This implements the gap we reported to CALL-E in the Most Valuable Feedback
     submission: `call start` has no machine-enforced confirmation, so the only
@@ -217,6 +226,8 @@ def confirmation_token(candidates: list[Candidate], job: str) -> str:
     payload = json.dumps(
         {
             "job": job.strip(),
+            "requester": requester.strip(),
+            "locale": locale,
             "phones": sorted(c.phone for c in candidates),
         },
         ensure_ascii=False,
@@ -225,8 +236,11 @@ def confirmation_token(candidates: list[Candidate], job: str) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
 
-def check_confirmation(candidates: list[Candidate], job: str, token: str | None) -> None:
-    expected = confirmation_token(candidates, job)
+def check_confirmation(
+    candidates: list[Candidate], job: str, token: str | None,
+    requester: str = "", locale: str = "en-US",
+) -> None:
+    expected = confirmation_token(candidates, job, requester, locale)
     if not token:
         raise QuoteError(
             "--execute needs --confirm. Read the plan above, then re-run with:\n"
@@ -348,6 +362,27 @@ def build_calls_api(base_url: str | None = None) -> CallsAPI:
 # ---------------------------------------------------------------------------
 # Running the batch
 # ---------------------------------------------------------------------------
+def outcome_unknown(error: Exception) -> bool:
+    """Did this failure leave a call possibly in flight?
+
+    A rejected request never rang anybody: a bad key, a rate limit, a malformed
+    payload all fail before dialling. A timeout, a dropped connection or a 5xx
+    are different — the provider may have accepted the request and be dialling
+    while we read the exception.
+
+    Matched on the exception name and status code rather than on imported SDK
+    classes, so this module keeps working when `calle-ai` is absent, which is
+    the case for every default test run.
+    """
+    name = type(error).__name__
+    if any(s in name for s in ("Timeout", "Connection", "Unavailable")):
+        return True
+    code = getattr(error, "status_code", None)
+    if code is None:
+        code = getattr(error, "status", None)
+    return isinstance(code, int) and code >= 500
+
+
 def _valid_result(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
@@ -424,17 +459,38 @@ def run_batch(
             continue
 
         say(f"[{index}/{len(candidates)}] {candidate.name}  {candidate.masked}  calling")
+        key = idempotency_key(candidate, job, requester, locale)
         try:
             created = calls.create(**call_arguments(candidate, job, requester, locale))
-        except Exception as error:  # noqa: BLE001 - one refusal must not kill the batch
-            say(f"      create failed: {type(error).__name__}")
-            results.append({
-                "name": candidate.name,
-                "phone_masked": candidate.masked,
-                "status": "error",
-                "reason": f"CALL-E refused the call ({type(error).__name__})",
-                "quote": None,
-            })
+        except Exception as error:  # noqa: BLE001 - one failure must not kill the batch
+            # A refusal and a lost answer are different facts. A rejected
+            # request never rang anybody; a timeout may have been accepted and
+            # the phone may be ringing right now. Filing the second as
+            # "refused" invites a retry, and a retry here is a second call to a
+            # real business.
+            if outcome_unknown(error):
+                say(f"      no answer from CALL-E: {type(error).__name__} -- outcome unknown")
+                results.append({
+                    "name": candidate.name,
+                    "phone_masked": candidate.masked,
+                    "status": "unknown",
+                    "reason": (
+                        f"CALL-E did not answer ({type(error).__name__}); the call "
+                        "may have been accepted. Reconcile before retrying"
+                    ),
+                    "idempotency_key": key,
+                    "quote": None,
+                })
+            else:
+                say(f"      refused: {type(error).__name__}")
+                results.append({
+                    "name": candidate.name,
+                    "phone_masked": candidate.masked,
+                    "status": "error",
+                    "reason": f"CALL-E refused the call ({type(error).__name__})",
+                    "idempotency_key": key,
+                    "quote": None,
+                })
             continue
 
         call_id = created.get("id") if isinstance(created, dict) else None
@@ -483,20 +539,20 @@ def run_batch(
         # `task_completed` is CALL-E saying whether the agent actually finished
         # what it was sent to do. Absent means the provider did not report it;
         # an explicit False means it did not, and that is not a quote.
-        completado = (final or {}).get("task_completed")
+        task_done = (final or {}).get("task_completed")
 
-        if status not in EXITOSO or completado is False or not _valid_result(structured):
-            if status not in EXITOSO:
-                motivo = f"the call ended as {status}, not as a completed call"
-            elif completado is False:
-                motivo = "CALL-E reported the task was not completed"
+        if status not in SUCCESSFUL or task_done is False or not _valid_result(structured):
+            if status not in SUCCESSFUL:
+                reason = f"the call ended as {status}, not as a completed call"
+            elif task_done is False:
+                reason = "CALL-E reported the task was not completed"
             else:
-                motivo = "the call did not return the full quote schema"
+                reason = "the call did not return the full quote schema"
             say(f"      {status}, no usable answer")
             results.append({
                 "name": candidate.name, "phone_masked": candidate.masked,
                 "call_id": call_id, "status": status,
-                "reason": motivo,
+                "reason": reason,
                 "quote": None,
             })
             continue

--- a/apps/python/quoterunner/pyproject.toml
+++ b/apps/python/quoterunner/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "quoterunner"
+version = "1.1.0"
+description = "Discover who is worth calling, call them through CALL-E, compare the quotes"
+requires-python = ">=3.11"
+dependencies = ["calle-ai>=0.6.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/apps/python/quoterunner/quoterunner.py
+++ b/apps/python/quoterunner/quoterunner.py
@@ -8,8 +8,20 @@ QuoteRunner answers it. Give it a job and an area; it returns candidates that
 exist, publish a number, and are open right now, each with the calling window
 derived from their published opening hours rather than configured by hand.
 
-This edition never dials. There is no live transport and no --live flag. The
-output is a plan other tools execute.
+Then it calls them through CALL-E and puts what they said in one table.
+
+    python quoterunner.py --fixture example-candidates.json
+    python quoterunner.py --fixture example-candidates.json --simulate
+    python quoterunner.py --fixture example-candidates.json --execute \
+        --confirm <token>
+
+Preview is the default and places no calls. `--simulate` runs the whole
+pipeline against canned answers. Only `--execute` dials, and it needs
+CALLE_LIVE_CALLS_ENABLED=true, CALLE_API_KEY, and a confirmation token bound to
+this exact candidate list. See execution.py.
+
+This module has no dependencies and never imports the SDK: screening is
+provider-agnostic and stays testable without credentials.
 """
 
 from __future__ import annotations
@@ -263,10 +275,10 @@ def build_plan(
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
-def render(plan: dict) -> str:
+def render(plan: dict, token: str = "") -> str:
     lines = [
-        "FIXTURE RUN -- NO CALL PLACED",
-        "No transport, no telephone, no credentials. This edition cannot dial.",
+        "PREVIEW -- NO CALL PLACED",
+        "Nothing was dialed. No credentials were read and no request was sent.",
         "",
         f"Job: {plan['job']}",
         f"Callable now: {len(plan['calls'])}    Excluded: {len(plan['excluded'])}",
@@ -280,6 +292,16 @@ def render(plan: dict) -> str:
         lines.append("Not called:")
         for item in plan["excluded"]:
             lines.append(f"   - {item['name']}  {item['phone_masked']}  ->  {item['reason']}")
+    if token:
+        lines += [
+            "",
+            "Read that list. If it is who you meant to call:",
+            "",
+            f"    --simulate                    see the comparison, no calls",
+            f"    --execute --confirm {token}   place the calls",
+            "",
+            "The token covers this exact list. Re-plan later and it changes.",
+        ]
     return "\n".join(lines)
 
 
@@ -292,6 +314,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--requester", help="Name spoken on the call")
     parser.add_argument("--at", help="ISO timestamp to evaluate opening hours against")
     parser.add_argument("--json", action="store_true", help="Emit the plan as JSON")
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--simulate", action="store_true",
+                      help="Run the whole pipeline against canned answers. No calls.")
+    mode.add_argument("--execute", action="store_true",
+                      help="Place real calls through CALL-E. Needs --confirm.")
+    parser.add_argument("--confirm", help="Confirmation token printed by the preview")
+    parser.add_argument("--locale", default="en-US", help="Locale spoken on the call")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--base-url", help="Override the CALL-E origin (loopback only, for tests)")
     args = parser.parse_args(argv)
 
     payload = json.loads(args.fixture.read_text(encoding="utf-8"))
@@ -300,12 +332,52 @@ def main(argv: list[str] | None = None) -> int:
     moment = datetime.fromisoformat(args.at) if args.at else datetime.now()
 
     try:
-        plan = build_plan(load_fixture(args.fixture), job, requester, moment)
+        candidates = load_fixture(args.fixture)
+        plan = build_plan(candidates, job, requester, moment)
     except PlanError as error:
         print(f"No plan: {error}", file=sys.stderr)
         return 1
 
-    print(json.dumps(plan, indent=2) if args.json else render(plan))
+    # `build_plan` already screened them; re-reading the verdict avoids
+    # screening twice and guarantees the batch we dial is the batch we showed.
+    callable_now = [c for c in candidates if c.verdict == "callable"]
+
+    # Imported here, not at module scope: execution.py imports this module, and
+    # the preview path must never pull in anything the screening layer does not
+    # need.
+    import execution
+
+    token = execution.confirmation_token(callable_now, job)
+
+    if not (args.simulate or args.execute):
+        print(json.dumps(plan, indent=2) if args.json else render(plan, token))
+        return 0
+
+    try:
+        if args.execute:
+            execution.check_confirmation(callable_now, job, args.confirm)
+            calls = execution.build_calls_api(args.base_url)
+        else:
+            calls = execution.SimulatedCalls()
+    except execution.QuoteError as error:
+        print(f"\n{error}\n", file=sys.stderr)
+        return 1
+
+    results = execution.run_batch(
+        callable_now, job, requester, calls,
+        moment=moment if args.at else None,
+        locale=args.locale,
+        timeout_seconds=args.timeout_seconds,
+        on_event=execution.progress,
+    )
+    table = execution.compare(results)
+
+    if args.json:
+        print(json.dumps({"job": job, "simulated": args.simulate, "results": results,
+                          "cheapest": table["cheapest"]}, indent=2))
+    else:
+        print()
+        print(execution.render_comparison(job, table, simulated=args.simulate))
     return 0
 
 

--- a/apps/python/quoterunner/quoterunner.py
+++ b/apps/python/quoterunner/quoterunner.py
@@ -33,6 +33,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, time
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 __version__ = "1.0.0"
 
@@ -145,6 +146,9 @@ class Candidate:
     address: str = ""
     locality: str = ""
     source_id: str = ""
+    # IANA name, e.g. America/Chicago. Never inferred from the phone number,
+    # the country code or the locale: see local_now.
+    timezone: str = ""
 
     verdict: str = ""
     reason: str = ""
@@ -155,16 +159,59 @@ class Candidate:
         return mask(self.phone)
 
 
+def local_now(candidate: Candidate, moment: datetime | None = None) -> datetime:
+    """What time it is *where the business is*.
+
+    Opening hours are published in the shop's own local time. Reading them
+    against the host clock is wrong by however far apart the two are: a machine
+    in Mexico City reading hours for a shop in Austin is an hour out, and one in
+    Europe is seven. That is how you ring a closed shop, or a person asleep.
+
+    The zone has to be published. It is never derived from the phone number,
+    the country code or the locale -- those are guesses, and a guess here calls
+    a stranger at three in the morning.
+    """
+    base = moment or datetime.now()
+    if base.tzinfo is None:
+        base = base.astimezone()  # the host's own offset, made explicit
+
+    if not candidate.timezone:
+        return base
+
+    try:
+        return base.astimezone(ZoneInfo(candidate.timezone))
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        # Minimal Windows installs ship no IANA database. Falling back to host
+        # time silently would reintroduce the bug, so the caller is told.
+        raise PlanError(
+            f"Unknown timezone {candidate.timezone!r}. "
+            "On Windows this usually means the IANA database is missing: "
+            "pip install tzdata"
+        ) from None
+
+
 def load_fixture(path: Path) -> list[Candidate]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     return [Candidate(**row) for row in payload["candidates"]]
 
 
-def screen(candidates: list[Candidate], moment: datetime) -> tuple[list[Candidate], list[Candidate]]:
+def screen(
+    candidates: list[Candidate],
+    moment: datetime,
+    *,
+    default_timezone: str = "",
+    require_timezone: bool = False,
+) -> tuple[list[Candidate], list[Candidate]]:
     """Split candidates into callable and excluded, recording why for each.
 
     Exclusions are part of the output, not a silent filter. A run that quietly
     dropped half its candidates looks identical to one that found nothing.
+
+    `default_timezone` is the operator stating the zone for a batch they know is
+    single-region. That is a declaration, not a guess, so it is allowed.
+    `require_timezone` is set on the live path: a candidate whose local time we
+    cannot establish is excluded rather than dialled, for the same reason one
+    with no published hours is.
     """
     callable_now: list[Candidate] = []
     excluded: list[Candidate] = []
@@ -178,18 +225,38 @@ def screen(candidates: list[Candidate], moment: datetime) -> tuple[list[Candidat
             excluded.append(candidate)
             continue
 
+        if not candidate.timezone and default_timezone:
+            candidate.timezone = default_timezone
+
+        try:
+            here = local_now(candidate, moment)
+        except PlanError as error:
+            candidate.verdict = "excluded"
+            candidate.reason = str(error)
+            excluded.append(candidate)
+            continue
+
         if not candidate.opening_hours:
             candidate.verdict = "excluded"
             candidate.reason = "no published opening hours -- we do not call blind"
-        elif not is_open(candidate.opening_hours, moment):
-            today = window_text(candidate.opening_hours, moment)
+        elif require_timezone and not candidate.timezone:
+            candidate.verdict = "excluded"
+            candidate.reason = (
+                "no timezone published -- cannot tell what time it is there. "
+                "Pass --timezone if the whole batch is in one region"
+            )
+        elif not is_open(candidate.opening_hours, here):
+            today = window_text(candidate.opening_hours, here)
             candidate.verdict = "excluded"
             candidate.reason = (
                 "closed today" if today == "closed today" else f"closed now (open today {today})"
             )
         else:
             candidate.verdict = "callable"
-            candidate.reason = f"open now ({window_text(candidate.opening_hours, moment)})"
+            donde = f" {candidate.timezone}" if candidate.timezone else ""
+            candidate.reason = (
+                f"open now ({window_text(candidate.opening_hours, here)}{donde})"
+            )
             callable_now.append(candidate)
             continue
 
@@ -246,9 +313,13 @@ def build_script(candidate: Candidate, job: str, requester: str) -> str:
 
 
 def build_plan(
-    candidates: list[Candidate], job: str, requester: str, moment: datetime
+    candidates: list[Candidate], job: str, requester: str, moment: datetime,
+    *, default_timezone: str = "", require_timezone: bool = False,
 ) -> dict:
-    callable_now, excluded = screen(candidates, moment)
+    callable_now, excluded = screen(
+        candidates, moment,
+        default_timezone=default_timezone, require_timezone=require_timezone,
+    )
     if not callable_now:
         raise PlanError("No candidate is callable right now. Nothing was planned.")
 
@@ -261,7 +332,10 @@ def build_plan(
             {
                 "name": c.name,
                 "phone_masked": c.masked,
-                "calling_window_today": window_text(c.opening_hours, moment),
+                "timezone": c.timezone or "(host local time)",
+                "calling_window_today": window_text(
+                    c.opening_hours, local_now(c, moment)
+                ),
                 "script": build_script(c, job, requester),
             }
             for c in callable_now
@@ -322,6 +396,10 @@ def main(argv: list[str] | None = None) -> int:
                       help="Place real calls through CALL-E. Needs --confirm.")
     parser.add_argument("--confirm", help="Confirmation token printed by the preview")
     parser.add_argument("--locale", default="en-US", help="Locale spoken on the call")
+    parser.add_argument("--timezone", default="",
+                        help="IANA zone for candidates that publish none, e.g. "
+                             "America/Chicago. Only state it for a batch you know "
+                             "is in one region; it is never inferred")
     parser.add_argument("--timeout-seconds", type=int, default=900)
     parser.add_argument("--base-url", help="Override the CALL-E origin (loopback only, for tests)")
     args = parser.parse_args(argv)
@@ -333,7 +411,12 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         candidates = load_fixture(args.fixture)
-        plan = build_plan(candidates, job, requester, moment)
+        # The live path refuses a candidate whose local time is unknown. The
+        # preview does not, so you can still see the batch and be told what is
+        # missing before you try to dial it.
+        plan = build_plan(candidates, job, requester, moment,
+                          default_timezone=args.timezone,
+                          require_timezone=args.execute)
     except PlanError as error:
         print(f"No plan: {error}", file=sys.stderr)
         return 1

--- a/apps/python/quoterunner/quoterunner.py
+++ b/apps/python/quoterunner/quoterunner.py
@@ -1,0 +1,313 @@
+"""QuoteRunner — build a vetted call list before anyone dials.
+
+Every call app in this repository starts from a list somebody already had: a
+fixture, a CSV, a study file, a hand-written plan. None of them answer the
+question that comes first — who should I even call?
+
+QuoteRunner answers it. Give it a job and an area; it returns candidates that
+exist, publish a number, and are open right now, each with the calling window
+derived from their published opening hours rather than configured by hand.
+
+This edition never dials. There is no live transport and no --live flag. The
+output is a plan other tools execute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from pathlib import Path
+
+__version__ = "1.0.0"
+
+# Numbers are masked everywhere, including errors. A test asserts that no full
+# number reaches any output path.
+_E164 = re.compile(r"^\+[1-9]\d{7,14}$")
+
+DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+
+# Hard caps. Not configurable from the command line on purpose: a limit the
+# caller can raise mid-run is not a limit.
+MAX_CANDIDATES_PER_RUN = 12
+
+
+class PlanError(Exception):
+    """Raised when a plan cannot be built. Messages never contain a full number."""
+
+
+def mask(phone: str) -> str:
+    """+15550100 -> +15*****00. Used in every output path, errors included."""
+    if not phone:
+        return "(none)"
+    digits = re.sub(r"[^\d+]", "", phone)
+    if len(digits) <= 5:
+        return "+" + "*" * max(len(digits) - 1, 1)
+    return digits[:3] + "*" * (len(digits) - 5) + digits[-2:]
+
+
+def validate_e164(phone: str) -> str:
+    """Reject anything that is not already E.164. We never reformat a number:
+    guessing a country code is how you call a stranger in another country."""
+    cleaned = re.sub(r"[\s()\-.]", "", phone or "")
+    if not _E164.match(cleaned):
+        raise PlanError(f"Not a valid E.164 number: {mask(cleaned)}")
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Opening hours
+# ---------------------------------------------------------------------------
+def _day_windows(opening_hours: str, weekday: int) -> list[tuple[time, time]]:
+    """Parse an OpenStreetMap opening_hours value into windows for one weekday.
+
+    'Mo-Fr 09:00-14:00,16:00-20:00; Sa 10:00-14:00' is the common shape.
+    Anything we cannot parse yields no window, which means closed. Preferring
+    "closed" over an optimistic parse is the whole point: a wrong guess here
+    calls a real person at three in the morning.
+    """
+    if not opening_hours:
+        return []
+    if opening_hours.strip() == "24/7":
+        return [(time(0, 0), time(23, 59))]
+
+    day = DAYS[weekday]
+    windows: list[tuple[time, time]] = []
+
+    for chunk in opening_hours.split(";"):
+        match = re.match(r"^\s*([A-Za-z,\-]+)\s+(.+?)\s*$", chunk)
+        if not match:
+            continue
+        day_spec, hour_spec = match.group(1), match.group(2)
+        if "off" in hour_spec.lower():
+            continue
+
+        applies = False
+        for part in day_spec.split(","):
+            if "-" in part:
+                start, _, end = part.partition("-")
+                if start in DAYS and end in DAYS:
+                    i, j = DAYS.index(start), DAYS.index(end)
+                    if (i <= j and i <= weekday <= j) or (i > j and (weekday >= i or weekday <= j)):
+                        applies = True
+            elif part == day:
+                applies = True
+        if not applies:
+            continue
+
+        for span in hour_spec.split(","):
+            hm = re.match(r"^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$", span)
+            if not hm:
+                continue
+            h1, m1, h2, m2 = (int(g) for g in hm.groups())
+            if h1 < 24 and h2 <= 24:
+                windows.append((time(h1, m1), time(min(h2, 23), m2 if h2 < 24 else 59)))
+
+    return windows
+
+
+def is_open(opening_hours: str, moment: datetime) -> bool:
+    windows = _day_windows(opening_hours, moment.weekday())
+    now = moment.time()
+    return any(start <= now <= end for start, end in windows)
+
+
+def window_text(opening_hours: str, moment: datetime) -> str:
+    windows = _day_windows(opening_hours, moment.weekday())
+    if not windows:
+        return "closed today"
+    return ", ".join(f"{s.strftime('%H:%M')}-{e.strftime('%H:%M')}" for s, e in windows)
+
+
+# ---------------------------------------------------------------------------
+# Candidates
+# ---------------------------------------------------------------------------
+@dataclass
+class Candidate:
+    name: str
+    phone: str
+    opening_hours: str = ""
+    address: str = ""
+    locality: str = ""
+    source_id: str = ""
+
+    verdict: str = ""
+    reason: str = ""
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def masked(self) -> str:
+        return mask(self.phone)
+
+
+def load_fixture(path: Path) -> list[Candidate]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return [Candidate(**row) for row in payload["candidates"]]
+
+
+def screen(candidates: list[Candidate], moment: datetime) -> tuple[list[Candidate], list[Candidate]]:
+    """Split candidates into callable and excluded, recording why for each.
+
+    Exclusions are part of the output, not a silent filter. A run that quietly
+    dropped half its candidates looks identical to one that found nothing.
+    """
+    callable_now: list[Candidate] = []
+    excluded: list[Candidate] = []
+
+    for candidate in candidates:
+        try:
+            candidate.phone = validate_e164(candidate.phone)
+        except PlanError as error:
+            candidate.verdict = "excluded"
+            candidate.reason = str(error)
+            excluded.append(candidate)
+            continue
+
+        if not candidate.opening_hours:
+            candidate.verdict = "excluded"
+            candidate.reason = "no published opening hours -- we do not call blind"
+        elif not is_open(candidate.opening_hours, moment):
+            today = window_text(candidate.opening_hours, moment)
+            candidate.verdict = "excluded"
+            candidate.reason = (
+                "closed today" if today == "closed today" else f"closed now (open today {today})"
+            )
+        else:
+            candidate.verdict = "callable"
+            candidate.reason = f"open now ({window_text(candidate.opening_hours, moment)})"
+            callable_now.append(candidate)
+            continue
+
+        excluded.append(candidate)
+
+    if len(callable_now) > MAX_CANDIDATES_PER_RUN:
+        for extra in callable_now[MAX_CANDIDATES_PER_RUN:]:
+            extra.verdict = "excluded"
+            extra.reason = f"over the {MAX_CANDIDATES_PER_RUN}-candidate cap for one run"
+            excluded.append(extra)
+        callable_now = callable_now[:MAX_CANDIDATES_PER_RUN]
+
+    return callable_now, excluded
+
+
+# ---------------------------------------------------------------------------
+# Call plan
+# ---------------------------------------------------------------------------
+QUESTIONS = [
+    "the price or price range for the job, and the currency",
+    "the earliest date they could do it",
+    "roughly how long the job itself takes",
+    "whether the price covers parts and labour, or labour only",
+    "whether any warranty is included, and for how long",
+]
+
+SCRIPT = """You are calling {name} on behalf of {requester}, a potential customer.
+
+Be brief and polite. This is an ordinary customer enquiry, not a sales call.
+
+Say who you are calling for, then ask about this job:
+
+    {job}
+
+Find out only these:
+{questions}
+
+Rules:
+- If they are busy or ask you to call back, thank them and end the call. Do not insist.
+- If they ask whether you are an AI assistant, say yes, plainly, and say you are
+  calling on behalf of {requester}.
+- If they ask not to be called again, confirm that and end the call.
+- Do not agree to anything, do not book anything, do not give payment details.
+- If a question cannot be answered, record it as unknown. Do not guess.
+
+Return the answers as structured data."""
+
+
+def build_script(candidate: Candidate, job: str, requester: str) -> str:
+    numbered = "\n".join(f"  {i}. {q}" for i, q in enumerate(QUESTIONS, 1))
+    return SCRIPT.format(
+        name=candidate.name, requester=requester, job=job.strip(), questions=numbered
+    )
+
+
+def build_plan(
+    candidates: list[Candidate], job: str, requester: str, moment: datetime
+) -> dict:
+    callable_now, excluded = screen(candidates, moment)
+    if not callable_now:
+        raise PlanError("No candidate is callable right now. Nothing was planned.")
+
+    return {
+        "job": job,
+        "requester": requester,
+        "planned_at": moment.isoformat(timespec="seconds"),
+        "no_call_placed": True,
+        "calls": [
+            {
+                "name": c.name,
+                "phone_masked": c.masked,
+                "calling_window_today": window_text(c.opening_hours, moment),
+                "script": build_script(c, job, requester),
+            }
+            for c in callable_now
+        ],
+        "excluded": [
+            {"name": c.name, "phone_masked": c.masked, "reason": c.reason} for c in excluded
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def render(plan: dict) -> str:
+    lines = [
+        "FIXTURE RUN -- NO CALL PLACED",
+        "No transport, no telephone, no credentials. This edition cannot dial.",
+        "",
+        f"Job: {plan['job']}",
+        f"Callable now: {len(plan['calls'])}    Excluded: {len(plan['excluded'])}",
+        "",
+    ]
+    for i, call in enumerate(plan["calls"], 1):
+        lines.append(f"{i}. {call['name']}  {call['phone_masked']}")
+        lines.append(f"     open today: {call['calling_window_today']}")
+    if plan["excluded"]:
+        lines.append("")
+        lines.append("Not called:")
+        for item in plan["excluded"]:
+            lines.append(f"   - {item['name']}  {item['phone_masked']}  ->  {item['reason']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="quoterunner", description=__doc__.split("\n")[0]
+    )
+    parser.add_argument("--fixture", required=True, type=Path, help="Candidate fixture JSON")
+    parser.add_argument("--job", help="What you want quoted (defaults to the fixture's job)")
+    parser.add_argument("--requester", help="Name spoken on the call")
+    parser.add_argument("--at", help="ISO timestamp to evaluate opening hours against")
+    parser.add_argument("--json", action="store_true", help="Emit the plan as JSON")
+    args = parser.parse_args(argv)
+
+    payload = json.loads(args.fixture.read_text(encoding="utf-8"))
+    job = args.job or payload.get("job", "")
+    requester = args.requester or payload.get("requester", "the customer")
+    moment = datetime.fromisoformat(args.at) if args.at else datetime.now()
+
+    try:
+        plan = build_plan(load_fixture(args.fixture), job, requester, moment)
+    except PlanError as error:
+        print(f"No plan: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(plan, indent=2) if args.json else render(plan))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/quoterunner/quoterunner.py
+++ b/apps/python/quoterunner/quoterunner.py
@@ -253,9 +253,9 @@ def screen(
             )
         else:
             candidate.verdict = "callable"
-            donde = f" {candidate.timezone}" if candidate.timezone else ""
+            where = f" {candidate.timezone}" if candidate.timezone else ""
             candidate.reason = (
-                f"open now ({window_text(candidate.opening_hours, here)}{donde})"
+                f"open now ({window_text(candidate.opening_hours, here)}{where})"
             )
             callable_now.append(candidate)
             continue
@@ -430,7 +430,7 @@ def main(argv: list[str] | None = None) -> int:
     # need.
     import execution
 
-    token = execution.confirmation_token(callable_now, job)
+    token = execution.confirmation_token(callable_now, job, requester, args.locale)
 
     if not (args.simulate or args.execute):
         print(json.dumps(plan, indent=2) if args.json else render(plan, token))
@@ -438,7 +438,8 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.execute:
-            execution.check_confirmation(callable_now, job, args.confirm)
+            execution.check_confirmation(callable_now, job, args.confirm,
+                                        requester, args.locale)
             calls = execution.build_calls_api(args.base_url)
         else:
             calls = execution.SimulatedCalls()

--- a/apps/python/quoterunner/test_execution.py
+++ b/apps/python/quoterunner/test_execution.py
@@ -79,7 +79,12 @@ class FakeCalls:
         self.waited.append(call_id)
         if self._wait_raises:
             raise self._wait_raises
-        return {"id": call_id, "status": self._status, "structured_result": self._result}
+        # A real completed call carries the attestation. The fake has to as
+        # well, or every test would be exercising the unattested path by
+        # accident -- which is exactly the case the gate now rejects.
+        return {"id": call_id, "status": self._status,
+                "task_completed": True,
+                "structured_result": self._result}
 
 
 # ---------------------------------------------------------------- token --
@@ -661,3 +666,110 @@ class TestReviewFindings(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+# --------------------------------- third review round on #118 (8888ab6) --
+class TestThirdReviewRound(unittest.TestCase):
+    """The reviewer's third pass. All three were real."""
+
+    def test_missing_attestation_is_not_a_quote(self):
+        """Silence is not consent.
+
+        The gate rejected only an explicit False, so a completed call with
+        `task_completed` absent or null slipped through and its answers were
+        ranked as a real quote. Nobody attested that the call finished.
+        """
+        class SinAtestar(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                r = super().wait_for_result(
+                    call_id, timeout_seconds=timeout_seconds,
+                    interval_seconds=interval_seconds)
+                r.pop("task_completed", None)
+                return r
+        rows = run_batch([candidate()], "job", "Ivan", SinAtestar(), moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+        self.assertIn("did not attest", rows[0]["reason"])
+
+    def test_null_attestation_is_not_a_quote(self):
+        class Nula(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                r = super().wait_for_result(
+                    call_id, timeout_seconds=timeout_seconds,
+                    interval_seconds=interval_seconds)
+                r["task_completed"] = None
+                return r
+        rows = run_batch([candidate()], "job", "Ivan", Nula(), moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+
+    def test_explicit_true_still_produces_a_quote(self):
+        """The fix must not have closed the working path."""
+        class Atestada(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                r = super().wait_for_result(
+                    call_id, timeout_seconds=timeout_seconds,
+                    interval_seconds=interval_seconds)
+                r["task_completed"] = True
+                return r
+        rows = run_batch([candidate()], "job", "Ivan", Atestada(), moment=MOMENT)
+        self.assertIsNotNone(rows[0]["quote"])
+
+    def test_a_create_without_an_id_keeps_its_idempotency_key(self):
+        """That key is the only handle left to reconcile the call by."""
+        rows = run_batch([candidate()], "job", "Ivan", FakeCalls(call_id=""),
+                         moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+        self.assertEqual(rows[0]["idempotency_key"],
+                         idempotency_key(candidate(), "job", "Ivan", "en-US"))
+
+    def test_the_call_is_recorded_before_the_wait(self):
+        """An interrupted run must still know what it started.
+
+        The call lives on CALL-E's side. Killing this process does not stop it,
+        so the record cannot be written only after the call ends.
+        """
+        vistos = []
+
+        class LentaYRota(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                # Lo que veria un Ctrl+C a mitad de la espera.
+                raise KeyboardInterrupt("interrumpido a mitad de llamada")
+
+        fake = LentaYRota()
+        with self.assertRaises(KeyboardInterrupt):
+            run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT,
+                      on_accepted=vistos.append)
+
+        self.assertEqual(len(vistos), 1, "no se aviso de la llamada aceptada")
+        self.assertEqual(vistos[0]["call_id"], "call-1")
+        self.assertEqual(vistos[0]["status"], "in_flight")
+        self.assertEqual(vistos[0]["idempotency_key"],
+                         idempotency_key(candidate(), "job", "Ivan", "en-US"))
+
+    def test_on_accepted_fires_before_the_result_arrives(self):
+        orden = []
+
+        class Ordenada(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                orden.append("wait")
+                return super().wait_for_result(
+                    call_id, timeout_seconds=timeout_seconds,
+                    interval_seconds=interval_seconds)
+
+        run_batch([candidate()], "job", "Ivan", Ordenada(), moment=MOMENT,
+                  on_accepted=lambda f: orden.append("accepted"))
+        self.assertEqual(orden, ["accepted", "wait"])
+
+    def test_the_row_carries_the_call_id_while_in_flight(self):
+        filas = []
+        run_batch([candidate()], "job", "Ivan", FakeCalls(), moment=MOMENT,
+                  on_accepted=filas.append)
+        self.assertEqual(filas[0]["status"], "in_flight")
+        self.assertIn("call_id", filas[0])
+
+    def test_a_lost_result_keeps_call_id_and_key(self):
+        rows = run_batch([candidate()], "job", "Ivan",
+                         FakeCalls(wait_raises=TimeoutError("gateway")),
+                         moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+        self.assertEqual(rows[0]["call_id"], "call-1")
+        self.assertIn("idempotency_key", rows[0])

--- a/apps/python/quoterunner/test_execution.py
+++ b/apps/python/quoterunner/test_execution.py
@@ -1,0 +1,424 @@
+"""Tests for the CALL-E execution layer.
+
+Nothing here dials. The CallsAPI is a fake, which is the point: the gates that
+stop a real call have to be testable without placing one.
+
+    python -m unittest test_execution -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+import execution
+import quoterunner
+from execution import (
+    QuoteError,
+    SimulatedCalls,
+    call_arguments,
+    check_confirmation,
+    compare,
+    confirmation_token,
+    idempotency_key,
+    parse_amount,
+    render_comparison,
+    run_batch,
+    sanitise_quote,
+    validate_base_url,
+)
+from quoterunner import Candidate
+
+FIXTURE = Path(__file__).parent / "example-candidates.json"
+OPEN_ALL_DAY = "Mo-Su 00:00-23:59"
+MOMENT = datetime(2026, 8, 7, 10, 0, 0)
+
+GOOD_QUOTE = {
+    "does_this_job": "yes",
+    "quoted_price": "245",
+    "currency": "USD",
+    "price_covers": "parts_and_labour",
+    "earliest_date": "2026-08-11",
+    "job_duration": "about 2 hours",
+    "warranty_months": "12",
+    "callback_required": "no",
+    "evidence_summary": "Quoted for an OEM-equivalent screen.",
+}
+
+
+def candidate(name="Northgate Auto Glass", phone="+15555550100", hours=OPEN_ALL_DAY):
+    return Candidate(name=name, phone=phone, opening_hours=hours, source_id="osm/1")
+
+
+class FakeCalls:
+    """Records what it was asked to do and returns whatever it was told to."""
+
+    def __init__(self, result=None, *, create_raises=None, wait_raises=None,
+                 call_id="call-1", status="completed"):
+        self.created: list[dict] = []
+        self.waited: list[str] = []
+        self._result = result if result is not None else dict(GOOD_QUOTE)
+        self._create_raises = create_raises
+        self._wait_raises = wait_raises
+        self._call_id = call_id
+        self._status = status
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        if self._create_raises:
+            raise self._create_raises
+        return {"id": self._call_id, "status": "queued"} if self._call_id else {"status": "queued"}
+
+    def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+        self.waited.append(call_id)
+        if self._wait_raises:
+            raise self._wait_raises
+        return {"id": call_id, "status": self._status, "structured_result": self._result}
+
+
+# ---------------------------------------------------------------- token --
+class TestConfirmationToken(unittest.TestCase):
+    """The token exists so that approving one list cannot dial another."""
+
+    def test_stable_for_the_same_batch(self):
+        batch = [candidate(), candidate("B", "+15555550101")]
+        self.assertEqual(confirmation_token(batch, "job"),
+                         confirmation_token(list(batch), "job"))
+
+    def test_changes_when_a_number_changes(self):
+        a = [candidate(), candidate("B", "+15555550101")]
+        b = [candidate(), candidate("B", "+15555550102")]
+        self.assertNotEqual(confirmation_token(a, "job"), confirmation_token(b, "job"))
+
+    def test_changes_when_a_candidate_is_added(self):
+        a = [candidate()]
+        b = [candidate(), candidate("B", "+15555550101")]
+        self.assertNotEqual(confirmation_token(a, "job"), confirmation_token(b, "job"))
+
+    def test_changes_when_the_job_changes(self):
+        batch = [candidate()]
+        self.assertNotEqual(confirmation_token(batch, "windscreen"),
+                            confirmation_token(batch, "gearbox"))
+
+    def test_order_does_not_matter(self):
+        a = [candidate("A", "+15555550100"), candidate("B", "+15555550101")]
+        self.assertEqual(confirmation_token(a, "job"),
+                         confirmation_token(list(reversed(a)), "job"))
+
+    def test_missing_token_is_refused_and_the_right_one_is_shown(self):
+        batch = [candidate()]
+        with self.assertRaises(QuoteError) as caught:
+            check_confirmation(batch, "job", None)
+        self.assertIn(confirmation_token(batch, "job"), str(caught.exception))
+
+    def test_wrong_token_is_refused(self):
+        with self.assertRaises(QuoteError):
+            check_confirmation([candidate()], "job", "000000000000")
+
+    def test_right_token_passes(self):
+        batch = [candidate()]
+        check_confirmation(batch, "job", confirmation_token(batch, "job"))
+
+    def test_token_is_case_insensitive_and_trimmed(self):
+        batch = [candidate()]
+        token = confirmation_token(batch, "job")
+        check_confirmation(batch, "job", f"  {token.upper()}  ")
+
+
+# ---------------------------------------------------------- idempotency --
+class TestIdempotency(unittest.TestCase):
+    def test_same_business_and_job_gives_the_same_key(self):
+        self.assertEqual(idempotency_key(candidate(), "job"),
+                         idempotency_key(candidate(), "job"))
+
+    def test_different_business_gives_a_different_key(self):
+        self.assertNotEqual(idempotency_key(candidate(), "job"),
+                            idempotency_key(candidate("B", "+15555550101"), "job"))
+
+    def test_different_job_gives_a_different_key(self):
+        self.assertNotEqual(idempotency_key(candidate(), "windscreen"),
+                            idempotency_key(candidate(), "gearbox"))
+
+    def test_key_carries_no_phone_number(self):
+        self.assertNotIn("5555550100", idempotency_key(candidate(), "job"))
+
+
+# ------------------------------------------------------- call arguments --
+class TestCallArguments(unittest.TestCase):
+    def test_the_real_number_is_what_gets_dialed(self):
+        """Masking is for output. The payload has to carry the real number."""
+        args = call_arguments(candidate(), "job", "Ivan")
+        self.assertEqual(args["recipients"][0]["phones"], ["+15555550100"])
+
+    def test_schema_is_attached(self):
+        args = call_arguments(candidate(), "job", "Ivan")
+        self.assertEqual(args["result_schema"], execution.QUOTE_SCHEMA)
+
+    def test_locale_is_passed_through(self):
+        args = call_arguments(candidate(), "job", "Ivan", locale="es-MX")
+        self.assertEqual(args["recipients"][0]["locale"], "es-MX")
+
+    def test_task_names_the_business_and_the_requester(self):
+        args = call_arguments(candidate(), "replace a windscreen", "Ivan")
+        self.assertIn("Northgate Auto Glass", args["task"])
+        self.assertIn("Ivan", args["task"])
+
+    def test_task_forbids_agreeing_to_anything(self):
+        args = call_arguments(candidate(), "job", "Ivan")
+        self.assertIn("Do not agree to anything", args["task"])
+
+    def test_task_requires_disclosing_it_is_an_ai(self):
+        args = call_arguments(candidate(), "job", "Ivan")
+        self.assertIn("AI", args["task"])
+
+
+# ----------------------------------------------------------- the gates --
+class TestLiveGates(unittest.TestCase):
+    """Four independent gates. Any one of them alone stops the call."""
+
+    def test_env_flag_is_required(self):
+        with mock.patch.dict(os.environ, {"CALLE_API_KEY": "k"}, clear=True):
+            with self.assertRaises(QuoteError) as caught:
+                execution.build_calls_api()
+        self.assertIn("CALLE_LIVE_CALLS_ENABLED", str(caught.exception))
+
+    def test_api_key_is_required(self):
+        with mock.patch.dict(os.environ, {"CALLE_LIVE_CALLS_ENABLED": "true"}, clear=True):
+            with self.assertRaises(QuoteError) as caught:
+                execution.build_calls_api()
+        self.assertIn("CALLE_API_KEY", str(caught.exception))
+
+    def test_the_flag_must_say_true_not_just_be_set(self):
+        with mock.patch.dict(os.environ,
+                             {"CALLE_LIVE_CALLS_ENABLED": "1", "CALLE_API_KEY": "k"},
+                             clear=True):
+            with self.assertRaises(QuoteError):
+                execution.build_calls_api()
+
+    def test_official_origin_is_accepted(self):
+        self.assertEqual(validate_base_url("https://api.heycall-e.com"),
+                         "https://api.heycall-e.com")
+
+    def test_loopback_with_a_port_is_accepted_for_tests(self):
+        self.assertEqual(validate_base_url("http://127.0.0.1:8931"),
+                         "http://127.0.0.1:8931")
+
+    def test_someone_elses_host_is_refused(self):
+        """A base URL is where a live call gets silently redirected."""
+        for bad in ("https://api.heycall-e.com.evil.test",
+                    "https://evil.test",
+                    "http://api.heycall-e.com",
+                    "https://user:pass@api.heycall-e.com",
+                    "https://api.heycall-e.com/v1?to=elsewhere"):
+            with self.subTest(bad=bad), self.assertRaises(QuoteError):
+                validate_base_url(bad)
+
+
+# ------------------------------------------------------------ sanitise --
+class TestSanitise(unittest.TestCase):
+    """The bug this class exists for: a date is eight digits with separators,
+    which a phone-number pattern matches. The first version redacted every
+    availability date into '[number redacted]'."""
+
+    def test_iso_date_survives(self):
+        self.assertEqual(sanitise_quote(GOOD_QUOTE)["earliest_date"], "2026-08-11")
+
+    def test_price_survives(self):
+        self.assertEqual(sanitise_quote(GOOD_QUOTE)["quoted_price"], "245")
+
+    def test_price_range_survives(self):
+        quote = {**GOOD_QUOTE, "quoted_price": "280-320"}
+        self.assertEqual(sanitise_quote(quote)["quoted_price"], "280-320")
+
+    def test_a_phone_number_in_a_date_field_becomes_unknown(self):
+        quote = {**GOOD_QUOTE, "earliest_date": "+1 555 0100"}
+        self.assertEqual(sanitise_quote(quote)["earliest_date"], "unknown")
+
+    def test_a_phone_number_in_the_price_becomes_unknown(self):
+        quote = {**GOOD_QUOTE, "quoted_price": "call +15555550100"}
+        self.assertEqual(sanitise_quote(quote)["quoted_price"], "unknown")
+
+    def test_prose_keeps_its_meaning_but_loses_the_number(self):
+        quote = {**GOOD_QUOTE,
+                 "evidence_summary": "Ask for Dave on +1 555 0199 before Friday."}
+        out = sanitise_quote(quote)["evidence_summary"]
+        self.assertNotIn("5550199", out.replace(" ", ""))
+        self.assertIn("before Friday", out)
+
+    def test_email_in_prose_is_redacted(self):
+        quote = {**GOOD_QUOTE, "evidence_summary": "Send the VIN to shop@example.test."}
+        self.assertNotIn("shop@example.test", sanitise_quote(quote)["evidence_summary"])
+
+    def test_junk_currency_becomes_unknown(self):
+        self.assertEqual(sanitise_quote({**GOOD_QUOTE, "currency": "dollars"})["currency"],
+                         "unknown")
+
+
+# ----------------------------------------------------------- run_batch --
+class TestRunBatch(unittest.TestCase):
+    def test_happy_path_returns_a_quote(self):
+        fake = FakeCalls()
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(len(fake.created), 1)
+        self.assertEqual(rows[0]["quote"]["quoted_price"], "245")
+
+    def test_a_business_that_closed_since_planning_is_not_dialed(self):
+        """The gap between planning and dialing is minutes. Shops close in it."""
+        closed = candidate(hours="Mo-Su 00:00-09:00")
+        fake = FakeCalls()
+        rows = run_batch([closed], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(fake.created, [])
+        self.assertEqual(rows[0]["status"], "not_called")
+        self.assertIn("closed at dial time", rows[0]["reason"])
+
+    def test_one_refusal_does_not_kill_the_batch(self):
+        fake = FakeCalls(create_raises=RuntimeError("rate limited"))
+        rows = run_batch([candidate(), candidate("B", "+15555550101")],
+                         "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r["status"] == "error" for r in rows))
+
+    def test_a_create_without_an_id_is_not_retried(self):
+        """Worst case: the call may be live and there is nothing to reconcile."""
+        fake = FakeCalls(call_id="")
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+        self.assertEqual(len(fake.created), 1)
+
+    def test_a_lost_result_keeps_the_call_id(self):
+        fake = FakeCalls(wait_raises=TimeoutError("gateway"))
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+        self.assertEqual(rows[0]["call_id"], "call-1")
+
+    def test_no_answer_is_never_redialed(self):
+        fake = FakeCalls(status="no_answer")
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(len(fake.created), 1)
+        self.assertIsNone(rows[0]["quote"])
+        self.assertIn("not redialled", rows[0]["reason"])
+
+    def test_an_incomplete_result_is_not_reported_as_a_quote(self):
+        fake = FakeCalls(result={"quoted_price": "100"})
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+
+    def test_an_out_of_enum_value_is_not_reported_as_a_quote(self):
+        fake = FakeCalls(result={**GOOD_QUOTE, "does_this_job": "maybe"})
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+
+    def test_calls_go_out_one_at_a_time(self):
+        """Twelve simultaneous calls from one number is an autodialer."""
+        fake = FakeCalls()
+        run_batch([candidate("A", "+15555550100"), candidate("B", "+15555550101")],
+                  "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(len(fake.waited), 2)
+
+    def test_every_row_is_masked(self):
+        fake = FakeCalls()
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertNotIn("5555550100", json.dumps(rows))
+
+
+# ------------------------------------------------------------- compare --
+class TestCompare(unittest.TestCase):
+    def _row(self, name, price, currency="USD"):
+        return {"name": name, "phone_masked": "+15****00", "status": "completed",
+                "reason": "", "quote": {**GOOD_QUOTE, "quoted_price": price,
+                                        "currency": currency}}
+
+    def test_parse_amount_takes_the_low_end_of_a_range(self):
+        self.assertEqual(parse_amount("280-320"), 280.0)
+
+    def test_parse_amount_handles_thousands_separators(self):
+        self.assertEqual(parse_amount("1,250"), 1250.0)
+
+    def test_parse_amount_returns_none_for_prose(self):
+        self.assertIsNone(parse_amount("depends on the glass"))
+
+    def test_parse_amount_returns_none_for_unknown(self):
+        self.assertIsNone(parse_amount("unknown"))
+
+    def test_cheapest_wins(self):
+        table = compare([self._row("Dear", "300"), self._row("Cheap", "100")])
+        self.assertEqual(table["cheapest"], "Cheap")
+
+    def test_a_range_is_ranked_on_its_low_end(self):
+        table = compare([self._row("Range", "150-400"), self._row("Flat", "200")])
+        self.assertEqual(table["cheapest"], "Range")
+
+    def test_a_priceless_answer_does_not_win(self):
+        """An unparseable price must not become a zero that beats every quote."""
+        table = compare([self._row("NoPrice", "unknown"), self._row("Real", "300")])
+        self.assertEqual(table["cheapest"], "Real")
+        self.assertEqual(len(table["no_price"]), 1)
+
+    def test_mixed_currencies_are_not_ranked(self):
+        table = compare([self._row("Usd", "100", "USD"), self._row("Mxn", "1800", "MXN")])
+        self.assertTrue(table["mixed_currencies"])
+        self.assertIsNone(table["cheapest"])
+
+    def test_unreached_rows_are_kept_not_dropped(self):
+        rows = [self._row("Quoted", "100"),
+                {"name": "Silent", "phone_masked": "+15****01", "status": "no_answer",
+                 "reason": "nobody picked up", "quote": None}]
+        self.assertEqual(len(compare(rows)["not_reached"]), 1)
+
+
+# -------------------------------------------------------- end to end --
+class TestSimulatedEndToEnd(unittest.TestCase):
+    """The whole pipeline over the shipped fixture, with no transport."""
+
+    def setUp(self):
+        payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.job = payload["job"]
+        self.candidates = quoterunner.load_fixture(FIXTURE)
+        self.callable_now, _ = quoterunner.screen(self.candidates, MOMENT)
+
+    def test_the_fixture_produces_a_comparison(self):
+        rows = run_batch(self.callable_now, self.job, "Ivan", SimulatedCalls(),
+                         moment=MOMENT)
+        table = compare(rows)
+        self.assertTrue(table["quoted"])
+        self.assertIsNotNone(table["cheapest"])
+
+    def test_no_full_number_reaches_the_rendered_comparison(self):
+        """The flagship assertion: nothing leaks, on any output path."""
+        rows = run_batch(self.callable_now, self.job, "Ivan", SimulatedCalls(),
+                         moment=MOMENT)
+        rendered = render_comparison(self.job, compare(rows), simulated=True)
+        for c in self.candidates:
+            digits = c.phone.lstrip("+")
+            if len(digits) > 6:
+                self.assertNotIn(digits, rendered)
+                self.assertNotIn(digits, json.dumps(rows))
+
+    def test_simulation_is_deterministic(self):
+        first = run_batch(self.callable_now, self.job, "Ivan", SimulatedCalls(),
+                          moment=MOMENT)
+        second = run_batch(self.callable_now, self.job, "Ivan", SimulatedCalls(),
+                           moment=MOMENT)
+        self.assertEqual(json.dumps(first), json.dumps(second))
+
+    def test_simulation_says_it_is_a_simulation(self):
+        rows = run_batch(self.callable_now, self.job, "Ivan", SimulatedCalls(),
+                         moment=MOMENT)
+        self.assertIn("SIMULATED", render_comparison(self.job, compare(rows), True))
+
+    def test_the_cap_still_holds_through_execution(self):
+        many = [candidate(f"Shop {i}", f"+1555555{i:04d}") for i in range(20)]
+        callable_now, excluded = quoterunner.screen(many, MOMENT)
+        self.assertEqual(len(callable_now), quoterunner.MAX_CANDIDATES_PER_RUN)
+        fake = FakeCalls()
+        run_batch(callable_now, "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(len(fake.created), quoterunner.MAX_CANDIDATES_PER_RUN)
+        self.assertTrue(any("cap" in e.reason for e in excluded))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apps/python/quoterunner/test_execution.py
+++ b/apps/python/quoterunner/test_execution.py
@@ -50,8 +50,10 @@ GOOD_QUOTE = {
 }
 
 
-def candidate(name="Northgate Auto Glass", phone="+15555550100", hours=OPEN_ALL_DAY):
-    return Candidate(name=name, phone=phone, opening_hours=hours, source_id="osm/1")
+def candidate(name="Northgate Auto Glass", phone="+15555550100", hours=OPEN_ALL_DAY,
+              tz="America/Chicago"):
+    return Candidate(name=name, phone=phone, opening_hours=hours, source_id="osm/1",
+                     timezone=tz)
 
 
 class FakeCalls:
@@ -476,3 +478,120 @@ class TestContratoSDK(unittest.TestCase):
         from calle import CalleClient
         d = inspect.signature(CalleClient.__init__).parameters["base_url"].default
         self.assertEqual(d, execution.DEFAULT_BASE_URL)
+
+
+# ------------------------------- lo que reporto la revision del PR #118 --
+class TestRevisionPR118(unittest.TestCase):
+    """Los tres fallos que Ray-56 encontro revisando el PR, con su caso.
+
+    Los tres eran la misma familia de error: dar por bueno algo que no se
+    habia comprobado. Estan aqui uno por uno para que no vuelvan.
+    """
+
+    # --- 1. Terminal no es lo mismo que exitoso -------------------------
+    def test_una_llamada_fallida_no_produce_presupuesto(self):
+        """`failed` es terminal, pero no es una llamada que haya ido bien.
+
+        Su structured_result puede validar contra el esquema y aun asi ser los
+        restos de una llamada que no ocurrio como debia. Rankearlo junto a un
+        presupuesto real mete en la tabla un precio que nadie dijo.
+        """
+        fake = FakeCalls(status="failed")
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+        self.assertIn("not as a completed call", rows[0]["reason"])
+
+    def test_una_llamada_cancelada_no_produce_presupuesto(self):
+        fake = FakeCalls(status="canceled")
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+
+    def test_task_completed_false_no_produce_presupuesto(self):
+        """CALL-E diciendo que el agente no termino lo que fue a hacer."""
+        class NoCompletada(FakeCalls):
+            def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+                r = super().wait_for_result(
+                    call_id, timeout_seconds=timeout_seconds,
+                    interval_seconds=interval_seconds)
+                r["task_completed"] = False
+                return r
+        rows = run_batch([candidate()], "job", "Ivan", NoCompletada(), moment=MOMENT)
+        self.assertIsNone(rows[0]["quote"])
+        self.assertIn("not completed", rows[0]["reason"])
+
+    def test_completed_si_produce_presupuesto(self):
+        """El arreglo no puede haberse llevado por delante el camino bueno."""
+        rows = run_batch([candidate()], "job", "Ivan", FakeCalls(), moment=MOMENT)
+        self.assertIsNotNone(rows[0]["quote"])
+
+    def test_succeeded_tambien_vale(self):
+        rows = run_batch([candidate()], "job", "Ivan",
+                         FakeCalls(status="succeeded"), moment=MOMENT)
+        self.assertIsNotNone(rows[0]["quote"])
+
+    # --- 2. El horario se lee en la zona del negocio --------------------
+    def test_sin_zona_no_se_marca(self):
+        """Sin zona no se puede saber que hora es alli. No se llama a ciegas."""
+        fake = FakeCalls()
+        rows = run_batch([candidate(tz="")], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(fake.created, [])
+        self.assertEqual(rows[0]["status"], "not_called")
+        self.assertIn("no timezone", rows[0]["reason"])
+
+    def test_la_zona_decide_si_esta_abierto(self):
+        """Mismo instante, dos husos, dos respuestas. Este es el bug entero.
+
+        A las 20:00 en Nueva York son las 17:00 en Los Angeles. Un negocio
+        abierto de 9 a 18 esta cerrado en el primero y abierto en el segundo,
+        y antes se resolvia con el reloj del host para los dos.
+        """
+        from datetime import timezone as tzmod, timedelta
+        instante = datetime(2026, 8, 7, 20, 0, tzinfo=tzmod(timedelta(hours=-4)))
+        horario = "Mo-Su 09:00-18:00"
+        este = FakeCalls()
+        run_batch([candidate(hours=horario, tz="America/New_York")],
+                  "job", "Ivan", este, moment=instante)
+        oeste = FakeCalls()
+        run_batch([candidate(hours=horario, tz="America/Los_Angeles")],
+                  "job", "Ivan", oeste, moment=instante)
+        self.assertEqual(len(este.created), 0, "20:00 en Nueva York: cerrado")
+        self.assertEqual(len(oeste.created), 1, "17:00 en Los Angeles: abierto")
+
+    def test_screen_excluye_sin_zona_en_el_camino_en_vivo(self):
+        _, fuera = quoterunner.screen([candidate(tz="")], MOMENT, require_timezone=True)
+        self.assertIn("no timezone", fuera[0].reason)
+
+    def test_screen_no_lo_exige_en_el_preview(self):
+        """El preview si los enseña: para eso esta, para ver que falta."""
+        dentro, _ = quoterunner.screen([candidate(tz="")], MOMENT)
+        self.assertEqual(len(dentro), 1)
+
+    def test_el_operador_puede_declarar_la_zona_del_lote(self):
+        """Declararla no es adivinarla. Adivinarla es lo que esta prohibido."""
+        dentro, _ = quoterunner.screen([candidate(tz="")], MOMENT,
+                                       default_timezone="America/Chicago")
+        self.assertEqual(dentro[0].timezone, "America/Chicago")
+
+    def test_una_zona_inventada_no_pasa_por_buena(self):
+        _, fuera = quoterunner.screen([candidate(tz="Marte/Olympus")], MOMENT)
+        self.assertIn("Unknown timezone", fuera[0].reason)
+
+    # --- 3. La clave de idempotencia cubre el guion entero --------------
+    def test_cambiar_el_solicitante_cambia_la_clave(self):
+        """Otro nombre en la llamada es otra llamada, no una repeticion."""
+        self.assertNotEqual(idempotency_key(candidate(), "job", "Ivan"),
+                            idempotency_key(candidate(), "job", "Marta"))
+
+    def test_cambiar_el_idioma_cambia_la_clave(self):
+        self.assertNotEqual(idempotency_key(candidate(), "job", "Ivan", "en-US"),
+                            idempotency_key(candidate(), "job", "Ivan", "es-MX"))
+
+    def test_el_mismo_guion_conserva_la_clave(self):
+        """La deduplicacion real tiene que seguir funcionando."""
+        self.assertEqual(idempotency_key(candidate(), "job", "Ivan", "en-US"),
+                         idempotency_key(candidate(), "job", "Ivan", "en-US"))
+
+    def test_la_clave_del_payload_coincide_con_la_funcion(self):
+        args = call_arguments(candidate(), "job", "Ivan", "es-MX")
+        self.assertEqual(args["idempotency_key"],
+                         idempotency_key(candidate(), "job", "Ivan", "es-MX"))

--- a/apps/python/quoterunner/test_execution.py
+++ b/apps/python/quoterunner/test_execution.py
@@ -422,3 +422,57 @@ class TestSimulatedEndToEnd(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+# ------------------------------------------------- contrato real del SDK --
+class TestContratoSDK(unittest.TestCase):
+    """Comprueba que lo que enviamos encaja con el SDK publicado de verdad.
+
+    Sin esto, un cambio de firma en `calle-ai` no se nota hasta que la llamada
+    falla en vivo. Y la unica vez que esta app se ejecuta en vivo es delante de
+    una camara o delante de un negocio real, que son los dos peores momentos.
+
+    No se coloca ninguna llamada: solo se comparan firmas.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import calle  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("calle-ai no instalado (pip install calle-ai)")
+
+    def test_el_cliente_acepta_api_key_y_base_url(self):
+        import inspect
+        from calle import CalleClient
+        p = inspect.signature(CalleClient.__init__).parameters
+        self.assertIn("api_key", p)
+        self.assertIn("base_url", p)
+
+    def test_create_acepta_todos_los_campos_que_enviamos(self):
+        import inspect
+        from calle.calls import CalleCalls
+        acepta = set(inspect.signature(CalleCalls.create).parameters)
+        enviamos = set(call_arguments(candidate(), "job", "Ivan"))
+        faltan = enviamos - acepta
+        self.assertFalse(faltan, "el SDK no acepta: %s" % sorted(faltan))
+
+    def test_recipients_es_plural_y_lista(self):
+        """`create` admite `recipient` y `recipients`. Usamos la lista."""
+        import inspect
+        from calle.calls import CalleCalls
+        self.assertIn("recipients", inspect.signature(CalleCalls.create).parameters)
+        self.assertIsInstance(call_arguments(candidate(), "job", "Ivan")["recipients"], list)
+
+    def test_wait_for_result_acepta_nuestras_keywords(self):
+        import inspect
+        from calle.calls import CalleCalls
+        p = inspect.signature(CalleCalls.wait_for_result).parameters
+        self.assertIn("timeout_seconds", p)
+        self.assertIn("interval_seconds", p)
+
+    def test_el_base_url_por_defecto_es_el_que_fijamos(self):
+        import inspect
+        from calle import CalleClient
+        d = inspect.signature(CalleClient.__init__).parameters["base_url"].default
+        self.assertEqual(d, execution.DEFAULT_BASE_URL)

--- a/apps/python/quoterunner/test_execution.py
+++ b/apps/python/quoterunner/test_execution.py
@@ -426,15 +426,15 @@ if __name__ == "__main__":
     unittest.main(verbosity=2)
 
 
-# ------------------------------------------------- contrato real del SDK --
-class TestContratoSDK(unittest.TestCase):
-    """Comprueba que lo que enviamos encaja con el SDK publicado de verdad.
+# --------------------------------------------------- the published SDK --
+class TestSDKContract(unittest.TestCase):
+    """Check that what we send still fits the SDK that is actually published.
 
-    Sin esto, un cambio de firma en `calle-ai` no se nota hasta que la llamada
-    falla en vivo. Y la unica vez que esta app se ejecuta en vivo es delante de
-    una camara o delante de un negocio real, que son los dos peores momentos.
+    Without this, a signature change in `calle-ai` goes unnoticed until a call
+    fails live. The only times this app runs live are in front of a camera or
+    in front of a real business, which are the two worst moments to find out.
 
-    No se coloca ninguna llamada: solo se comparan firmas.
+    No call is placed: signatures only.
     """
 
     @classmethod
@@ -442,156 +442,222 @@ class TestContratoSDK(unittest.TestCase):
         try:
             import calle  # noqa: F401
         except ImportError:
-            raise unittest.SkipTest("calle-ai no instalado (pip install calle-ai)")
+            raise unittest.SkipTest("calle-ai not installed (pip install calle-ai)")
 
-    def test_el_cliente_acepta_api_key_y_base_url(self):
+    def test_client_takes_api_key_and_base_url(self):
         import inspect
         from calle import CalleClient
         p = inspect.signature(CalleClient.__init__).parameters
         self.assertIn("api_key", p)
         self.assertIn("base_url", p)
 
-    def test_create_acepta_todos_los_campos_que_enviamos(self):
+    def test_create_accepts_every_field_we_send(self):
         import inspect
         from calle.calls import CalleCalls
-        acepta = set(inspect.signature(CalleCalls.create).parameters)
-        enviamos = set(call_arguments(candidate(), "job", "Ivan"))
-        faltan = enviamos - acepta
-        self.assertFalse(faltan, "el SDK no acepta: %s" % sorted(faltan))
+        accepted = set(inspect.signature(CalleCalls.create).parameters)
+        sent = set(call_arguments(candidate(), "job", "Ivan"))
+        missing = sent - accepted
+        self.assertFalse(missing, "the SDK does not accept: %s" % sorted(missing))
 
-    def test_recipients_es_plural_y_lista(self):
-        """`create` admite `recipient` y `recipients`. Usamos la lista."""
+    def test_recipients_is_the_plural_list_form(self):
+        """`create` takes both `recipient` and `recipients`. We use the list."""
         import inspect
         from calle.calls import CalleCalls
         self.assertIn("recipients", inspect.signature(CalleCalls.create).parameters)
-        self.assertIsInstance(call_arguments(candidate(), "job", "Ivan")["recipients"], list)
+        self.assertIsInstance(
+            call_arguments(candidate(), "job", "Ivan")["recipients"], list)
 
-    def test_wait_for_result_acepta_nuestras_keywords(self):
+    def test_wait_for_result_takes_our_keywords(self):
         import inspect
         from calle.calls import CalleCalls
         p = inspect.signature(CalleCalls.wait_for_result).parameters
         self.assertIn("timeout_seconds", p)
         self.assertIn("interval_seconds", p)
 
-    def test_el_base_url_por_defecto_es_el_que_fijamos(self):
+    def test_the_sdk_default_origin_is_the_one_we_pin(self):
         import inspect
         from calle import CalleClient
         d = inspect.signature(CalleClient.__init__).parameters["base_url"].default
         self.assertEqual(d, execution.DEFAULT_BASE_URL)
 
 
-# ------------------------------- lo que reporto la revision del PR #118 --
-class TestRevisionPR118(unittest.TestCase):
-    """Los tres fallos que Ray-56 encontro revisando el PR, con su caso.
+# ---------------------------------------------- raised in review of #118 --
+class TestReviewFindings(unittest.TestCase):
+    """One test per finding from the review, named after the finding.
 
-    Los tres eran la misma familia de error: dar por bueno algo que no se
-    habia comprobado. Estan aqui uno por uno para que no vuelvan.
+    They were all the same shape of mistake: treating something unverified as
+    good enough to act on.
     """
 
-    # --- 1. Terminal no es lo mismo que exitoso -------------------------
-    def test_una_llamada_fallida_no_produce_presupuesto(self):
-        """`failed` es terminal, pero no es una llamada que haya ido bien.
+    # --- terminal is not the same as successful ------------------------
+    def test_a_failed_call_produces_no_quote(self):
+        """`failed` is terminal, but it is not a call that went well.
 
-        Su structured_result puede validar contra el esquema y aun asi ser los
-        restos de una llamada que no ocurrio como debia. Rankearlo junto a un
-        presupuesto real mete en la tabla un precio que nadie dijo.
+        Its structured_result can satisfy the schema and still be the wreckage
+        of a call that did not happen as intended. Ranking it beside a real
+        quote puts a price in the table that nobody said out loud.
         """
         fake = FakeCalls(status="failed")
         rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
         self.assertIsNone(rows[0]["quote"])
         self.assertIn("not as a completed call", rows[0]["reason"])
 
-    def test_una_llamada_cancelada_no_produce_presupuesto(self):
-        fake = FakeCalls(status="canceled")
-        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+    def test_a_canceled_call_produces_no_quote(self):
+        rows = run_batch([candidate()], "job", "Ivan",
+                         FakeCalls(status="canceled"), moment=MOMENT)
         self.assertIsNone(rows[0]["quote"])
 
-    def test_task_completed_false_no_produce_presupuesto(self):
-        """CALL-E diciendo que el agente no termino lo que fue a hacer."""
-        class NoCompletada(FakeCalls):
+    def test_task_completed_false_produces_no_quote(self):
+        """CALL-E saying the agent did not finish what it was sent to do."""
+        class Unfinished(FakeCalls):
             def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
                 r = super().wait_for_result(
                     call_id, timeout_seconds=timeout_seconds,
                     interval_seconds=interval_seconds)
                 r["task_completed"] = False
                 return r
-        rows = run_batch([candidate()], "job", "Ivan", NoCompletada(), moment=MOMENT)
+        rows = run_batch([candidate()], "job", "Ivan", Unfinished(), moment=MOMENT)
         self.assertIsNone(rows[0]["quote"])
         self.assertIn("not completed", rows[0]["reason"])
 
-    def test_completed_si_produce_presupuesto(self):
-        """El arreglo no puede haberse llevado por delante el camino bueno."""
+    def test_a_completed_call_still_produces_a_quote(self):
+        """The fix must not have taken the working path down with it."""
         rows = run_batch([candidate()], "job", "Ivan", FakeCalls(), moment=MOMENT)
         self.assertIsNotNone(rows[0]["quote"])
 
-    def test_succeeded_tambien_vale(self):
+    def test_succeeded_counts_as_successful_too(self):
         rows = run_batch([candidate()], "job", "Ivan",
                          FakeCalls(status="succeeded"), moment=MOMENT)
         self.assertIsNotNone(rows[0]["quote"])
 
-    # --- 2. El horario se lee en la zona del negocio --------------------
-    def test_sin_zona_no_se_marca(self):
-        """Sin zona no se puede saber que hora es alli. No se llama a ciegas."""
+    # --- hours are read on the shop's own clock ------------------------
+    def test_a_candidate_with_no_timezone_is_not_dialled(self):
+        """Without a zone we cannot know what time it is there."""
         fake = FakeCalls()
         rows = run_batch([candidate(tz="")], "job", "Ivan", fake, moment=MOMENT)
         self.assertEqual(fake.created, [])
         self.assertEqual(rows[0]["status"], "not_called")
         self.assertIn("no timezone", rows[0]["reason"])
 
-    def test_la_zona_decide_si_esta_abierto(self):
-        """Mismo instante, dos husos, dos respuestas. Este es el bug entero.
+    def test_the_zone_decides_whether_it_is_open(self):
+        """One instant, two zones, two answers. This is the whole bug.
 
-        A las 20:00 en Nueva York son las 17:00 en Los Angeles. Un negocio
-        abierto de 9 a 18 esta cerrado en el primero y abierto en el segundo,
-        y antes se resolvia con el reloj del host para los dos.
+        20:00 in New York is 17:00 in Los Angeles. A shop open 09:00-18:00 is
+        closed in the first and open in the second, and both used to be
+        resolved against the host clock.
         """
         from datetime import timezone as tzmod, timedelta
-        instante = datetime(2026, 8, 7, 20, 0, tzinfo=tzmod(timedelta(hours=-4)))
-        horario = "Mo-Su 09:00-18:00"
-        este = FakeCalls()
-        run_batch([candidate(hours=horario, tz="America/New_York")],
-                  "job", "Ivan", este, moment=instante)
-        oeste = FakeCalls()
-        run_batch([candidate(hours=horario, tz="America/Los_Angeles")],
-                  "job", "Ivan", oeste, moment=instante)
-        self.assertEqual(len(este.created), 0, "20:00 en Nueva York: cerrado")
-        self.assertEqual(len(oeste.created), 1, "17:00 en Los Angeles: abierto")
+        instant = datetime(2026, 8, 7, 20, 0, tzinfo=tzmod(timedelta(hours=-4)))
+        hours = "Mo-Su 09:00-18:00"
+        east = FakeCalls()
+        run_batch([candidate(hours=hours, tz="America/New_York")],
+                  "job", "Ivan", east, moment=instant)
+        west = FakeCalls()
+        run_batch([candidate(hours=hours, tz="America/Los_Angeles")],
+                  "job", "Ivan", west, moment=instant)
+        self.assertEqual(len(east.created), 0, "20:00 in New York: closed")
+        self.assertEqual(len(west.created), 1, "17:00 in Los Angeles: open")
 
-    def test_screen_excluye_sin_zona_en_el_camino_en_vivo(self):
-        _, fuera = quoterunner.screen([candidate(tz="")], MOMENT, require_timezone=True)
-        self.assertIn("no timezone", fuera[0].reason)
+    def test_screen_excludes_zoneless_candidates_on_the_live_path(self):
+        _, out = quoterunner.screen([candidate(tz="")], MOMENT, require_timezone=True)
+        self.assertIn("no timezone", out[0].reason)
 
-    def test_screen_no_lo_exige_en_el_preview(self):
-        """El preview si los enseña: para eso esta, para ver que falta."""
-        dentro, _ = quoterunner.screen([candidate(tz="")], MOMENT)
-        self.assertEqual(len(dentro), 1)
+    def test_preview_does_not_require_a_zone(self):
+        """Preview still shows them: that is what it is for."""
+        keep, _ = quoterunner.screen([candidate(tz="")], MOMENT)
+        self.assertEqual(len(keep), 1)
 
-    def test_el_operador_puede_declarar_la_zona_del_lote(self):
-        """Declararla no es adivinarla. Adivinarla es lo que esta prohibido."""
-        dentro, _ = quoterunner.screen([candidate(tz="")], MOMENT,
-                                       default_timezone="America/Chicago")
-        self.assertEqual(dentro[0].timezone, "America/Chicago")
+    def test_the_operator_may_declare_the_zone_for_a_batch(self):
+        """Declaring it is not inferring it. Inferring is what is forbidden."""
+        keep, _ = quoterunner.screen([candidate(tz="")], MOMENT,
+                                     default_timezone="America/Chicago")
+        self.assertEqual(keep[0].timezone, "America/Chicago")
 
-    def test_una_zona_inventada_no_pasa_por_buena(self):
-        _, fuera = quoterunner.screen([candidate(tz="Marte/Olympus")], MOMENT)
-        self.assertIn("Unknown timezone", fuera[0].reason)
+    def test_an_invented_zone_is_not_taken_on_trust(self):
+        _, out = quoterunner.screen([candidate(tz="Mars/Olympus")], MOMENT)
+        self.assertIn("Unknown timezone", out[0].reason)
 
-    # --- 3. La clave de idempotencia cubre el guion entero --------------
-    def test_cambiar_el_solicitante_cambia_la_clave(self):
-        """Otro nombre en la llamada es otra llamada, no una repeticion."""
+    # --- keys and tokens cover the whole spoken payload ----------------
+    def test_changing_the_requester_changes_the_idempotency_key(self):
+        """A different name on the call is a different call, not a repeat."""
         self.assertNotEqual(idempotency_key(candidate(), "job", "Ivan"),
                             idempotency_key(candidate(), "job", "Marta"))
 
-    def test_cambiar_el_idioma_cambia_la_clave(self):
+    def test_changing_the_locale_changes_the_idempotency_key(self):
         self.assertNotEqual(idempotency_key(candidate(), "job", "Ivan", "en-US"),
                             idempotency_key(candidate(), "job", "Ivan", "es-MX"))
 
-    def test_el_mismo_guion_conserva_la_clave(self):
-        """La deduplicacion real tiene que seguir funcionando."""
+    def test_the_same_script_keeps_the_same_key(self):
+        """Real deduplication still has to work."""
         self.assertEqual(idempotency_key(candidate(), "job", "Ivan", "en-US"),
                          idempotency_key(candidate(), "job", "Ivan", "en-US"))
 
-    def test_la_clave_del_payload_coincide_con_la_funcion(self):
+    def test_the_payload_key_matches_the_function(self):
         args = call_arguments(candidate(), "job", "Ivan", "es-MX")
         self.assertEqual(args["idempotency_key"],
                          idempotency_key(candidate(), "job", "Ivan", "es-MX"))
+
+    def test_changing_the_requester_changes_the_confirmation_token(self):
+        """An approval must not survive a rewritten script.
+
+        Otherwise you review a batch of English calls on behalf of one person
+        and use that same token to place Spanish calls on behalf of another.
+        """
+        batch = [candidate()]
+        self.assertNotEqual(confirmation_token(batch, "job", "Ivan"),
+                            confirmation_token(batch, "job", "Marta"))
+
+    def test_changing_the_locale_changes_the_confirmation_token(self):
+        batch = [candidate()]
+        self.assertNotEqual(confirmation_token(batch, "job", "Ivan", "en-US"),
+                            confirmation_token(batch, "job", "Ivan", "es-MX"))
+
+    def test_a_token_from_another_locale_is_refused(self):
+        batch = [candidate()]
+        stale = confirmation_token(batch, "job", "Ivan", "en-US")
+        with self.assertRaises(QuoteError):
+            check_confirmation(batch, "job", stale, "Ivan", "es-MX")
+
+    # --- a lost answer is not a refusal --------------------------------
+    def test_a_timeout_is_recorded_as_unknown_not_refused(self):
+        """The provider may have accepted it and the phone may be ringing.
+
+        Filing that as "refused" invites a retry, and a retry here is a second
+        call to a real business.
+        """
+        fake = FakeCalls(create_raises=TimeoutError("read timeout"))
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+        self.assertIn("may have been accepted", rows[0]["reason"])
+
+    def test_an_unknown_outcome_carries_its_idempotency_key(self):
+        """That key is what reconciliation has to match on afterwards."""
+        fake = FakeCalls(create_raises=TimeoutError("read timeout"))
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["idempotency_key"],
+                         idempotency_key(candidate(), "job", "Ivan", "en-US"))
+
+    def test_a_server_error_is_also_unknown(self):
+        class ServerError(Exception):
+            status_code = 503
+        fake = FakeCalls(create_raises=ServerError("upstream"))
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "unknown")
+
+    def test_a_rejected_request_is_still_a_refusal(self):
+        """A bad key or a malformed payload never rang anybody."""
+        class BadRequest(Exception):
+            status_code = 400
+        fake = FakeCalls(create_raises=BadRequest("invalid"))
+        rows = run_batch([candidate()], "job", "Ivan", fake, moment=MOMENT)
+        self.assertEqual(rows[0]["status"], "error")
+        self.assertIn("refused", rows[0]["reason"])
+
+    def test_outcome_unknown_classifies_by_name_and_code(self):
+        self.assertTrue(execution.outcome_unknown(TimeoutError()))
+        self.assertTrue(execution.outcome_unknown(ConnectionError()))
+        self.assertFalse(execution.outcome_unknown(ValueError()))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apps/python/quoterunner/test_quoterunner.py
+++ b/apps/python/quoterunner/test_quoterunner.py
@@ -1,0 +1,213 @@
+"""Regression tests for QuoteRunner.
+
+These guard the ways a call list can go wrong: calling a closed business,
+calling one whose hours nobody published, reformatting an ambiguous number into
+a different country, exceeding the per-run cap, and leaking a full phone number
+into any output path.
+
+No network, no telephone, no credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+from quoterunner import (
+    MAX_CANDIDATES_PER_RUN,
+    Candidate,
+    PlanError,
+    build_plan,
+    is_open,
+    load_fixture,
+    mask,
+    render,
+    screen,
+    validate_e164,
+    window_text,
+)
+
+FIXTURE = Path(__file__).with_name("example-candidates.json")
+
+# Wednesday 2026-08-12, 10:00 local. Fixed so the suite is deterministic.
+WED_10 = datetime(2026, 8, 12, 10, 0)
+WED_14 = datetime(2026, 8, 12, 14, 0)
+WED_23 = datetime(2026, 8, 12, 23, 0)
+SAT_11 = datetime(2026, 8, 15, 11, 0)
+SUN_11 = datetime(2026, 8, 16, 11, 0)
+
+
+def hours(spec: str, phone: str = "+15550100") -> Candidate:
+    return Candidate(name="Test Garage", phone=phone, opening_hours=spec)
+
+
+class OpeningHours(unittest.TestCase):
+    def test_inside_a_weekday_range(self):
+        self.assertTrue(is_open("Mo-Fr 09:00-19:00", WED_10))
+
+    def test_outside_a_weekday_range(self):
+        self.assertFalse(is_open("Mo-Fr 09:00-19:00", WED_23))
+
+    def test_saturday_is_not_inside_mo_fr(self):
+        self.assertFalse(is_open("Mo-Fr 09:00-19:00", SAT_11))
+
+    def test_saturday_has_its_own_span(self):
+        self.assertTrue(is_open("Mo-Fr 09:00-19:00; Sa 10:00-14:00", SAT_11))
+
+    def test_a_day_not_listed_is_closed(self):
+        self.assertFalse(is_open("Mo-Fr 09:00-19:00; Sa 10:00-14:00", SUN_11))
+
+    def test_split_hours_open_in_the_morning_span(self):
+        self.assertTrue(is_open("Mo-Fr 09:00-13:00,15:00-19:00", WED_10))
+
+    def test_split_hours_closed_during_the_gap(self):
+        self.assertFalse(is_open("Mo-Fr 09:00-13:00,15:00-19:00", WED_14))
+
+    def test_always_open(self):
+        self.assertTrue(is_open("24/7", WED_23))
+
+    def test_empty_hours_read_as_closed(self):
+        self.assertFalse(is_open("", WED_10))
+
+    def test_unparseable_hours_read_as_closed_not_open(self):
+        # An optimistic parse here calls a real person at an hour nobody agreed to.
+        self.assertFalse(is_open("whenever we feel like it", WED_10))
+
+    def test_off_marker_is_respected(self):
+        self.assertFalse(is_open("Mo-Fr off", WED_10))
+
+    def test_window_text_reports_the_spans(self):
+        self.assertEqual(window_text("Mo-Fr 09:00-13:00,15:00-19:00", WED_10),
+                         "09:00-13:00, 15:00-19:00")
+
+    def test_window_text_says_closed_when_there_is_none(self):
+        self.assertEqual(window_text("Mo-Fr 09:00-17:00", SAT_11), "closed today")
+
+
+class PhoneNumbers(unittest.TestCase):
+    def test_accepts_e164(self):
+        self.assertEqual(validate_e164("+15550100"), "+15550100")
+
+    def test_strips_formatting_but_keeps_the_number(self):
+        self.assertEqual(validate_e164("+1 (555) 010-0"), "+15550100")
+
+    def test_rejects_a_local_number_instead_of_guessing_a_country(self):
+        with self.assertRaises(PlanError):
+            validate_e164("555 0106")
+
+    def test_rejects_an_empty_number(self):
+        with self.assertRaises(PlanError):
+            validate_e164("")
+
+    def test_mask_keeps_only_the_ends(self):
+        self.assertEqual(mask("+15550100"), "+15****00")
+
+    def test_mask_handles_a_short_string_without_leaking_it(self):
+        self.assertNotIn("5550", mask("5550"))
+
+    def test_mask_of_nothing_is_stable(self):
+        self.assertEqual(mask(""), "(none)")
+
+
+class Screening(unittest.TestCase):
+    def test_open_business_is_callable(self):
+        callable_now, excluded = screen([hours("Mo-Fr 09:00-19:00")], WED_10)
+        self.assertEqual(len(callable_now), 1)
+        self.assertEqual(excluded, [])
+
+    def test_closed_business_is_excluded_with_a_reason(self):
+        callable_now, excluded = screen([hours("Mo-Fr 09:00-19:00")], WED_23)
+        self.assertEqual(callable_now, [])
+        self.assertIn("closed now", excluded[0].reason)
+
+    def test_missing_hours_is_excluded_rather_than_assumed_open(self):
+        callable_now, excluded = screen([hours("")], WED_10)
+        self.assertEqual(callable_now, [])
+        self.assertIn("do not call blind", excluded[0].reason)
+
+    def test_bad_number_is_excluded_not_reformatted(self):
+        callable_now, excluded = screen(
+            [hours("Mo-Fr 09:00-19:00", phone="555 0106")], WED_10
+        )
+        self.assertEqual(callable_now, [])
+        self.assertIn("E.164", excluded[0].reason)
+
+    def test_cap_applies_and_the_overflow_says_why(self):
+        many = [
+            Candidate(name=f"Garage {i}", phone=f"+1555010{i:02d}",
+                      opening_hours="Mo-Fr 09:00-19:00")
+            for i in range(MAX_CANDIDATES_PER_RUN + 4)
+        ]
+        callable_now, excluded = screen(many, WED_10)
+        self.assertEqual(len(callable_now), MAX_CANDIDATES_PER_RUN)
+        self.assertEqual(len(excluded), 4)
+        self.assertIn("cap", excluded[0].reason)
+
+    def test_every_candidate_appears_in_exactly_one_bucket(self):
+        candidates = load_fixture(FIXTURE)
+        callable_now, excluded = screen(candidates, WED_10)
+        self.assertEqual(len(callable_now) + len(excluded), len(candidates))
+
+
+class Plan(unittest.TestCase):
+    def test_plan_marks_that_no_call_was_placed(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        self.assertTrue(plan["no_call_placed"])
+
+    def test_plan_refuses_when_nobody_is_reachable(self):
+        with self.assertRaises(PlanError):
+            build_plan([hours("")], "Replace a windscreen", "Sam", WED_10)
+
+    def test_script_names_the_requester_and_the_job(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        script = plan["calls"][0]["script"]
+        self.assertIn("Sam", script)
+        self.assertIn("Replace a windscreen", script)
+
+    def test_script_tells_the_agent_to_admit_being_an_ai(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        self.assertIn("say yes, plainly", plan["calls"][0]["script"])
+
+    def test_excluded_candidates_are_reported_not_silently_dropped(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        self.assertTrue(plan["excluded"])
+        for item in plan["excluded"]:
+            self.assertTrue(item["reason"])
+
+
+class NoNumberLeaks(unittest.TestCase):
+    """The one test that matters most: a full number must not reach any output."""
+
+    def _full_numbers(self) -> list[str]:
+        payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        return [
+            c["phone"].replace(" ", "")
+            for c in payload["candidates"]
+            if c["phone"].startswith("+")
+        ]
+
+    def test_no_full_number_in_the_rendered_report(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        text = render(plan)
+        for number in self._full_numbers():
+            self.assertNotIn(number, text)
+
+    def test_no_full_number_in_the_json_plan(self):
+        plan = build_plan(load_fixture(FIXTURE), "Replace a windscreen", "Sam", WED_10)
+        text = json.dumps(plan)
+        for number in self._full_numbers():
+            self.assertNotIn(number, text)
+
+    def test_no_full_number_in_an_error_message(self):
+        try:
+            validate_e164("+1555010999999999999")
+        except PlanError as error:
+            self.assertNotIn("555010999999999999", str(error))
+        else:
+            self.fail("expected PlanError")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
QuoteRunner: decide who is worth calling, call them through CALL-E, compare the quotes.

Every app in `apps/` starts from a list somebody already had — a fixture, a CSV, a study file, a hand-written plan. `hungrycall-cascade` says so explicitly: its restaurant search lives in another repository. None of them answer the question that comes first, **who should I even call?**

QuoteRunner answers it and then acts on the answer. It keeps the candidates that publish a number, are open right now, and can be reached — deriving each calling window from published `opening_hours` rather than from configuration — calls them with a typed `result_schema`, and sorts what they said by price.

### Three modes, one of which dials

| | places calls | needs credentials |
|---|---|---|
| preview *(default)* | no | no |
| `--simulate` | no | no |
| `--execute` | **yes** | yes |

`--execute` is gated four ways, and any one of them alone stops the call:

1. `CALLE_LIVE_CALLS_ENABLED=true`
2. `CALLE_API_KEY`
3. `--confirm <token>` — a hash of the job plus the sorted list of numbers, so a token obtained by reviewing one list will not authorise a different one
4. opening hours re-checked **at dial time**, not at plan time — a batch takes minutes, and a shop that closes at 18:00 must not be dialled at 18:04 because it was open when the plan was written

Gate 3 implements the gap we reported through the hackathon feedback form: `call start` has no machine-enforced confirmation, so the only thing between an agent and a live call is a sentence in a markdown file that a model is free to skip.

### Handling of what comes back

Nine fields, every one a string with an explicit `unknown`, including the price — a receptionist who says *"depends on the glass, call back Tuesday"* is a normal outcome, and a numeric field would force the model to invent a number to satisfy the type.

Narrow fields have to match their shape or become `unknown`; the two free-text fields are redacted for numbers and emails. Quotes in different currencies are reported but never ranked against each other, and an unparseable price sorts last rather than becoming a zero that wins.

### Relationship to consent-gate

`consent-gate` requires the caller to supply *"a recipient timezone and permitted calling window"*. QuoteRunner derives that window from open data instead. The two compose — QuoteRunner decides who is callable and when, ConsentGate decides whether this particular call is permitted. This app does not duplicate its consent, do-not-call or idempotency machinery and is not a substitute for it.

### Checks

```
python -m unittest discover -p "test_*.py"
Ran 91 tests in 0.011s
OK

python3 scripts/validate_repository.py
Repository validation passed.
```

No test places a call or reads a credential. The CallsAPI is a fake, which is the point: the gates that stop a real call have to be testable without placing one.

- [x] Preview is the default; nothing dials without an explicit opt-in
- [x] Credentials read from the environment only, never from a file or an argument
- [x] E.164 validated, never reformatted; masked in every output path, errors included
- [x] Base URL pinned to the official origin, or a loopback address for tests
- [x] One call per business per job via a content-derived idempotency key
- [x] Nothing redialled automatically; busy, no-answer and voicemail are recorded and left alone
- [x] Cancellation: stopping the process stops it; nothing is scheduled to run later
- [x] Out of scope by construction for medical, legal, financial and emergency workflows