### PR TITLE
feat(apps): distinguish wrong-person pickups and voicemail in ringedingeding

### DIFF
--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -12,11 +12,11 @@ They do not. This app keeps the groups apart and names the denominator every tim
 | --- | --- |
 | `answered` | said something |
 | `refused` | picked up and declined to take part |
-| `unreached` | nobody answered, or the line was busy |
+| `unreached` | nobody answered, the line was busy, a machine picked up, or the wrong person did |
 | `pending` | not called yet |
 | `unknown` | the call ended in a state nobody can interpret |
 
-Three rules follow, and they are what the regressions defend:
+Four rules follow, and they are what the regressions defend:
 
 - **Every share is reported against those who answered** — never against those who were
   invited — and the report says so in words.
@@ -24,6 +24,15 @@ Three rules follow, and they are what the regressions defend:
   mentioned Thursday has not ruled Thursday out.
 - **A tie stays a tie.** Nothing breaks the draw, because the caller was not asked to decide
   anything.
+- **A stranger's answer is never this participant's answer.** If the wrong person picked up
+  and declined on the participant's behalf, that is `unreached`, not `refused` — the
+  participant was never actually asked.
+
+Set `status` to `voicemail` when the call reached an answering machine, and to
+`wrong_person` when someone other than the invited participant picked up and no handover
+happened. Both land in `unreached` (see `Status.bucket` in `aggregate.py`), both are offered
+another call in a catch-up round, and neither is ever read as this participant's `answered`
+or `refused`.
 
 ## Setup
 
@@ -117,8 +126,9 @@ catch-up, it is pestering. Folding fresh answers in never overwrites an existing
 
 ## Deliberate limits
 
-- **`no_answer`, `busy` and `declined` never collapse into one group.** They mean different
-  things for a follow-up: two are worth another call, one is not.
+- **`no_answer`, `busy`, `voicemail`, `wrong_person` and `declined` never collapse into one
+  group.** They mean different things for a follow-up: four are worth another call, one is
+  not.
 - **An uninterpretable call lands in `unknown`**, not in `unreached`. Not knowing what
   happened is not the same as knowing nobody picked up.
 - **An incomplete result always carries its caveat**, generated from the coverage rather
@@ -133,14 +143,15 @@ python -m pytest -q
 ```
 
 ```text
-.......................                                                  [100%]
-23 passed in 0.08s
+..........................                                               [100%]
+26 passed in 0.28s
 ```
 
 The regressions guard the ways a summary could lie: unreached people counted as
-indifferent, statuses collapsing into one another, silence read as consent, a tie quietly
-broken, conditions or reasons dropped, a catch-up round overwriting an answer, and a full
-number reaching an output.
+indifferent, statuses collapsing into one another, a wrong-person pickup counted as this
+participant's refusal, a voicemail pickup skipped by a catch-up round, silence read as
+consent, a tie quietly broken, conditions or reasons dropped, a catch-up round overwriting
+an answer, and a full number reaching an output.
 
 ## The full application
 

--- a/apps/python/ringedingeding/aggregate.py
+++ b/apps/python/ringedingeding/aggregate.py
@@ -87,6 +87,17 @@ class Status(str, Enum):
     DECLINED = "declined"
     NO_ANSWER = "no_answer"
     BUSY = "busy"
+    # An answering machine is not "nobody answered" and not "the person declined" --
+    # it is its own outcome. Folding it into either would misreport a common,
+    # innocuous case as its neighbour. Set by the fixture author when the call
+    # reached a mailbox rather than a person.
+    VOICEMAIL = "voicemail"
+    # Set when the call reached someone, but confirming it was the invited person
+    # failed -- a different person answered and no handover happened. Bucketed as
+    # UNREACHED, not REFUSED: a stranger's answer, whatever it was, is not this
+    # participant's answer. Collapsing it into REFUSED is exactly the
+    # misattribution this aggregator exists to keep out of a merged result.
+    WRONG_PERSON = "wrong_person"
     NOT_CALLED = "not_called"
     UNKNOWN = "unknown"
 
@@ -97,6 +108,8 @@ class Status(str, Enum):
             Status.DECLINED: Bucket.REFUSED,
             Status.NO_ANSWER: Bucket.UNREACHED,
             Status.BUSY: Bucket.UNREACHED,
+            Status.VOICEMAIL: Bucket.UNREACHED,
+            Status.WRONG_PERSON: Bucket.UNREACHED,
             Status.NOT_CALLED: Bucket.PENDING,
             Status.UNKNOWN: Bucket.UNKNOWN,
         }[self]

--- a/apps/python/ringedingeding/test_aggregate.py
+++ b/apps/python/ringedingeding/test_aggregate.py
@@ -104,6 +104,45 @@ def test_an_uninterpretable_call_lands_in_unknown_not_in_unreached():
     assert coverage.by_bucket[Bucket.UNKNOWN] and not coverage.by_bucket[Bucket.UNREACHED]
 
 
+def test_voicemail_and_wrong_person_land_in_unreached_not_answered_or_refused():
+    assert Status.VOICEMAIL.bucket is Bucket.UNREACHED
+    assert Status.WRONG_PERSON.bucket is Bucket.UNREACHED
+    # Neither is "nobody picked up" and neither is the invited person's own
+    # answer -- both stay apart from ANSWERED and REFUSED, so a follow-up round
+    # can act on them differently from an outright refusal.
+    assert Status.VOICEMAIL.bucket is not Bucket.ANSWERED
+    assert Status.WRONG_PERSON.bucket is not Bucket.REFUSED
+
+
+def test_a_wrong_person_answer_is_never_counted_as_this_participants_refusal():
+    """A stranger's answer is never this participant's answer -- not even a stranger's no."""
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.COMPLETED, choice="A"),
+        "ben": Answer(
+            "ben",
+            Status.WRONG_PERSON,
+            raw="Someone else answered and declined on Ben's behalf.",
+        ),
+    }
+    coverage, result = merge_opinions(persons, answers)
+
+    assert coverage.by_bucket[Bucket.REFUSED] == []
+    assert len(coverage.by_bucket[Bucket.UNREACHED]) == 1
+    assert sum(result.tally.values()) == 1  # only Ana's own choice counts
+
+
+def test_a_mailbox_pickup_is_offered_a_catch_up_round_a_refusal_is_not():
+    persons = people(2)
+    answers = {
+        "ana": Answer("ana", Status.DECLINED),
+        "ben": Answer("ben", Status.VOICEMAIL),
+    }
+    targets = [p.id for p in pending_for_catch_up(persons, answers)]
+    assert targets == ["ben"]
+    assert "ana" not in targets  # a refusal is an answer, not a machine's greeting
+
+
 # -- silence is not a no -----------------------------------------------------------------
 
 


### PR DESCRIPTION
## What

Two new Status values in the ringedingeding collection edition, both bucketed as unreached (not
answered or refused), extending the existing outcome model rather than changing current
behaviour:

- `wrong_person`: someone other than the invited participant picked up and no handover
  happened. A stranger's answer — whatever it was — is never read as this participant's answer.
- `voicemail`: the call reached an answering machine rather than a person.

Both are offered another call in a catch-up round, the same as `no_answer` and `busy`, and
neither is ever counted toward a participant's own tally the way `declined` is.

## Why

A supervised field trial of the corresponding full application, using real outbound calls,
found a live instance of the first gap: a call where the wrong person answered and declined on
their own behalf was read as the invited participant's own refusal, because the app checked two
separate signals from the call in the wrong order. It also found the second gap: a mailbox
pickup came back indistinguishable from a completed call. Both are now fixed in the full
application. This PR carries the same two lessons into the fixture-driven model here, since the
underlying principle — a stranger's answer is not a participant's answer, and a machine's
greeting is not a person answering — does not depend on how the call was actually placed.

## Testing

- `python -m pytest -q` in apps/python/ringedingeding: 26 passed (was 23).
- `python3 scripts/validate_repository.py`: passed.
- Branch name checked with scripts/check_branch_name.py.

No behaviour of the existing statuses changes; both additions are purely additive, and none of
the existing regressions needed to change.
