### PR TITLE
feat(apps): add fintech-collections-callback consent-gated collections app

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/oauth-login-client`](apps/typescript/oauth-login-client/) | TypeScript | CALL-E OAuth login client for MCP Streamable HTTP. |
 | [`apps/typescript/vibehub-founder-relay`](apps/typescript/vibehub-founder-relay/) | TypeScript | Consent-first founder-match readiness call with masked preview, stable idempotency, and structured CALL-E results. |
 | [`apps/typescript/ringer`](apps/typescript/ringer/) | TypeScript | Consumer web app that turns dreaded phone tasks — bill negotiation, cancellations, bookings, refunds, and multi-business quote comparison — into consent-first, multilingual CALL-E workflows with strict per-call and per-recipient result schemas, human-in-the-loop decision authority, evidence-gated and denominator-honest outcomes, and a no-call demo mode by default. |
+| [`apps/typescript/fintech-collections-callback`](apps/typescript/fintech-collections-callback/) | TypeScript | Payment-reminder calls to overdue fintech accounts behind a pre-dial gate — consent, E.164, timezone quiet-hours and a per-run spend cap — with idempotent dialing and structured promise-to-pay, dispute or callback outcomes, no-call dry-run by default. |
 
 The default e2e tests use a local fake broker/OAuth/MCP server or dry-run paths, so they do not require real CALL-E credentials or browser login. Live verification is opt-in in each app README.
 

--- a/apps/typescript/fintech-collections-callback/.env.example
+++ b/apps/typescript/fintech-collections-callback/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill in. Only needed for --live runs; dry-run needs nothing.
+CALLE_API_KEY=calle_live_your_key_here
+
+# Optional. Defaults to the public API base URL.
+# CALLE_BASE_URL=https://api.heycall-e.com

--- a/apps/typescript/fintech-collections-callback/.gitignore
+++ b/apps/typescript/fintech-collections-callback/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+runs/
+.env
+*.log

--- a/apps/typescript/fintech-collections-callback/README.md
+++ b/apps/typescript/fintech-collections-callback/README.md
@@ -1,0 +1,186 @@
+# fintech-collections-callback
+
+A runnable phone-call workflow app that places **consent-gated, compliant
+payment-reminder calls** to overdue fintech accounts using
+[CALL-E](https://www.heycall-e.com), and returns a **structured collections
+outcome** per account (promise-to-pay date, dispute, or callback request).
+
+It is built for the exact place voice agents earn their keep in lending and BPO
+operations: first-party soft collections and appointment/payment reminders —
+where *who you may call, when, and what you may say* is as important as the call
+itself. An operator (or an agent administering this workflow) hands the app a
+batch of accounts; the app decides which ones are eligible to dial right now,
+places those calls under a spend cap, and writes an auditable report.
+
+## What it does
+
+1. Loads a batch of overdue accounts (sample fixtures included).
+2. Runs a **pre-dial gate** on each account:
+   - explicit, timestamped **consent** to be contacted;
+   - valid **E.164** phone number;
+   - valid **IANA timezone**, used to enforce **quiet hours** (no calls before
+     08:00 or at/after 21:00 local time);
+   - a per-run **spend cap** on the number of calls.
+3. For each allowed account, calls CALL-E with a task whose compliance rules are
+   fixed in code (identify as automated, right-party only, no threats, never
+   collect payment on the call), and a `recipientResultSchema` so the result
+   comes back structured.
+4. Writes a JSON report of every decision and outcome.
+
+CALL-E is imported and invoked at runtime in
+[`src/calle.ts`](src/calle.ts); orchestration and the gate live in
+[`src/client.ts`](src/client.ts) and [`src/gate.ts`](src/gate.ts).
+
+## Setup
+
+Requires Node.js 20+.
+
+```bash
+npm install
+```
+
+## Credentials
+
+Only **live** runs need credentials. Provide them either way:
+
+- **A `.env` file** — copy `.env.example` to `.env` and fill it in. If a `.env`
+  exists in this directory it is loaded automatically at startup (via Node's
+  built-in `process.loadEnvFile`; requires Node ≥ 20.12). `.env` is git-ignored.
+- **Or shell variables** — export them yourself, e.g. PowerShell
+  `$env:CALLE_API_KEY = "…"` or bash `export CALLE_API_KEY=…`.
+
+Variables:
+
+- `CALLE_API_KEY` — your key from the CALL-E dashboard. **Required for `--live`.**
+- `CALLE_BASE_URL` — optional; defaults to `https://api.heycall-e.com`.
+
+The key is read from the environment only and never written to logs. A dry-run
+needs no key, so no `.env` is required for it.
+
+## Dry-run / preview behavior (default)
+
+The app is **dry-run by default and places no calls**. It runs the full gate and
+prints exactly which accounts *would* be dialed and which are blocked and why —
+counting eligible accounts against the same spend cap a live run would use.
+
+```bash
+npm run dry-run
+# or override the cap:
+npm run dev -- --max-calls=3
+```
+
+`npm test` runs the gate unit tests with no credentials, network, or calls.
+
+## Going live
+
+```bash
+# with CALLE_API_KEY set in your environment or .env
+npm run live
+npm run dev -- --live --max-calls=5
+```
+
+Each eligible account triggers one real outbound call via
+`client.calls.createAndWait(...)`, guarded by a deterministic idempotency key
+(`collections_<accountId>_<dueDate>`) so a re-run never double-dials.
+
+> **Never `--live` against the sample fixtures.** Their numbers are
+> reserved-for-fiction (e.g. `+12025550143` passes the gate) and must not be
+> dialed. Use the smoke test below to place a real call to a number you control.
+
+### Live smoke test (one number you control)
+
+`--smoke` ignores the fixtures and builds a **single** recipient from `SMOKE_*`
+environment variables, then hard-caps the run at one call. It runs the same
+pre-dial gate as a full batch. Preview it in dry-run first (no call placed):
+
+```bash
+SMOKE_PHONE=+1XXXXXXXXXX SMOKE_CONSENT=true npm run dev -- --smoke
+```
+
+When the preview shows `would call …`, place the real call:
+
+```bash
+# CALLE_API_KEY must be set; consent is OFF unless you set SMOKE_CONSENT=true
+SMOKE_PHONE=+1XXXXXXXXXX SMOKE_CONSENT=true npm run dev -- --live --smoke
+```
+
+> The inline `VAR=value command` form above is bash-only. On Windows/PowerShell,
+> set each first (`$env:SMOKE_PHONE = "+1XXXXXXXXXX"`), **or** — simplest — put
+> `CALLE_API_KEY` and the `SMOKE_*` values in `.env` (auto-loaded) and just run
+> `npm run dev -- --live --smoke`.
+
+Recognized variables (only `SMOKE_PHONE` is required):
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `SMOKE_PHONE` | — | **Required.** E.164 number you control and consent to call. |
+| `SMOKE_CONSENT` | `false` | Must be `true` or the gate blocks with `no-consent`. |
+| `SMOKE_CONSENT_TIMESTAMP` | now | ISO datetime; auto-set when consent is `true`. |
+| `SMOKE_NAME` | `Test Customer` | Name the agent asks for. |
+| `SMOKE_TIMEZONE` | this machine's zone | IANA id; drives quiet-hours (08:00–21:00 local). |
+| `SMOKE_REGION` | `US` | ISO 3166-1 alpha-2. |
+| `SMOKE_AMOUNT_CENTS` / `SMOKE_CURRENCY` | `10000` / `USD` | Amount quoted on the call. |
+| `SMOKE_DUE_DATE` / `SMOKE_DAYS_PAST_DUE` | derived / `30` | Due date and days past due. |
+| `SMOKE_ACCOUNT_ID` | `SMOKE-1` | Part of the idempotency key — change it to force a fresh call. |
+| `SMOKE_LANGUAGE` | `en-US` | BCP-47 locale for the spoken call. |
+
+## Side effects
+
+- **Live mode places real phone calls** that cost money (CALL-E bills per
+  billable call) and are subject to telecom regulations in the recipient's
+  jurisdiction. You are responsible for having a lawful basis and consent to
+  call each recipient.
+- Dry-run mode has no external side effects.
+- The only local side effect is a report written under `runs/` (see below).
+
+## Cancellation and rollback
+
+- Press **Ctrl-C** to cancel a run: no new call is started, the in-progress
+  report is still written, and remaining accounts are left untouched.
+- Because the idempotency key is derived from the account and due date, safely
+  **re-running the batch will not re-dial** accounts already handled for that
+  billing cycle — the effective rollback for "I ran it twice."
+- A call already answered cannot be un-placed; the report records it so
+  operators can reconcile.
+
+## Where results are stored
+
+Every run writes a timestamped JSON report to `runs/<ISO-timestamp>.json`
+containing the mode, spend cap, per-account decisions, structured outcomes, and
+estimated cost. The `runs/` directory is git-ignored.
+
+## Project layout
+
+```
+fintech-collections-callback/
+├── src/
+│   ├── client.ts     # entry point: batch loop, spend cap, cancellation, report
+│   ├── gate.ts       # consent + E.164 + IANA timezone + quiet-hours checks
+│   ├── calle.ts      # the only CALL-E SDK integration (task + structured result)
+│   ├── fixtures.ts   # sample accounts (fictional numbers; some intentionally blocked)
+│   ├── smoke.ts      # SMOKE_* env -> single recipient for a one-number live test
+│   ├── types.ts      # domain types
+│   ├── gate.test.ts  # gate unit tests (no network)
+│   ├── calle.test.ts # result-mapping unit tests (no network)
+│   └── smoke.test.ts # SMOKE_* account-builder unit tests (no network)
+├── .env.example
+├── package.json
+└── tsconfig.json
+```
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `npm run dry-run` | Full gate, no calls (default) |
+| `npm run live` | Place real calls (needs `CALLE_API_KEY`) |
+| `npm run dev -- <args>` | Run directly with custom flags (`--live`, `--smoke`, `--max-calls=N`) |
+| `npm run dev -- --smoke` | One-number test from `SMOKE_*` env (add `--live` to dial) |
+| `npm run build` | Compile to `dist/` |
+| `npm start` | Run the compiled build |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm test` | Unit tests — gate, result mapping, smoke builder (no network) |
+
+## License
+
+MIT

--- a/apps/typescript/fintech-collections-callback/package-lock.json
+++ b/apps/typescript/fintech-collections-callback/package-lock.json
@@ -1,0 +1,596 @@
+{
+  "name": "fintech-collections-callback",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fintech-collections-callback",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@call-e/calle": "^0.6.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@call-e/calle": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@call-e/calle/-/calle-0.6.0.tgz",
+      "integrity": "sha512-B1Rsj8NAYbhEh4fC05hBEiVn8xxcnfsjeSc9AvcIkyiaG/b8JqYvbiUrK/saYOzy5x+hHAV7TFSQQZNwqWtNow==",
+      "dependencies": {
+        "openapi-fetch": "^0.14.0"
+      },
+      "bin": {
+        "calle": "dist/cli.js"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/typescript/fintech-collections-callback/package.json
+++ b/apps/typescript/fintech-collections-callback/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fintech-collections-callback",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Consent-gated CALL-E app that places compliant payment-reminder phone calls to overdue fintech accounts and returns structured collections outcomes.",
+  "license": "MIT",
+  "scripts": {
+    "dev": "tsx src/client.ts",
+    "dry-run": "tsx src/client.ts",
+    "live": "tsx src/client.ts --live",
+    "build": "tsc",
+    "start": "node dist/client.js",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts"
+  },
+  "dependencies": {
+    "@call-e/calle": "^0.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/typescript/fintech-collections-callback/src/calle.test.ts
+++ b/apps/typescript/fintech-collections-callback/src/calle.test.ts
@@ -1,0 +1,43 @@
+// Tests for mapResult: the narrowing of CALL-E's opaque structuredResult
+// (snake_case JsonObject) into our CollectionsResult. No network, no calls.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mapResult } from "./calle.js";
+
+test("mapResult returns undefined for a missing result", () => {
+  assert.equal(mapResult(undefined), undefined);
+  assert.equal(mapResult(null), undefined);
+});
+
+test("mapResult maps snake_case fields to camelCase", () => {
+  const result = mapResult({
+    outcome: "promise-to-pay",
+    promise_to_pay_date: "2026-08-20",
+    callback_at: "2026-08-15T14:00:00Z",
+    notes: "Customer will pay Friday.",
+  });
+  assert.deepEqual(result, {
+    outcome: "promise-to-pay",
+    promiseToPayDate: "2026-08-20",
+    callbackAt: "2026-08-15T14:00:00Z",
+    notes: "Customer will pay Friday.",
+  });
+});
+
+test("mapResult defaults a missing outcome to 'unknown'", () => {
+  const result = mapResult({ notes: "call dropped" });
+  assert.equal(result?.outcome, "unknown");
+  assert.equal(result?.notes, "call dropped");
+});
+
+test("mapResult leaves optional fields undefined when absent", () => {
+  const result = mapResult({ outcome: "refused" });
+  assert.deepEqual(result, {
+    outcome: "refused",
+    promiseToPayDate: undefined,
+    callbackAt: undefined,
+    notes: undefined,
+  });
+});

--- a/apps/typescript/fintech-collections-callback/src/calle.ts
+++ b/apps/typescript/fintech-collections-callback/src/calle.ts
@@ -1,0 +1,118 @@
+// The only module that imports the CALL-E SDK. Loaded lazily by client.ts so a
+// dry-run never constructs a client or requires an API key.
+
+import { CalleClient } from "@call-e/calle";
+import type { Call } from "@call-e/calle";
+import type { OverdueAccount, CollectionsResult } from "./types.js";
+
+export type CalleClientLike = CalleClient;
+
+/** Per-recipient structured-output schema CALL-E fills in when the call ends. */
+const RECIPIENT_RESULT_SCHEMA = {
+  type: "object",
+  required: ["outcome"],
+  properties: {
+    outcome: {
+      type: "string",
+      enum: [
+        "promise-to-pay",
+        "dispute",
+        "callback-requested",
+        "wrong-number",
+        "no-answer",
+        "refused",
+        "unknown",
+      ],
+    },
+    promise_to_pay_date: { type: "string" },
+    callback_at: { type: "string" },
+    notes: { type: "string" },
+  },
+} as const;
+
+// How long to wait for a single call to reach a terminal state before giving up.
+// The SDK's default is 10 min; we cap at 5 so one stalled call can't block the
+// batch for that long, while still leaving headroom for a real call to finish.
+// A placed-then-timed-out call is still billed, so don't set this too tight.
+const CALL_TIMEOUT_MS = 300_000;
+
+export function createCalleClient(apiKey: string, baseUrl?: string): CalleClient {
+  return new CalleClient({ apiKey, baseUrl: baseUrl ?? "https://api.heycall-e.com" });
+}
+
+/** Deterministic idempotency key so a retried run never double-dials an account. */
+export function idempotencyKey(account: OverdueAccount): string {
+  return `collections_${account.accountId}_${account.dueDate}`.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+/** The spoken instructions for CALL-E. Compliance rules are baked in, not optional. */
+export function buildTask(account: OverdueAccount): string {
+  const amount = (account.amountDueCents / 100).toLocaleString("en-US", {
+    style: "currency",
+    currency: account.currency,
+  });
+  return [
+    `Call ${account.phone} and ask to speak with ${account.customerName}.`,
+    `Purpose: a courtesy reminder that a payment of ${amount} was due on ${account.dueDate} and is now ${account.daysPastDue} days past due.`,
+    "Rules you MUST follow:",
+    "- Identify yourself as an automated assistant calling on behalf of the lender.",
+    `- Only discuss the account with ${account.customerName}. If someone else answers or it is the wrong number, apologize and end the call.`,
+    "- Be respectful. Do not threaten, pressure, or imply legal consequences.",
+    "- Do NOT collect card numbers, bank details, or any payment on this call.",
+    "- Offer the customer a choice: give a promise-to-pay date, raise a dispute, or schedule a callback.",
+    "When the call ends, report the outcome and any promise-to-pay date or requested callback time.",
+  ].join("\n");
+}
+
+export interface PlacedCall {
+  callId: string;
+  status: string;
+  taskCompleted: boolean;
+  confidence?: number;
+  structured?: CollectionsResult;
+  raw: unknown;
+}
+
+export async function placeCall(client: CalleClient, account: OverdueAccount): Promise<PlacedCall> {
+  const call = await client.calls.createAndWait(
+    {
+      task: buildTask(account),
+      recipients: [
+        { phones: [account.phone], region: account.region, locale: account.language ?? "en-US" },
+      ],
+      recipientResultSchema: RECIPIENT_RESULT_SCHEMA,
+      metadata: { account_id: account.accountId, days_past_due: String(account.daysPastDue) },
+    },
+    { idempotencyKey: idempotencyKey(account), timeoutMs: CALL_TIMEOUT_MS },
+  );
+
+  return {
+    callId: call.id,
+    status: call.status,
+    taskCompleted: Boolean(call.taskCompleted),
+    // completionConfidence is { score: 0..1, label }; the report wants the numeric score.
+    confidence: call.completionConfidence?.score,
+    structured: mapResult(call.recipients?.[0]?.structuredResult),
+    raw: call,
+  };
+}
+
+// The recipient-result payload we asked CALL-E for (see RECIPIENT_RESULT_SCHEMA).
+// The SDK types structuredResult as an opaque JsonObject, so we narrow it here.
+interface RawResult {
+  outcome?: CollectionsResult["outcome"];
+  promise_to_pay_date?: string;
+  callback_at?: string;
+  notes?: string;
+}
+
+export function mapResult(raw: Call["recipients"][number]["structuredResult"] | undefined): CollectionsResult | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as RawResult;
+  return {
+    outcome: r.outcome ?? "unknown",
+    promiseToPayDate: r.promise_to_pay_date,
+    callbackAt: r.callback_at,
+    notes: r.notes,
+  };
+}

--- a/apps/typescript/fintech-collections-callback/src/client.ts
+++ b/apps/typescript/fintech-collections-callback/src/client.ts
@@ -1,0 +1,181 @@
+// Entry point. Iterates overdue accounts, runs the pre-dial gate, and (in live
+// mode) places one CALL-E call per allowed account under a spend cap. Dry-run is
+// the default and never touches the network.
+//
+//   npm run dry-run              # default: no calls placed
+//   npm run live                 # requires CALLE_API_KEY
+//   npm run dev -- --max-calls=3 # override the spend cap
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
+
+import type { CallOutcome, OverdueAccount } from "./types.js";
+import { DEFAULT_GATE, checkAccount, type GateConfig } from "./gate.js";
+import { SAMPLE_ACCOUNTS } from "./fixtures.js";
+import { buildSmokeAccount } from "./smoke.js";
+
+// Load a local .env (from the current directory) if present, so CALLE_API_KEY
+// and friends can live there for --live runs instead of being exported by hand.
+// No-op when the file is absent or the runtime predates process.loadEnvFile
+// (Node < 20.12) — variables set in the shell still work either way.
+if (typeof process.loadEnvFile === "function") {
+  try {
+    process.loadEnvFile();
+  } catch {
+    // No .env in the current directory; dry-run needs none, so carry on.
+  }
+}
+
+const COST_PER_CALL_USD = 0.05;
+const DEFAULT_MAX_CALLS = 10;
+
+interface CliArgs {
+  live: boolean;
+  maxCalls: number;
+  smoke: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const live = argv.includes("--live");
+  const smoke = argv.includes("--smoke");
+  const capArg = argv.find((a) => a.startsWith("--max-calls="));
+  const parsed = capArg ? Number(capArg.slice("--max-calls=".length)) : DEFAULT_MAX_CALLS;
+  const maxCalls = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_MAX_CALLS;
+  return { live, maxCalls, smoke };
+}
+
+interface RunOptions {
+  live: boolean;
+  maxCalls: number;
+  accounts: OverdueAccount[];
+  gate: GateConfig;
+}
+
+async function run(opts: RunOptions): Promise<CallOutcome[]> {
+  const outcomes: CallOutcome[] = [];
+  let placed = 0;
+  let cancelled = false;
+
+  const onSigint = () => {
+    cancelled = true;
+    console.error("\n[cancel] no new calls will start; finishing report…");
+  };
+  process.on("SIGINT", onSigint);
+
+  // Lazy-load the SDK only for live runs, so dry-run needs no key and no install-time network.
+  let calle: typeof import("./calle.js") | undefined;
+  let client: import("./calle.js").CalleClientLike | undefined;
+  if (opts.live) {
+    const apiKey = process.env.CALLE_API_KEY;
+    if (!apiKey) {
+      throw new Error("CALLE_API_KEY is required for --live runs. Set it, or drop --live to dry-run.");
+    }
+    calle = await import("./calle.js");
+    client = calle.createCalleClient(apiKey, process.env.CALLE_BASE_URL);
+  }
+
+  const mode: CallOutcome["mode"] = opts.live ? "live" : "dry-run";
+
+  for (const account of opts.accounts) {
+    if (cancelled) break;
+    const at = new Date().toISOString();
+
+    const decision = checkAccount(account, opts.gate);
+    if (!decision.allowed) {
+      outcomes.push({ accountId: account.accountId, phone: account.phone, mode, placed: false, blockedReason: decision.reason, at });
+      console.log(`[skip] ${account.accountId} ${account.phone} — blocked: ${decision.reason}`);
+      continue;
+    }
+
+    if (placed >= opts.maxCalls) {
+      outcomes.push({ accountId: account.accountId, phone: account.phone, mode, placed: false, blockedReason: "spend-cap-reached", at });
+      console.log(`[skip] ${account.accountId} — spend cap reached (${opts.maxCalls} calls)`);
+      continue;
+    }
+
+    if (!opts.live) {
+      // Count against the cap so a dry-run mirrors live budgeting exactly.
+      placed++;
+      outcomes.push({ accountId: account.accountId, phone: account.phone, mode, placed: false, at });
+      console.log(`[dry-run] would call ${account.phone} for ${account.customerName} (${account.daysPastDue}d past due)`);
+      continue;
+    }
+
+    try {
+      const res = await calle!.placeCall(client!, account);
+      placed++;
+      outcomes.push({
+        accountId: account.accountId,
+        phone: account.phone,
+        mode,
+        placed: true,
+        callId: res.callId,
+        status: res.status,
+        taskCompleted: res.taskCompleted,
+        confidence: res.confidence,
+        structured: res.structured,
+        at,
+      });
+      console.log(`[live] ${account.accountId} ${account.phone} — ${res.status} — ${res.structured?.outcome ?? "no-result"}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      outcomes.push({ accountId: account.accountId, phone: account.phone, mode, placed: false, error: message, at });
+      console.error(`[error] ${account.accountId} ${account.phone} — ${message}`);
+    }
+  }
+
+  process.off("SIGINT", onSigint);
+  return outcomes;
+}
+
+async function writeReport(opts: CliArgs, outcomes: CallOutcome[]): Promise<string> {
+  const placedCount = outcomes.filter((o) => o.placed).length;
+  const dir = join(process.cwd(), "runs");
+  await mkdir(dir, { recursive: true });
+  const file = join(dir, `${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+  const report = {
+    mode: opts.live ? "live" : "dry-run",
+    smoke: opts.smoke,
+    maxCalls: opts.maxCalls,
+    costPerCallUsd: COST_PER_CALL_USD,
+    placedCount,
+    estCostUsd: Number((placedCount * COST_PER_CALL_USD).toFixed(2)),
+    outcomes,
+  };
+  await writeFile(file, JSON.stringify(report, null, 2), "utf8");
+  return file;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Smoke mode targets exactly one recipient built from SMOKE_* env vars, so a
+  // real --live call can hit a number you control instead of the fixtures.
+  const accounts = args.smoke ? [buildSmokeAccount()] : SAMPLE_ACCOUNTS;
+  const maxCalls = args.smoke ? 1 : args.maxCalls;
+  const effectiveArgs: CliArgs = { ...args, maxCalls };
+
+  const banner = args.smoke ? " SMOKE(1 recipient from SMOKE_* env)" : "";
+  console.log(`CALL-E fintech collections callback — mode=${args.live ? "LIVE" : "DRY-RUN"}${banner} cap=${maxCalls} calls`);
+  if (!args.live) {
+    console.log("No calls will be placed. Re-run with --live and CALLE_API_KEY set to dial.\n");
+  } else if (args.smoke) {
+    console.log("SMOKE live run: places ONE real call to SMOKE_PHONE if it passes the gate.\n");
+  }
+
+  const outcomes = await run({ live: args.live, maxCalls, accounts, gate: DEFAULT_GATE });
+
+  const placedCount = outcomes.filter((o) => o.placed).length;
+  const skipped = outcomes.length - placedCount;
+  const estCost = (placedCount * COST_PER_CALL_USD).toFixed(2);
+  console.log(`\nSummary: ${placedCount} placed, ${skipped} skipped. Est. cost: $${estCost}`);
+
+  const file = await writeReport(effectiveArgs, outcomes);
+  console.log(`Results written to ${file}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/typescript/fintech-collections-callback/src/fixtures.ts
+++ b/apps/typescript/fintech-collections-callback/src/fixtures.ts
@@ -1,0 +1,80 @@
+// Sample overdue accounts for dry-run demos.
+// Phone numbers are fictional: US/UK values use official reserved-for-fiction
+// ranges (NANP 555-0100..0199; Ofcom 020 7946 0xxx). Ghana has no reserved
+// range, so its number is an obvious placeholder and must never be dialed.
+// Deliberately includes accounts the gate will BLOCK, to show enforcement.
+
+import type { OverdueAccount } from "./types.js";
+
+export const SAMPLE_ACCOUNTS: OverdueAccount[] = [
+  {
+    accountId: "ACC-1001",
+    customerName: "Ama Boateng",
+    phone: "+12025550143",
+    region: "US",
+    timezone: "America/New_York",
+    amountDueCents: 24999,
+    currency: "USD",
+    dueDate: "2026-07-15",
+    daysPastDue: 25,
+    consentToContact: true,
+    consentTimestamp: "2026-06-01T10:00:00Z",
+    language: "en-US",
+  },
+  {
+    accountId: "ACC-1002",
+    customerName: "Kwame Mensah",
+    phone: "+233302000000", // fictional placeholder (Ghana has no reserved range)
+    region: "GH",
+    timezone: "Africa/Accra",
+    amountDueCents: 180000,
+    currency: "GHS",
+    dueDate: "2026-07-20",
+    daysPastDue: 20,
+    consentToContact: true,
+    consentTimestamp: "2026-05-12T09:30:00Z",
+    language: "en-GH",
+  },
+  {
+    // BLOCKED: no consent on file.
+    accountId: "ACC-1003",
+    customerName: "Jordan Rivera",
+    phone: "+12025550188",
+    region: "US",
+    timezone: "America/Los_Angeles",
+    amountDueCents: 5000,
+    currency: "USD",
+    dueDate: "2026-07-28",
+    daysPastDue: 12,
+    consentToContact: false,
+  },
+  {
+    // BLOCKED: consent flag set but no timestamp to prove it.
+    accountId: "ACC-1004",
+    customerName: "Priya Nair",
+    phone: "+442079460958", // Ofcom reserved-for-drama range (020 7946 0xxx)
+    region: "GB",
+    timezone: "Europe/London",
+    amountDueCents: 42000,
+    currency: "GBP",
+    dueDate: "2026-07-10",
+    daysPastDue: 30,
+    consentToContact: true,
+    language: "en-GB",
+  },
+  {
+    // BLOCKED: phone is not valid E.164.
+    accountId: "ACC-1005",
+    customerName: "Sam Osei",
+    phone: "0202555017",
+    region: "US",
+    timezone: "America/Chicago",
+    amountDueCents: 9900,
+    currency: "USD",
+    dueDate: "2026-07-22",
+    daysPastDue: 18,
+    consentToContact: true,
+    consentTimestamp: "2026-06-18T14:00:00Z",
+    language: "en-US",
+  },
+];

--- a/apps/typescript/fintech-collections-callback/src/gate.test.ts
+++ b/apps/typescript/fintech-collections-callback/src/gate.test.ts
@@ -1,0 +1,75 @@
+// Gate unit tests. Run with `npm test`. No credentials, no network, no calls.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { checkAccount, isQuietHour, isValidTimeZone, localHour, DEFAULT_GATE } from "./gate.js";
+import type { OverdueAccount } from "./types.js";
+
+const base: OverdueAccount = {
+  accountId: "T-1",
+  customerName: "Test Person",
+  phone: "+12025550143",
+  region: "US",
+  timezone: "America/New_York",
+  amountDueCents: 10000,
+  currency: "USD",
+  dueDate: "2026-07-15",
+  daysPastDue: 10,
+  consentToContact: true,
+  consentTimestamp: "2026-06-01T10:00:00Z",
+};
+
+// 2026-08-10T15:00:00Z == 11:00 in New York (EDT) -> business hours.
+const daytime = new Date("2026-08-10T15:00:00Z");
+// 2026-08-10T04:00:00Z == 00:00 in New York -> quiet hours.
+const midnight = new Date("2026-08-10T04:00:00Z");
+
+test("allows a consented, valid account during business hours", () => {
+  assert.deepEqual(checkAccount(base, { ...DEFAULT_GATE, now: daytime }), { allowed: true });
+});
+
+test("blocks when consent is missing", () => {
+  const d = checkAccount({ ...base, consentToContact: false }, { ...DEFAULT_GATE, now: daytime });
+  assert.equal(d.allowed, false);
+  assert.equal(d.allowed === false && d.reason, "no-consent");
+});
+
+test("blocks when consent timestamp is absent", () => {
+  const acct = { ...base, consentTimestamp: undefined };
+  const d = checkAccount(acct, { ...DEFAULT_GATE, now: daytime });
+  assert.equal(d.allowed === false && d.reason, "missing-consent-timestamp");
+});
+
+test("blocks a non-E.164 phone", () => {
+  const d = checkAccount({ ...base, phone: "0202555017" }, { ...DEFAULT_GATE, now: daytime });
+  assert.equal(d.allowed === false && d.reason, "invalid-e164-phone");
+});
+
+test("blocks an invalid IANA timezone", () => {
+  const d = checkAccount({ ...base, timezone: "Mars/Phobos" }, { ...DEFAULT_GATE, now: daytime });
+  assert.equal(d.allowed === false && d.reason, "invalid-iana-timezone");
+});
+
+test("blocks during quiet hours", () => {
+  const d = checkAccount(base, { ...DEFAULT_GATE, now: midnight });
+  assert.equal(d.allowed, false);
+  assert.match(d.allowed === false ? d.reason : "", /^quiet-hours-local-/);
+});
+
+test("isQuietHour handles the midnight-wrapping window", () => {
+  assert.equal(isQuietHour(23, DEFAULT_GATE), true);
+  assert.equal(isQuietHour(3, DEFAULT_GATE), true);
+  assert.equal(isQuietHour(12, DEFAULT_GATE), false);
+});
+
+test("isValidTimeZone accepts IANA ids and rejects junk", () => {
+  assert.equal(isValidTimeZone("Africa/Accra"), true);
+  assert.equal(isValidTimeZone("Not/AZone"), false);
+});
+
+test("localHour resolves a timezone to a 0-23 hour", () => {
+  const h = localHour("America/New_York", daytime);
+  assert.ok(h >= 0 && h <= 23);
+  assert.equal(h, 11);
+});

--- a/apps/typescript/fintech-collections-callback/src/gate.ts
+++ b/apps/typescript/fintech-collections-callback/src/gate.ts
@@ -1,0 +1,70 @@
+// Pre-dial gate: consent, input validation, and quiet-hours enforcement.
+//
+// Design principle 2 (explicit consent) and principle 3 (never assume critical
+// values) live here. No call is placed unless checkAccount returns { allowed: true }.
+
+import type { OverdueAccount, GateDecision } from "./types.js";
+
+/** Strict E.164: leading +, first digit 1-9, total 7-15 digits. */
+const E164 = /^\+[1-9]\d{6,14}$/;
+
+export interface GateConfig {
+  /** Local hour (0-23) at/after which calls are NOT allowed. */
+  quietHoursStart: number;
+  /** Local hour (0-23) before which calls are NOT allowed. */
+  quietHoursEnd: number;
+  /** Override "now" for deterministic testing. */
+  now?: Date;
+}
+
+/** Default quiet hours: no calls before 08:00 or at/after 21:00 local time. */
+export const DEFAULT_GATE: GateConfig = {
+  quietHoursStart: 21,
+  quietHoursEnd: 8,
+};
+
+/** True if the string is a valid IANA timezone the runtime can resolve. */
+export function isValidTimeZone(tz: string): boolean {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Local hour (0-23) for a timezone at a given instant. */
+export function localHour(timezone: string, when: Date): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    hour12: false,
+  }).formatToParts(when);
+  const raw = parts.find((p) => p.type === "hour")?.value ?? "0";
+  const hour = Number(raw);
+  // Intl can report hour "24" for midnight in some environments; normalize to 0.
+  return hour === 24 ? 0 : hour;
+}
+
+/** True if `hour` falls inside the (possibly midnight-wrapping) quiet window. */
+export function isQuietHour(hour: number, cfg: GateConfig): boolean {
+  const { quietHoursStart: start, quietHoursEnd: end } = cfg;
+  if (start > end) return hour >= start || hour < end; // wraps midnight
+  return hour >= start && hour < end;
+}
+
+/** Run every gate check for one account. Order is deliberate: consent first. */
+export function checkAccount(account: OverdueAccount, cfg: GateConfig): GateDecision {
+  if (!account.consentToContact) return { allowed: false, reason: "no-consent" };
+  if (!account.consentTimestamp) return { allowed: false, reason: "missing-consent-timestamp" };
+  if (!E164.test(account.phone)) return { allowed: false, reason: "invalid-e164-phone" };
+  if (!isValidTimeZone(account.timezone)) return { allowed: false, reason: "invalid-iana-timezone" };
+
+  const when = cfg.now ?? new Date();
+  const hour = localHour(account.timezone, when);
+  if (isQuietHour(hour, cfg)) {
+    return { allowed: false, reason: `quiet-hours-local-${hour}` };
+  }
+  return { allowed: true };
+}

--- a/apps/typescript/fintech-collections-callback/src/smoke.test.ts
+++ b/apps/typescript/fintech-collections-callback/src/smoke.test.ts
@@ -1,0 +1,59 @@
+// Tests for the SMOKE_* env -> account builder. No network, no calls.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSmokeAccount, isoDateDaysAgo } from "./smoke.js";
+
+test("buildSmokeAccount throws when SMOKE_PHONE is absent", () => {
+  assert.throws(() => buildSmokeAccount({}), /SMOKE_PHONE is required/);
+});
+
+test("consent is OFF by default so the gate blocks unless asserted", () => {
+  const acct = buildSmokeAccount({ SMOKE_PHONE: "+12025550143" });
+  assert.equal(acct.consentToContact, false);
+  assert.equal(acct.consentTimestamp, undefined);
+});
+
+test("SMOKE_CONSENT=true attaches a consent timestamp (defaults to now)", () => {
+  const acct = buildSmokeAccount({ SMOKE_PHONE: "+12025550143", SMOKE_CONSENT: "true" });
+  assert.equal(acct.consentToContact, true);
+  assert.ok(acct.consentTimestamp, "expected a consent timestamp");
+  assert.ok(!Number.isNaN(Date.parse(acct.consentTimestamp!)), "timestamp should be ISO-parseable");
+});
+
+test("an explicit consent timestamp is preserved", () => {
+  const acct = buildSmokeAccount({
+    SMOKE_PHONE: "+12025550143",
+    SMOKE_CONSENT: "true",
+    SMOKE_CONSENT_TIMESTAMP: "2026-01-02T03:04:05Z",
+  });
+  assert.equal(acct.consentTimestamp, "2026-01-02T03:04:05Z");
+});
+
+test("overrides are respected; sensible defaults otherwise", () => {
+  const acct = buildSmokeAccount({
+    SMOKE_PHONE: "+441632960001",
+    SMOKE_NAME: "Alex Doe",
+    SMOKE_REGION: "GB",
+    SMOKE_TIMEZONE: "Europe/London",
+    SMOKE_AMOUNT_CENTS: "42000",
+    SMOKE_CURRENCY: "GBP",
+    SMOKE_DAYS_PAST_DUE: "12",
+    SMOKE_LANGUAGE: "en-GB",
+  });
+  assert.equal(acct.customerName, "Alex Doe");
+  assert.equal(acct.region, "GB");
+  assert.equal(acct.timezone, "Europe/London");
+  assert.equal(acct.amountDueCents, 42000);
+  assert.equal(acct.currency, "GBP");
+  assert.equal(acct.daysPastDue, 12);
+  assert.equal(acct.language, "en-GB");
+  assert.equal(acct.accountId, "SMOKE-1"); // default
+});
+
+test("isoDateDaysAgo returns a YYYY-MM-DD date the given number of days back", () => {
+  const from = new Date("2026-08-10T00:00:00Z");
+  assert.equal(isoDateDaysAgo(30, from), "2026-07-11");
+  assert.match(isoDateDaysAgo(30), /^\d{4}-\d{2}-\d{2}$/);
+});

--- a/apps/typescript/fintech-collections-callback/src/smoke.ts
+++ b/apps/typescript/fintech-collections-callback/src/smoke.ts
@@ -1,0 +1,54 @@
+// Builds a single overdue account from SMOKE_* environment variables for a
+// one-number live smoke test. This exists so a real --live call can target a
+// number you control and consent to, WITHOUT touching the fictional fixtures
+// (whose reserved-for-fiction numbers must never be dialed).
+//
+// The only required variable is SMOKE_PHONE. Consent is OFF unless you set
+// SMOKE_CONSENT=true explicitly, so the pre-dial gate blocks by default rather
+// than assuming consent on your behalf.
+
+import type { OverdueAccount } from "./types.js";
+
+type Env = Record<string, string | undefined>;
+
+/** YYYY-MM-DD for `days` before `from` (UTC). */
+export function isoDateDaysAgo(days: number, from: Date = new Date()): string {
+  const safe = Number.isFinite(days) ? days : 30;
+  const d = new Date(from);
+  d.setUTCDate(d.getUTCDate() - safe);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Assemble one account from SMOKE_* vars. Throws if SMOKE_PHONE is absent.
+ * Format/consent/quiet-hours are NOT checked here — that is the gate's job, so
+ * a smoke run exercises the exact same pre-dial checks a real batch would.
+ */
+export function buildSmokeAccount(env: Env = process.env): OverdueAccount {
+  const phone = env.SMOKE_PHONE;
+  if (!phone) {
+    throw new Error(
+      "SMOKE_PHONE is required for --smoke runs (E.164, a number you control and consent to call).",
+    );
+  }
+
+  const consent = env.SMOKE_CONSENT === "true";
+  const daysPastDue = Number(env.SMOKE_DAYS_PAST_DUE ?? 30);
+
+  return {
+    accountId: env.SMOKE_ACCOUNT_ID ?? "SMOKE-1",
+    customerName: env.SMOKE_NAME ?? "Test Customer",
+    phone,
+    region: env.SMOKE_REGION ?? "US",
+    // Default to this machine's timezone so "call me now" respects local quiet hours.
+    timezone: env.SMOKE_TIMEZONE ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+    amountDueCents: Number(env.SMOKE_AMOUNT_CENTS ?? 10000),
+    currency: env.SMOKE_CURRENCY ?? "USD",
+    dueDate: env.SMOKE_DUE_DATE ?? isoDateDaysAgo(Number.isFinite(daysPastDue) ? daysPastDue : 30),
+    daysPastDue: Number.isFinite(daysPastDue) ? daysPastDue : 30,
+    consentToContact: consent,
+    // Only attach a timestamp when consent is asserted; defaults to "now".
+    consentTimestamp: consent ? (env.SMOKE_CONSENT_TIMESTAMP ?? new Date().toISOString()) : undefined,
+    language: env.SMOKE_LANGUAGE ?? "en-US",
+  };
+}

--- a/apps/typescript/fintech-collections-callback/src/types.ts
+++ b/apps/typescript/fintech-collections-callback/src/types.ts
@@ -1,0 +1,63 @@
+// Domain types for the fintech collections callback app.
+
+/** A single overdue account that may be contacted by phone. */
+export interface OverdueAccount {
+  accountId: string;
+  customerName: string;
+  /** E.164 phone number, e.g. "+12025550143". */
+  phone: string;
+  /** ISO 3166-1 alpha-2 region for the recipient, e.g. "US", "GH". */
+  region: string;
+  /** IANA timezone identifier, e.g. "America/New_York". Never inferred from the phone. */
+  timezone: string;
+  amountDueCents: number;
+  /** ISO 4217 currency code, e.g. "USD", "GHS". */
+  currency: string;
+  /** ISO date the payment was due, e.g. "2026-07-15". */
+  dueDate: string;
+  daysPastDue: number;
+  /** Explicit, recorded consent to be contacted by phone about this debt. */
+  consentToContact: boolean;
+  /** When consent was captured (ISO datetime). Required when consentToContact is true. */
+  consentTimestamp?: string;
+  /** BCP-47 locale for the spoken call, e.g. "en-US". Defaults to "en-US". */
+  language?: string;
+}
+
+/** Result of running the pre-dial gate for one account. */
+export type GateDecision =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+/** Normalized structured outcome CALL-E returns for a single account. */
+export interface CollectionsResult {
+  outcome:
+    | "promise-to-pay"
+    | "dispute"
+    | "callback-requested"
+    | "wrong-number"
+    | "no-answer"
+    | "refused"
+    | "unknown";
+  /** ISO date the customer promised to pay, if any. */
+  promiseToPayDate?: string;
+  /** ISO datetime the customer asked to be called back, if any. */
+  callbackAt?: string;
+  notes?: string;
+}
+
+/** One row in the run report. */
+export interface CallOutcome {
+  accountId: string;
+  phone: string;
+  mode: "dry-run" | "live";
+  placed: boolean;
+  blockedReason?: string;
+  callId?: string;
+  status?: string;
+  taskCompleted?: boolean;
+  confidence?: number;
+  structured?: CollectionsResult;
+  error?: string;
+  at: string;
+}

--- a/apps/typescript/fintech-collections-callback/tsconfig.json
+++ b/apps/typescript/fintech-collections-callback/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Adds `apps/typescript/fintech-collections-callback`, a consent-gated CALL-E app that places compliant payment-reminder calls to overdue fintech accounts and returns a **structured collections outcome** (promise-to-pay, dispute, or callback) per account.

First-party soft-collections is an unoccupied niche in the current apps list. The app leads with the safety mechanism: a **pre-dial gate** enforces recorded consent (with timestamp), E.164 numbers, a valid IANA timezone with **quiet-hours** enforcement (no calls before 08:00 or at/after 21:00 local time), and a **per-run spend cap**. Each call runs a fixed right-party, no-payment-collection script and passes a `recipientResultSchema` so CALL-E returns a machine-readable result, which is written to an auditable JSON report under `runs/`. A deterministic idempotency key (`collections_<accountId>_<dueDate>`) prevents double-dialing on re-runs, and Ctrl-C cancels without starting new calls.

- **Dry-run by default** (no key, no calls placed); `--live` requires `CALLE_API_KEY`.
- Gate + result-mapping unit tests (13, no network): `npm test`.
- `npm run typecheck` clean; `npm run dry-run` shows 2 dialed / 3 blocked with reasons.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described. (README "Side effects" + live-cost warning.)
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional. (US 555-0100..0199 and UK Ofcom 020 7946 0xxx reserved-for-fiction ranges; the Ghana sample is an obvious placeholder as Ghana has no reserved range.)
- [x] Recurring workflows include cancellation behavior. *(N/A — one-shot batch, not a recurring job; SIGINT cancellation and idempotent re-runs are provided regardless.)*
- [x] Runnable code has a dry-run, fake-server, or no-call path by default. (Dry-run is the default mode.)
- [x] `python3 scripts/validate_repository.py` passes. *(Ran locally against current `main` with this app added → `Repository validation passed.` Branch rebased onto latest `main` to resolve the earlier README-table conflict; `check_branch_name.py` also passes.)*

