### PR TITLE
feat(apps): require AI-disclosure-before-consent and add a voicemail outcome to researchcall-survey

### DIFF
--- a/apps/python/researchcall-survey/README.md
+++ b/apps/python/researchcall-survey/README.md
@@ -3,7 +3,7 @@
 Run a telephone survey — and report it honestly afterwards.
 
 A survey that dials is easy. A survey whose numbers survive scrutiny is not, and almost
-every way of getting it wrong flatters the result. Three of those ways are structural here
+every way of getting it wrong flatters the result. Four of those ways are structural here
 rather than configurable.
 
 ## The denominator
@@ -52,10 +52,16 @@ anywhere in either output.
 
 | Rule | |
 | --- | --- |
+| `ai_disclosure_before_consent` | The call states, before anything else and before it asks for consent, that an automated assistant is calling. |
 | `explicit_consent_before_questions` | No question is asked before the person has consented in this call. |
 | `right_to_stop_immediately` | The interview ends the moment the person asks, without a further question. |
 | `right_to_withdraw_afterwards` | A withdrawal removes the identifier and the number, and the record leaves every later denominator. |
 | `no_high_risk_topics` | Medical, legal, financial and emergency topics are refused, not handled — checked for the study subject and for every single question. |
+
+`ai_disclosure_before_consent` is listed first because it is also an ordering requirement,
+not only a rule to keep: consent obtained from someone who was never told they were talking
+to a machine is not informed consent, so the disclosure has to land before the consent
+question, not folded into it or spoken after.
 
 A study file may **add** rules. It cannot overwrite these — the load path raises instead. A
 survey whose consent requirement can be switched off in configuration does not have a
@@ -104,8 +110,10 @@ Non-response by contact window:
 
 ## Deliberate limits
 
-- **`consent_refused`, `broke_off`, `no_answer`, `busy`, `ineligible` and `not_attempted`
-  stay distinct.** Collapsing them loses exactly the information a methods section needs.
+- **`consent_refused`, `broke_off`, `no_answer`, `busy`, `voicemail`, `ineligible` and
+  `not_attempted` stay distinct.** Collapsing them loses exactly the information a methods
+  section needs — a mailbox pickup is not the same non-response as an unanswered line, and
+  neither counts toward `reached`.
 - **A break-off keeps no partial answers.** Someone who ended the call did not finish
   answering, and half an answer is not data — partial answers after stopping are deleted
   at construction, so they are never stored and never emitted.
@@ -123,13 +131,14 @@ python -m pytest -q
 ```
 
 ```text
-.........................................                                [100%]
-41 passed in 0.76s
+..............................................                           [100%]
+46 passed in 0.50s
 ```
 
 The regressions guard the ways a study could flatter itself: an irreproducible sample, a
-person contacted twice, a locked ethics rule overwritten, answers recorded without consent,
-a category without its source, the wrong denominator, a withdrawal that only sets a flag
+person contacted twice, a locked ethics rule overwritten, disclosure spoken after consent
+instead of before it, answers recorded without consent, a category without its source, the
+wrong denominator, a mailbox pickup counted as reached, a withdrawal that only sets a flag
 instead of deleting the data, a break-off that keeps partial answers, a high-risk question
 hiding under a benign subject, and a full number reaching an output.
 

--- a/apps/python/researchcall-survey/survey.py
+++ b/apps/python/researchcall-survey/survey.py
@@ -11,9 +11,14 @@ almost every way of getting it wrong flatters the result:
   reading of what was said.
 * Treating withdrawal as a flag rather than a deletion leaves the person in the
   data they asked to leave.
+* Asking for consent before the call has said it is automated puts the decision in
+  the wrong order: a person cannot meaningfully consent to being interviewed by a
+  machine if nobody told them a machine was on the line.
 
-So three things are structural here rather than configurable:
+So four things are structural here rather than configurable:
 
+    disclosure   the call states that it is automated before it asks anything
+                 else, including for consent
     consent      no question is asked before explicit consent is recorded
     withdrawal   removes the identifier and the number, and drops the record out
                  of every later denominator
@@ -44,7 +49,19 @@ from typing import Any, Sequence
 # Locked ethics
 # --------------------------------------------------------------------------------------
 
+# ``ai_disclosure_before_consent`` comes first in this dict on purpose, and not
+# only because ``merge_ethics`` treats every locked rule the same afterwards: an
+# automated caller has to say what it is before it asks for anything, consent
+# included. Consent obtained from someone who was never told they were talking to
+# a machine is not informed consent -- it is a question asked in the wrong order.
+# Like every other entry here, a study file may add rules of its own but cannot
+# redefine this one; a survey whose disclosure can be switched off in
+# configuration does not have a disclosure requirement.
 LOCKED_ETHICS: dict[str, str] = {
+    "ai_disclosure_before_consent": (
+        "The call states, before anything else and before it asks for consent, "
+        "that an automated assistant is calling."
+    ),
     "explicit_consent_before_questions": (
         "No question is asked before the person has consented in this call."
     ),
@@ -180,6 +197,11 @@ class Disposition(str, Enum):
     BROKE_OFF = "broke_off"
     NO_ANSWER = "no_answer"
     BUSY = "busy"
+    # A mailbox pickup is not a person declining and not a person absent for a
+    # different, unknown reason -- it is its own outcome, and collapsing it into
+    # either loses exactly the distinction ``Report.reached`` exists to keep. It
+    # is therefore treated like ``NO_ANSWER``/``BUSY`` below: nobody was reached.
+    VOICEMAIL = "voicemail"
     INELIGIBLE = "ineligible"
     NOT_ATTEMPTED = "not_attempted"
 

--- a/apps/python/researchcall-survey/test_survey.py
+++ b/apps/python/researchcall-survey/test_survey.py
@@ -104,6 +104,23 @@ def test_a_study_may_add_rules_of_its_own():
     assert set(LOCKED_ETHICS) <= set(merged)
 
 
+def test_disclosure_is_the_first_locked_rule_a_study_meets():
+    """A person cannot consent to talking to a machine before being told it is one."""
+    assert next(iter(LOCKED_ETHICS)) == "ai_disclosure_before_consent"
+
+
+def test_disclosure_is_named_before_consent_in_the_rendered_report():
+    report = build_report("s", 1, [])
+    rendered = render(report, [], merge_ethics(None))
+    disclosure_line = next(
+        line for line in rendered.splitlines() if "automated assistant is calling" in line
+    )
+    consent_line = next(
+        line for line in rendered.splitlines() if "consented in this call" in line
+    )
+    assert rendered.index(disclosure_line) < rendered.index(consent_line)
+
+
 def test_no_answers_may_be_recorded_without_consent():
     with pytest.raises(EthicsViolation, match="without consent"):
         Interview(
@@ -279,6 +296,27 @@ def test_dispositions_stay_distinct():
         "busy": 1,
         "ineligible": 1,
     }
+
+
+def test_voicemail_stays_distinct_from_no_answer_and_busy():
+    records = [
+        record("a", Disposition.VOICEMAIL),
+        record("b", Disposition.NO_ANSWER),
+        record("c", Disposition.BUSY),
+    ]
+    report = build_report("s", 1, records)
+    assert report.dispositions == {"voicemail": 1, "no_answer": 1, "busy": 1}
+
+
+def test_a_mailbox_pickup_does_not_count_as_reached():
+    records = [
+        record("a", Disposition.COMPLETED, consent_given=True),
+        record("b", Disposition.VOICEMAIL),
+    ]
+    report = build_report("s", 1, records)
+    assert report.included_drawn == 2
+    assert report.reached == 1
+    assert report.completion_yield == pytest.approx(0.5)
 
 
 def test_an_empty_denominator_does_not_divide_by_zero():


### PR DESCRIPTION
## What

Two additions to the researchcall-survey collection edition, both extending the existing
"structural, not configurable" ethics/outcome model rather than changing any of its current
behaviour:

- A new locked ethics rule, `ai_disclosure_before_consent`: the call must state that an
  automated assistant is calling before it asks for consent, not after. It sits first in
  LOCKED_ETHICS, ahead of the consent rule it gates, and is enforced the same way every other
  locked rule already is (a study file may add rules, it cannot redefine this one).
- A new `Disposition.VOICEMAIL`, distinct from NO_ANSWER and BUSY and excluded from
  `Report.reached`, so a mailbox pickup is never counted as a person who was reached.

## Why

A supervised field trial of the corresponding full application, using real outbound calls to a
single consenting test line, found both gaps live: the first call disclosed neither that a
machine was calling nor a way to opt out, and a mailbox pickup came back indistinguishable from
a completed call in the outcome data. Both are now fixed in the full application. This PR
carries the same two lessons into the much smaller fixture-driven model here, since neither
lesson is specific to live telephony — both are properties any correct outcome model for this
kind of survey should have.

## Testing

- `python -m pytest -q` in apps/python/researchcall-survey: 46 passed (was 41; four new tests
  plus one additional parametrized case from the new locked-rule key).
- `python3 scripts/validate_repository.py`: passed.
- Branch name checked with scripts/check_branch_name.py.

No behaviour of the existing rules or dispositions changes; both additions are purely additive,
and none of the existing regressions needed to change.
