### PR TITLE
fix(consent-gate): reconcile malformed provider results

### DIFF
--- a/apps/python/consent-gate/consent_gate/__main__.py
+++ b/apps/python/consent-gate/consent_gate/__main__.py
@@ -281,8 +281,10 @@ def _update_event(
 
 
 def _finalize_result(
-    ledger: DurableLedger, reservation_id: str, result: dict
+    ledger: DurableLedger, reservation_id: str, result: object
 ) -> dict:
+    if not isinstance(result, dict):
+        raise PolicyError("provider result must be a JSON object")
     outcome = _verified_outcome(result)
     _update_event(
         ledger,
@@ -396,6 +398,7 @@ def _execute(
             provider_call_id=call_id,
         )
         result = client.calls.wait_for_result(call_id)
+        return _finalize_result(ledger, reservation["reservation_id"], result)
     except Exception:
         # Keep an ambiguous dispatch reserved. A human must reconcile it with
         # the provider before another attempt; automatic redial is unsafe.
@@ -405,7 +408,6 @@ def _execute(
             state="reconciliation_required",
         )
         raise
-    return _finalize_result(ledger, reservation["reservation_id"], result)
 
 
 def _reconcile(
@@ -479,10 +481,10 @@ def _reconcile(
                 provider_call_id=call_id,
             )
         result = client.calls.wait_for_result(call_id)
+        return _finalize_result(ledger, reservation_id, result)
     except Exception:
         _update_event(ledger, reservation_id, state="reconciliation_required")
         raise
-    return _finalize_result(ledger, reservation_id, result)
 
 
 def _simulate(plan: dict, history: list[dict]) -> dict:

--- a/apps/python/consent-gate/tests/test_policy.py
+++ b/apps/python/consent-gate/tests/test_policy.py
@@ -597,6 +597,51 @@ class PolicyTests(unittest.TestCase):
             )
             self.assertEqual(observed["during_wait"]["attempt_number"], 1)
 
+    def test_malformed_provider_result_requires_reconciliation(self):
+        plan = valid_plan()
+        plan["execution_allowed"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "ledger.json"
+
+            class FakeCalls:
+                def create(self, **_kwargs):
+                    return {"id": "call_malformed"}
+
+                def wait_for_result(self, _call_id):
+                    return ["not", "a", "result", "object"]
+
+            class FakeClient:
+                def __init__(self, **_kwargs):
+                    self.calls = FakeCalls()
+
+            with (
+                patch.dict(
+                    sys.modules,
+                    {"calle": types.SimpleNamespace(CalleClient=FakeClient)},
+                ),
+                patch.dict(
+                    os.environ,
+                    {
+                        "CALLE_API_KEY": "test-only",
+                        "CALLE_IDEMPOTENCY_NAMESPACE": PROVIDER_NAMESPACE,
+                    },
+                ),
+                patch(
+                    "consent_gate.__main__.validate_dispatch_window",
+                    return_value=[],
+                ),
+            ):
+                with self.assertRaisesRegex(PolicyError, "JSON object"):
+                    _execute(
+                        plan,
+                        "I reviewed this call plan",
+                        str(state_path),
+                    )
+
+            event = json.loads(state_path.read_text(encoding="utf-8"))[0]
+            self.assertEqual(event["provider_call_id"], "call_malformed")
+            self.assertEqual(event["state"], "reconciliation_required")
+
     def test_terminal_retry_uses_persisted_second_attempt_identity(self):
         plan = valid_plan()
         plan["execution_allowed"] = True


### PR DESCRIPTION
## Summary
- validate that provider results are JSON objects before outcome derivation
- keep finalization inside the guarded dispatch/reconciliation boundary
- persist `reconciliation_required` when a malformed result is returned, preventing unsafe retry

## Validation
- `python3 -m unittest discover -s tests -v` (57 passed)
- `python3 scripts/validate_repository.py`