### PR TITLE
feat(apps): add No-Show Guard appointment confirmation agent

### DIFF
--- a/apps/python/no-show-guard/.env.example
+++ b/apps/python/no-show-guard/.env.example
@@ -1,0 +1,26 @@
+# ---- No-Show Guard environment configuration ----
+# Copy this file to `.env` and fill in your real values.
+# NEVER commit your real `.env` file (it is git-ignored).
+
+# --- CALL-E credentials -----------------------------------------------------
+# Your CALL-E API key (issued by CALL-E). The Python SDK reads this directly.
+CALLE_API_KEY=iams_live_BneNxihw20J3rw3b5PT1_8e20bbf15f5cb02feff69ffd17de5da63e549590a567845b9b9d549aa0a31ebd
+
+# --- App behaviour ------------------------------------------------------------
+# Default region / locale / language for outbound calls.
+CALLE_REGION=IN
+CALLE_LOCALE=en-US
+
+# Hours before an appointment at which we place the confirmation call.
+# Default is 24 (i.e. call ~24h before).
+CONFIRMATION_HOURS_BEFORE=24
+
+# Retry policy for "no answer" calls.
+MAX_RETRIES=2
+RETRY_HOURS_APART=2
+
+# Path to the SQLite database file.
+DATABASE_PATH=appointments.db
+
+# Path to the appointments CSV to load on first run.
+APPOINTMENTS_CSV=sample_appointments.csv

--- a/apps/python/no-show-guard/.gitignore
+++ b/apps/python/no-show-guard/.gitignore
@@ -1,0 +1,21 @@
+# ---- Secrets ----
+# The real CALLE_API_KEY lives in .env (never committed).
+.env
+
+# ---- Runtime artifacts ----
+__pycache__/
+*.py[cod]
+*.db
+*_report.csv
+*.log
+
+# ---- Virtual environments ----
+.venv/
+venv/
+env/
+
+# ---- OS / editor ----
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/

--- a/apps/python/no-show-guard/README.md
+++ b/apps/python/no-show-guard/README.md
@@ -1,0 +1,279 @@
+# No-Show Guard
+
+> **"CALL-E: Your Code Is Calling"** — automatic appointment confirmation
+> calls that stop the no-shows.
+
+No-Show Guard is a small, installable Python application that helps clinics,
+salons, and service businesses **cut missed appointments** by automatically
+placing an AI outbound confirmation call to each customer ~24 hours before
+their booking. The CALL-E agent on the phone confirms the customer's identity,
+reads out the appointment, and captures whether they want to **Confirm**,
+**Reschedule**, or **Cancel** — then the app stores the structured result and
+tells staff exactly what to do next.
+
+---
+
+## The problem it solves
+
+Missed appointments are expensive. Every "no-show" is lost revenue, a wasted
+time slot, and a gap in the calendar staff can't fill at the last minute.
+Studies routinely show that **confirmation calls dramatically reduce no-show
+rates** — but calling each customer manually doesn't scale for a busy clinic.
+
+No-Show Guard automates the whole loop:
+
+1. **Load** upcoming appointments (name, phone, date/time, service).
+2. **Call** each customer 24 hours beforehand using the real CALL-E API.
+3. **Capture** a structured outcome (confirmed / rescheduled / cancelled /
+   no answer) from the AI agent.
+4. **Act** — log reschedule requests for staff, retry no-answers, and report.
+
+---
+
+## How it works
+
+```
+                 +----------------------------+
+appointments |  sample_appointments.csv   |   (or any CSV)
+   (input)      +-------------+--------------+
+                              |
+                              v
+                    +------------------+
+                    |   scheduler.py    |  picks appointments due for a call
+                    +------------------+
+                              |
+                              v
+                    +------------------+      calle-ai SDK
+                    |   call_agent.py   |  CalleClient.calls
+                    +------------------+  .create_and_wait(task, schema)
+                              |                |
+                              |                v
+                              |          CALL-E AI agent
+                              |          (speaks to customer)
+                              v
+                    structured result (task_completed, completion_confidence)
+                    +---------+---------+
+                    |   call_agent.py   |  maps sdk call -> CallOutcome
+                    +---------+---------+
+                              |
+                              v
+                    +------------------+        +-------------------+
+                    |     db.py        | -----> |  appointments.db  |
+                    |  (SQLite)        |        |  (calls + results)|
+                    +------------------+        +-------------------+
+                              |
+                              v
+                    +------------------+        +-------------------------+
+                    |   report.py      | -----> |  console table + CSV    |
+                    +------------------+        |  daily summary          |
+                                                +-------------------------+
+```
+
+**Flow in a nutshell:** `scheduler` finds who to call → `call_agent` talks to
+CALL-E (create + poll) → `db` persists the outcome → `report` sums up the day.
+A `--dry-run` flag simulates calls locally so you can develop without dialing.
+
+---
+
+## Project structure
+
+```
+noshow-guard/
+  noshow_guard/
+    __init__.py       # package metadata
+    config.py         # env loading + settings
+    prompts.py        # configurable agent call script + result schema
+    call_agent.py     # CALL-E API client (create + poll calls)
+    db.py             # SQLite models + helpers
+    scheduler.py      # decides which appointments need a call today
+    report.py         # daily summary (console + CSV)
+    cli.py            # entry point
+  sample_appointments.csv
+  .env.example
+  requirements.txt
+  README.md
+```
+
+---
+
+## Setup
+
+### 1. Get a CALL-E account & API key
+
+1. Sign up for a CALL-E account.
+2. Create an API key from your dashboard.
+3. Keep it private — never commit it to git.
+
+### 2. Install
+
+```bash
+cd noshow-guard
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 3. Configure the environment
+
+```bash
+cp .env.example .env
+# edit .env and paste your key
+```
+
+At minimum set:
+
+```
+CALLE_API_KEY=your_calle_api_key_here
+```
+
+Other useful knobs (all in `.env.example`):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `CALLE_API_KEY` | *(none)* | Your CALL-E API key (read by the SDK) |
+| `CONFIRMATION_HOURS_BEFORE` | `24` | Hours before the appointment to call |
+| `CALLE_REGION` / `CALLE_LOCALE` | `IN` / `en-US` | Caller region + language |
+| `MAX_RETRIES` | `2` | Max retry attempts for no-answer |
+| `RETRY_HOURS_APART` | `2` | Hours between retries |
+| `DATABASE_PATH` | `appointments.db` | SQLite file |
+| `APPOINTMENTS_CSV` | `sample_appointments.csv` | Input CSV |
+
+---
+
+## How to run
+
+```bash
+# 1) Create the database and import the sample appointments
+python -m noshow_guard init
+
+# 2) Safely test the whole pipeline WITHOUT dialing (no API key needed)
+python -m noshow_guard run --dry-run
+
+# 3) Run for real — dials today's due appointments via CALL-E
+python -m noshow_guard run
+
+# 4) Inspect the database
+python -m noshow_guard status
+```
+
+Arguments for `run`:
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Simulate calls locally (no dialing, no API key required) |
+| `--report-csv PATH` | Also write a CSV audit report to `PATH` |
+
+---
+
+## Example report output
+
+Console summary produced by `python -m noshow_guard run`:
+
+```
+====================================================
+  No-Show Guard — Daily Call Summary
+  Generated: 2025-12-19 10:02:11 UTC
+====================================================
++--------------+-------+
+|    Metric    | Count |
++--------------+-------+
+| Total calls  |   5   |
+| Confirmed    |   2   |
+| Rescheduled  |   1   |
+| Cancelled    |   1   |
+| No answer    |   1   |
++--------------+-------+
+
+Awaiting staff review — customers who asked to RESCHEDULE:
++---------------+----------------+---------------------+------------------+
+|     Name      |     Phone      |      Original       |  Requested new   |
++---------------+----------------+---------------------+------------------+
+| Rohan Mehta   | +919930345603  | 2025-12-21 09:15    | 2025-12-28 15:00 |
++---------------+----------------+---------------------+------------------+
+
+Full audit CSV written to: appointments_report.csv
+```
+
+---
+
+## Real CALL-E integration
+
+`call_agent.py` uses the **official CALL-E Python SDK** (`calle-ai`) for
+authentication and placing calls. The SDK is initialised with your
+`CALLE_API_KEY`:
+
+```python
+from calle import CalleClient
+
+client = CalleClient(api_key="YOUR_KEY")
+call = client.calls.create_and_wait(
+    task=task_prompt,
+    result_schema=RESULT_SCHEMA,
+)
+```
+
+The SDK fully manages authentication, calling the CALL-E agent, and waiting
+for a structured result. The returned `call` dict exposes:
+
+| Field | Meaning |
+|-------|---------|
+| `call["status"]` | e.g. `completed`, `failed`, `no_answer` |
+| `call["structured_result"]` | The parsed JSON per your `result_schema` |
+| `call["task_completed"]` | Whether the agent completed the task |
+| `call["completion_confidence"]` | Confidence score (float) |
+| `call["evidence"]` | Transcript / supporting detail |
+
+**Key details handled for you:**
+
+- **Auth** — handled by the SDK using `CALLE_API_KEY`.
+- **Result schema** — the app tells CALL-E exactly what JSON to return
+  (`outcome`, `new_datetime`, `cancel_reason`), so results are structured and
+  safe to parse. The app maps `structured_result` onto its `CallOutcome` type.
+- **No mock at runtime** — `python -m noshow_guard run` genuinely dials via
+  the SDK; only the explicit `--dry-run` flag simulates calls for safe local
+  testing.
+
+### The agent's call script
+
+The prompt sent to the AI agent lives in **`prompts.py`** (`TASK_TEMPLATE`).
+It instructs the agent to confirm identity, read out the appointment, and ask
+for Confirm / Reschedule / Cancel. Change it there to demo a different agent
+behaviour — no other code changes needed.
+
+---
+
+## Error handling
+
+- **Missing/invalid phone numbers** are rejected before a call is created.
+- **API failures & rate limits** raise `CallError` with a clear message; the
+  CLI catches them, reports the error, and marks the appointment so it can be
+  retried on a later run.
+- **No-answer** appointments are automatically queued for retry (default
+  `MAX_RETRIES=2`, `RETRY_HOURS_APART=2` hours).
+- **Exhausted retries** — after `MAX_RETRIES` no-answers, the appointment is
+  marked `call_failed` and surfaced in the report for staff to call manually.
+
+---
+
+## Contribution to awesome-phone-call-agents
+
+This project is structured as an **installable, reusable module** (not a bare
+script) so it can be published as an Agent Skill / Workflow Plugin
+contribution. It is self-contained: the official `calle-ai` SDK,
+`python-dotenv`, and `prettytable` only, with a clear `prompts.py` seam for
+customising agent behaviour and a `--dry-run` mode for safe demoing.
+
+---
+
+## Testing the pipeline locally
+
+No phone, no API key? Use dry-run:
+
+```bash
+python -m noshow_guard init
+python -m noshow_guard run --dry-run
+```
+
+This runs the full scheduler → database → report loop with simulated outcomes,
+so you can verify the report, the SQLite updates, and the retry logic end to
+end before enabling real calls.

--- a/apps/python/no-show-guard/noshow_guard/__init__.py
+++ b/apps/python/no-show-guard/noshow_guard/__init__.py
@@ -1,0 +1,28 @@
+"""
+No-Show Guard
+=============
+
+A small-business appointment confirmation agent backed by the CALL-E API.
+
+"No-Show Guard" automatically places an outbound AI confirmation call to each
+customer ~24 hours before their upcoming appointment. On the call, the agent
+confirms identity, reads out appointment details, and captures whether the
+customer wants to *Confirm*, *Reschedule*, or *Cancel*.
+
+The structured result returned by CALL-E is parsed and stored in a local
+SQLite database, "no answer" outcomes are retried (max 2 retries, 2 hours
+apart), and a daily summary report is generated.
+
+Module layout
+-------------
+- ``config``      : environment loading + shared settings
+- ``prompts``     : the configurable agent call script / result schema
+- ``call_agent``  : low-level CALL-E HTTP client (create + poll calls)
+- ``db``          : SQLite models + persistence helpers
+- ``scheduler``   : decides which appointments need a call *today*
+- ``report``      : daily summary generation (console + CSV)
+- ``cli``         : ``python -m noshow_guard run`` entry point
+"""
+
+__version__ = "0.1.0"
+__all__ = ["__version__"]

--- a/apps/python/no-show-guard/noshow_guard/__main__.py
+++ b/apps/python/no-show-guard/noshow_guard/__main__.py
@@ -1,0 +1,9 @@
+"""Allow ``python -m noshow_guard run`` to invoke the CLI.
+
+This simply delegates to :func:`noshow_guard.cli.main`.
+"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/no-show-guard/noshow_guard/call_agent.py
+++ b/apps/python/no-show-guard/noshow_guard/call_agent.py
@@ -1,0 +1,228 @@
+"""CALL-E integration using the official ``calle-ai`` Python SDK.
+
+This module replaces the earlier raw-HTTP client with the official CALL-E SDK.
+Authentication is handled by the SDK via ``CalleClient(api_key=...)``, which
+reads the key from the ``CALLE_API_KEY`` environment variable.
+
+The core call is placed with::
+
+    call = client.calls.create_and_wait(
+        task=task_prompt,          # built from prompts.py TASK_TEMPLATE
+        result_schema=RESULT_SCHEMA,
+    )
+
+The returned ``call`` dict exposes (among others):
+    call["status"]                 # e.g. "completed", "failed", "no_answer"
+    call["structured_result"]      # the parsed JSON per result_schema
+    call["task_completed"]         # bool
+    call["completion_confidence"]  # float
+    call["evidence"]               # transcript / supporting detail
+
+We map ``call["structured_result"]`` onto our :class:`CallOutcome` the same way
+the old code mapped the raw API response, so ``db.py`` / ``scheduler.py`` /
+``report.py`` are unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+try:
+    from calle import CalleClient
+except ImportError:  # pragma: no cover - surfaced clearly at runtime
+    CalleClient = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Call statuses returned by the SDK. A call is "final" once it reaches one of
+# these and ``create_and_wait`` has returned.
+# ---------------------------------------------------------------------------
+CALL_COMPLETED = "completed"
+CALL_FAILED = "failed"
+CALL_NO_ANSWER = "no_answer"
+
+FINAL_STATUSES = {CALL_COMPLETED, CALL_FAILED, CALL_NO_ANSWER}
+
+
+class CallError(Exception):
+    """Raised when CALL-E rejects or fails a call request."""
+
+
+class CallTimeoutError(CallError):
+    """Raised when a call does not yield a usable result in time."""
+
+
+@dataclass
+class CallOutcome:
+    """The parsed, structured result of a single confirmation call.
+
+    Mirrors the fields the rest of the app expects (unchanged from before), so
+    ``db.py`` / ``scheduler.py`` / ``report.py`` need no changes.
+    """
+
+    outcome: str = "unknown"  # confirmed | rescheduled | cancelled | no_answer | unknown
+    new_datetime: Optional[str] = None
+    cancel_reason: Optional[str] = None
+    call_id: str = ""
+    status: str = ""
+    raw_result: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_sdk(cls, call: dict) -> "CallOutcome":
+        """Build a :class:`CallOutcome` from the SDK's ``call`` dict.
+
+        Args:
+            call: The dict returned by ``client.calls.create_and_wait(...)``.
+
+        Returns:
+            A normalised :class:`CallOutcome`. If the call never connected
+            (no answer / failed) or the structured result is missing, sensible
+            defaults are used so downstream code never has to handle ``None``.
+        """
+        status = str(call.get("status", "")).lower()
+        result = call.get("structured_result") or {}
+
+        if isinstance(result, str):  # tolerate a JSON-encoded result string
+            try:
+                result = json.loads(result)
+            except (ValueError, TypeError):
+                result = {}
+
+        norm = result.get("outcome") or "unknown"
+
+        # If the call never connected, force the outcome to something useful.
+        if status in (CALL_NO_ANSWER, CALL_FAILED):
+            norm = "no_answer"
+
+        return cls(
+            outcome=norm,
+            new_datetime=result.get("new_datetime"),
+            cancel_reason=result.get("cancel_reason"),
+            call_id=str(call.get("call_id") or call.get("id") or ""),
+            status=status,
+            raw_result=dict(result),
+        )
+
+
+class CallAgent:
+    """Thin wrapper around the official :class:`CalleClient`.
+
+    Args:
+        api_key: Optional CALL-E API key. Defaults to the ``CALLE_API_KEY``
+            environment variable (which the SDK also reads directly).
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        if CalleClient is None:
+            raise CallError(
+                "The `calle` SDK is not installed. Run `pip install calle-ai`."
+            )
+        key = api_key or os.environ.get("CALLE_API_KEY", "")
+        if not key:
+            raise CallError(
+                "CALLE_API_KEY is required. Set it in your .env file or export it."
+            )
+        self.api_key = key
+        self.client = CalleClient(api_key=key)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def create_and_wait(
+        self,
+        task: str,
+        result_schema: dict | None = None,
+        *,
+        recipient: dict | None = None,
+        metadata: dict | None = None,
+        webhook_url: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> CallOutcome:
+        """Create a confirmation call and block until the result is ready.
+
+        All keyword arguments are forwarded to the SDK's
+        ``client.calls.create_and_wait(...)`` (which passes them to ``create``),
+        so recipient, metadata, webhook and idempotency are used when the SDK
+        supports them.
+
+        Args:
+            task: The rendered agent prompt for this call (from ``prompts.py``).
+            result_schema: Optional JSON schema for the structured result.
+                Defaults to :data:`prompts.RESULT_SCHEMA`.
+            recipient: Recipient dict (e.g. ``{"phone": ...}``).
+            metadata: App metadata (e.g. appointment id).
+            webhook_url: Optional result webhook.
+            idempotency_key: Optional idempotency key.
+
+        Returns:
+            A parsed :class:`CallOutcome`.
+
+        Raises:
+            CallError: On any SDK/API failure.
+        """
+        from . import prompts
+
+        schema = result_schema or prompts.RESULT_SCHEMA
+        kwargs: dict = {"task": task, "result_schema": schema}
+        if recipient:
+            kwargs["recipient"] = recipient
+        if metadata:
+            kwargs["metadata"] = metadata
+        if webhook_url:
+            kwargs["webhook_url"] = webhook_url
+        if idempotency_key:
+            kwargs["idempotency_key"] = idempotency_key
+
+        try:
+            call = self.client.calls.create_and_wait(**kwargs)
+        except Exception as exc:  # SDK/network/API errors
+            raise CallError(f"CALL-E SDK call failed: {exc}") from exc
+
+        if not isinstance(call, dict):
+            raise CallError(f"CALL-E returned an unexpected payload: {call!r}")
+
+        return CallOutcome.from_sdk(call)
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrapper used by the CLI.
+# ---------------------------------------------------------------------------
+def place_confirmation_call(
+    phone: str,
+    date: str,
+    time: str,
+    service: str,
+    appointment_id: str,
+    settings: Any = None,
+    idempotency_key: Optional[str] = None,
+) -> CallOutcome:
+    """Place a confirmation call via the SDK and wait for its structured result.
+
+    Args:
+        phone: Recipient phone number (kept for traceability/metadata).
+        date / time / service: Appointment details used to render the task prompt.
+        appointment_id: Stable identifier used for logging.
+        settings: Optional :class:`Settings` (only used for the API key).
+        idempotency_key: Optional explicit key (informational; the SDK manages
+            idempotency per call).
+
+    Returns:
+        The parsed :class:`CallOutcome`.
+    """
+    from . import prompts
+
+    api_key = None
+    if settings is not None:
+        api_key = getattr(settings, "calle_api_key", None)
+    agent = CallAgent(api_key=api_key)
+    task = prompts.build_task(date, time, service)
+    return agent.create_and_wait(
+        task=task,
+        result_schema=prompts.RESULT_SCHEMA,
+        recipient={"phone": phone},
+        metadata={"appointment_id": appointment_id},
+        idempotency_key=idempotency_key or f"apt-{appointment_id}",
+    )

--- a/apps/python/no-show-guard/noshow_guard/cli.py
+++ b/apps/python/no-show-guard/noshow_guard/cli.py
@@ -1,0 +1,239 @@
+"""Command-line entry point for No-Show Guard.
+
+Run with::
+
+    python -m noshow_guard run [--dry-run] [--report-csv PATH]
+
+Subcommands:
+    init      Create the database and import ``sample_appointments.csv``.
+    run       Process today's appointments needing confirmation calls.
+    status    Show the current database contents as a table.
+
+``--dry-run`` simulates calls locally (no dialing) so the whole pipeline can
+be tested safely without a CALL-E API key or phone calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from . import __version__
+from .call_agent import CallAgent, CallError, CallTimeoutError, CallOutcome
+from .config import Settings, get_settings
+from .db import Database
+from .report import generate_report
+from .scheduler import due_appointments, format_apt_datetime
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: simulate a call locally so development needs no API key / dialing.
+# ---------------------------------------------------------------------------
+def _simulate_outcome(name: str) -> CallOutcome:
+    """Return a deterministic fake outcome for ``--dry-run`` mode."""
+    bucket = hash(name) % 5
+    outcomes = ["confirmed", "confirmed", "rescheduled", "cancelled", "no_answer"]
+    out = outcomes[bucket]
+    return CallOutcome(
+        outcome=out,
+        new_datetime="2025-12-28 15:00" if out == "rescheduled" else None,
+        cancel_reason="Work conflict" if out == "cancelled" else None,
+        call_id="dry-run",
+        status="completed",
+    )
+
+
+def _normalize_e164(phone: str) -> str:
+    """Normalise a phone number to E.164 format (``+<digits>``).
+
+    Strips spaces, dashes, parentheses and dots, and ensures a leading ``+``.
+    A number with no leading ``+`` is assumed to already carry its country
+    code (as in the sample data, e.g. ``+91 85738 54153``).
+
+    Args:
+        phone: The raw phone string (e.g. ``"+91 85738 54153"``).
+
+    Returns:
+        An E.164-style string (e.g. ``+918573845153``).
+    """
+    digits = "".join(ch for ch in phone if ch.isdigit() or ch == "+").replace(" ", "")
+    if not digits:
+        return ""
+    if not digits.startswith("+"):
+        digits = "+" + digits
+    return digits
+
+
+def _dial(appointment, *, settings: Settings, dry_run: bool = False) -> CallOutcome:
+    """Place (or simulate) the confirmation call and return the outcome.
+
+    In ``--dry-run`` mode the SDK is NOT called — a simulated outcome is
+    returned instead so the whole pipeline can be tested safely offline.
+
+    For real calls, the appointment's phone number is normalised to E.164 and
+    passed to ``create_and_wait`` as the ``recipient`` so the CALL-E SDK knows
+    who to dial.
+    """
+    date, time_ = format_apt_datetime(appointment["appointment_datetime"])
+    if dry_run:
+        return _simulate_outcome(appointment["name"])
+
+    from . import prompts
+
+    e164 = _normalize_e164(appointment["phone"])
+    if not e164:
+        raise CallError(f"Invalid phone number for appointment #{appointment['id']}: {appointment['phone']!r}")
+
+    agent = CallAgent(api_key=settings.calle_api_key)
+    return agent.create_and_wait(
+        task=prompts.build_task(date, time_, appointment["service"]),
+        result_schema=prompts.RESULT_SCHEMA,
+        recipient={"phone": e164},
+        metadata={"appointment_id": appointment["id"]},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+def _cmd_init(args) -> int:
+    settings = get_settings()
+    db = Database(settings.database_path)
+    inserted = db.import_csv(settings.appointments_csv)
+    print(f"Imported {inserted} appointment(s) from {settings.appointments_csv}.")
+    print(f"Database: {settings.database_path}")
+    return 0
+
+
+def _cmd_run(args) -> int:
+    settings = get_settings()
+    if not args.dry_run:
+        settings.validate(require_key=True)
+
+    db = Database(settings.database_path)
+    db.import_csv(settings.appointments_csv)  # idempotent import on every run
+
+    due = due_appointments(db, settings=settings)
+    if not due:
+        print("No appointments are due for a confirmation call right now.")
+    else:
+        print(f"Found {len(due)} appointment(s) due for a call.\n")
+
+    for apt in due:
+        label = f"#{apt['id']} {apt['name']} ({apt['phone']}) — {apt['service']}"
+        print(f"[{apt['status']}] Calling {label} ...")
+
+        # Determine attempt number (increment retries for retry calls).
+        attempt = 1
+        if apt["status"] == "pending_retry":
+            attempt = db.record_retry_attempt(apt["id"])
+
+        try:
+            outcome = _dial(apt, settings=settings, dry_run=args.dry_run)
+            db.record_call(
+                appointment_id=apt["id"],
+                outcome=outcome.outcome,
+                call_id=outcome.call_id,
+                status=outcome.status,
+                attempt=attempt,
+                new_datetime=outcome.new_datetime,
+                cancel_reason=outcome.cancel_reason,
+                adjacent=(apt["status"] == "pending_retry"),
+            )
+            extra = ""
+            if outcome.outcome == "rescheduled" and outcome.new_datetime:
+                extra = f" -> requested new: {outcome.new_datetime}"
+            elif outcome.outcome == "cancelled" and outcome.cancel_reason:
+                extra = f" -> reason: {outcome.cancel_reason}"
+            print(f"   Result: {outcome.outcome}{extra}")
+            print(f"   Call ID: {outcome.call_id}")
+        except (CallError, CallTimeoutError) as exc:
+            print(f"   ERROR placing/reading call: {exc}", file=sys.stderr)
+            # Mark this call as failed so it can be retried later.
+            db.record_call(
+                appointment_id=apt["id"],
+                outcome="no_answer",
+                status="failed",
+                attempt=attempt,
+                adjacent=(apt["status"] == "pending_retry"),
+            )
+        except Exception as exc:  # noqa: BLE001 - keep the batch going
+            print(f"   UNEXPECTED error: {exc}", file=sys.stderr)
+
+    # Generate the daily report after processing.
+    print()
+    report = generate_report(db, csv_output=args.report_csv, settings=settings)
+    print(report["console"])
+    if report["csv"]:
+        print(f"\nFull audit CSV written to: {report['csv']}")
+    return 0
+
+
+def _cmd_status(args) -> int:
+    settings = get_settings()
+    db = Database(settings.database_path)
+    rows = db.list_appointments()
+    if not rows:
+        print("Database is empty. Run `python -m noshow_guard init` first.")
+        return 0
+    print(f"{'id':<4}{'name':<18}{'phone':<16}{'datetime':<18}{'service':<22}{'status':<14}outcome")
+    print("-" * 100)
+    for r in rows:
+        print(
+            f"{r['id']:<4}{r['name']:<18}{r['phone']:<16}"
+            f"{r['appointment_datetime']:<18}{r['service']:<22}"
+            f"{r['status']:<14}{(r['outcome'] or ''):<10}"
+        )
+    return 0
+
+
+def _cmd_version(args) -> int:
+    print(f"noshow_guard {__version__}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="noshow_guard",
+        description="No-Show Guard — automatic appointment confirmation calls via CALL-E.",
+    )
+    parser.add_argument("--version", action="store_true", help="Show version and exit.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_init = sub.add_parser("init", help="Create DB and import sample appointments.")
+    p_init.set_defaults(func=_cmd_init)
+
+    p_run = sub.add_parser("run", help="Process today's appointments needing calls.")
+    p_run.add_argument("--dry-run", action="store_true",
+                       help="Simulate calls without dialing (no API key needed).")
+    p_run.add_argument("--report-csv", default=None,
+                       help="Write a CSV audit report to this path.")
+    p_run.set_defaults(func=_cmd_run)
+
+    p_status = sub.add_parser("status", help="Show the current database contents.")
+    p_status.set_defaults(func=_cmd_status)
+
+    return parser
+
+
+def main(argv: Optional[list] = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if getattr(args, "version", False):
+        return _cmd_version(args)
+
+    try:
+        return args.func(args)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/no-show-guard/noshow_guard/config.py
+++ b/apps/python/no-show-guard/noshow_guard/config.py
@@ -1,0 +1,91 @@
+"""Central configuration for No-Show Guard.
+
+Reads environment variables (optionally from a ``.env`` file via python-dotenv)
+and exposes them as typed, validated settings. Keeping all configuration in one
+place makes the app easy to set up and easy to demo.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load any .env file found in the project root or current working directory.
+load_dotenv()
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+
+def _get_bool(name: str, default: bool = False) -> bool:
+    """Parse an env var as a boolean, falling back to ``default``."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _get_int(name: str, default: int) -> int:
+    """Parse an env var as an integer, falling back to ``default`` on error."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Immutable application settings loaded from the environment."""
+
+    # CALL-E API key (read by the official `calle` Python SDK).
+    calle_api_key: str = field(
+        default_factory=lambda: os.getenv("CALLE_API_KEY", "").strip()
+    )
+
+    # Outbound call defaults (region / language).
+    region: str = field(default_factory=lambda: os.getenv("CALLE_REGION", "IN").strip())
+    locale: str = field(default_factory=lambda: os.getenv("CALLE_LOCALE", "en-US").strip())
+
+    # Scheduling / retry policy.
+    confirmation_hours_before: int = field(
+        default_factory=lambda: _get_int("CONFIRMATION_HOURS_BEFORE", 24)
+    )
+    max_retries: int = field(default_factory=lambda: _get_int("MAX_RETRIES", 2))
+    retry_hours_apart: int = field(default_factory=lambda: _get_int("RETRY_HOURS_APART", 2))
+
+    # Storage / data paths.
+    database_path: str = field(
+        default_factory=lambda: os.getenv("DATABASE_PATH", "appointments.db").strip()
+    )
+    appointments_csv: str = field(
+        default_factory=lambda: os.getenv("APPOINTMENTS_CSV", "sample_appointments.csv").strip()
+    )
+
+    # Timeouts / polling.
+    call_timeout_seconds: int = field(default_factory=lambda: _get_int("CALL_TIMEOUT_SECONDS", 15))
+    poll_interval_seconds: int = field(default_factory=lambda: _get_int("POLL_INTERVAL_SECONDS", 5))
+    poll_max_seconds: int = field(default_factory=lambda: _get_int("POLL_MAX_SECONDS", 300))
+
+    @property
+    def has_api_key(self) -> bool:
+        """True when a CALL-E API key has been configured."""
+        return bool(self.calle_api_key)
+
+    def validate(self, *, require_key: bool = True) -> None:
+        """Raise ``RuntimeError`` if required settings are missing/invalid."""
+        if require_key and not self.has_api_key:
+            raise RuntimeError(
+                "CALLE_API_KEY is not set. Copy .env.example to .env and "
+                "paste your CALL-E API key, or export CALLE_API_KEY."
+            )
+        if self.confirmation_hours_before <= 0:
+            raise RuntimeError("CONFIRMATION_HOURS_BEFORE must be a positive integer.")
+
+
+def get_settings() -> Settings:
+    """Build and return the current :class:`Settings`."""
+    return Settings()

--- a/apps/python/no-show-guard/noshow_guard/db.py
+++ b/apps/python/no-show-guard/noshow_guard/db.py
@@ -1,0 +1,328 @@
+"""SQLite persistence for appointments and call outcomes.
+
+Uses the standard-library :mod:`sqlite3` module (no ORM dependency) with a
+``row_factory`` so results come back as dictionaries. Two tables are kept:
+
+``appointments``
+    The master list of upcoming appointments (imported from CSV and enriched
+    with call outcomes).
+
+``calls``
+    One row per outbound call attempt, including the CALL-E ``call_id`` and
+    the parsed structured result.
+
+Helper functions here are minimal and focused; orchestration lives in the
+application / CLI layer.
+"""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional
+
+from .config import Settings
+
+# Column names expected in the appointments CSV.
+CSV_REQUIRED = {"name", "phone", "appointment_datetime", "service"}
+# Output outcomes tracked in reports (order matters for the summary).
+OUTCOMES = ["confirmed", "rescheduled", "cancelled", "no_answer"]
+
+
+class Database:
+    """Wraps a SQLite database connection with a row factory."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._setup()
+
+    # ------------------------------------------------------------------
+    # Connection + schema
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True) if Path(self.path).parent != Path("") else None
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    @contextmanager
+    def conn(self) -> Iterator[sqlite3.Connection]:
+        """Yield a connection as a context manager (auto commit/close)."""
+        con = self._connect()
+        try:
+            yield con
+            con.commit()
+        finally:
+            con.close()
+
+    def _setup(self) -> None:
+        with self.conn() as con:
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS appointments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    phone TEXT NOT NULL,
+                    appointment_datetime TEXT NOT NULL,
+                    service TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    outcome TEXT,
+                    new_datetime TEXT,
+                    cancel_reason TEXT,
+                    retries INTEGER NOT NULL DEFAULT 0,
+                    last_call_at TEXT,
+                    call_id TEXT,
+                    created_at TEXT NOT NULL,
+                    token TEXT
+                )
+                """
+            )
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS calls (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    appointment_id INTEGER NOT NULL,
+                    call_id TEXT,
+                    attempt INTEGER NOT NULL DEFAULT 1,
+                    outcome TEXT NOT NULL,
+                    status TEXT,
+                    new_datetime TEXT,
+                    cancel_reason TEXT,
+                    called_at TEXT NOT NULL,
+                    FOREIGN KEY (appointment_id) REFERENCES appointments(id)
+                )
+                """
+            )
+
+    # ------------------------------------------------------------------
+    # Appointments
+    # ------------------------------------------------------------------
+    def import_csv(self, csv_path: str) -> int:
+        """Load appointments from a CSV, skipping rows that already exist.
+
+        Rows are de-duplicated by ``phone + appointment_datetime``.
+
+        Args:
+            csv_path: Path to the appointments CSV.
+
+        Returns:
+            The number of newly inserted rows.
+        """
+        path = Path(csv_path)
+        if not path.exists():
+            raise FileNotFoundError(f"CSV not found: {path}")
+
+        inserted = 0
+        with self.conn() as con:
+            existing = {
+                (r["phone"], r["appointment_datetime"])
+                for r in con.execute("SELECT phone, appointment_datetime FROM appointments")
+            }
+            with path.open("r", encoding="utf-8-sig") as fh:
+                reader = csv.DictReader(fh)
+                missing = CSV_REQUIRED - set(reader.fieldnames or [])
+                if missing:
+                    raise ValueError(f"CSV missing required columns: {sorted(missing)}")
+                for row in reader:
+                    phone = row["phone"].strip()
+                    dt = row["appointment_datetime"].strip()
+                    if not phone or not dt:
+                        continue
+                    if (phone, dt) in existing:
+                        continue
+                    con.execute(
+                        """
+                        INSERT INTO appointments
+                            (name, phone, appointment_datetime, service, created_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (
+                            row["name"].strip(),
+                            phone,
+                            dt,
+                            row["service"].strip(),
+                            datetime.utcnow().isoformat(timespec="seconds"),
+                        ),
+                    )
+                    existing.add((phone, dt))
+                    inserted += 1
+        return inserted
+
+    def list_appointments(self, status: Optional[str] = None) -> list[sqlite3.Row]:
+        """Return all appointments, optionally filtered by status."""
+        with self.conn() as con:
+            if status:
+                return list(
+                    con.execute(
+                        "SELECT * FROM appointments WHERE status = ? ORDER BY appointment_datetime",
+                        (status,),
+                    )
+                )
+            return list(con.execute("SELECT * FROM appointments ORDER BY appointment_datetime"))
+
+    def get_appointment(self, appointment_id: int) -> Optional[sqlite3.Row]:
+        """Return a single appointment by id (or ``None``)."""
+        with self.conn() as con:
+            row = con.execute(
+                "SELECT * FROM appointments WHERE id = ?", (appointment_id,)
+            ).fetchone()
+            return row
+
+    def mark_pending(self, appointment_id: int) -> None:
+        """Set an appointment back to its 'pending' waiting-for-call state."""
+        with self.conn() as con:
+            con.execute(
+                "UPDATE appointments SET status='pending' WHERE id=?",
+                (appointment_id,),
+            )
+
+    # ------------------------------------------------------------------
+    # Call recording
+    # ------------------------------------------------------------------
+    def record_call(
+        self,
+        appointment_id: int,
+        outcome: str,
+        *,
+        call_id: str = "",
+        status: str = "",
+        attempt: int = 1,
+        new_datetime: Optional[str] = None,
+        cancel_reason: Optional[str] = None,
+        adjacent: bool = False,
+    ) -> None:
+        """Persist a call outcome and update the parent appointment.
+
+        Args:
+            appointment_id: The appointment being called.
+            outcome: One of the :data:`OUTCOMES`.
+            call_id: CALL-E call identifier.
+            status: Raw CALL-E call status.
+            attempt: Which retry attempt this was (1-based).
+            new_datetime: New requested date/time if the customer rescheduled.
+            cancel_reason: Reason for cancellation, if provided.
+            adjacent: If True, do not bump the appointment's retry counter
+                (used when the caller already incremented retries).
+        """
+        with self.conn() as con:
+            con.execute(
+                """
+                INSERT INTO calls
+                    (appointment_id, call_id, attempt, outcome, status,
+                     new_datetime, cancel_reason, called_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    appointment_id,
+                    call_id,
+                    attempt,
+                    outcome,
+                    status,
+                    new_datetime,
+                    cancel_reason,
+                    datetime.utcnow().isoformat(timespec="seconds"),
+                ),
+            )
+
+            if outcome == "confirmed":
+                new_status = "confirmed"
+            elif outcome == "rescheduled":
+                new_status = "rescheduled"
+            elif outcome == "cancelled":
+                new_status = "cancelled"
+            elif outcome == "no_answer":
+                new_status = "call_failed" if not self._below_max_retries(appointment_id) else "pending_retry"
+            else:  # unknown
+                new_status = "unknown"
+
+            if not adjacent:
+                con.execute(
+                    """
+                    UPDATE appointments SET
+                        status = ?,
+                        outcome = ?,
+                        new_datetime = ?,
+                        cancel_reason = ?,
+                        call_id = ?,
+                        last_call_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        new_status,
+                        outcome,
+                        new_datetime,
+                        cancel_reason,
+                        call_id,
+                        datetime.utcnow().isoformat(timespec="seconds"),
+                        appointment_id,
+                    ),
+                )
+
+    def _below_max_retries(self, appointment_id: int, settings: Optional[Settings] = None) -> bool:
+        settings = settings or Settings()
+        with self.conn() as con:
+            row = con.execute(
+                "SELECT retries FROM appointments WHERE id = ?", (appointment_id,)
+            ).fetchone()
+            return bool(row) and row["retries"] < settings.max_retries
+
+    def should_retry(self, appointment_id: int, settings: Optional[Settings] = None) -> bool:
+        """Return True if a ``no_answer`` appointment should be retried.
+
+        Retry eligibility: the appointment is still 'pending_retry', it has
+        made fewer than ``max_retries`` calls, and ``retry_hours_apart`` hours
+        have elapsed since ``last_call_at``.
+        """
+        settings = settings or Settings()
+        with self.conn() as con:
+            row = con.execute(
+                "SELECT * FROM appointments WHERE id = ?", (appointment_id,)
+            ).fetchone()
+            if not row or row["status"] != "pending_retry":
+                return False
+            if row["retries"] >= settings.max_retries:
+                return False
+            last = row["last_call_at"]
+            if not last:
+                return True
+            try:
+                last_dt = datetime.fromisoformat(last)
+            except ValueError:
+                return True
+            elapsed = datetime.utcnow() - last_dt
+            return elapsed.total_seconds() >= settings.retry_hours_apart * 3600
+
+    def record_retry_attempt(self, appointment_id: int) -> int:
+        """Increment the retry counter for an appointment.
+
+        Returns:
+            The new (1-based) attempt number.
+        """
+        with self.conn() as con:
+            con.execute(
+                "UPDATE appointments SET retries = retries + 1 WHERE id = ?",
+                (appointment_id,),
+            )
+            row = con.execute(
+                "SELECT retries FROM appointments WHERE id = ?", (appointment_id,)
+            ).fetchone()
+            attempt = int(row["retries"]) + 1 if row else 1
+            return attempt
+
+    def summary_counts(self) -> tuple[int, int, int, int, int]:
+        """Return aggregate call counts ``(t, confirmed, resched, cancelled, noanswer)``.
+
+        ``t`` is the total number of call attempts.
+        """
+        with self.conn() as con:
+            total = con.execute("SELECT COUNT(*) FROM calls").fetchone()[0]
+            counts = {}
+            for outcome in OUTCOMES:
+                counts[outcome] = con.execute(
+                    "SELECT COUNT(*) FROM calls WHERE outcome = ?", (outcome,)
+                ).fetchone()[0]
+        return (total, counts["confirmed"], counts["rescheduled"], counts["cancelled"], counts["no_answer"])

--- a/apps/python/no-show-guard/noshow_guard/prompts.py
+++ b/apps/python/no-show-guard/noshow_guard/prompts.py
@@ -1,0 +1,65 @@
+"""Configurable agent call script and structured result schema.
+
+Keeping the prompt and the ``result_schema`` in one dedicated module makes it
+trivial to demo how changing the agent's behaviour affects the app: tweak the
+``TASK_TEMPLATE`` below and the confirmation call changes without touching any
+other code.
+
+The ``TASK_TEMPLATE`` is sent to CALL-E as the ``task`` field of the call
+request. It instructs the AI agent on the phone to confirm identity, read the
+appointment details and ask for Confirm / Reschedule / Cancel.
+
+The ``RESULT_SCHEMA`` tells CALL-E exactly what structured JSON to return for
+each call, which the app then parses and stores.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# The agent's spoken-task prompt. ``{date}``, ``{time}`` and ``{service}`` are
+# formatted with the real appointment details before the call is placed.
+# ---------------------------------------------------------------------------
+TASK_TEMPLATE = (
+    "You are a helpful appointment-confirmation assistant calling a customer "
+    "for a small business. Greet them politely and confirm you are speaking "
+    "with the correct person. Then read out their appointment clearly: it is "
+    "on {date} at {time} for {service}. "
+    "Ask the customer whether they would like to Confirm, Reschedule, or "
+    "Cancel the appointment. "
+    "If they choose Reschedule, ask for their preferred new date and time. "
+    "If they choose Cancel, briefly ask (optional) for a reason. "
+    "Thank them and end the call politely. "
+    "You must produce a structured result matching the provided result_schema."
+)
+
+# ---------------------------------------------------------------------------
+# The structured JSON result CALL-E must return for every completed call.
+# The app parses this to update the local appointments database.
+# ---------------------------------------------------------------------------
+RESULT_SCHEMA: dict = {
+    "type": "object",
+    "required": ["outcome"],
+    "properties": {
+        "outcome": {
+            "type": "string",
+            "enum": ["confirmed", "rescheduled", "cancelled", "no_answer", "unknown"],
+        },
+        "new_datetime": {"type": "string"},
+        "cancel_reason": {"type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+
+def build_task(date: str, time: str, service: str) -> str:
+    """Render the agent task prompt with the given appointment details.
+
+    Args:
+        date: Appointment date, e.g. ``"2025-12-20"``.
+        time: Appointment time, e.g. ``"10:30"``.
+        service: Service name, e.g. ``"General Consultation"``.
+
+    Returns:
+        A fully rendered prompt string ready to send to CALL-E.
+    """
+    return TASK_TEMPLATE.format(date=date, time=time, service=service)

--- a/apps/python/no-show-guard/noshow_guard/report.py
+++ b/apps/python/no-show-guard/noshow_guard/report.py
@@ -1,0 +1,152 @@
+"""Daily summary report generation.
+
+Produces a human-readable console report (a pretty table) and, optionally, a
+CSV audit file. The summary answers the question: *"How did today's
+confirmation calls go?"* — total calls made, confirmed, rescheduled,
+cancelled, and no-answer counts, plus the list of customers who asked to
+reschedule (for staff to follow up).
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from prettytable import PrettyTable
+
+from .db import Database, OUTCOMES
+from .config import Settings, get_settings
+
+
+def build_summary_data(db: Database) -> dict:
+    """Aggregate call counts into a dict for the report."""
+    total, confirmed, rescheduled, cancelled, no_answer = db.summary_counts()
+    return {
+        "total_calls": total,
+        "confirmed": confirmed,
+        "rescheduled": rescheduled,
+        "cancelled": cancelled,
+        "no_answer": no_answer,
+    }
+
+
+def print_console_report(db: Database, data: Optional[dict] = None) -> str:
+    """Render and return a console-friendly ASCII table report.
+
+    Args:
+        db: The database to read from.
+        data: Optional pre-computed summary dict (via :func:`build_summary_data`).
+
+    Returns:
+        The rendered report as a string.
+    """
+    data = data or build_summary_data(db)
+
+    lines = []
+    lines.append("=" * 52)
+    lines.append("  No-Show Guard — Daily Call Summary")
+    lines.append(f"  Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
+    lines.append("=" * 52)
+
+    table = PrettyTable()
+    table.field_names = ["Metric", "Count"]
+    table.add_row(["Total calls placed", data["total_calls"]])
+    for outcome in OUTCOMES:
+        label = {"confirmed": "Confirmed", "rescheduled": "Rescheduled",
+                 "cancelled": "Cancelled", "no_answer": "No answer"}[outcome]
+        table.add_row([label, data[outcome]])
+    lines.append(table.get_string())
+
+    # Reschedule follow-ups for staff.
+    resched = [
+        r for r in db.list_appointments(status="rescheduled")
+        if r["new_datetime"]
+    ]
+    if resched:
+        lines.append("\nAwaiting staff review — customers who asked to RESCHEDULE:")
+        stable = PrettyTable()
+        stable.field_names = ["Name", "Phone", "Original", "Requested new"]
+        for r in resched:
+            stable.add_row(
+                [r["name"], r["phone"], r["appointment_datetime"], r["new_datetime"]]
+            )
+        lines.append(stable.get_string())
+    else:
+        lines.append("\nNo reschedule requests to review.")
+
+    return "\n".join(lines)
+
+
+def write_csv_report(db: Database, output_path: str, data: Optional[dict] = None) -> str:
+    """Write a CSV audit report and return the path it was written to.
+
+    Contains one row per call attempt with the appointment and outcome.
+    """
+    data = data or build_summary_data(db)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "appointment_id", "name", "phone", "service",
+                "appointment_datetime", "status", "outcome", "new_datetime",
+                "cancel_reason", "last_call_at", "call_id",
+            ],
+        )
+        writer.writeheader()
+        for r in db.list_appointments():
+            writer.writerow(
+                {
+                    "appointment_id": r["id"],
+                    "name": r["name"],
+                    "phone": r["phone"],
+                    "service": r["service"],
+                    "appointment_datetime": r["appointment_datetime"],
+                    "status": r["status"],
+                    "outcome": r["outcome"] or "",
+                    "new_datetime": r["new_datetime"] or "",
+                    "cancel_reason": r["cancel_reason"] or "",
+                    "last_call_at": r["last_call_at"] or "",
+                    "call_id": r["call_id"] or "",
+                }
+            )
+
+    # Summary block appended as comments at the bottom.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n# summary,")
+        fh.write(",".join(str(data[k]) for k in
+                          ["total_calls", "confirmed", "rescheduled",
+                           "cancelled", "no_answer"]))
+        fh.write("\n")
+    return str(path)
+
+
+def generate_report(
+    db: Database,
+    *,
+    csv_output: Optional[str] = None,
+    settings: Optional[Settings] = None,
+) -> dict:
+    """Generate both the console report and (optionally) a CSV report.
+
+    Args:
+        db: The database.
+        csv_output: If provided, also write a CSV audit file to this path.
+        settings: Application settings (used for the default CSV path).
+
+    Returns:
+        A dict with ``console`` text and ``csv`` path (if written).
+    """
+    settings = settings or get_settings()
+    data = build_summary_data(db)
+    console = print_console_report(db, data)
+
+    result = {"console": console, "csv": None}
+    target = csv_output or settings.database_path.replace(".db", "_report.csv")
+    if target:
+        result["csv"] = write_csv_report(db, target, data)
+    return result

--- a/apps/python/no-show-guard/noshow_guard/scheduler.py
+++ b/apps/python/no-show-guard/noshow_guard/scheduler.py
@@ -1,0 +1,89 @@
+"""Decides which appointments need a confirmation call *today*.
+
+- Brand-new appointments whose appointment time is ``confirmation_hours_before``
+  away (default 24h) are due for their first call.
+- Appointments that were recently called and got a "no answer" are due for a
+  retry once ``retry_hours_apart`` hours have passed, up to ``max_retries``.
+
+The scheduler only *selects* candidates; the CLI layer actually dials them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from .config import Settings, get_settings
+from .db import Database
+
+
+def _parse_dt(value: str) -> Optional[datetime]:
+    """Best-effort parse of an appointment datetime string."""
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value.strip(), fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def due_appointments(
+    db: Database,
+    *,
+    now: Optional[datetime] = None,
+    settings: Optional[Settings] = None,
+) -> list:
+    """Return appointments that should be called right now.
+
+    Two groups are considered:
+
+    1. **First calls** — appointments whose scheduled time is between
+       ``confirmation_hours_before`` and ``confirmation_hours_before + 1``
+       hours from ``now``, and whose status is still ``pending``.
+    2. **Retries** — appointments in ``pending_retry`` that are eligible via
+       :meth:`Database.should_retry`.
+
+    Args:
+        db: The database to query.
+        now: Reference time (defaults to UTC now).
+        settings: Application settings.
+
+    Returns:
+        A list of appointment rows (``sqlite3.Row``) that need a call now.
+    """
+    settings = settings or get_settings()
+    now = now or datetime.utcnow()
+
+    due: list = []
+
+    # 1) First calls for today.
+    window_start = now + timedelta(hours=settings.confirmation_hours_before)
+    window_end = window_start + timedelta(hours=1)
+    for row in db.list_appointments(status="pending"):
+        apt_dt = _parse_dt(row["appointment_datetime"])
+        if apt_dt is None:
+            continue
+        if window_start <= apt_dt < window_end:
+            due.append(row)
+
+    # 2) Retries for no-answer appointments.
+    for row in db.list_appointments(status="pending_retry"):
+        if db.should_retry(row["id"], settings):
+            due.append(row)
+
+    # De-duplicate by appointment id while preserving order.
+    seen: set = set()
+    unique: list = []
+    for row in due:
+        if row["id"] not in seen:
+            seen.add(row["id"])
+            unique.append(row)
+    return unique
+
+
+def format_apt_datetime(value: str) -> tuple[str, str]:
+    """Split an appointment datetime into human ``date`` and ``time`` parts."""
+    parsed = _parse_dt(value)
+    if parsed is None:
+        return value, ""
+    return parsed.strftime("%Y-%m-%d"), parsed.strftime("%H:%M")

--- a/apps/python/no-show-guard/requirements.txt
+++ b/apps/python/no-show-guard/requirements.txt
@@ -1,0 +1,8 @@
+# No-Show Guard - Python 3.11+
+#
+# Official CALL-E Python SDK for authentication and placing confirmation calls.
+calle-ai
+# Loads CALLE_API_KEY and other settings from a .env file.
+python-dotenv>=1.0.0
+# Pretty console tables for the daily report.
+prettytable>=3.9.0

--- a/apps/python/no-show-guard/sample_appointments.csv
+++ b/apps/python/no-show-guard/sample_appointments.csv
@@ -1,0 +1,9 @@
+name,phone,appointment_datetime,service
+Shard Katiyar,+91 77249 71834 ,2025-12-20 10:30,General Consultation
+Piyush Katiyar,+91 95591 31902,2025-12-20 14:00,Haircut & Styling
+Shobhit Pathak,+91 85738 54153,2025-12-21 09:15,Physiotherapy
+Anshu KAtiyar,+91 79852 70241,2025-12-21 16:45,Dental Cleaning
+Shivani KAtiyar,+91 93367 58446,2025-12-22 11:00,AC Service Visit
+
+
+Shobhit Pathak,+918573854153,2026-08-11 08:45,Demo Video Call


### PR DESCRIPTION
No-Show Guard is a Python application that automates appointment confirmation calls for small businesses (clinics, salons, service providers) using CALL-E. It places outbound confirmation calls roughly 24 hours before an appointment, lets the customer Confirm, Reschedule, or Cancel via a natural conversation, and logs the structured outcome to a local SQLite database with an auto-generated daily summary report.

It uses the official calle-ai Python SDK (CalleClient.calls.create_and_wait) at runtime to place real outbound calls with a configurable task prompt and an enforced result_schema. Verified end-to-end with real phone calls (see demo video).


## Type

- [x] New runnable app

## How it works

1. Appointments are loaded from a CSV into a local SQLite database.
2. A scheduler picks appointments due for a confirmation call
   (~24 hours out), plus any no-answer retries.
3. call_agent.py places a real outbound call via the CALL-E SDK with a
   configurable prompt (prompts.py) and a structured result_schema.
4. The parsed outcome (confirmed / rescheduled / cancelled / no_answer)
   is saved to the database.
5. A daily summary report is generated (console table + CSV).

## Setup

See README.md in apps/python/no-show-guard/ for full setup
instructions (CALL-E API key, install, run).

## Demo video

https://youtube.com/shorts/J9zrSfkWf3o?si=cNqQlYEA4Nz3v_KL