### PR TITLE
feat(skills): add critical-alert-escalation skill

### DIFF
--- a/skills/critical-alert-escalation/SKILL.md
+++ b/skills/critical-alert-escalation/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: critical-alert-escalation
+description: Escalate a critical alert by phone until a human acknowledges. Given an alert, an ordered on-call contact chain, and an acknowledgment schema, it places calls through CALL-E (plan_call → run_call → get_call_run), captures a structured verbal acknowledgment, and escalates to the next responder if the alert isn't confirmed — logging every attempt. Use for on-call, incident, safety, or readiness alerts where a screen notification can be missed and confirmed receipt matters.
+---
+
+# Critical Alert Escalation
+
+A dashboard notification is worthless if the responsible human isn't looking at a screen. This skill closes the loop over the phone: when a critical alert fires, it **calls** a human, delivers the alert in plain language, captures a **structured acknowledgment**, and — if no one confirms — **escalates up an on-call chain** until someone does, logging every attempt with a timestamp.
+
+It is the phone equivalent of an on-call escalation policy (PagerDuty-style), built on CALL-E's outbound calling and structured results.
+
+Operating principle: **fail toward escalation.** Anything short of a clear, confident acknowledgment (declined, no answer, ambiguous, low confidence) is treated as *not acknowledged*, and the skill moves to the next responder. A missed alert is worse than an extra call.
+
+## When to use
+
+- On-call / incident escalation (ops, IT, security) where an ack must be confirmed by voice.
+- Safety or readiness alerts (e.g. a physiological-readiness flag for an athlete or operator) that a responsible human must receive and act on.
+- Any "someone has to confirm they've got this, now" situation where email/Slack can be missed.
+
+Not for: marketing, cold outreach, or any call to a number that hasn't opted into the escalation chain.
+
+## The call lifecycle (per responder)
+
+Runs CALL-E's standard sequence for each contact, in chain order, until acknowledged:
+
+1. **Auth** — `calle auth status` (browser-login token held by the CALL-E CLI).
+2. **plan_call** — prepare one outbound call to the next responder; the goal delivers the alert + recommendation and asks for confirmation.
+3. **run_call** — dial.
+4. **get_call_run** — poll (or receive the terminal webhook) for the structured result.
+5. **Evaluate** — acknowledged with confidence → stop; otherwise log the attempt and continue to the next responder. If the chain is exhausted, escalate to the owner/on-call manager (out-of-band notification).
+
+## Inputs
+
+- **alert**: `{ title, detail, recommendation }` — what happened and the recommended action, in non-jargon language.
+- **contact_chain**: ordered `[{ role, phone_e164, order }]` — the responders, most-responsible first. All numbers must be on the allowlist.
+- **acknowledgment schema** (the CALL-E result target):
+
+```json
+{
+  "reached": "boolean — a live human answered",
+  "acknowledged": "boolean — they confirmed receipt of the alert",
+  "responder_role": "string — who acknowledged",
+  "action_taken": "string — what they said they'd do",
+  "notes": "string"
+}
+```
+
+- **disclosure**: the AI-identification line prepended to every call goal.
+
+> CALL-E returns its own outcome envelope (`{ task_completed, confidence, evidence }` + a `summary`). Map `acknowledged = task_completed && confidence high`; keep `summary` as `notes`. Treat low confidence as not acknowledged.
+
+## Guardrails & safety (non-negotiable)
+
+Phone calls have real-world side effects. This skill enforces:
+
+- **Allowlist only.** Calls are placed only to numbers explicitly registered in the escalation chain. Never dial an unknown or unconsented number.
+- **AI disclosure on every call.** The goal opens with an identification line, e.g. `"This is an automated readiness assistant calling on behalf of <org>."`
+- **Consent.** Responders opt into the on-call chain in advance; this skill is for people who expect these calls, not the public.
+- **Human decides.** The call delivers a classification + recommendation and requests acknowledgment. It never makes the operational or medical decision. For health/readiness use, language stays non-diagnostic (state the flag and recommendation; do not diagnose).
+- **Fail toward escalation** (see operating principle) — ambiguity advances the chain, never silently closes the alert.
+- **Nothing hidden.** Every attempt (reached/declined/acknowledged) is logged with responder, timestamp, and structured result. Escalations are visible to the alert owner.
+
+## Setup
+
+1. Install and authenticate CALL-E (CLI + browser login) per the CALL-E integration guide; confirm `calle mcp tools` lists `plan_call`, `run_call`, `get_call_run`.
+2. Define the **allowlist** and the **contact_chain** (roles, E.164 numbers, order).
+3. Provide the alert source (your monitor/flag system) that invokes the skill with an `alert` payload.
+
+## Side effects, cancellation, results
+
+- **Side effects:** places real outbound phone calls (billable; reaches real people). Use test numbers while developing.
+- **Cancellation:** an in-progress escalation is stopped by marking the alert acknowledged/closed in the owning system before the next leg dials; the skill checks alert status between legs.
+- **Result handling:** each leg writes a structured record (reached, acknowledged, responder, action_taken, run id, status). On acknowledgment the alert closes; on chain exhaustion the owner is notified out-of-band.
+
+## Example (masked numbers)
+
+Readiness-flag escalation, two-leg chain:
+
+```
+alert: { title: "Athlete flagged RED", detail: "HRV 33, load +54%, 3-day strain",
+         recommendation: "hold from recovery" }
+chain: [ { role: "trainer",   phone_e164: "+15550101234", order: 1 },
+         { role: "physician", phone_e164: "+15550105678", order: 2 } ]
+
+Leg 1 → trainer (+15550101234): no answer / declined  → not acknowledged → escalate
+Leg 2 → physician (+15550105678): "Got it, I'll hold him for recovery."
+        → acknowledged=true, action_taken="hold from recovery" → alert closed, logged.
+```
+
+## Field notes for integrators
+
+- CALL-E dials from **rotating caller IDs**; recipients using call-screening may auto-decline. Responders should expect the call (or whitelist on their device) — allowlisting your own number in the skill does not affect their screening.
+- Prefer the **terminal webhook** over long polling; a call can sit in `PREPARING` for a while before it connects.
+
+## Reference implementation
+
+`scripts/run_escalation.ts` orchestrates the chain over the CALL-E CLI (`plan_call` → `run_call` → `get_call_run`) with the guardrails above — a single guarded entry point; the raw MCP tools are never exposed to the calling model. `scripts/run_escalation.test.ts` covers the acknowledgment evaluation. See `references/` for the acknowledgment schema and a production reference (Vector Research Labs' "Readiness Escalation Line" built on this pattern). Adapt the alert source and contact chain to your system.

--- a/skills/critical-alert-escalation/SKILL.md
+++ b/skills/critical-alert-escalation/SKILL.md
@@ -47,7 +47,7 @@ Runs CALL-E's standard sequence for each contact, in chain order, until acknowle
 
 - **disclosure**: the AI-identification line prepended to every call goal.
 
-> CALL-E returns its own outcome envelope (`{ task_completed, confidence, evidence }` + a `summary`). Map `acknowledged = task_completed && confidence high`; keep `summary` as `notes`. Treat low confidence as not acknowledged.
+> CALL-E returns its own outcome envelope (`{ task_completed, confidence, evidence }` + a `summary`). **Authoritative ack only:** `acknowledged = task_completed === true AND confidence ≥ threshold AND evidence present`. A bare `acknowledged: true` in the payload is **not** sufficient and is ignored. Keep `summary` as `notes`. Anything else — low confidence, missing evidence, `task_completed !== true`, a terminal-negative status — is *not acknowledged* (fail toward escalation).
 
 ## Guardrails & safety (non-negotiable)
 
@@ -57,8 +57,16 @@ Phone calls have real-world side effects. This skill enforces:
 - **AI disclosure on every call.** The goal opens with an identification line, e.g. `"This is an automated readiness assistant calling on behalf of <org>."`
 - **Consent.** Responders opt into the on-call chain in advance; this skill is for people who expect these calls, not the public.
 - **Human decides.** The call delivers a classification + recommendation and requests acknowledgment. It never makes the operational or medical decision. For health/readiness use, language stays non-diagnostic (state the flag and recommendation; do not diagnose).
-- **Fail toward escalation** (see operating principle) — ambiguity advances the chain, never silently closes the alert.
+- **Fail toward escalation** (see operating principle) — a *resolvable* negative (declined/no-answer/voicemail/low-confidence) advances the chain, never silently closes the alert.
 - **Nothing hidden.** Every attempt (reached/declined/acknowledged) is logged with responder, timestamp, and structured result. Escalations are visible to the alert owner.
+
+These are enforced in `scripts/run_escalation.ts` (not just documented) and covered by no-call unit tests in `scripts/run_escalation.test.ts`:
+
+- **E.164 only.** A number that doesn't match `^\+[1-9]\d{1,14}$` is rejected before dialing.
+- **Dry-run by default.** A live call requires **both** the env opt-in `CALLE_LIVE=1` **and** an explicit `confirmLiveCall` on the run. Without both, the skill previews the chain and places no call — it is impossible to dial live without both.
+- **Stable idempotency.** A deterministic key per `(alertId, contact, attempt)` is passed to `plan_call`/`run_call`, so a retry with the same inputs can't double-dial.
+- **Ambiguous-leg reconciliation.** A leg with no terminal outcome is re-polled (`get_call_run`) to a terminal state; if it still can't be resolved, the skill **stops and flags for review** rather than advancing on a guess.
+- **Between-legs status check.** Before each leg, the skill checks the alert isn't already acknowledged/resolved out-of-band; if it is, it halts.
 
 ## Setup
 

--- a/skills/critical-alert-escalation/references/acknowledgment-schema.json
+++ b/skills/critical-alert-escalation/references/acknowledgment-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Critical alert acknowledgment",
+  "description": "The structured result CALL-E extracts from each escalation call.",
+  "type": "object",
+  "properties": {
+    "reached": { "type": "boolean", "description": "A live human answered." },
+    "acknowledged": { "type": "boolean", "description": "They confirmed receipt of the alert." },
+    "responder_role": { "type": "string", "description": "Who acknowledged (e.g. trainer, physician, on-call)." },
+    "action_taken": { "type": "string", "description": "What they said they'd do." },
+    "notes": { "type": "string" }
+  },
+  "required": ["reached", "acknowledged"]
+}

--- a/skills/critical-alert-escalation/references/examples.md
+++ b/skills/critical-alert-escalation/references/examples.md
@@ -1,0 +1,51 @@
+# Examples
+
+All numbers below are fictional (`+1555…`). Use test numbers while developing.
+
+## Two-leg readiness escalation (chain advances, then acknowledges)
+
+```
+alert: { title: "Athlete flagged RED", detail: "HRV 33, load +54%, 3-day strain",
+         recommendation: "hold from recovery" }
+chain: [ { role: "trainer",   phone_e164: "+15550101234", order: 1 },
+         { role: "physician", phone_e164: "+15550105678", order: 2 } ]
+disclosure: "This is an automated readiness assistant calling on behalf of Example Org."
+
+Leg 1 → trainer (+15550101234): no answer / declined  → not acknowledged → escalate
+Leg 2 → physician (+15550105678): "Got it, I'll hold him for recovery."
+        → { reached: true, acknowledged: true, responder_role: "physician",
+            action_taken: "hold from recovery", notes: "confirmed by physician" }
+        → alert closed, both attempts logged.
+```
+
+## Single responder acknowledges immediately
+
+```
+alert: { title: "Deploy approval needed", detail: "prod release blocked on sign-off",
+         recommendation: "approve or hold the 3pm deploy" }
+chain: [ { role: "on-call-lead", phone_e164: "+15550100000", order: 1 } ]
+
+Leg 1 → on-call-lead: "Approved, ship it."
+        → { reached: true, acknowledged: true, action_taken: "approve deploy" }
+        → alert closed after one call.
+```
+
+## Chain exhausted (nobody acknowledges → owner notified)
+
+```
+chain: [ { role: "trainer", phone_e164: "+15550101234", order: 1 } ]
+
+Leg 1 → trainer: voicemail → not acknowledged
+        → chain exhausted → owner notified out-of-band; alert left OPEN, all attempts logged.
+```
+
+## Running the reference
+
+```bash
+# unit-test the acknowledgment evaluation (no calls placed)
+node --test --experimental-strip-types scripts/run_escalation.test.ts
+```
+
+See [`../scripts/run_escalation.ts`](../scripts/run_escalation.ts) for the guarded
+orchestration and [`acknowledgment-schema.json`](acknowledgment-schema.json) for the
+structured result CALL-E returns.

--- a/skills/critical-alert-escalation/references/reference-implementation.md
+++ b/skills/critical-alert-escalation/references/reference-implementation.md
@@ -11,10 +11,15 @@ every attempt logged with its structured acknowledgment.
 - Guardrails: allowlist-only, AI disclosure, non-diagnostic language, human-in-the-loop
 - Lifecycle: `plan_call → run_call → get_call_run` via the `calle` CLI (browser-login auth)
 
-The mapping from CALL-E's outcome envelope to an acknowledgment boolean
-(`acknowledged = task_completed && confidence high`, terminal-negative → not
-acknowledged) is implemented in [`../scripts/run_escalation.ts`](../scripts/run_escalation.ts)
-and covered by [`../scripts/run_escalation.test.ts`](../scripts/run_escalation.test.ts).
+The mapping from CALL-E's outcome envelope to an acknowledgment boolean is
+authoritative-ack-only (`acknowledged = task_completed === true AND confidence ≥
+threshold AND evidence`; a bare `acknowledged:true` is not sufficient;
+terminal-negative / ambiguous → not acknowledged) and is implemented in
+[`../scripts/run_escalation.ts`](../scripts/run_escalation.ts) and covered by
+[`../scripts/run_escalation.test.ts`](../scripts/run_escalation.test.ts). The same
+file enforces E.164 validation, a dry-run-by-default live gate (`CALLE_LIVE=1` +
+explicit confirmation), stable per-`(alertId, contact, attempt)` idempotency keys,
+ambiguous-leg reconciliation, and the between-legs alert-status check.
 
 Source: https://github.com/CALLE-AI/awesome-phone-call-agents (this repo) ·
 reference build: Juliet (Strands Agents + Bedrock AgentCore).

--- a/skills/critical-alert-escalation/references/reference-implementation.md
+++ b/skills/critical-alert-escalation/references/reference-implementation.md
@@ -1,0 +1,20 @@
+# Production reference
+
+**Vector Research Labs — "Readiness Escalation Line"** is a production implementation
+of this pattern. When a physiological-readiness engine flags an athlete RED, an
+autonomous assistant (Juliet) phones a role-based responder chain (trainer →
+physician) until someone acknowledges, then escalates to the owner if no one does —
+every attempt logged with its structured acknowledgment.
+
+- Alert shape: `{ athlete, metric, level, driver, recommendation }`
+- Contact chain: ordered `escalation_contacts` (role, phone, chain_order), allowlist-gated
+- Guardrails: allowlist-only, AI disclosure, non-diagnostic language, human-in-the-loop
+- Lifecycle: `plan_call → run_call → get_call_run` via the `calle` CLI (browser-login auth)
+
+The mapping from CALL-E's outcome envelope to an acknowledgment boolean
+(`acknowledged = task_completed && confidence high`, terminal-negative → not
+acknowledged) is implemented in [`../scripts/run_escalation.ts`](../scripts/run_escalation.ts)
+and covered by [`../scripts/run_escalation.test.ts`](../scripts/run_escalation.test.ts).
+
+Source: https://github.com/CALLE-AI/awesome-phone-call-agents (this repo) ·
+reference build: Juliet (Strands Agents + Bedrock AgentCore).

--- a/skills/critical-alert-escalation/references/safety.md
+++ b/skills/critical-alert-escalation/references/safety.md
@@ -26,6 +26,23 @@ and escalation calls are, by design, high-stakes. These rules are non-negotiable
 - **No exposed secrets.** Auth is the CALL-E CLI browser-login state — no API keys
   in code, config, or logs. Do not print tokens or personal data.
 
+## Enforced in code (not just policy)
+
+`scripts/run_escalation.ts` makes these executable, with no-call tests in
+`scripts/run_escalation.test.ts`:
+
+- **E.164 validation** — a number failing `^\+[1-9]\d{1,14}$` is rejected before dialing.
+- **Dry-run by default** — a live call requires BOTH `CALLE_LIVE=1` and an explicit
+  `confirmLiveCall`; without both, the chain is previewed and nothing is dialed.
+- **Stable idempotency** — a deterministic key per `(alertId, contact, attempt)` on
+  `plan_call`/`run_call` prevents a retry from double-dialing.
+- **Ambiguous-leg reconciliation** — a non-terminal outcome is re-polled to terminal;
+  if unresolved, the run stops and flags rather than advancing on a guess.
+- **Between-legs alert-status check** — before each leg, an already-acknowledged/resolved
+  alert halts the chain.
+- **Authoritative ack** — acknowledged requires `task_completed === true` AND confidence
+  ≥ threshold AND evidence; a bare `acknowledged:true` is not sufficient.
+
 ## Cancellation / rollback
 
 This is a recurring, multi-leg workflow. To stop an in-progress escalation, mark

--- a/skills/critical-alert-escalation/references/safety.md
+++ b/skills/critical-alert-escalation/references/safety.md
@@ -1,0 +1,34 @@
+# Safety
+
+Phone calls have real-world side effects (they cost money and reach real people),
+and escalation calls are, by design, high-stakes. These rules are non-negotiable.
+
+## Rules
+
+- **Allowlist only.** Place calls only to numbers explicitly registered in the
+  escalation chain. Never dial an unknown, guessed, or unconsented number, and
+  never guess a country code — ask if a number is ambiguous.
+- **AI disclosure on every call.** The call goal opens with an identification line,
+  e.g. "This is an automated readiness assistant calling on behalf of <org>."
+- **Consent.** Responders opt into the on-call chain in advance. This skill is for
+  people who expect these calls, not the public. Do not add a third party to the
+  chain without their documented prior consent.
+- **Human decides.** The call delivers a classification + recommendation and
+  requests acknowledgment. It never makes the operational or medical decision. For
+  health/readiness use, language stays **non-diagnostic** — state the flag and the
+  recommendation; do not diagnose.
+- **Fail toward escalation.** Anything short of a clear, confident acknowledgment
+  (declined, no answer, voicemail, ambiguous, low confidence) is treated as *not
+  acknowledged*, and the chain advances. Never silently close an alert.
+- **Nothing hidden.** Every attempt (reached / declined / acknowledged) is logged
+  with responder, timestamp, and the structured result. Chain exhaustion escalates
+  to the alert owner out-of-band; escalations are visible to that owner.
+- **No exposed secrets.** Auth is the CALL-E CLI browser-login state — no API keys
+  in code, config, or logs. Do not print tokens or personal data.
+
+## Cancellation / rollback
+
+This is a recurring, multi-leg workflow. To stop an in-progress escalation, mark
+the alert acknowledged/closed in the owning system before the next leg dials — the
+skill checks alert status between legs and halts. There is no way to recall a call
+already placed; the guardrail is the between-legs status check plus the allowlist.

--- a/skills/critical-alert-escalation/scripts/run_escalation.test.ts
+++ b/skills/critical-alert-escalation/scripts/run_escalation.test.ts
@@ -1,31 +1,211 @@
-// Tests for the acknowledgment evaluation — the core "fail toward escalation" rule.
+// No-call unit tests for the enforced safety gates. NONE of these place a call:
+// interpretAck is pure; runEscalation runs in dry-run or with an injected `_placeCall`
+// stub, so the `calle` CLI is never spawned.
 // Run: node --test --experimental-strip-types scripts/run_escalation.test.ts
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { interpretAck } from "./run_escalation.ts";
+import {
+  interpretAck,
+  isValidE164,
+  liveCallAllowed,
+  idempotencyKey,
+  runEscalation,
+  type Alert,
+  type Contact,
+  type AckResult,
+} from "./run_escalation.ts";
 
-test("confident completion → acknowledged", () => {
-  const r = interpretAck("COMPLETED", { summary: "Got it, I'll hold him.", outcome: { task_completed: true, completion_confidence: { label: "high", score: 0.84 } } }, "trainer");
+const ALERT: Alert = { id: "alert-1", title: "Athlete flagged RED", detail: "HRV 33", recommendation: "hold" };
+const DISCLOSURE = "This is an automated readiness assistant calling on behalf of Example Org.";
+const okOutcome = { task_completed: true, completion_confidence: { label: "high", score: 0.84 }, evidence: "Trainer said: I'll hold him for recovery." };
+
+function baseOpts(over: Partial<Parameters<typeof runEscalation>[0]> = {}) {
+  return {
+    alert: ALERT,
+    contactChain: [{ role: "trainer", phone_e164: "+15550101234", order: 1 }] as Contact[],
+    disclosure: DISCLOSURE,
+    isAllowlisted: () => true,
+    isAlertResolved: () => false,
+    notifyOwner: () => {},
+    confirmLiveCall: true,
+    env: { CALLE_LIVE: "1" } as NodeJS.ProcessEnv, // live enabled for loop tests; _placeCall stubs the dial
+    ...over,
+  };
+}
+
+// ---------------- Gate 6 — authoritative ack only ----------------
+test("gate6: task_completed + high confidence + evidence → acknowledged", () => {
+  const r = interpretAck("COMPLETED", { summary: "Got it.", outcome: okOutcome }, "trainer");
   assert.equal(r.acknowledged, true);
   assert.equal(r.reached, true);
 });
 
-test("low confidence → NOT acknowledged (fail toward escalation)", () => {
-  const r = interpretAck("COMPLETED", { summary: "Unclear response.", outcome: { task_completed: true, completion_confidence: { label: "low", score: 0.3 } } }, "trainer");
+test("gate6: bare acknowledged:true is NOT sufficient", () => {
+  const r = interpretAck("COMPLETED", { acknowledged: true, reached: true, summary: "sounds ok" }, "trainer");
   assert.equal(r.acknowledged, false);
 });
 
-test("no answer / voicemail / declined → NOT acknowledged", () => {
+test("gate6: task_completed + high confidence but NO evidence → NOT acknowledged", () => {
+  const r = interpretAck("COMPLETED", { summary: "ok", outcome: { task_completed: true, completion_confidence: { label: "high", score: 0.9 } } }, "trainer");
+  assert.equal(r.acknowledged, false);
+});
+
+test("gate6: task_completed=false (even with evidence + confidence) → NOT acknowledged", () => {
+  const r = interpretAck("COMPLETED", { outcome: { task_completed: false, completion_confidence: { score: 0.95 }, evidence: "said maybe later" } }, "trainer");
+  assert.equal(r.acknowledged, false);
+});
+
+test("gate6: low confidence → NOT acknowledged (fail toward escalation)", () => {
+  const r = interpretAck("COMPLETED", { outcome: { task_completed: true, completion_confidence: { label: "low", score: 0.3 }, evidence: "unclear" } }, "trainer");
+  assert.equal(r.acknowledged, false);
+});
+
+test("gate6: no answer / voicemail / busy / declined → NOT acknowledged", () => {
   for (const s of ["NO_ANSWER", "VOICEMAIL", "BUSY", "DECLINED"]) {
     assert.equal(interpretAck(s, {}, "trainer").acknowledged, false);
   }
 });
 
-test("explicit acknowledged=false is respected", () => {
+test("gate6: explicit acknowledged=false is respected", () => {
   const r = interpretAck("COMPLETED", { acknowledged: false, reached: true, summary: "Refused." }, "physician");
   assert.equal(r.acknowledged, false);
 });
 
-test("unavailable (CALL-E not reachable) → NOT acknowledged", () => {
+test("gate6: unavailable (CALL-E not reachable) → NOT acknowledged", () => {
   assert.equal(interpretAck("unavailable", { note: "CALL-E not available" }, "trainer").acknowledged, false);
+});
+
+// ---------------- Gate 1 — E.164 validation ----------------
+test("gate1: isValidE164 accepts well-formed numbers", () => {
+  for (const p of ["+15550101234", "+447911123456", "+81312345678"]) assert.equal(isValidE164(p), true);
+});
+
+test("gate1: isValidE164 rejects malformed numbers", () => {
+  for (const p of ["5550101234", "+0123456789", "+1", "+1-555-010-1234", "+15550101234x", "", "  ", "tel:+15550101234", null as any, undefined as any]) {
+    assert.equal(isValidE164(p), false, `expected reject: ${String(p)}`);
+  }
+});
+
+test("gate1: runEscalation blocks a non-E.164 number and never dials it", async () => {
+  let dialed = 0;
+  const res = await runEscalation(baseOpts({
+    contactChain: [{ role: "trainer", phone_e164: "5550101234", order: 1 }],
+    _placeCall: async () => { dialed++; return {} as AckResult; },
+  }));
+  assert.equal(dialed, 0);
+  assert.equal(res.attempts[0].blocked, true);
+  assert.match(res.attempts[0].notes, /not a valid E\.164/);
+});
+
+// ---------------- Gate 2 — live-enable + confirmation ----------------
+test("gate2: liveCallAllowed requires BOTH env opt-in AND confirmation", () => {
+  assert.equal(liveCallAllowed({ CALLE_LIVE: "1" }, true), true);
+  assert.equal(liveCallAllowed({ CALLE_LIVE: "1" }, false), false);
+  assert.equal(liveCallAllowed({}, true), false);
+  assert.equal(liveCallAllowed({ CALLE_LIVE: "0" }, true), false);
+  assert.equal(liveCallAllowed({}, false), false);
+});
+
+test("gate2: default is dry-run — no env, no confirm → nothing dialed (real placeCall, no spawn)", async () => {
+  // Uses the REAL placeCall (no _placeCall stub). With live disabled it short-circuits
+  // to a dry-run BEFORE spawning the calle CLI, so this test places no call.
+  const res = await runEscalation({
+    alert: ALERT,
+    contactChain: [{ role: "trainer", phone_e164: "+15550101234", order: 1 }],
+    disclosure: DISCLOSURE,
+    isAllowlisted: () => true,
+    isAlertResolved: () => false,
+    notifyOwner: () => { throw new Error("dry-run must not notify owner"); },
+    // no confirmLiveCall, no env → dry-run
+    env: {} as NodeJS.ProcessEnv,
+  });
+  assert.equal(res.outcome, "dry_run");
+  assert.equal(res.attempts[0].dry_run, true);
+  assert.ok(res.attempts[0].idempotency_key);
+});
+
+test("gate2: env set but confirm missing → still dry-run", async () => {
+  const res = await runEscalation({
+    alert: ALERT,
+    contactChain: [{ role: "trainer", phone_e164: "+15550101234", order: 1 }],
+    disclosure: DISCLOSURE,
+    isAllowlisted: () => true,
+    isAlertResolved: () => false,
+    notifyOwner: () => {},
+    env: { CALLE_LIVE: "1" } as NodeJS.ProcessEnv,
+    confirmLiveCall: false,
+  });
+  assert.equal(res.outcome, "dry_run");
+  assert.equal(res.attempts[0].dry_run, true);
+});
+
+// ---------------- Gate 3 — stable idempotency ----------------
+test("gate3: idempotencyKey is deterministic for the same inputs", () => {
+  assert.equal(idempotencyKey("alert-1", "+15550101234", 1), idempotencyKey("alert-1", "+15550101234", 1));
+});
+
+test("gate3: idempotencyKey differs by alert, contact, and attempt", () => {
+  const a = idempotencyKey("alert-1", "+15550101234", 1);
+  assert.notEqual(a, idempotencyKey("alert-2", "+15550101234", 1));
+  assert.notEqual(a, idempotencyKey("alert-1", "+15550105678", 1));
+  assert.notEqual(a, idempotencyKey("alert-1", "+15550101234", 2));
+});
+
+// ---------------- Gate 4 — ambiguous-leg reconciliation ----------------
+test("gate4: an unresolved-ambiguous leg STOPS the chain (does not advance) and flags", async () => {
+  let dialed = 0;
+  let notified = 0;
+  const res = await runEscalation(baseOpts({
+    contactChain: [
+      { role: "trainer", phone_e164: "+15550101234", order: 1 },
+      { role: "physician", phone_e164: "+15550105678", order: 2 },
+    ],
+    notifyOwner: () => { notified++; },
+    _placeCall: async (_a, c) => {
+      dialed++;
+      return { reached: false, acknowledged: false, responder_role: c.role, action_taken: "", ambiguous: true, resolved: false, notes: "never terminal" };
+    },
+  }));
+  assert.equal(res.outcome, "unresolved");
+  assert.equal(dialed, 1, "must NOT advance to the second contact");
+  assert.equal(notified, 1, "must flag the owner");
+});
+
+// ---------------- Gate 5 — between-legs alert-status check ----------------
+test("gate5: alert already resolved out-of-band → halts before dialing", async () => {
+  let dialed = 0;
+  const res = await runEscalation(baseOpts({
+    isAlertResolved: () => true,
+    _placeCall: async () => { dialed++; return {} as AckResult; },
+  }));
+  assert.equal(res.outcome, "already_resolved");
+  assert.equal(dialed, 0);
+});
+
+test("gate5: resolved BETWEEN legs stops the chain mid-way", async () => {
+  let dialed = 0;
+  const resolvedAfter = { n: 0 };
+  const res = await runEscalation(baseOpts({
+    contactChain: [
+      { role: "trainer", phone_e164: "+15550101234", order: 1 },
+      { role: "physician", phone_e164: "+15550105678", order: 2 },
+    ],
+    isAlertResolved: () => { const done = resolvedAfter.n >= 1; resolvedAfter.n++; return done; }, // resolves before leg 2
+    _placeCall: async (_a, c) => { dialed++; return { reached: true, acknowledged: false, responder_role: c.role, action_taken: "", notes: "no ack" }; },
+  }));
+  assert.equal(dialed, 1, "second leg must be skipped once the alert is resolved");
+  assert.equal(res.outcome, "already_resolved");
+});
+
+// ---------------- Integration — happy path still acknowledges ----------------
+test("integration: a confident acknowledgment stops the chain with outcome=acknowledged", async () => {
+  const res = await runEscalation(baseOpts({
+    contactChain: [
+      { role: "trainer", phone_e164: "+15550101234", order: 1 },
+      { role: "physician", phone_e164: "+15550105678", order: 2 },
+    ],
+    _placeCall: async (_a, c) => interpretAck("COMPLETED", { outcome: okOutcome }, c.role),
+  }));
+  assert.equal(res.outcome, "acknowledged");
+  assert.equal(res.attempts.length, 1);
 });

--- a/skills/critical-alert-escalation/scripts/run_escalation.test.ts
+++ b/skills/critical-alert-escalation/scripts/run_escalation.test.ts
@@ -1,0 +1,31 @@
+// Tests for the acknowledgment evaluation — the core "fail toward escalation" rule.
+// Run: node --test --experimental-strip-types scripts/run_escalation.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { interpretAck } from "./run_escalation.ts";
+
+test("confident completion → acknowledged", () => {
+  const r = interpretAck("COMPLETED", { summary: "Got it, I'll hold him.", outcome: { task_completed: true, completion_confidence: { label: "high", score: 0.84 } } }, "trainer");
+  assert.equal(r.acknowledged, true);
+  assert.equal(r.reached, true);
+});
+
+test("low confidence → NOT acknowledged (fail toward escalation)", () => {
+  const r = interpretAck("COMPLETED", { summary: "Unclear response.", outcome: { task_completed: true, completion_confidence: { label: "low", score: 0.3 } } }, "trainer");
+  assert.equal(r.acknowledged, false);
+});
+
+test("no answer / voicemail / declined → NOT acknowledged", () => {
+  for (const s of ["NO_ANSWER", "VOICEMAIL", "BUSY", "DECLINED"]) {
+    assert.equal(interpretAck(s, {}, "trainer").acknowledged, false);
+  }
+});
+
+test("explicit acknowledged=false is respected", () => {
+  const r = interpretAck("COMPLETED", { acknowledged: false, reached: true, summary: "Refused." }, "physician");
+  assert.equal(r.acknowledged, false);
+});
+
+test("unavailable (CALL-E not reachable) → NOT acknowledged", () => {
+  assert.equal(interpretAck("unavailable", { note: "CALL-E not available" }, "trainer").acknowledged, false);
+});

--- a/skills/critical-alert-escalation/scripts/run_escalation.ts
+++ b/skills/critical-alert-escalation/scripts/run_escalation.ts
@@ -9,12 +9,27 @@
 // get_call_run MCP tools are reached only through the `calle` CLI here, never
 // exposed to the calling model. Auth is the CLI browser-login state (no API key).
 //
+// ENFORCED SAFETY GATES (not documentation — code):
+//   1. E.164 validation      — reject non ^\+[1-9]\d{1,14}$ numbers before dialing.
+//   2. Live-enable + confirm — default DRY-RUN. A live call needs BOTH the env
+//                              opt-in (CALLE_LIVE=1) AND an explicit confirmLiveCall.
+//                              Placing a live call is impossible without both.
+//   3. Stable idempotency    — deterministic key per (alertId, contact, attempt),
+//                              passed to plan_call/run_call so a retry can't double-dial.
+//   4. Ambiguous reconcile   — an ambiguous/non-terminal leg is re-polled to a terminal
+//                              state; if still unresolved, STOP + flag (never advance).
+//   5. Between-legs check     — before each leg, verify the alert isn't already
+//                              acknowledged/resolved out-of-band; if it is, halt.
+//   6. Authoritative ack only — acknowledged requires task_completed===true AND
+//                              confidence>=threshold AND evidence. A bare
+//                              acknowledged:true is NOT sufficient. Else -> escalate.
+//
 // This is a generic reference — wire your own alert source, contact chain, and
 // owner-notification. Numbers in examples are fictional.
 
 import { spawn } from "node:child_process";
 
-export type Alert = { title: string; detail: string; recommendation: string };
+export type Alert = { id: string; title: string; detail: string; recommendation: string };
 export type Contact = { role: string; phone_e164: string; order: number };
 
 export type AckResult = {
@@ -23,6 +38,12 @@ export type AckResult = {
   responder_role: string;
   action_taken: string;
   notes: string;
+  // gate metadata (present when a gate short-circuited or a leg was inconclusive)
+  blocked?: boolean;      // failed E.164 / allowlist / alert-status gate — not dialed
+  dry_run?: boolean;      // live calling disabled — previewed, not dialed (gate 2)
+  ambiguous?: boolean;    // no terminal outcome (gate 4)
+  resolved?: boolean;     // for an ambiguous leg: did reconciliation reach terminal?
+  idempotency_key?: string;
 };
 
 const ACK_SCHEMA = {
@@ -39,6 +60,39 @@ const ACK_SCHEMA = {
 
 // CALL-E's guide asks callers to identify their source/integration on every call.
 const CALLE_ENV = { CALLE_SOURCE: "skills_sh", CALLE_INTEGRATION: "skills_sh_skill", CALLE_INTEGRATION_VERSION: "0.1.0" };
+
+// ---------------------------------------------------------------------------
+// Gate 1 — E.164 validation.
+// ---------------------------------------------------------------------------
+export const E164_RE = /^\+[1-9]\d{1,14}$/;
+export function isValidE164(phone: unknown): boolean {
+  return typeof phone === "string" && E164_RE.test(phone.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2 — live-enable + confirmation. BOTH are required to place a live call:
+// the environment opt-in (CALLE_LIVE=1) and an explicit per-run confirmation.
+// Default is dry-run: without both, no call is ever spawned.
+// ---------------------------------------------------------------------------
+export const LIVE_ENV_FLAG = "CALLE_LIVE";
+export function liveCallAllowed(env: NodeJS.ProcessEnv, confirmLiveCall: boolean): boolean {
+  return env?.[LIVE_ENV_FLAG] === "1" && confirmLiveCall === true;
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3 — stable idempotency key per (alertId, contact, attempt). Deterministic:
+// the same inputs always produce the same key, so a retry of the same leg reuses it
+// and CALL-E can dedup instead of double-dialing.
+// ---------------------------------------------------------------------------
+export function idempotencyKey(alertId: string, phoneE164: string, attempt: number): string {
+  const safe = (s: string) => String(s).replace(/[^A-Za-z0-9+._-]/g, "_");
+  return `cae:${safe(alertId)}:${safe(phoneE164)}:${attempt}`;
+}
+
+// ---------------------------------------------------------------------------
+// Gate 6 — authoritative acknowledgment.
+// ---------------------------------------------------------------------------
+export const ACK_CONFIDENCE_THRESHOLD = 0.7;
 
 function calle(args: string[], timeoutMs = 180_000): Promise<any> {
   const [cmd, argv]: [string, string[]] =
@@ -67,28 +121,47 @@ function calle(args: string[], timeoutMs = 180_000): Promise<any> {
 }
 
 const TERMINAL = /(complete|completed|done|finished|ended|success|failed|error|no[_-]?answer|busy|cancel|reject|voicemail|declin|unavailable)/i;
+const NEGATIVE = /no[_-]?answer|voicemail|busy|expired|cancel|fail|error|unavailable|declin/i;
+
+function hasEvidence(outcome: any, result: any): boolean {
+  const ev = outcome?.evidence ?? result?.evidence;
+  if (Array.isArray(ev)) return ev.some((e) => String(e ?? "").trim().length > 0);
+  return typeof ev === "string" && ev.trim().length > 0;
+}
 
 /**
- * Map CALL-E's outcome envelope to a boolean ack. Acknowledged only on a confident
- * completion; a terminal negative status, low confidence, or an explicit
- * acknowledged=false all count as NOT acknowledged (fail toward escalation).
+ * Map CALL-E's outcome envelope to a boolean ack — AUTHORITATIVE ACK ONLY (gate 6).
+ * `acknowledged` is true ONLY when task_completed === true AND confidence meets the
+ * threshold AND there is evidence. A bare `acknowledged:true` in the payload is NOT
+ * sufficient and is ignored. A terminal negative status, low confidence, missing
+ * evidence, or task_completed !== true all count as NOT acknowledged (fail toward
+ * escalation).
  */
-export function interpretAck(status: string, result: any, role: string): AckResult {
+export function interpretAck(status: string, result: any, role: string, threshold = ACK_CONFIDENCE_THRESHOLD): AckResult {
   const s = String(status ?? "").toLowerCase();
   const notes = String(result?.summary ?? result?.notes ?? "");
-  const negative = /no[_-]?answer|voicemail|busy|expired|cancel|fail|error|unavailable|declin/.test(s);
-  if (negative) return { reached: /declin|reject/.test(s), acknowledged: false, responder_role: role, action_taken: "", notes: notes || s };
+  const negative = NEGATIVE.test(s);
+  if (negative) {
+    return { reached: /declin|reject/.test(s), acknowledged: false, responder_role: role, action_taken: "", notes: notes || s };
+  }
 
-  const explicit = result?.acknowledged;
-  const confidenceHigh = (result?.outcome?.completion_confidence?.label ?? "").toLowerCase() === "high"
-    || Number(result?.outcome?.completion_confidence?.score ?? 0) >= 0.7;
-  const taskCompleted = result?.outcome?.task_completed === true;
-  const acknowledged = typeof explicit === "boolean" ? explicit : taskCompleted && confidenceHigh;
+  const outcome = result?.outcome ?? {};
+  const taskCompleted = outcome?.task_completed === true;
+  const conf = outcome?.completion_confidence ?? outcome?.confidence ?? {};
+  const score = Number(conf?.score ?? (typeof conf === "number" ? conf : NaN));
+  const label = String(conf?.label ?? "").toLowerCase();
+  const confidenceOk = (Number.isFinite(score) && score >= threshold) || label === "high";
+  const evidence = hasEvidence(outcome, result);
+
+  // Bare `acknowledged:true` is deliberately NOT part of this decision.
+  const acknowledged = taskCompleted && confidenceOk && evidence;
+
+  const reached = typeof result?.reached === "boolean" ? result.reached : taskCompleted || acknowledged;
   return {
-    reached: acknowledged || true,
+    reached,
     acknowledged,
     responder_role: role,
-    action_taken: String(result?.action_taken ?? ""),
+    action_taken: String(result?.action_taken ?? outcome?.action_taken ?? ""),
     notes,
   };
 }
@@ -103,24 +176,68 @@ function goalFor(alert: Alert, role: string, disclosure: string): string {
   );
 }
 
-async function callOne(alert: Alert, c: Contact, disclosure: string, timezone: string): Promise<AckResult> {
-  const plan = await calle(["call", "plan", "--to-phone", c.phone_e164, "--goal", goalFor(alert, c.role, disclosure), "--timezone", timezone]);
+type LegConfig = { disclosure: string; timezone: string; live: boolean; attempt: number };
+
+/**
+ * Place and resolve ONE guarded call. Enforces gate 2 (never spawns unless `live`),
+ * gate 3 (idempotency key on plan + run), and gate 4 (poll + reconcile to terminal).
+ * Returns an AckResult; `ambiguous:true, resolved:false` means the outcome could not
+ * be resolved and the caller MUST stop rather than advance.
+ */
+async function placeCall(alert: Alert, c: Contact, cfg: LegConfig): Promise<AckResult> {
+  const key = idempotencyKey(alert.id, c.phone_e164, cfg.attempt);
+
+  // Gate 2: dry-run unless a live call is explicitly enabled. No spawn here.
+  if (!cfg.live) {
+    return {
+      reached: false, acknowledged: false, responder_role: c.role, action_taken: "",
+      dry_run: true, idempotency_key: key,
+      notes: `dry-run: live calling disabled (set ${LIVE_ENV_FLAG}=1 and pass confirmLiveCall). Would call ${c.role} ${c.phone_e164}.`,
+    };
+  }
+
+  const plan = await calle(["call", "plan", "--to-phone", c.phone_e164, "--goal", goalFor(alert, c.role, cfg.disclosure), "--timezone", cfg.timezone, "--idempotency-key", key]);
   const planId = plan.plan_id ?? plan.planId;
   const token = plan.confirm_token ?? plan.confirmToken;
-  if (!planId || !token) return { reached: false, acknowledged: false, responder_role: c.role, action_taken: "", notes: "plan_call did not return plan id + confirm token" };
+  if (!planId || !token) return { reached: false, acknowledged: false, responder_role: c.role, action_taken: "", idempotency_key: key, notes: "plan_call did not return plan id + confirm token" };
 
-  const run = await calle(["call", "run", "--plan-id", planId, "--confirm-token", token, "--timezone", timezone]);
+  const run = await calle(["call", "run", "--plan-id", planId, "--confirm-token", token, "--timezone", cfg.timezone, "--idempotency-key", key]);
   const runId = run.run_id ?? run.runId ?? run.id;
-  let status = run.status ?? "RUNNING";
+  let status = String(run.status ?? "RUNNING");
   let payload: any = run;
 
+  if (!runId) return { reached: false, acknowledged: false, responder_role: c.role, action_taken: "", idempotency_key: key, notes: "run_call did not return a run id" };
+
+  // Gate 4, part 1: poll get_call_run until terminal or the primary deadline.
   const deadline = Date.now() + 8 * 60_000;
-  while (runId && !TERMINAL.test(String(status)) && Date.now() < deadline) {
+  while (!TERMINAL.test(status) && Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 10_000));
-    payload = await calle(["call", "status", "--run-id", runId, "--timezone", timezone], 60_000);
-    status = payload.status ?? status;
+    payload = await calle(["call", "status", "--run-id", runId, "--timezone", cfg.timezone], 60_000);
+    status = String(payload.status ?? status);
   }
-  return interpretAck(status, payload.result ?? payload, c.role);
+
+  // Gate 4, part 2: if still not terminal, RECONCILE — a bounded set of extra polls
+  // to let an in-flight leg settle before we decide anything.
+  if (!TERMINAL.test(status)) {
+    for (let i = 0; i < 6 && !TERMINAL.test(status); i++) {
+      await new Promise((r) => setTimeout(r, 15_000));
+      payload = await calle(["call", "status", "--run-id", runId, "--timezone", cfg.timezone], 60_000);
+      status = String(payload.status ?? status);
+    }
+  }
+
+  // Still ambiguous after reconciliation → do NOT guess. Flag it and stop.
+  if (!TERMINAL.test(status)) {
+    return {
+      reached: false, acknowledged: false, responder_role: c.role, action_taken: "",
+      ambiguous: true, resolved: false, idempotency_key: key,
+      notes: `ambiguous: run ${runId} never reached a terminal state (last status: ${status}). Stopped for manual review.`,
+    };
+  }
+
+  const ack = interpretAck(status, payload.result ?? payload, c.role);
+  ack.idempotency_key = key;
+  return ack;
 }
 
 /** Guarded entry point: call the chain in order until acknowledged. */
@@ -130,21 +247,53 @@ export async function runEscalation(opts: {
   disclosure: string;
   timezone?: string;
   isAllowlisted: (phone: string) => boolean;
+  isAlertResolved: (alertId: string) => Promise<boolean> | boolean; // gate 5
   notifyOwner: (alert: Alert, attempts: AckResult[]) => Promise<void> | void;
-}): Promise<{ outcome: "acknowledged" | "unacknowledged"; attempts: AckResult[] }> {
+  confirmLiveCall?: boolean;             // gate 2 — explicit per-run confirmation
+  env?: NodeJS.ProcessEnv;               // gate 2 — env source (defaults to process.env)
+  _placeCall?: typeof placeCall;         // test seam; defaults to the guarded placeCall
+}): Promise<{ outcome: "acknowledged" | "unacknowledged" | "already_resolved" | "unresolved" | "dry_run"; attempts: AckResult[] }> {
   const tz = opts.timezone ?? "UTC";
+  const env = opts.env ?? process.env;
+  const live = liveCallAllowed(env, opts.confirmLiveCall === true); // gate 2
+  const doCall = opts._placeCall ?? placeCall;
   const chain = [...opts.contactChain].sort((a, b) => a.order - b.order);
   const attempts: AckResult[] = [];
 
+  let leg = 0;
   for (const c of chain) {
-    if (!opts.isAllowlisted(c.phone_e164)) {
-      attempts.push({ reached: false, acknowledged: false, responder_role: c.role, action_taken: "", notes: `blocked: ${c.phone_e164} not on allowlist` });
+    // Gate 5: before EACH leg, stop if the alert was acknowledged/resolved out-of-band.
+    if (await opts.isAlertResolved(opts.alert.id)) {
+      attempts.push({ reached: false, acknowledged: false, responder_role: c.role, action_taken: "", blocked: true, notes: "alert already acknowledged/resolved out-of-band — halting before dialing" });
+      return { outcome: "already_resolved", attempts };
+    }
+    // Gate 1: reject non-E.164 numbers before dialing.
+    if (!isValidE164(c.phone_e164)) {
+      attempts.push({ reached: false, acknowledged: false, responder_role: c.role, action_taken: "", blocked: true, notes: `blocked: "${c.phone_e164}" is not a valid E.164 number (^\\+[1-9]\\d{1,14}$)` });
       continue;
     }
-    const ack = await callOne(opts.alert, c, opts.disclosure, tz);
+    // Allowlist invariant.
+    if (!opts.isAllowlisted(c.phone_e164)) {
+      attempts.push({ reached: false, acknowledged: false, responder_role: c.role, action_taken: "", blocked: true, notes: `blocked: ${c.phone_e164} not on allowlist` });
+      continue;
+    }
+
+    leg += 1;
+    const ack = await doCall(opts.alert, c, { disclosure: opts.disclosure, timezone: tz, live, attempt: leg });
     attempts.push(ack);
+
     if (ack.acknowledged) return { outcome: "acknowledged", attempts };
+
+    // Gate 4: an unresolved-ambiguous leg halts the whole escalation and flags for
+    // review — we never advance the chain on an outcome we couldn't resolve.
+    if (ack.ambiguous && ack.resolved === false) {
+      await opts.notifyOwner(opts.alert, attempts);
+      return { outcome: "unresolved", attempts };
+    }
   }
+
+  // Gate 2: a dry-run never dials, never escalates — it's a safe preview of the chain.
+  if (!live) return { outcome: "dry_run", attempts };
 
   await opts.notifyOwner(opts.alert, attempts); // chain exhausted — escalate out of band
   return { outcome: "unacknowledged", attempts };

--- a/skills/critical-alert-escalation/scripts/run_escalation.ts
+++ b/skills/critical-alert-escalation/scripts/run_escalation.ts
@@ -1,0 +1,151 @@
+// Reference implementation of the critical-alert-escalation pattern.
+//
+// Given an alert, an ordered on-call contact chain, and an acknowledgment schema,
+// this places calls through CALL-E (plan_call -> run_call -> get_call_run) in chain
+// order until a human acknowledges, escalating on anything short of a confident
+// ack ("fail toward escalation"), and notifying the owner if the chain is exhausted.
+//
+// Single guarded entry point: `runEscalation`. The raw plan_call/run_call/
+// get_call_run MCP tools are reached only through the `calle` CLI here, never
+// exposed to the calling model. Auth is the CLI browser-login state (no API key).
+//
+// This is a generic reference — wire your own alert source, contact chain, and
+// owner-notification. Numbers in examples are fictional.
+
+import { spawn } from "node:child_process";
+
+export type Alert = { title: string; detail: string; recommendation: string };
+export type Contact = { role: string; phone_e164: string; order: number };
+
+export type AckResult = {
+  reached: boolean;
+  acknowledged: boolean;
+  responder_role: string;
+  action_taken: string;
+  notes: string;
+};
+
+const ACK_SCHEMA = {
+  type: "object",
+  properties: {
+    reached: { type: "boolean" },
+    acknowledged: { type: "boolean" },
+    responder_role: { type: "string" },
+    action_taken: { type: "string" },
+    notes: { type: "string" },
+  },
+  required: ["reached", "acknowledged"],
+} as const;
+
+// CALL-E's guide asks callers to identify their source/integration on every call.
+const CALLE_ENV = { CALLE_SOURCE: "skills_sh", CALLE_INTEGRATION: "skills_sh_skill", CALLE_INTEGRATION_VERSION: "0.1.0" };
+
+function calle(args: string[], timeoutMs = 180_000): Promise<any> {
+  const [cmd, argv]: [string, string[]] =
+    process.platform === "win32" ? ["cmd", ["/c", "calle", ...args, "--json"]] : ["calle", [...args, "--json"]];
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, argv, { env: { ...process.env, ...CALLE_ENV } });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    const t = setTimeout(() => { child.kill(); reject(new Error(`calle ${args.join(" ")} timed out`)); }, timeoutMs);
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(t);
+      if (code !== 0) return reject(new Error(`calle ${args.join(" ")} failed: ${err || out}`));
+      try {
+        const j = JSON.parse(out.slice(out.indexOf("{"), out.lastIndexOf("}") + 1));
+        // Unwrap the MCP content-text envelope if present.
+        const text = j?.result?.content?.find?.((c: any) => typeof c?.text === "string")?.text;
+        resolve(text ? JSON.parse(text) : j);
+      } catch (e) {
+        reject(new Error(`calle ${args.join(" ")} unparseable: ${out.slice(0, 200)}`));
+      }
+    });
+  });
+}
+
+const TERMINAL = /(complete|completed|done|finished|ended|success|failed|error|no[_-]?answer|busy|cancel|reject|voicemail|declin|unavailable)/i;
+
+/**
+ * Map CALL-E's outcome envelope to a boolean ack. Acknowledged only on a confident
+ * completion; a terminal negative status, low confidence, or an explicit
+ * acknowledged=false all count as NOT acknowledged (fail toward escalation).
+ */
+export function interpretAck(status: string, result: any, role: string): AckResult {
+  const s = String(status ?? "").toLowerCase();
+  const notes = String(result?.summary ?? result?.notes ?? "");
+  const negative = /no[_-]?answer|voicemail|busy|expired|cancel|fail|error|unavailable|declin/.test(s);
+  if (negative) return { reached: /declin|reject/.test(s), acknowledged: false, responder_role: role, action_taken: "", notes: notes || s };
+
+  const explicit = result?.acknowledged;
+  const confidenceHigh = (result?.outcome?.completion_confidence?.label ?? "").toLowerCase() === "high"
+    || Number(result?.outcome?.completion_confidence?.score ?? 0) >= 0.7;
+  const taskCompleted = result?.outcome?.task_completed === true;
+  const acknowledged = typeof explicit === "boolean" ? explicit : taskCompleted && confidenceHigh;
+  return {
+    reached: acknowledged || true,
+    acknowledged,
+    responder_role: role,
+    action_taken: String(result?.action_taken ?? ""),
+    notes,
+  };
+}
+
+function goalFor(alert: Alert, role: string, disclosure: string): string {
+  return (
+    `${disclosure} ${alert.title}. ${alert.detail}. Recommendation: ${alert.recommendation}. ` +
+    `This is a classification and recommendation, not a diagnosis or instruction. ` +
+    `Please confirm you have received this alert as the ${role}, and say what action you will take. ` +
+    `If you cannot take it, say so and it will be escalated to the next responder. ` +
+    `When the call concludes, return ONLY a JSON object matching: ${JSON.stringify(ACK_SCHEMA)}`
+  );
+}
+
+async function callOne(alert: Alert, c: Contact, disclosure: string, timezone: string): Promise<AckResult> {
+  const plan = await calle(["call", "plan", "--to-phone", c.phone_e164, "--goal", goalFor(alert, c.role, disclosure), "--timezone", timezone]);
+  const planId = plan.plan_id ?? plan.planId;
+  const token = plan.confirm_token ?? plan.confirmToken;
+  if (!planId || !token) return { reached: false, acknowledged: false, responder_role: c.role, action_taken: "", notes: "plan_call did not return plan id + confirm token" };
+
+  const run = await calle(["call", "run", "--plan-id", planId, "--confirm-token", token, "--timezone", timezone]);
+  const runId = run.run_id ?? run.runId ?? run.id;
+  let status = run.status ?? "RUNNING";
+  let payload: any = run;
+
+  const deadline = Date.now() + 8 * 60_000;
+  while (runId && !TERMINAL.test(String(status)) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10_000));
+    payload = await calle(["call", "status", "--run-id", runId, "--timezone", timezone], 60_000);
+    status = payload.status ?? status;
+  }
+  return interpretAck(status, payload.result ?? payload, c.role);
+}
+
+/** Guarded entry point: call the chain in order until acknowledged. */
+export async function runEscalation(opts: {
+  alert: Alert;
+  contactChain: Contact[];
+  disclosure: string;
+  timezone?: string;
+  isAllowlisted: (phone: string) => boolean;
+  notifyOwner: (alert: Alert, attempts: AckResult[]) => Promise<void> | void;
+}): Promise<{ outcome: "acknowledged" | "unacknowledged"; attempts: AckResult[] }> {
+  const tz = opts.timezone ?? "UTC";
+  const chain = [...opts.contactChain].sort((a, b) => a.order - b.order);
+  const attempts: AckResult[] = [];
+
+  for (const c of chain) {
+    if (!opts.isAllowlisted(c.phone_e164)) {
+      attempts.push({ reached: false, acknowledged: false, responder_role: c.role, action_taken: "", notes: `blocked: ${c.phone_e164} not on allowlist` });
+      continue;
+    }
+    const ack = await callOne(opts.alert, c, opts.disclosure, tz);
+    attempts.push(ack);
+    if (ack.acknowledged) return { outcome: "acknowledged", attempts };
+  }
+
+  await opts.notifyOwner(opts.alert, attempts); // chain exhausted — escalate out of band
+  return { outcome: "unacknowledged", attempts };
+}


### PR DESCRIPTION
## Summary

Adds **`critical-alert-escalation`** — an Agent Skill (`skills/`) that escalates a critical alert by phone until a human acknowledges. Given an alert, an ordered on-call contact chain, and an acknowledgment schema, it places calls through CALL-E (`plan_call` → `run_call` → `get_call_run`) in chain order, captures a structured verbal acknowledgment, and escalates to the next responder on anything short of a confident ack ("fail toward escalation") — notifying the owner if the chain is exhausted and logging every attempt.

It generalizes a common need (on-call/incident, safety, readiness alerts) that a screen notification can miss: PagerDuty-style escalation, over the phone. A production build (Vector Research Labs' "Readiness Escalation Line," on Strands + Bedrock AgentCore) is referenced.

Contents: `SKILL.md`, `references/safety.md`, `references/examples.md`, `references/acknowledgment-schema.json`, `references/reference-implementation.md`, a guarded reference `scripts/run_escalation.ts`, and `scripts/run_escalation.test.ts` (no-call unit tests for the ack evaluation).

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
