### PR TITLE
docs(apps): add CallmeMaybe to apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Apps
 
+- [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
+
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.
 
 | App | Language | Purpose |


### PR DESCRIPTION
## Summary

Adds CallmeMaybe to the apps awesome list. It belongs here as a Shopify order-exception workflow that uses CALL-E for carrier trace calls and customer callbacks, then places deterministic policy, merchant approval, and fresh-order drift checks between the conversation and any Shopify mutation.

The linked app defaults to a no-call fixture provider, requires two explicit server-side gates for live calls, masks or encrypts personal data, and documents controlled-number demo safety.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior (not applicable; CallmeMaybe creates one-off calls only).
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
