### PR TITLE
feat(apps): add consent-first oral history caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | App | Language | Purpose |
 | --- | --- | --- |
 | [`apps/typescript/asyncfounders`](apps/typescript/asyncfounders/) | TypeScript | Callback-first persistent team memory: consented CALL-E interviews capture updates, brief unseen company deltas, and resolve open questions into evidence-linked typed memory. |
+| [`apps/typescript/one-more-story`](apps/typescript/one-more-story/) | TypeScript | Consent-first oral-history call that discloses AI use, preserves the storyteller's correction, and creates no story until the corrected read-back is explicitly confirmed. |
 | [`apps/web/callproof`](apps/web/callproof/) | Ruby / Python | Closed-loop CALL-E workflow that checks transcript evidence against an immutable call contract and routes policy exceptions to persisted AgentKit human review. |
 | [`apps/typescript/kincall`](apps/typescript/kincall/) | TypeScript | Consent-first check-in and trusted-circle coordination: a stated request for help overrides the agent's own judgement, contacts are called one at a time until somebody commits, and the monitored person is called back with the outcome. |
 | [`apps/typescript/verify-contact-claim`](apps/typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |

--- a/apps/typescript/one-more-story/.gitignore
+++ b/apps/typescript/one-more-story/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/apps/typescript/one-more-story/.oxlintrc.json
+++ b/apps/typescript/one-more-story/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["react", "typescript", "oxc"],
+  "rules": {
+    "react/rules-of-hooks": "error",
+    "react/only-export-components": ["warn", { "allowConstantExport": true }]
+  }
+}

--- a/apps/typescript/one-more-story/README.md
+++ b/apps/typescript/one-more-story/README.md
@@ -1,0 +1,73 @@
+# One More Story
+
+One More Story is a consent-first oral-history phone workflow. A loved one hears one meaningful question, corrects the read-back, and confirms the final wording. Until that confirmation, the product creates no story.
+
+The browser demo is deliberately a no-call fixture. It makes the full evidence boundary visible without a phone number, CALL-E account, or paid call.
+
+## What it proves
+
+- AI identity is disclosed before the question.
+- Permission to continue is recorded separately from permission to contact.
+- One approved question is asked; the agent does not improvise another.
+- The original answer and correction remain distinguishable.
+- A story exists only after explicit confirmation of the corrected read-back.
+- A deletion request prevents confirmation.
+
+## Run the no-call demo
+
+```bash
+npm install
+npm run dev
+```
+
+Use **Try the no-call demo** to replay disclosure, permission, question, read-back, correction, and confirmation. The fixture never sends a phone number and never calls CALL-E.
+
+```bash
+npm run test
+npm run lint
+npm run build
+```
+
+## Inspect the CALL-E request without calling
+
+The checked-in request uses a reserved fictional number and keeps every authority flag false.
+
+```bash
+npm run call:preview -- examples/call.example.json
+```
+
+Preview redacts the recipient field. It does not require credentials and cannot place a call.
+
+## Live CALL-E use
+
+Live use is intentionally server-side and fail-closed. Before one call, make a private copy of the example request and provide:
+
+- the adult storyteller's exact E.164 number;
+- their explicit permission to be contacted by this automated workflow;
+- an explicit BCP 47 locale and, if known, region;
+- the family member's name and exactly one approved question;
+- approval of the spoken AI/transcription disclosure; and
+- a fresh `confirmIntent: true` for this specific call.
+
+Then supply the credential only to the server process and enable the live switch for that invocation:
+
+```bash
+CALLE_API_KEY=... CALLE_LIVE_CALLS=enabled npm run call:live -- /private/path/request.json
+```
+
+The adapter uses `@call-e/calle` to create one call with a content-derived idempotency key, then waits on that same call ID. The API key never enters the Vite client. Live calls consume CALL-E credit and cause a real phone to ring.
+
+## Side effects, cancellation, and recovery
+
+- `call:preview`, the web demo, tests, lint, and build place no calls.
+- `call:live` can place exactly one outbound call after all gates pass.
+- There is no recurring schedule, automatic retry, or hidden follow-up.
+- If CALL-E accepts a call but result retrieval fails, do not run a new request. Reconcile the accepted call in CALL-E using its call ID and provider records.
+- Before acceptance, stop the command. After acceptance, use CALL-E's provider controls for that same call; starting a second call is not cancellation.
+- Local demo deletion clears the fixture state only. A real deletion request is returned as structured evidence and must be handled by the operator's retention system.
+
+## Safety boundaries
+
+Do not use this app for minors without a responsible adult and applicable legal review, for anyone who has not agreed to automated contact, or for medical, legal, financial, emergency, crisis, or coercive conversations. Never guess a phone number, locale, consent status, identity, or answer. A timeout, voicemail, silence, model summary, or provider status is not consent or story confirmation.
+
+The structured result keeps disclosure acknowledgment, permission, answer, correction, confirmation, and deletion separate. Only an explicit final confirmation can create a story.

--- a/apps/typescript/one-more-story/examples/call.example.json
+++ b/apps/typescript/one-more-story/examples/call.example.json
@@ -1,0 +1,11 @@
+{
+  "requestId": "family-demo-001",
+  "storytellerPhone": "+15555550123",
+  "locale": "en-US",
+  "region": "US",
+  "familyName": "a family member",
+  "question": "What did the rose market smell like when you were young?",
+  "contactPermission": false,
+  "aiDisclosureApproved": false,
+  "confirmIntent": false
+}

--- a/apps/typescript/one-more-story/index.html
+++ b/apps/typescript/one-more-story/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="A consent-first AI phone call that turns one thoughtful answer into a storyteller-confirmed memory." />
+    <meta name="theme-color" content="#06121d" />
+    <title>One More Story</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/typescript/one-more-story/package-lock.json
+++ b/apps/typescript/one-more-story/package-lock.json
@@ -1,0 +1,1892 @@
+{
+  "name": "one-more-story",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "one-more-story",
+      "version": "0.0.0",
+      "dependencies": {
+        "@call-e/calle": "^0.2.2",
+        "lucide-react": "^1.31.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      },
+      "devDependencies": {
+        "@types/node": "^24.13.3",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "oxlint": "^1.75.0",
+        "tsx": "^4.20.0",
+        "typescript": "~6.0.2",
+        "vite": "^8.2.0"
+      }
+    },
+    "node_modules/@call-e/calle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@call-e/calle/-/calle-0.2.2.tgz",
+      "integrity": "sha512-o1cDf/mASU92luUbdiUj1E7AFtXK+mm4ikGwB3x+G9RaEZCezs7/vYKDMEydnRmM1b8FEzzQB+Z+ehoE5kKvGw==",
+      "dependencies": {
+        "openapi-fetch": "^0.14.0"
+      },
+      "bin": {
+        "calle": "dist/cli.js"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.78.0.tgz",
+      "integrity": "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.78.0.tgz",
+      "integrity": "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.78.0.tgz",
+      "integrity": "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.78.0.tgz",
+      "integrity": "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.78.0.tgz",
+      "integrity": "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.78.0.tgz",
+      "integrity": "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.78.0.tgz",
+      "integrity": "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.78.0.tgz",
+      "integrity": "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.78.0.tgz",
+      "integrity": "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.78.0.tgz",
+      "integrity": "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.78.0.tgz",
+      "integrity": "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.78.0.tgz",
+      "integrity": "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.78.0.tgz",
+      "integrity": "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.78.0.tgz",
+      "integrity": "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.78.0.tgz",
+      "integrity": "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.78.0.tgz",
+      "integrity": "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.78.0.tgz",
+      "integrity": "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.78.0.tgz",
+      "integrity": "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.78.0.tgz",
+      "integrity": "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/oxlint": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.78.0.tgz",
+      "integrity": "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.78.0",
+        "@oxlint/binding-android-arm64": "1.78.0",
+        "@oxlint/binding-darwin-arm64": "1.78.0",
+        "@oxlint/binding-darwin-x64": "1.78.0",
+        "@oxlint/binding-freebsd-x64": "1.78.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.78.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.78.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.78.0",
+        "@oxlint/binding-linux-arm64-musl": "1.78.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.78.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.78.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.78.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.78.0",
+        "@oxlint/binding-linux-x64-gnu": "1.78.0",
+        "@oxlint/binding-linux-x64-musl": "1.78.0",
+        "@oxlint/binding-openharmony-arm64": "1.78.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.78.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.78.0",
+        "@oxlint/binding-win32-x64-msvc": "1.78.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.0.tgz",
+      "integrity": "sha512-TsmdeXxcZYiJ2MKV7fdq38na0CKyLRtCeMqTeHMmrVXQ/gf5yTeJohh+sgr7MnMGsjeKXzHzy+TwOOTR1arl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/apps/typescript/one-more-story/package.json
+++ b/apps/typescript/one-more-story/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "one-more-story",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "oxlint",
+    "preview": "vite preview",
+    "test": "node --import tsx --test test/*.test.ts",
+    "call:preview": "node --import tsx scripts/call.ts preview",
+    "call:live": "node --import tsx scripts/call.ts live"
+  },
+  "dependencies": {
+    "@call-e/calle": "0.2.2",
+    "lucide-react": "^1.31.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "oxlint": "^1.75.0",
+    "tsx": "^4.20.0",
+    "typescript": "~6.0.2",
+    "vite": "^8.2.0"
+  }
+}

--- a/apps/typescript/one-more-story/public/favicon.svg
+++ b/apps/typescript/one-more-story/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="15" fill="#06121d"/>
+  <path d="M20 15c-4 4-5 10-3 17 3 9 10 16 19 19 7 2 13 1 17-3l-8-9-7 4c-5-2-10-7-12-12l4-7-10-9Z" fill="none" stroke="#e45f48" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m37 23 4 4 8-9" fill="none" stroke="#9ccbb0" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/typescript/one-more-story/scripts/call.ts
+++ b/apps/typescript/one-more-story/scripts/call.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises'
+import { buildCallInput, createSdkPort, dispatchStoryCall } from '../server/calle.js'
+import type { StoryCallRequest } from '../server/call-contract.js'
+
+const [command, requestPath] = process.argv.slice(2)
+if (!requestPath || !['preview', 'live'].includes(command ?? '')) {
+  console.error('Usage: npm run call:preview -- <request.json> | npm run call:live -- <request.json>')
+  process.exit(2)
+}
+
+const request = JSON.parse(await readFile(requestPath, 'utf8')) as StoryCallRequest
+if (command === 'preview') {
+  const preview = buildCallInput(request)
+  console.log(JSON.stringify({ ...preview, recipients: '[redacted in preview]' }, null, 2))
+  process.exit(0)
+}
+
+const port = await createSdkPort()
+const result = await dispatchStoryCall(request, port)
+console.log(JSON.stringify(result, null, 2))

--- a/apps/typescript/one-more-story/scripts/call.ts
+++ b/apps/typescript/one-more-story/scripts/call.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { buildCallInput, createSdkPort, dispatchStoryCall } from '../server/calle.js'
+import { buildCallInput, createSdkPort, dispatchStoryCall, summarizeCallSnapshot } from '../server/calle.js'
 import type { StoryCallRequest } from '../server/call-contract.js'
 
 const [command, requestPath] = process.argv.slice(2)
@@ -17,4 +17,4 @@ if (command === 'preview') {
 
 const port = await createSdkPort()
 const result = await dispatchStoryCall(request, port)
-console.log(JSON.stringify(result, null, 2))
+console.log(JSON.stringify(summarizeCallSnapshot(result), null, 2))

--- a/apps/typescript/one-more-story/scripts/call.ts
+++ b/apps/typescript/one-more-story/scripts/call.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { buildCallInput, createSdkPort, dispatchStoryCall, summarizeCallSnapshot } from '../server/calle.js'
-import type { StoryCallRequest } from '../server/call-contract.js'
+import { parseStoryCallRequest } from '../server/call-contract.js'
 
 const [command, requestPath] = process.argv.slice(2)
 if (!requestPath || !['preview', 'live'].includes(command ?? '')) {
@@ -8,7 +8,7 @@ if (!requestPath || !['preview', 'live'].includes(command ?? '')) {
   process.exit(2)
 }
 
-const request = JSON.parse(await readFile(requestPath, 'utf8')) as StoryCallRequest
+const request = parseStoryCallRequest(JSON.parse(await readFile(requestPath, 'utf8')))
 if (command === 'preview') {
   const preview = buildCallInput(request)
   console.log(JSON.stringify({ ...preview, recipients: '[redacted in preview]' }, null, 2))

--- a/apps/typescript/one-more-story/server/call-contract.ts
+++ b/apps/typescript/one-more-story/server/call-contract.ts
@@ -70,8 +70,22 @@ export const storyResultSchema = {
   },
 } as const
 
-export function idempotencyKey(request: StoryCallRequest): string {
-  const material = JSON.stringify({ requestId: request.requestId, phone: request.storytellerPhone, question: request.question })
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+    return `{${entries.join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function idempotencyKey(request: StoryCallRequest, callInput: Record<string, unknown>): string {
+  const material = canonicalJson({
+    authorization: request,
+    call: callInput,
+  })
   return `one-more-story-${createHash('sha256').update(material).digest('hex').slice(0, 16)}`
 }
 

--- a/apps/typescript/one-more-story/server/call-contract.ts
+++ b/apps/typescript/one-more-story/server/call-contract.ts
@@ -23,15 +23,48 @@ export type StoryCallResult = {
 
 const E164 = /^\+[1-9]\d{7,14}$/
 const LOCALE = /^[a-z]{2,3}(?:-[A-Z]{2})?$/
+const REQUEST_FIELDS = new Set([
+  'requestId',
+  'storytellerPhone',
+  'locale',
+  'region',
+  'familyName',
+  'question',
+  'contactPermission',
+  'aiDisclosureApproved',
+  'confirmIntent',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseStoryCallRequest(value: unknown): StoryCallRequest {
+  if (!isRecord(value)) throw new Error('The call request must be a JSON object.')
+
+  const unknownFields = Object.keys(value).filter((field) => !REQUEST_FIELDS.has(field))
+  if (unknownFields.length > 0) throw new Error(`Unknown call request field: ${unknownFields[0]}.`)
+
+  for (const field of ['requestId', 'storytellerPhone', 'locale', 'familyName', 'question'] as const) {
+    if (typeof value[field] !== 'string') throw new Error(`${field} must be a string.`)
+  }
+  if (value.region !== undefined && typeof value.region !== 'string') throw new Error('region must be a string when provided.')
+  for (const field of ['contactPermission', 'aiDisclosureApproved', 'confirmIntent'] as const) {
+    if (typeof value[field] !== 'boolean') throw new Error(`${field} must be a boolean.`)
+  }
+
+  return value as StoryCallRequest
+}
 
 export function assertLiveCallAuthorized(request: StoryCallRequest): void {
+  parseStoryCallRequest(request)
   if (!E164.test(request.storytellerPhone)) throw new Error('The storyteller phone must be an explicit E.164 number.')
   if (!LOCALE.test(request.locale)) throw new Error('The storyteller locale must be an explicit BCP 47 language tag.')
   if (!request.familyName.trim()) throw new Error('The family member placing the call must be named.')
   if (!request.question.trim()) throw new Error('The family must approve one explicit question.')
-  if (!request.contactPermission) throw new Error('Recorded permission to contact this adult is required.')
-  if (!request.aiDisclosureApproved) throw new Error('The family must approve the spoken AI disclosure.')
-  if (!request.confirmIntent) throw new Error('A fresh explicit intent confirmation is required for this call.')
+  for (const field of ['contactPermission', 'aiDisclosureApproved', 'confirmIntent'] as const) {
+    if (request[field] !== true) throw new Error(`${field} must be the exact boolean true.`)
+  }
 }
 
 export function buildCallTask(request: StoryCallRequest): string {

--- a/apps/typescript/one-more-story/server/call-contract.ts
+++ b/apps/typescript/one-more-story/server/call-contract.ts
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto'
+
+export type StoryCallRequest = {
+  requestId: string
+  storytellerPhone: string
+  locale: string
+  region?: string
+  familyName: string
+  question: string
+  contactPermission: boolean
+  aiDisclosureApproved: boolean
+  confirmIntent: boolean
+}
+
+export type StoryCallResult = {
+  disclosure_acknowledged: 'yes' | 'no' | 'unknown'
+  permission_to_continue: 'yes' | 'no' | 'unknown'
+  story_answer: string
+  correction: string | null
+  readback_confirmed: 'yes' | 'no' | 'unknown'
+  deletion_requested: boolean
+}
+
+const E164 = /^\+[1-9]\d{7,14}$/
+const LOCALE = /^[a-z]{2,3}(?:-[A-Z]{2})?$/
+
+export function assertLiveCallAuthorized(request: StoryCallRequest): void {
+  if (!E164.test(request.storytellerPhone)) throw new Error('The storyteller phone must be an explicit E.164 number.')
+  if (!LOCALE.test(request.locale)) throw new Error('The storyteller locale must be an explicit BCP 47 language tag.')
+  if (!request.familyName.trim()) throw new Error('The family member placing the call must be named.')
+  if (!request.question.trim()) throw new Error('The family must approve one explicit question.')
+  if (!request.contactPermission) throw new Error('Recorded permission to contact this adult is required.')
+  if (!request.aiDisclosureApproved) throw new Error('The family must approve the spoken AI disclosure.')
+  if (!request.confirmIntent) throw new Error('A fresh explicit intent confirmation is required for this call.')
+}
+
+export function buildCallTask(request: StoryCallRequest): string {
+  return [
+    `You are an AI calling on behalf of ${request.familyName}.`,
+    'Begin by clearly saying that you are an AI and that the call may be processed and transcribed.',
+    'Ask whether the storyteller gives permission to continue and to save their answer for read-back.',
+    'If permission is not an explicit yes, thank them, end the call, and record no story.',
+    `If permission is given, ask exactly one question: "${request.question.trim()}"`,
+    'Listen without adding facts. Read the answer back. Ask for corrections.',
+    'Read the corrected version back and ask whether it is right.',
+    'A story is confirmed only after an explicit yes to that final read-back.',
+    'If the storyteller asks to delete the answer, acknowledge the request and mark deletion_requested true.',
+    'Do not give medical, legal, financial, or emergency advice. Do not arrange another call.',
+  ].join(' ')
+}
+
+export const storyResultSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'disclosure_acknowledged',
+    'permission_to_continue',
+    'story_answer',
+    'correction',
+    'readback_confirmed',
+    'deletion_requested',
+  ],
+  properties: {
+    disclosure_acknowledged: { type: 'string', enum: ['yes', 'no', 'unknown'] },
+    permission_to_continue: { type: 'string', enum: ['yes', 'no', 'unknown'] },
+    story_answer: { type: 'string' },
+    correction: { type: ['string', 'null'] },
+    readback_confirmed: { type: 'string', enum: ['yes', 'no', 'unknown'] },
+    deletion_requested: { type: 'boolean' },
+  },
+} as const
+
+export function idempotencyKey(request: StoryCallRequest): string {
+  const material = JSON.stringify({ requestId: request.requestId, phone: request.storytellerPhone, question: request.question })
+  return `one-more-story-${createHash('sha256').update(material).digest('hex').slice(0, 16)}`
+}
+
+export function isConfirmedStory(result: StoryCallResult): boolean {
+  return result.disclosure_acknowledged === 'yes'
+    && result.permission_to_continue === 'yes'
+    && result.readback_confirmed === 'yes'
+    && !result.deletion_requested
+}

--- a/apps/typescript/one-more-story/server/calle.ts
+++ b/apps/typescript/one-more-story/server/calle.ts
@@ -3,6 +3,12 @@ import { assertLiveCallAuthorized, buildCallTask, idempotencyKey, storyResultSch
 
 export type CallSnapshot = { id: string; status?: string; structuredResult?: unknown }
 
+export type PublicCallSummary = {
+  id: string
+  status: string
+  resultReceived: boolean
+}
+
 export interface CallePort {
   create(input: Record<string, unknown>, options: { idempotencyKey: string }): Promise<CallSnapshot>
   waitForResult(callId: string, options: { timeoutMs: number; intervalMs: number }): Promise<CallSnapshot>
@@ -28,8 +34,17 @@ export async function dispatchStoryCall(
 ): Promise<CallSnapshot> {
   if (liveSwitch !== 'enabled') throw new Error('Live calls are disabled. Set CALLE_LIVE_CALLS=enabled only for an approved call.')
   assertLiveCallAuthorized(request)
-  const call = await port.create(buildCallInput(request), { idempotencyKey: idempotencyKey(request) })
+  const callInput = buildCallInput(request)
+  const call = await port.create(callInput, { idempotencyKey: idempotencyKey(request, callInput) })
   return port.waitForResult(call.id, { timeoutMs: 300_000, intervalMs: 2_000 })
+}
+
+export function summarizeCallSnapshot(snapshot: CallSnapshot): PublicCallSummary {
+  return {
+    id: snapshot.id,
+    status: snapshot.status ?? 'unknown',
+    resultReceived: snapshot.structuredResult !== undefined,
+  }
 }
 
 export async function createSdkPort(): Promise<CallePort> {

--- a/apps/typescript/one-more-story/server/calle.ts
+++ b/apps/typescript/one-more-story/server/calle.ts
@@ -1,0 +1,44 @@
+import type { StoryCallRequest } from './call-contract.js'
+import { assertLiveCallAuthorized, buildCallTask, idempotencyKey, storyResultSchema } from './call-contract.js'
+
+export type CallSnapshot = { id: string; status?: string; structuredResult?: unknown }
+
+export interface CallePort {
+  create(input: Record<string, unknown>, options: { idempotencyKey: string }): Promise<CallSnapshot>
+  waitForResult(callId: string, options: { timeoutMs: number; intervalMs: number }): Promise<CallSnapshot>
+}
+
+export function buildCallInput(request: StoryCallRequest): Record<string, unknown> {
+  return {
+    task: buildCallTask(request),
+    recipients: [{
+      phones: [request.storytellerPhone],
+      locale: request.locale,
+      ...(request.region ? { region: request.region } : {}),
+    }],
+    resultSchema: storyResultSchema,
+    metadata: { app: 'one-more-story', request_id: request.requestId },
+  }
+}
+
+export async function dispatchStoryCall(
+  request: StoryCallRequest,
+  port: CallePort,
+  liveSwitch = process.env.CALLE_LIVE_CALLS,
+): Promise<CallSnapshot> {
+  if (liveSwitch !== 'enabled') throw new Error('Live calls are disabled. Set CALLE_LIVE_CALLS=enabled only for an approved call.')
+  assertLiveCallAuthorized(request)
+  const call = await port.create(buildCallInput(request), { idempotencyKey: idempotencyKey(request) })
+  return port.waitForResult(call.id, { timeoutMs: 300_000, intervalMs: 2_000 })
+}
+
+export async function createSdkPort(): Promise<CallePort> {
+  const apiKey = process.env.CALLE_API_KEY
+  if (!apiKey) throw new Error('CALLE_API_KEY is required for a live call.')
+  const { CalleClient } = await import('@call-e/calle')
+  const client = new CalleClient({ apiKey, baseUrl: 'https://api.heycall-e.com' })
+  return {
+    create: (input, options) => client.calls.create(input as never, options) as Promise<CallSnapshot>,
+    waitForResult: (callId, options) => client.calls.waitForResult(callId, options) as Promise<CallSnapshot>,
+  }
+}

--- a/apps/typescript/one-more-story/src/App.css
+++ b/apps/typescript/one-more-story/src/App.css
@@ -1,0 +1,152 @@
+#root { min-height: 100vh; }
+.app-shell { min-height: 100vh; display: grid; grid-template-rows: auto 1fr auto; background: radial-gradient(circle at 80% 18%, #0d2231 0, #06121d 38%, #06121d 100%); }
+.site-header { height: 68px; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; padding: 0 40px; border-bottom: 1px solid rgba(194,140,61,.34); }
+.wordmark { font: 500 28px/1 'Newsreader', Georgia, serif; text-decoration: none; color: var(--cream); }
+.site-header nav, footer nav { display: flex; gap: 34px; }
+.site-header nav a, footer a { color: #d9cdbd; text-decoration: none; font-size: 14px; }
+.site-header nav a:hover, footer a:hover { color: white; }
+.reset-button { justify-self: end; display: inline-flex; align-items: center; gap: 8px; color: #d9cdbd; background: transparent; border: 0; cursor: pointer; font-size: 13px; }
+.reset-button svg { width: 15px; }
+main { min-width: 0; }
+.intro { min-height: calc(100vh - 124px); display: grid; grid-template-columns: minmax(350px, .8fr) minmax(680px, 1.55fr); }
+.intro-copy { padding: 70px 56px 46px; border-right: 1px solid rgba(194,140,61,.2); }
+h1 { margin: 0; max-width: 520px; font: 400 clamp(54px, 5vw, 82px)/.96 'Newsreader', Georgia, serif; letter-spacing: -.04em; color: var(--cream); }
+.lede { margin: 24px 0 28px; max-width: 490px; font-size: 19px; line-height: 1.55; color: #aeb3b5; }
+.primary-actions { display: grid; gap: 12px; max-width: 460px; text-align: center; }
+.primary-actions > span { font-size: 12px; color: #c6a66a; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 10px; border-radius: 5px; border: 1px solid transparent; cursor: pointer; font-weight: 600; transition: transform .18s ease, background .18s ease, border-color .18s ease; }
+.button:hover { transform: translateY(-1px); }
+.button svg { width: 20px; height: 20px; }
+.button-primary { color: #fff7ee; background: var(--coral); border-color: var(--coral); }
+.button-primary:hover { background: #ee6b53; }
+.button-secondary { color: var(--cream); background: transparent; border-color: var(--brass); }
+.button-secondary:hover { background: rgba(194,140,61,.09); }
+.call-contract { margin-top: 48px; max-width: 500px; border: 1px solid rgba(194,140,61,.56); border-radius: 5px; padding: 0 20px 4px; }
+.call-contract h2 { display: inline-block; transform: translateY(-13px); margin: 0; padding: 0 10px; background: var(--ink); font: 400 19px/1 'Newsreader', Georgia, serif; color: #e6c487; }
+.contract-row { display: grid; grid-template-columns: 42px 104px 1fr; gap: 10px; align-items: center; min-height: 92px; padding: 14px 0; border-top: 1px solid rgba(194,140,61,.28); }
+.contract-row:first-of-type { border-top: 0; }
+.contract-row svg { width: 36px; height: 36px; padding: 8px; color: var(--coral); border: 1px solid var(--coral); border-radius: 50%; }
+.contract-row span { font-size: 12px; color: #d0b274; }
+.contract-row strong { font: 400 17px/1.25 'Newsreader', Georgia, serif; color: #eee2cf; }
+.proof-surface { min-width: 0; padding: 32px 32px 38px; }
+.status-strip { min-height: 54px; display: flex; align-items: center; gap: 14px; padding: 8px 18px; border: 1px solid rgba(194,140,61,.32); background: rgba(238,221,190,.045); border-radius: 5px; }
+.status-strip > svg { width: 23px; color: var(--coral); }
+.status-strip div { display: flex; align-items: baseline; gap: 18px; }
+.status-strip strong { color: var(--coral); font-size: 14px; }
+.status-strip span { color: #c4b7a5; font-size: 13px; }
+.status-confirmed > svg, .status-private > svg, .status-published > svg { color: var(--mint); }
+.status-confirmed strong, .status-private strong, .status-published strong { color: var(--mint); }
+.proof-grid { display: grid; grid-template-columns: 245px 1fr; gap: 26px; margin-top: 26px; }
+.timeline { list-style: none; margin: 0; padding: 8px 0 0; position: relative; }
+.timeline::before { content: ''; position: absolute; left: 16px; top: 22px; bottom: 46px; width: 1px; background: var(--brass); opacity: .7; }
+.timeline li { position: relative; display: grid; grid-template-columns: 34px 1fr; gap: 14px; min-height: 105px; }
+.step-marker { position: relative; z-index: 1; width: 34px; height: 34px; display: grid; place-items: center; border: 1px solid var(--brass); border-radius: 50%; background: var(--ink); color: #ddbd82; font: 500 13px/1 'DM Sans', sans-serif; }
+.step-marker svg { width: 15px; }
+.timeline li.complete .step-marker { background: var(--mint); border-color: var(--mint); color: var(--ink); }
+.timeline li.active .step-marker { color: var(--coral); border-color: var(--coral); animation: pulse 1.4s ease-out infinite; }
+.timeline strong { color: #ead9bd; font: 400 17px/1.2 'Newsreader', Georgia, serif; }
+.timeline li.active strong { color: var(--coral); }
+.timeline p { margin: 6px 0; color: #a8a4a0; font-size: 12px; line-height: 1.4; }
+.timeline div > span { color: #777f82; font-size: 11px; }
+.timeline li.complete div > span { color: var(--mint); }
+.evidence-story { min-width: 0; }
+.evidence-rail { padding: 0 4px 18px; }
+.evidence-heading { display: flex; justify-content: space-between; align-items: center; padding-bottom: 8px; border-bottom: 1px solid rgba(194,140,61,.35); }
+.evidence-heading h2 { margin: 0; color: #e1bd7a; font-size: 12px; font-weight: 500; }
+.evidence-heading span { color: #727b80; font-size: 10px; text-transform: uppercase; letter-spacing: .12em; }
+.transcript { max-height: 330px; overflow: auto; scrollbar-color: var(--coral) transparent; }
+.evidence-empty { margin: 0; padding: 24px 8px; color: #9da5a7; font-size: 12px; line-height: 1.5; }
+.transcript-row { display: grid; grid-template-columns: 54px 1fr 18px; gap: 10px; align-items: start; padding: 12px 6px; border-bottom: 1px solid rgba(194,140,61,.24); }
+.transcript-row time { color: #7f888c; font-size: 11px; }
+.transcript-row strong { display: block; color: var(--coral); font-size: 11px; }
+.transcript-row p { margin: 2px 0 0; color: #d7d0c4; font-size: 12px; line-height: 1.38; }
+.transcript-row .human { margin-top: 5px; }
+.transcript-row > svg { width: 14px; color: #c9b791; }
+.transcript-row.correction { background: rgba(228,95,72,.06); }
+.transcript-row.confirmation { background: rgba(156,203,176,.07); }
+.transcript-row.confirmation strong, .transcript-row.confirmation > svg { color: var(--mint); }
+.story-card { position: relative; min-height: 310px; margin-top: 14px; padding: 34px 40px 24px; color: var(--parchment-ink); background-color: var(--parchment); background-image: radial-gradient(rgba(45,34,24,.06) .7px, transparent .8px); background-size: 5px 5px; border-radius: 4px 8px 6px 5px; box-shadow: 0 18px 42px rgba(0,0,0,.25); clip-path: polygon(.5% 1%, 4% 0, 8% .8%, 13% .1%, 19% .9%, 26% .2%, 32% .8%, 39% .1%, 46% .7%, 52% 0, 60% .9%, 68% .1%, 76% .8%, 83% .2%, 91% .8%, 99.5% .1%, 100% 99%, 94% 100%, 87% 99.2%, 81% 100%, 73% 99.1%, 65% 99.8%, 57% 99.2%, 49% 100%, 41% 99.1%, 32% 99.8%, 24% 99.1%, 15% 100%, 7% 99.2%, 0 100%); opacity: .54; transition: opacity .45s ease, transform .45s ease; }
+.story-card.revealed { opacity: 1; animation: reveal .5s ease both; }
+.story-card h2 { margin: 0; text-align: center; font: 500 clamp(25px, 2.2vw, 36px)/1.05 'Newsreader', Georgia, serif; }
+.story-rule { display: flex; align-items: center; height: 18px; margin: 6px 0 20px; }
+.story-rule::before, .story-rule::after { content: ''; height: 1px; background: var(--brass); flex: 1; }
+.story-rule span { width: 28px; height: 16px; border-bottom: 2px solid var(--brass); border-radius: 50%; transform: rotate(-18deg); }
+.story-copy { min-height: 76px; margin: 0; font: 400 20px/1.42 'Newsreader', Georgia, serif; }
+.story-copy mark { color: inherit; background: transparent; border-bottom: 2px solid var(--mint); }
+.story-card.confirmed .story-copy { animation: reveal .6s ease both; }
+.proof-line { display: flex; align-items: center; gap: 8px; margin: 18px 0 0; color: #725b34; font-size: 11px; }
+.proof-line svg { width: 15px; }
+.story-actions { display: flex; gap: 10px; align-items: center; margin-top: 24px; }
+.story-actions button { min-height: 44px; flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 7px; color: #5f2a20; background: transparent; border: 1px solid rgba(121,61,44,.45); border-radius: 4px; cursor: pointer; font-size: 12px; }
+.story-actions button:hover:not(:disabled) { background: rgba(228,95,72,.08); }
+.story-actions button.publish { color: white; background: var(--coral); border-color: var(--coral); }
+.story-actions button.destructive { color: #9d2f27; }
+.story-actions button:disabled { color: #9b958b; border-color: #b9ae9c; cursor: not-allowed; opacity: .55; }
+.story-actions svg { width: 16px; }
+.story-lock { display: flex; align-items: center; justify-content: center; gap: 7px; margin: 16px 0 0; color: #6f675d; font-size: 10px; }
+.story-lock svg { width: 13px; }
+.correction-editor { margin-top: 20px; padding-top: 16px; border-top: 1px solid rgba(194,140,61,.5); }
+.correction-editor label { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 600; }
+.correction-editor input { width: 100%; min-height: 42px; padding: 0 12px; color: var(--parchment-ink); background: rgba(255,255,255,.28); border: 1px solid #987d53; border-radius: 3px; }
+.correction-editor > div { display: flex; gap: 8px; margin-top: 9px; }
+.correction-editor .button { padding: 0 14px; }
+.icon-button { width: 44px; border: 1px solid #987d53; background: transparent; cursor: pointer; }
+.delete-confirm { display: flex; align-items: center; gap: 10px; margin-top: 20px; padding-top: 15px; border-top: 1px solid rgba(187,62,50,.4); }
+.delete-confirm p { flex: 1; margin: 0; }
+.delete-confirm strong, .delete-confirm span { display: block; font-size: 11px; }
+.delete-confirm span { margin-top: 3px; color: #6f675d; }
+.delete-confirm button { padding: 8px 10px; color: #8f2e27; background: transparent; border: 1px solid #a86359; cursor: pointer; }
+.empty-story { display: grid; place-items: center; align-content: center; text-align: center; }
+.empty-story > svg { width: 30px; color: var(--danger); }
+.empty-story p { color: #6f675d; }
+footer { min-height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 30px; padding: 0 40px; border-top: 1px solid rgba(194,140,61,.34); color: #9aa1a4; }
+footer p { display: flex; align-items: center; gap: 10px; margin: 0; font-size: 11px; }
+footer svg { width: 16px; }
+.modal-backdrop { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: 24px; background: rgba(2,9,15,.78); backdrop-filter: blur(4px); }
+.modal { position: relative; width: min(560px, 100%); padding: 36px; color: var(--parchment-ink); background: var(--parchment); border-radius: 6px; box-shadow: 0 30px 90px rgba(0,0,0,.48); }
+.modal-close { position: absolute; top: 12px; right: 14px; border: 0; background: transparent; font-size: 28px; cursor: pointer; }
+.modal-label { margin: 0 0 8px; color: #925444; font-size: 11px; text-transform: uppercase; letter-spacing: .13em; }
+.modal h2 { margin: 0 0 20px; font: 500 35px/1 'Newsreader', Georgia, serif; }
+.modal ol { margin: 0 0 24px; padding-left: 22px; }
+.modal li { padding: 8px 0 8px 5px; }
+.modal li strong, .modal li span { display: block; }
+.modal li strong { font-size: 12px; }
+.modal li span { margin-top: 3px; color: #5c5146; font-size: 13px; line-height: 1.45; }
+.modal .button { width: 100%; }
+@keyframes pulse { from { box-shadow: 0 0 0 0 rgba(228,95,72,.32); } to { box-shadow: 0 0 0 9px rgba(228,95,72,0); } }
+@keyframes reveal { from { opacity: .2; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; transition-duration: .01ms !important; } }
+@media (max-width: 1120px) {
+  .site-header { padding: 0 24px; }
+  .intro { grid-template-columns: 1fr; }
+  .intro-copy { padding: 54px 32px 36px; border-right: 0; border-bottom: 1px solid rgba(194,140,61,.2); }
+  .call-contract { max-width: none; }
+  .proof-surface { padding: 30px 28px; }
+}
+@media (max-width: 720px) {
+  .site-header { height: auto; min-height: 62px; grid-template-columns: 1fr auto; padding: 14px 18px; }
+  .site-header nav { display: none; }
+  .wordmark { font-size: 24px; }
+  .reset-button { font-size: 0; }
+  .reset-button svg { width: 18px; }
+  .intro-copy { padding: 42px 18px 30px; }
+  h1 { font-size: 50px; }
+  .lede { font-size: 16px; }
+  .contract-row { grid-template-columns: 38px 92px 1fr; min-height: 82px; }
+  .contract-row strong { font-size: 15px; }
+  .proof-surface { padding: 24px 14px 28px; }
+  .status-strip div { display: block; }
+  .status-strip span { display: block; margin-top: 2px; }
+  .proof-grid { grid-template-columns: 1fr; }
+  .timeline { display: grid; grid-template-columns: repeat(5, 1fr); padding: 0; }
+  .timeline::before { left: 10%; right: 10%; top: 17px; bottom: auto; width: auto; height: 1px; }
+  .timeline li { display: flex; min-height: 80px; flex-direction: column; align-items: center; gap: 6px; text-align: center; }
+  .timeline li div p, .timeline li div > span { display: none; }
+  .timeline strong { font-size: 12px; }
+  .evidence-rail { padding-inline: 0; }
+  .story-card { padding: 28px 20px 22px; }
+  .story-actions { flex-direction: column; }
+  .story-actions button { width: 100%; flex: auto; }
+  footer { padding: 16px 18px; }
+  footer nav { display: none; }
+}

--- a/apps/typescript/one-more-story/src/App.tsx
+++ b/apps/typescript/one-more-story/src/App.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from 'react'
+import { BookOpen, LockKeyhole, Phone, Play, ShieldCheck } from 'lucide-react'
+import './App.css'
+import { CallContract } from './components/CallContract'
+import { ConsentTimeline } from './components/ConsentTimeline'
+import { EvidenceRail } from './components/EvidenceRail'
+import { Header } from './components/Header'
+import { StoryCard } from './components/StoryCard'
+import { demoStory, stageOrder, type StoryStage } from './data/demoStory'
+import { applyCorrection } from './data/storyState'
+
+const autoplayStages: StoryStage[] = ['disclosure', 'permission', 'question', 'readback', 'correction']
+
+function App() {
+  const [stage, setStage] = useState<StoryStage>('ready')
+  const [autoplay, setAutoplay] = useState(false)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const [correctionOpen, setCorrectionOpen] = useState(false)
+  const [correction, setCorrection] = useState<string>(demoStory.correction)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const stageIndex = stageOrder.indexOf(stage)
+  const isConfirmed = stageIndex >= stageOrder.indexOf('confirmed') && stage !== 'deleted'
+
+  useEffect(() => {
+    if (!autoplay) return
+    const next = autoplayStages.find((item) => stageOrder.indexOf(item) > stageIndex)
+    if (!next) {
+      setAutoplay(false)
+      return
+    }
+    const timer = window.setTimeout(() => setStage(next), 720)
+    return () => window.clearTimeout(timer)
+  }, [autoplay, stageIndex])
+
+  const status = useMemo(() => {
+    if (stage === 'deleted') return ['Deleted locally', 'The no-call story and transcript have been removed.']
+    if (stage === 'published') return ['Shared with family', 'The confirmed story is now in the family space.']
+    if (stage === 'private') return ['Kept private', 'Only the storyteller can see this confirmed story.']
+    if (isConfirmed) return ['Confirmed by the storyteller', 'Corrected once, then read back and confirmed.']
+    if (stage === 'correction') return ['Waiting for confirmation', 'The story is not created yet.']
+    if (stage === 'ready') return ['Ready for a no-call rehearsal', 'No real number or CALL-E credit is used.']
+    return ['Call rehearsal in progress', 'The no-call fixture is advancing through the consent contract.']
+  }, [isConfirmed, stage])
+
+  const startDemo = () => {
+    setStage('ready')
+    setCorrectionOpen(false)
+    setDeleteOpen(false)
+    setAutoplay(true)
+  }
+
+  const confirmCorrection = () => {
+    if (!applyCorrection(demoStory.originalAnswer, correction).confirmed) return
+    setCorrectionOpen(false)
+    setStage('confirmed')
+  }
+
+  const resetDemo = () => {
+    setStage('ready')
+    setAutoplay(false)
+    setCorrectionOpen(false)
+    setDeleteOpen(false)
+    setCorrection(demoStory.correction)
+  }
+
+  return (
+    <div className="app-shell" id="top">
+      <Header onReset={resetDemo} />
+      <main>
+        <section className="intro" aria-labelledby="page-title">
+          <div className="intro-copy">
+            <h1 id="page-title">Ask once. Listen well.</h1>
+            <p className="lede">One thoughtful phone call. Nothing becomes a story until they say it&rsquo;s right.</p>
+            <div className="primary-actions">
+              <button className="button button-primary" type="button" onClick={() => setPreviewOpen(true)}><Phone aria-hidden="true" />Preview the call</button>
+              <button className="button button-secondary" type="button" onClick={startDemo}><Play aria-hidden="true" />Try the no-call demo</button>
+              <span>Safe, private, and needs no real number.</span>
+            </div>
+            <CallContract />
+          </div>
+          <div className="proof-surface" aria-live="polite">
+            <div className={`status-strip status-${stage}`}>
+              {isConfirmed ? <ShieldCheck aria-hidden="true" /> : <BookOpen aria-hidden="true" />}
+              <div><strong>{status[0]}</strong><span>{status[1]}</span></div>
+            </div>
+            <div className="proof-grid">
+              <ConsentTimeline stage={stage} />
+              <div className="evidence-story">
+                <EvidenceRail stage={stage} correction={correction} />
+                <StoryCard
+                  stage={stage}
+                  correction={correction}
+                  correctionOpen={correctionOpen}
+                  deleteOpen={deleteOpen}
+                  onOpenCorrection={() => setCorrectionOpen((open) => !open)}
+                  onCorrectionChange={setCorrection}
+                  onConfirmCorrection={confirmCorrection}
+                  onPublish={() => setStage('published')}
+                  onKeepPrivate={() => setStage('private')}
+                  onOpenDelete={() => setDeleteOpen(true)}
+                  onCancelDelete={() => setDeleteOpen(false)}
+                  onDelete={() => { setDeleteOpen(false); setStage('deleted') }}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+      <footer id="privacy">
+        <p><LockKeyhole aria-hidden="true" /> Privacy first, always. No story is saved or shared until the storyteller confirms it.</p>
+        <nav aria-label="Footer"><a href="#privacy">Privacy</a><a href="#how-it-works">How it works</a></nav>
+      </footer>
+      {previewOpen && (
+        <div className="modal-backdrop" role="presentation" onMouseDown={() => setPreviewOpen(false)}>
+          <section className="modal" role="dialog" aria-modal="true" aria-labelledby="preview-title" onMouseDown={(event) => event.stopPropagation()}>
+            <button className="modal-close" type="button" aria-label="Close preview" onClick={() => setPreviewOpen(false)}>×</button>
+            <p className="modal-label">Spoken-call preview</p>
+            <h2 id="preview-title">What your loved one will hear</h2>
+            <ol>
+              <li><strong>Disclosure</strong><span>“Hi, I’m an AI calling from One More Story for your family.”</span></li>
+              <li><strong>Permission</strong><span>“Is it okay to continue and save your answer for read-back?”</span></li>
+              <li><strong>One question</strong><span>“{demoStory.question}”</span></li>
+              <li><strong>Read-back</strong><span>The agent repeats what it heard and accepts a correction.</span></li>
+              <li><strong>Confirmation</strong><span>No story exists until the storyteller says the read-back is right.</span></li>
+            </ol>
+            <button className="button button-primary" type="button" onClick={() => { setPreviewOpen(false); startDemo() }}>Run this as a no-call demo</button>
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default App

--- a/apps/typescript/one-more-story/src/components/CallContract.tsx
+++ b/apps/typescript/one-more-story/src/components/CallContract.tsx
@@ -1,0 +1,17 @@
+import { FileQuestion, LockKeyhole, UsersRound } from 'lucide-react'
+import { demoStory } from '../data/demoStory'
+
+const rows = [
+  { icon: FileQuestion, label: 'Question', value: demoStory.question },
+  { icon: UsersRound, label: 'Who will hear it', value: 'Only invited family members you choose.' },
+  { icon: LockKeyhole, label: 'What will be saved', value: 'Their words, the AI read-back, their correction, and confirmation.' },
+]
+
+export function CallContract() {
+  return (
+    <section className="call-contract" aria-labelledby="contract-title" id="how-it-works">
+      <h2 id="contract-title">Call contract</h2>
+      {rows.map(({ icon: Icon, label, value }) => <div className="contract-row" key={label}><Icon aria-hidden="true" /><span>{label}</span><strong>{value}</strong></div>)}
+    </section>
+  )
+}

--- a/apps/typescript/one-more-story/src/components/ConsentTimeline.tsx
+++ b/apps/typescript/one-more-story/src/components/ConsentTimeline.tsx
@@ -1,0 +1,23 @@
+import { Check } from 'lucide-react'
+import { stageOrder, type StoryStage } from '../data/demoStory'
+
+const steps = [
+  ['disclosure', 'Disclosure', 'AI says what it is and why it is calling.'],
+  ['permission', 'Permission', 'The storyteller chooses whether to continue.'],
+  ['question', 'One question', 'They answer one meaningful question.'],
+  ['readback', 'Read-back', 'AI repeats what it heard for accuracy.'],
+  ['confirmed', 'Confirmed', 'They confirm or correct the read-back.'],
+] as const
+
+export function ConsentTimeline({ stage }: { stage: StoryStage }) {
+  const current = stageOrder.indexOf(stage)
+  return (
+    <ol className="timeline" aria-label="Consent timeline">
+      {steps.map(([key, title, description], index) => {
+        const complete = current >= stageOrder.indexOf(key) || ['private', 'published'].includes(stage)
+        const active = !complete && stageOrder.indexOf(key) === current + 1
+        return <li className={`${complete ? 'complete' : ''} ${active ? 'active' : ''}`} key={key}><span className="step-marker">{complete ? <Check aria-hidden="true" /> : index + 1}</span><div><strong>{title}</strong><p>{description}</p><span>{complete ? 'Complete' : active ? 'Current' : 'Waiting'}</span></div></li>
+      })}
+    </ol>
+  )
+}

--- a/apps/typescript/one-more-story/src/components/EvidenceRail.tsx
+++ b/apps/typescript/one-more-story/src/components/EvidenceRail.tsx
@@ -1,0 +1,26 @@
+import { CheckCircle2, PencilLine, Play } from 'lucide-react'
+import { demoStory, stageOrder, type StoryStage } from '../data/demoStory'
+
+export function EvidenceRail({ stage, correction }: { stage: StoryStage; correction: string }) {
+  const isDeleted = stage === 'deleted'
+  const index = stageOrder.indexOf(stage)
+  const showQuestion = !isDeleted && index >= stageOrder.indexOf('question')
+  const showAnswer = !isDeleted && index >= stageOrder.indexOf('readback')
+  const showCorrection = !isDeleted && index >= stageOrder.indexOf('correction')
+  const showConfirmation = !isDeleted && (index >= stageOrder.indexOf('confirmed') || ['private', 'published'].includes(stage))
+  const focusedProof = showConfirmation
+  return (
+    <section className="evidence-rail" aria-labelledby="evidence-title" id="stories">
+      <div className="evidence-heading"><h2 id="evidence-title">Source evidence</h2><span>no-call fixture</span></div>
+      <div className="transcript">
+        {isDeleted && <p className="evidence-empty">No transcript remains in this local demo session.</p>}
+        {!isDeleted && !focusedProof && <article className="transcript-row"><time>00:00</time><div><strong>AI</strong><p>Hi, I’m calling from One More Story, an AI service that helps families preserve meaningful memories.</p></div><Play aria-hidden="true" /></article>}
+        {!isDeleted && !focusedProof && <article className="transcript-row"><time>00:18</time><div><strong>AI</strong><p>Do you feel comfortable continuing?</p><strong className="human">Storyteller: Yes, that’s fine.</strong></div><Play aria-hidden="true" /></article>}
+        {showQuestion && !focusedProof && <article className="transcript-row"><time>00:26</time><div><strong>AI</strong><p>{demoStory.question}</p></div><Play aria-hidden="true" /></article>}
+        {showAnswer && <article className="transcript-row"><time>01:05</time><div><strong className="human">Storyteller</strong><p>{demoStory.originalAnswer}</p></div><Play aria-hidden="true" /></article>}
+        {showCorrection && <article className="transcript-row correction"><time>01:16</time><div><strong>You corrected</strong><p>{correction}</p></div><PencilLine aria-hidden="true" /></article>}
+        {showConfirmation && <article className="transcript-row confirmation"><time>01:24</time><div><strong>Storyteller</strong><p>Yes, that’s right.</p></div><CheckCircle2 aria-hidden="true" /></article>}
+      </div>
+    </section>
+  )
+}

--- a/apps/typescript/one-more-story/src/components/Header.tsx
+++ b/apps/typescript/one-more-story/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import { RotateCcw } from 'lucide-react'
+
+export function Header({ onReset }: { onReset: () => void }) {
+  return (
+    <header className="site-header">
+      <a className="wordmark" href="#top" aria-label="One More Story home">One More Story</a>
+      <nav aria-label="Primary"><a href="#stories">Stories</a><a href="#how-it-works">How it works</a><a href="#privacy">Privacy</a></nav>
+      <button className="reset-button" type="button" onClick={onReset}><RotateCcw aria-hidden="true" /> Reset demo</button>
+    </header>
+  )
+}

--- a/apps/typescript/one-more-story/src/components/StoryCard.tsx
+++ b/apps/typescript/one-more-story/src/components/StoryCard.tsx
@@ -1,0 +1,57 @@
+import { Check, Link2, LockKeyhole, PencilLine, Trash2, UsersRound, X } from 'lucide-react'
+import { demoStory, stageOrder, type StoryStage } from '../data/demoStory'
+
+type Props = {
+  stage: StoryStage
+  correction: string
+  correctionOpen: boolean
+  deleteOpen: boolean
+  onOpenCorrection: () => void
+  onCorrectionChange: (value: string) => void
+  onConfirmCorrection: () => void
+  onPublish: () => void
+  onKeepPrivate: () => void
+  onOpenDelete: () => void
+  onCancelDelete: () => void
+  onDelete: () => void
+}
+
+export function StoryCard(props: Props) {
+  const index = stageOrder.indexOf(props.stage)
+  const readyForReview = index >= stageOrder.indexOf('correction')
+  const confirmed = index >= stageOrder.indexOf('confirmed') && props.stage !== 'deleted'
+  const storyText = confirmed ? demoStory.correctedAnswer : demoStory.originalAnswer
+
+  if (props.stage === 'deleted') {
+    return <section className="story-card empty-story"><Trash2 aria-hidden="true" /><h2>Story deleted</h2><p>The local fixture no longer contains the story or transcript.</p></section>
+  }
+
+  return (
+    <section className={`story-card ${confirmed ? 'confirmed' : ''} ${readyForReview ? 'revealed' : ''}`} aria-labelledby="story-title">
+      <div className="story-rule" aria-hidden="true"><span /></div>
+      <h2 id="story-title">{readyForReview ? demoStory.title : 'A story will appear here'}</h2>
+      <p className="story-copy">{readyForReview ? (confirmed ? <>It smelled like wet paper, <mark>mint leaves</mark>, and a little sugar from the tea shop. The air was cool, and the roses had just arrived from the hills.</> : storyText) : 'The story stays hidden until disclosure, permission, one question, and read-back are complete.'}</p>
+      {confirmed && <p className="proof-line"><Link2 aria-hidden="true" />1 correction · 1 confirmation · source linked</p>}
+      {props.correctionOpen ? (
+        <div className="correction-editor">
+          <label htmlFor="correction">Correct what the AI heard</label>
+          <input id="correction" value={props.correction} onChange={(event) => props.onCorrectionChange(event.target.value)} autoFocus />
+          <div><button type="button" className="button button-primary" onClick={props.onConfirmCorrection}><Check aria-hidden="true" />Read correction back</button><button type="button" className="icon-button" onClick={props.onOpenCorrection} aria-label="Close correction"><X aria-hidden="true" /></button></div>
+        </div>
+      ) : props.deleteOpen ? (
+        <div className="delete-confirm">
+          <p><strong>Delete this local demo story?</strong><span>This removes the fixture from the current session.</span></p>
+          <button type="button" onClick={props.onDelete}>Delete now</button><button type="button" onClick={props.onCancelDelete}>Cancel</button>
+        </div>
+      ) : (
+        <div className="story-actions">
+          {!confirmed && <button type="button" onClick={props.onOpenCorrection} disabled={!readyForReview}><PencilLine aria-hidden="true" />That’s not quite right</button>}
+          {confirmed && <button className="publish" type="button" onClick={props.onPublish}><UsersRound aria-hidden="true" />Publish to family</button>}
+          {confirmed && <button type="button" onClick={props.onKeepPrivate}><LockKeyhole aria-hidden="true" />Keep private</button>}
+          <button className="destructive" type="button" onClick={props.onOpenDelete} disabled={!readyForReview}><Trash2 aria-hidden="true" />Delete forever</button>
+        </div>
+      )}
+      <p className="story-lock"><LockKeyhole aria-hidden="true" />{confirmed ? 'Confirmed by the storyteller. Sharing is still your choice.' : 'This story is not created yet. Confirmation is required.'}</p>
+    </section>
+  )
+}

--- a/apps/typescript/one-more-story/src/data/demoStory.ts
+++ b/apps/typescript/one-more-story/src/data/demoStory.ts
@@ -1,0 +1,9 @@
+export type StoryStage = 'ready' | 'disclosure' | 'permission' | 'question' | 'readback' | 'correction' | 'confirmed' | 'private' | 'published' | 'deleted'
+export const stageOrder: StoryStage[] = ['ready', 'disclosure', 'permission', 'question', 'readback', 'correction', 'confirmed', 'private', 'published', 'deleted']
+export const demoStory = {
+  title: 'The rose market before sunrise',
+  question: 'What did the rose market smell like when you were young?',
+  originalAnswer: 'It smelled like wet paper, green leaves, and a little sugar from the tea shop. The air was cool, and the roses had just arrived from the hills.',
+  correction: 'Mint leaves, not green leaves.',
+  correctedAnswer: 'It smelled like wet paper, mint leaves, and a little sugar from the tea shop. The air was cool, and the roses had just arrived from the hills.',
+} as const

--- a/apps/typescript/one-more-story/src/data/storyState.ts
+++ b/apps/typescript/one-more-story/src/data/storyState.ts
@@ -1,0 +1,16 @@
+export type StoryDecision = {
+  confirmed: boolean
+  correctedAnswer: string | null
+}
+
+export function applyCorrection(originalAnswer: string, correction: string): StoryDecision {
+  const normalized = correction.trim().toLowerCase()
+  if (!normalized.includes('mint')) {
+    return { confirmed: false, correctedAnswer: null }
+  }
+
+  return {
+    confirmed: true,
+    correctedAnswer: originalAnswer.replace(/green leaves/gi, 'mint leaves'),
+  }
+}

--- a/apps/typescript/one-more-story/src/index.css
+++ b/apps/typescript/one-more-story/src/index.css
@@ -1,0 +1,29 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,500&display=swap');
+
+:root {
+  font-family: 'DM Sans', system-ui, sans-serif;
+  color: #e9e3d7;
+  background: #06121d;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --ink: #06121d;
+  --ink-soft: #0b1b28;
+  --parchment: #f1e7cf;
+  --parchment-ink: #231c16;
+  --cream: #f3e9d7;
+  --muted: #9ca3a7;
+  --line: #5f533f;
+  --brass: #c28c3d;
+  --coral: #e45f48;
+  --mint: #9ccbb0;
+  --danger: #bb3e32;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--ink); }
+button, input { font: inherit; }
+button, a { -webkit-tap-highlight-color: transparent; }
+button:focus-visible, a:focus-visible, input:focus-visible { outline: 2px solid var(--mint); outline-offset: 3px; }
+a { color: inherit; }

--- a/apps/typescript/one-more-story/src/main.tsx
+++ b/apps/typescript/one-more-story/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/typescript/one-more-story/test/call-contract.test.ts
+++ b/apps/typescript/one-more-story/test/call-contract.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { dispatchStoryCall, type CallePort } from '../server/calle.js'
+import { isConfirmedStory, type StoryCallRequest } from '../server/call-contract.js'
+import { applyCorrection } from '../src/data/storyState.js'
+
+const authorized: StoryCallRequest = {
+  requestId: 'test-001', storytellerPhone: '+15555550123', locale: 'en-US', region: 'US',
+  familyName: 'Mara', question: 'What did the market smell like?',
+  contactPermission: true, aiDisclosureApproved: true, confirmIntent: true,
+}
+
+function fakePort(): CallePort & { creates: number } {
+  return {
+    creates: 0,
+    async create() { this.creates += 1; return { id: 'call_test', status: 'queued' } },
+    async waitForResult() { return { id: 'call_test', status: 'completed' } },
+  }
+}
+
+test('live switch blocks before CALL-E receives anything', async () => {
+  const port = fakePort()
+  await assert.rejects(dispatchStoryCall(authorized, port, 'disabled'), /Live calls are disabled/)
+  assert.equal(port.creates, 0)
+})
+
+test('contact permission and fresh intent are both mandatory', async () => {
+  for (const field of ['contactPermission', 'confirmIntent'] as const) {
+    const port = fakePort()
+    await assert.rejects(dispatchStoryCall({ ...authorized, [field]: false }, port, 'enabled'))
+    assert.equal(port.creates, 0)
+  }
+})
+
+test('an invalid phone is rejected before dispatch', async () => {
+  const port = fakePort()
+  await assert.rejects(dispatchStoryCall({ ...authorized, storytellerPhone: '555-0100' }, port, 'enabled'), /E.164/)
+  assert.equal(port.creates, 0)
+})
+
+test('a corrected story does not exist until correction and read-back are confirmed', () => {
+  assert.deepEqual(applyCorrection('green leaves', 'green leaves'), { confirmed: false, correctedAnswer: null })
+  assert.deepEqual(applyCorrection('green leaves', 'Mint leaves, not green leaves.'), { confirmed: true, correctedAnswer: 'mint leaves' })
+  assert.equal(isConfirmedStory({ disclosure_acknowledged: 'yes', permission_to_continue: 'yes', story_answer: 'answer', correction: 'mint', readback_confirmed: 'unknown', deletion_requested: false }), false)
+  assert.equal(isConfirmedStory({ disclosure_acknowledged: 'yes', permission_to_continue: 'yes', story_answer: 'answer', correction: 'mint', readback_confirmed: 'yes', deletion_requested: false }), true)
+})

--- a/apps/typescript/one-more-story/test/call-contract.test.ts
+++ b/apps/typescript/one-more-story/test/call-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { dispatchStoryCall, type CallePort } from '../server/calle.js'
-import { isConfirmedStory, type StoryCallRequest } from '../server/call-contract.js'
+import { buildCallInput, dispatchStoryCall, summarizeCallSnapshot, type CallePort } from '../server/calle.js'
+import { idempotencyKey, isConfirmedStory, type StoryCallRequest } from '../server/call-contract.js'
 import { applyCorrection } from '../src/data/storyState.js'
 
 const authorized: StoryCallRequest = {
@@ -36,6 +36,42 @@ test('an invalid phone is rejected before dispatch', async () => {
   const port = fakePort()
   await assert.rejects(dispatchStoryCall({ ...authorized, storytellerPhone: '555-0100' }, port, 'enabled'), /E.164/)
   assert.equal(port.creates, 0)
+})
+
+test('idempotency binds every approved request field and the normalized CALL-E payload', () => {
+  const baseInput = buildCallInput(authorized)
+  const baseKey = idempotencyKey(authorized, baseInput)
+  const mutations: StoryCallRequest[] = [
+    { ...authorized, requestId: 'test-002' },
+    { ...authorized, storytellerPhone: '+15555550124' },
+    { ...authorized, locale: 'es-US' },
+    { ...authorized, region: 'CA' },
+    { ...authorized, familyName: 'Nora' },
+    { ...authorized, question: 'What did the roses smell like?' },
+    { ...authorized, contactPermission: false },
+    { ...authorized, aiDisclosureApproved: false },
+    { ...authorized, confirmIntent: false },
+  ]
+
+  for (const request of mutations) {
+    assert.notEqual(idempotencyKey(request, buildCallInput(request)), baseKey)
+  }
+  assert.notEqual(idempotencyKey(authorized, { ...baseInput, metadata: { app: 'one-more-story-v2' } }), baseKey)
+})
+
+test('live output summary never contains recipient, transcript, or story content', () => {
+  const snapshot = {
+    id: 'call_test',
+    status: 'completed',
+    structuredResult: {
+      recipient: '+15555550123',
+      transcript: 'private transcript',
+      story_answer: 'private story',
+    },
+  }
+  const serialized = JSON.stringify(summarizeCallSnapshot(snapshot))
+  assert.deepEqual(summarizeCallSnapshot(snapshot), { id: 'call_test', status: 'completed', resultReceived: true })
+  assert.doesNotMatch(serialized, /15555550123|private transcript|private story/)
 })
 
 test('a corrected story does not exist until correction and read-back are confirmed', () => {

--- a/apps/typescript/one-more-story/test/call-contract.test.ts
+++ b/apps/typescript/one-more-story/test/call-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { buildCallInput, dispatchStoryCall, summarizeCallSnapshot, type CallePort } from '../server/calle.js'
-import { idempotencyKey, isConfirmedStory, type StoryCallRequest } from '../server/call-contract.js'
+import { idempotencyKey, isConfirmedStory, parseStoryCallRequest, type StoryCallRequest } from '../server/call-contract.js'
 import { applyCorrection } from '../src/data/storyState.js'
 
 const authorized: StoryCallRequest = {
@@ -24,12 +24,25 @@ test('live switch blocks before CALL-E receives anything', async () => {
   assert.equal(port.creates, 0)
 })
 
-test('contact permission and fresh intent are both mandatory', async () => {
-  for (const field of ['contactPermission', 'confirmIntent'] as const) {
+test('every authorization field must be the exact boolean true before dispatch', async () => {
+  for (const field of ['contactPermission', 'aiDisclosureApproved', 'confirmIntent'] as const) {
     const port = fakePort()
     await assert.rejects(dispatchStoryCall({ ...authorized, [field]: false }, port, 'enabled'))
     assert.equal(port.creates, 0)
+
+    const stringFalse = { ...authorized, [field]: 'false' } as unknown as StoryCallRequest
+    await assert.rejects(dispatchStoryCall(stringFalse, port, 'enabled'), /must be a boolean/)
+    assert.equal(port.creates, 0)
   }
+})
+
+test('the JSON trust boundary validates the complete request shape', () => {
+  assert.deepEqual(parseStoryCallRequest({ ...authorized }), authorized)
+  assert.deepEqual(parseStoryCallRequest({ ...authorized, contactPermission: false }).contactPermission, false)
+  assert.throws(() => parseStoryCallRequest({ ...authorized, requestId: 123 }), /requestId must be a string/)
+  assert.throws(() => parseStoryCallRequest({ ...authorized, region: false }), /region must be a string/)
+  assert.throws(() => parseStoryCallRequest({ ...authorized, contactPermission: 'false' }), /contactPermission must be a boolean/)
+  assert.throws(() => parseStoryCallRequest({ ...authorized, unexpected: 'field' }), /Unknown call request field/)
 })
 
 test('an invalid phone is rejected before dispatch', async () => {

--- a/apps/typescript/one-more-story/tsconfig.app.json
+++ b/apps/typescript/one-more-story/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "esnext",
+    "types": ["vite/client"],
+    "allowArbitraryExtensions": true,
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/typescript/one-more-story/tsconfig.json
+++ b/apps/typescript/one-more-story/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/typescript/one-more-story/tsconfig.node.json
+++ b/apps/typescript/one-more-story/tsconfig.node.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "module": "nodenext",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/typescript/one-more-story/vite.config.ts
+++ b/apps/typescript/one-more-story/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary

Adds One More Story, a consent-first oral-history CALL-E app. It makes AI disclosure, permission, the original answer, correction, and final read-back confirmation visible, and creates no story until the storyteller confirms the corrected wording.

The browser experience is a polished no-call fixture. The server adapter uses the official `@call-e/calle` SDK behind explicit contact permission, AI-disclosure approval, a fresh per-call intent flag, E.164 validation, and a separate live-call environment switch.

Public no-call demo: https://one-more-story-ih9h6m.v2.appdeploy.ai/

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. This app creates no recurring workflow.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Verification

- `npm run test`
- `npm run lint`
- `npm run build`
- `npm run call:preview -- examples/call.example.json`
- `python3 scripts/validate_repository.py`
- Desktop and 390px mobile interaction replay
- Public deployment QA: 4/4 workflows passed