### PR TITLE
feat(candidate-availability-call): add recruiting availability skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Skills
 
 - [`accesscall`](skills/accesscall/) - Phone-based accessibility intake for VPAT 2.4/Section 508 audits. Run `npm install` in `skills/accesscall/` before using `scripts/format-to-vpat.js`, or it fails with `Cannot find module 'jszip'`.
+- [`candidate-availability-call`](skills/candidate-availability-call/) - Recruiting coordination skill that confirms candidate interview availability by phone, returns evidence-backed time windows, and leaves scheduling commitments to a human.
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
 - [`customer-onboarding-call`](skills/customer-onboarding-call/) - Welcome-call skill that turns a new signup into at most one conversation, a consent-gated structured result, and a CRM follow-up task, with evidence-backed dispositions, ordered outcome classification, per-attempt idempotency, and cancellable retries.
 - [`deployment-approval-call`](skills/deployment-approval-call/) - Spoken, code-verified human approval before an agent or pipeline does something irreversible.

--- a/skills/candidate-availability-call/SKILL.md
+++ b/skills/candidate-availability-call/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: candidate-availability-call
+description: Recruiting coordination phone-call skill that confirms candidate interview availability, captures evidence-backed time windows, and keeps final scheduling under human control.
+license: MIT
+---
+# Candidate Availability Call
+
+Use this skill when a recruiter, hiring coordinator, founder, or talent team has explicit authority to place one disclosed phone call to a candidate for interview availability. The call asks for available time windows, confirms timezone and constraints, and records whether the candidate consents to follow-up through phone, SMS, or email.
+
+This skill does not book, reschedule, cancel, or confirm an interview. It returns a structured availability result for a human coordinator to review before any calendar invite or ATS update is sent.
+
+## When To Use
+
+Use this skill for:
+
+- confirming 2-3 candidate interview availability windows
+- clarifying candidate timezone and scheduling constraints
+- asking whether the candidate prefers phone, SMS, or email follow-up
+- leaving a short voicemail that asks the candidate to reply through an approved channel
+- creating an evidence-backed disposition for a recruiting coordinator
+
+## When Not To Use
+
+Do not use this skill to:
+
+- screen the candidate or ask interview questions
+- discuss compensation, immigration, health, family status, disability, protected characteristics, or background-check topics
+- make employment promises or imply that an interview is already scheduled
+- call a candidate without authority from the recruiting team
+- call a private number that the user did not provide or authorize
+- place repeated retries, recurring calls, or hidden follow-ups
+- update calendars, ATS records, or CRM records without human review
+
+## Required Inputs
+
+- `request_id`: stable local request identifier
+- `candidate_name`: candidate name as provided by the recruiter
+- `to_phone_e164`: candidate phone number in E.164 format
+- `role_label`: role or interview label the candidate already knows
+- `company_name`: company or recruiting organization to disclose
+- `coordinator_name`: human coordinator responsible for the request
+- `authorized_contact_reason`: why this call is authorized
+- `interview_duration_minutes`: expected interview duration
+- `allowed_windows`: list of candidate-selectable windows the coordinator can support
+- `timezone`: IANA timezone to use when presenting windows
+- `followup_channels`: allowed follow-up channels, such as `phone`, `sms`, or `email`
+
+Optional inputs:
+
+- `voicemail_allowed`
+- `voicemail_message`
+- `language`
+- `region`
+- `candidate_context`
+- `do_not_discuss`
+
+## Preflight
+
+Before planning a call:
+
+1. Confirm the user explicitly authorized this one candidate availability call.
+2. Confirm the phone number is E.164 and was supplied by the recruiting workflow or candidate.
+3. Confirm the call purpose is availability coordination only.
+4. Confirm `allowed_windows` are real coordinator-supported options.
+5. Refuse compensation, screening, protected-class, legal, medical, or background-check questions.
+6. Prepare a dry-run preview before any CALL-E plan.
+
+## CALL-E Goal Template
+
+Use this as the CALL-E `--goal` body after filling the inputs:
+
+```text
+You are an AI phone assistant calling on behalf of {company_name}. Disclose that immediately and say that {coordinator_name} authorized this one scheduling-coordination call.
+
+Purpose: ask {candidate_name} about availability for {role_label}. This call is only for scheduling coordination. Do not interview, screen, discuss compensation, make employment promises, or confirm that an interview is booked.
+
+If the configured CALL-E workflow records or transcribes calls, disclose that before asking scheduling questions and say the transcript is used only to create a scheduling note for human review.
+
+Interview duration: {interview_duration_minutes} minutes.
+Timezone to use: {timezone}.
+Coordinator-supported windows:
+{allowed_windows}
+
+Ask:
+1. Which of these windows, if any, work for the candidate?
+2. What timezone should the coordinator use?
+3. Are there scheduling constraints the coordinator should know?
+4. Which allowed follow-up channel does the candidate prefer: {followup_channels}?
+5. Does the candidate consent to a follow-up through that channel about this interview scheduling request?
+
+If voicemail answers and voicemail is authorized, leave the approved voicemail message. If the candidate declines, is uncertain, or asks a question outside scheduling, thank them and mark the result for human review.
+
+Return a structured result with disposition, availability_windows, timezone_confirmed, constraints, preferred_followup_channel, consent_to_followup, voicemail_left, needs_human_review, and evidence. Do not infer availability or consent from silence.
+```
+
+## Structured Result
+
+```json
+{
+  "disposition": "available | unavailable | voicemail | no_answer | wrong_number | declined | needs_human_review",
+  "request_id": "string",
+  "candidate_name": "string",
+  "availability_windows": [
+    {
+      "start": "string",
+      "end": "string",
+      "timezone": "string",
+      "evidence": "string"
+    }
+  ],
+  "timezone_confirmed": "string",
+  "constraints": [
+    "string"
+  ],
+  "preferred_followup_channel": "phone | sms | email | none | unknown",
+  "consent_to_followup": "boolean; true only when the candidate explicitly consents",
+  "voicemail_left": false,
+  "needs_human_review": true,
+  "evidence": [
+    {
+      "claim": "string",
+      "transcript_span": "string"
+    }
+  ],
+  "do_not_rely_on": [
+    "string"
+  ],
+  "notes": "string"
+}
+```
+
+## Dry-Run Preview
+
+Run the local preview script before any live CALL-E action:
+
+```bash
+node scripts/validate-candidate-input.mjs assets/sample-candidate-request.json
+node scripts/preview-candidate-call.mjs assets/sample-candidate-request.json
+```
+
+The preview prints a masked phone number, a redacted CALL-E planning command, and the structured result schema. It does not place a call and does not contact CALL-E.
+
+## Live Planning
+
+Only after explicit user authorization and CALL-E authentication, copy the generated goal into a CALL-E planning command:
+
+```bash
+calle call plan --to-phone <E164_PHONE> --goal "<reviewed goal text>" --timezone America/New_York --language English --region US
+```
+
+Planning is not execution. Do not run `calle call start` or `calle call run` unless the user separately confirms the provider's plan details and confirmation token.
+
+## Human Gate
+
+A successful call result is not a scheduled interview. A human coordinator must review the transcript-backed availability windows, choose a time, send the calendar invite, and update any ATS or CRM system.
+
+## Cancellation And Idempotency
+
+Derive an idempotency key from `request_id`, candidate, role, and allowed windows. If the user cancels, mark the local request stopped and do not retry. If a call outcome is ambiguous, route to human review rather than calling again automatically.
+
+## Safety Notes
+
+Read `references/safety.md` before using live planning, and review `references/examples.md` for safe and unsafe examples.

--- a/skills/candidate-availability-call/assets/preview.example.json
+++ b/skills/candidate-availability-call/assets/preview.example.json
@@ -1,0 +1,50 @@
+{
+  "dry_run": true,
+  "would_place_call": false,
+  "request_id": "req-2026-10-06-001",
+  "candidate_name": "Jordan Lee",
+  "masked_to_phone": "+15******337",
+  "call_goal": "You are an AI phone assistant calling on behalf of Example Robotics. Disclose that immediately and say that Avery Chen authorized this one scheduling-coordination call.\n\nPurpose: ask Jordan Lee about availability for Product Engineer technical interview. This call is only for scheduling coordination. Do not interview, screen, discuss compensation, make employment promises, or confirm that an interview is booked.\n\nIf the configured CALL-E workflow records or transcribes calls, disclose that before asking scheduling questions and say the transcript is used only to create a scheduling note for human review.\n\nAuthorized contact reason: Jordan opted into phone coordination for this interview loop.\nInterview duration: 45 minutes.\nTimezone to use: America/New_York.\nCoordinator-supported windows:\n1. 2026-10-06T14:00:00-04:00 to 2026-10-06T17:00:00-04:00\n2. 2026-10-07T10:00:00-04:00 to 2026-10-07T12:00:00-04:00\n\nAsk:\n1. Which of these windows, if any, work for the candidate?\n2. What timezone should the coordinator use?\n3. Are there scheduling constraints the coordinator should know?\n4. Which allowed follow-up channel does the candidate prefer: email, sms?\n5. Does the candidate consent to a follow-up through that channel about this interview scheduling request?\n\nDo not discuss:\n- compensation\n- immigration\n- protected characteristics\n- technical screening\n\nIf voicemail answers, leave only this approved message: \"This is an AI phone assistant calling for Example Robotics about interview scheduling. Please reply to Avery's email with your availability.\"\n\nIf the candidate declines, is uncertain, or asks a question outside scheduling, thank them and mark the result for human review.\n\nReturn a structured result with disposition, availability_windows, timezone_confirmed, constraints, preferred_followup_channel, consent_to_followup, voicemail_left, needs_human_review, and evidence. Do not infer availability or consent from silence.",
+  "calle_cli_plan_command_preview": "calle call plan --to-phone '<E164_PHONE>' --goal 'You are an AI phone assistant calling on behalf of Example Robotics. Disclose that immediately and say that Avery Chen authorized this one scheduling-coordination call.\n\nPurpose: ask Jordan Lee about availability for Product Engineer technical interview. This call is only for scheduling coordination. Do not interview, screen, discuss compensation, make employment promises, or confirm that an interview is booked.\n\nIf the configured CALL-E workflow records or transcribes calls, disclose that before asking scheduling questions and say the transcript is used only to create a scheduling note for human review.\n\nAuthorized contact reason: Jordan opted into phone coordination for this interview loop.\nInterview duration: 45 minutes.\nTimezone to use: America/New_York.\nCoordinator-supported windows:\n1. 2026-10-06T14:00:00-04:00 to 2026-10-06T17:00:00-04:00\n2. 2026-10-07T10:00:00-04:00 to 2026-10-07T12:00:00-04:00\n\nAsk:\n1. Which of these windows, if any, work for the candidate?\n2. What timezone should the coordinator use?\n3. Are there scheduling constraints the coordinator should know?\n4. Which allowed follow-up channel does the candidate prefer: email, sms?\n5. Does the candidate consent to a follow-up through that channel about this interview scheduling request?\n\nDo not discuss:\n- compensation\n- immigration\n- protected characteristics\n- technical screening\n\nIf voicemail answers, leave only this approved message: \"This is an AI phone assistant calling for Example Robotics about interview scheduling. Please reply to Avery'\"'\"'s email with your availability.\"\n\nIf the candidate declines, is uncertain, or asks a question outside scheduling, thank them and mark the result for human review.\n\nReturn a structured result with disposition, availability_windows, timezone_confirmed, constraints, preferred_followup_channel, consent_to_followup, voicemail_left, needs_human_review, and evidence. Do not infer availability or consent from silence.' --timezone America/New_York --language English --region US",
+  "sensitive_command_note": "Dry-run output intentionally redacts --to-phone. Insert the reviewed E.164 number only at live planning time after explicit user authorization.",
+  "disposition_options": [
+    "available",
+    "unavailable",
+    "voicemail",
+    "no_answer",
+    "wrong_number",
+    "declined",
+    "needs_human_review"
+  ],
+  "expected_result_schema": {
+    "disposition": "available | unavailable | voicemail | no_answer | wrong_number | declined | needs_human_review",
+    "request_id": "string",
+    "candidate_name": "string",
+    "availability_windows": [
+      {
+        "start": "string",
+        "end": "string",
+        "timezone": "string",
+        "evidence": "string"
+      }
+    ],
+    "timezone_confirmed": "string",
+    "constraints": [
+      "string"
+    ],
+    "preferred_followup_channel": "phone | sms | email | none | unknown",
+    "consent_to_followup": "boolean; true only when the candidate explicitly consents",
+    "voicemail_left": false,
+    "needs_human_review": true,
+    "evidence": [
+      {
+        "claim": "string",
+        "transcript_span": "string"
+      }
+    ],
+    "do_not_rely_on": [
+      "string"
+    ],
+    "notes": "string"
+  }
+}

--- a/skills/candidate-availability-call/assets/sample-candidate-request.json
+++ b/skills/candidate-availability-call/assets/sample-candidate-request.json
@@ -1,0 +1,33 @@
+{
+  "request_id": "req-2026-10-06-001",
+  "candidate_name": "Jordan Lee",
+  "to_phone_e164": "+15550101337",
+  "role_label": "Product Engineer technical interview",
+  "company_name": "Example Robotics",
+  "coordinator_name": "Avery Chen",
+  "authorized_contact_reason": "Jordan opted into phone coordination for this interview loop.",
+  "interview_duration_minutes": 45,
+  "allowed_windows": [
+    {
+      "start": "2026-10-06T14:00:00-04:00",
+      "end": "2026-10-06T17:00:00-04:00"
+    },
+    {
+      "start": "2026-10-07T10:00:00-04:00",
+      "end": "2026-10-07T12:00:00-04:00"
+    }
+  ],
+  "timezone": "America/New_York",
+  "followup_channels": ["email", "sms"],
+  "voicemail_allowed": true,
+  "voicemail_message": "This is an AI phone assistant calling for Example Robotics about interview scheduling. Please reply to Avery's email with your availability.",
+  "language": "English",
+  "region": "US",
+  "candidate_context": "Fictional sample candidate for dry-run demonstration.",
+  "do_not_discuss": [
+    "compensation",
+    "immigration",
+    "protected characteristics",
+    "technical screening"
+  ]
+}

--- a/skills/candidate-availability-call/references/examples.md
+++ b/skills/candidate-availability-call/references/examples.md
@@ -1,0 +1,76 @@
+# Candidate Availability Call Examples
+
+## Safe Request
+
+```json
+{
+  "request_id": "req-2026-10-06-001",
+  "candidate_name": "Jordan Lee",
+  "to_phone_e164": "+15550101337",
+  "role_label": "Product Engineer technical interview",
+  "company_name": "Example Robotics",
+  "coordinator_name": "Avery Chen",
+  "authorized_contact_reason": "Jordan opted into phone coordination for this interview loop.",
+  "interview_duration_minutes": 45,
+  "allowed_windows": [
+    {"start": "2026-10-06T14:00:00-04:00", "end": "2026-10-06T17:00:00-04:00"},
+    {"start": "2026-10-07T10:00:00-04:00", "end": "2026-10-07T12:00:00-04:00"}
+  ],
+  "timezone": "America/New_York",
+  "followup_channels": ["email", "sms"],
+  "voicemail_allowed": true,
+  "voicemail_message": "This is an AI phone assistant calling for Example Robotics about interview scheduling. Please reply to Avery's email with your availability."
+}
+```
+
+Why it is safe:
+
+- the purpose is scheduling only
+- the call is authorized
+- the phone number is E.164
+- the candidate chooses from coordinator-supported windows
+- voicemail is explicit and limited
+- final scheduling remains human-controlled
+
+## Unsafe Request
+
+```json
+{
+  "candidate_name": "Jordan Lee",
+  "to_phone_e164": "+15550101337",
+  "role_label": "Engineering interview",
+  "company_name": "Example Robotics",
+  "permitted_questions": [
+    "Ask for salary expectations.",
+    "Ask whether they have children.",
+    "Ask whether they can legally work in the country without sponsorship.",
+    "Tell them the interview is confirmed for Tuesday."
+  ]
+}
+```
+
+Why it is unsafe:
+
+- it asks screening and protected-topic questions
+- it tries to confirm an interview without human review
+- it lacks explicit authority and allowed scheduling windows
+
+## Example Dry-Run Output Shape
+
+```json
+{
+  "dry_run": true,
+  "masked_to_phone": "+15******337",
+  "disposition_options": [
+    "available",
+    "unavailable",
+    "voicemail",
+    "no_answer",
+    "wrong_number",
+    "declined",
+    "needs_human_review"
+  ],
+  "calle_cli_plan_command_preview": "calle call plan --to-phone '<E164_PHONE>' --goal '<reviewed goal text>'",
+  "would_place_call": false
+}
+```

--- a/skills/candidate-availability-call/references/safety.md
+++ b/skills/candidate-availability-call/references/safety.md
@@ -1,0 +1,55 @@
+# Candidate Availability Call Safety
+
+Candidate availability calls affect real people and hiring processes. Keep the workflow narrow, disclosed, and reversible.
+
+## Disclosure
+
+The call must start with:
+
+- the caller is an AI phone assistant
+- the call is on behalf of the named company or coordinator
+- the call is only for interview availability coordination
+- the candidate can decline, ask for email follow-up, or stop the call
+- when recording or transcription is enabled by the configured provider workflow, the call may be recorded or transcribed into a scheduling note for human review
+
+Do not imply that the candidate is speaking with a recruiter or hiring manager directly.
+
+## Allowed Questions
+
+Allowed:
+
+- which coordinator-supported windows work
+- candidate timezone
+- scheduling constraints
+- preferred follow-up channel from the allowed list
+- consent for follow-up about this scheduling request
+
+Not allowed:
+
+- interview screening or scoring
+- compensation, benefits negotiation, or salary expectations
+- protected-class, immigration, disability, health, family, age, religion, race, or background-check topics
+- pressure to accept a time
+- claims that an interview is confirmed before a human sends the invite
+
+## Phone Numbers
+
+Use only E.164 numbers provided by the candidate, recruiter, ATS, or authorized intake. Mask phone numbers in logs and summaries. Use fictional reserved phone numbers in samples.
+
+## Voicemail
+
+Leave voicemail only when `voicemail_allowed` is true and an approved message is supplied. The voicemail must disclose the AI caller and give an approved callback or written follow-up route. Do not include sensitive recruiting details beyond the scheduling purpose.
+
+## Evidence
+
+Every availability window and consent claim must be backed by a transcript span. If a response is unclear, set `needs_human_review` to true and do not infer consent or availability.
+
+Store the minimum useful record: the structured scheduling result, evidence spans needed for review, and the call identifier if the recruiting team has a documented retention basis. Do not copy full transcripts into broad logs or summaries by default.
+
+## Human Review
+
+This skill never books, reschedules, cancels, rejects, advances, or evaluates a candidate. A human coordinator must make all calendar and ATS changes.
+
+## Retries
+
+No automatic repeated calls. If the result is no-answer, voicemail, ambiguous, or wrong number, the coordinator decides the next step.

--- a/skills/candidate-availability-call/scripts/preview-candidate-call.mjs
+++ b/skills/candidate-availability-call/scripts/preview-candidate-call.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import { loadCandidateRequest, maskPhone, validateCandidateRequest } from "./validate-candidate-input.mjs";
+
+function shellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function formatWindows(windows) {
+  return windows.map((window, index) => `${index + 1}. ${window.start} to ${window.end}`).join("\n");
+}
+
+function buildGoal(request) {
+  const channels = request.followup_channels.join(", ");
+  const voicemail = request.voicemail_allowed
+    ? `If voicemail answers, leave only this approved message: "${request.voicemail_message}"`
+    : "If voicemail answers, do not leave a message.";
+  const boundaries = Array.isArray(request.do_not_discuss) && request.do_not_discuss.length
+    ? request.do_not_discuss.map((item) => `- ${item}`).join("\n")
+    : "- screening\n- compensation\n- protected characteristics";
+
+  return `You are an AI phone assistant calling on behalf of ${request.company_name}. Disclose that immediately and say that ${request.coordinator_name} authorized this one scheduling-coordination call.
+
+Purpose: ask ${request.candidate_name} about availability for ${request.role_label}. This call is only for scheduling coordination. Do not interview, screen, discuss compensation, make employment promises, or confirm that an interview is booked.
+
+If the configured CALL-E workflow records or transcribes calls, disclose that before asking scheduling questions and say the transcript is used only to create a scheduling note for human review.
+
+Authorized contact reason: ${request.authorized_contact_reason}
+Interview duration: ${request.interview_duration_minutes} minutes.
+Timezone to use: ${request.timezone}.
+Coordinator-supported windows:
+${formatWindows(request.allowed_windows)}
+
+Ask:
+1. Which of these windows, if any, work for the candidate?
+2. What timezone should the coordinator use?
+3. Are there scheduling constraints the coordinator should know?
+4. Which allowed follow-up channel does the candidate prefer: ${channels}?
+5. Does the candidate consent to a follow-up through that channel about this interview scheduling request?
+
+Do not discuss:
+${boundaries}
+
+${voicemail}
+
+If the candidate declines, is uncertain, or asks a question outside scheduling, thank them and mark the result for human review.
+
+Return a structured result with disposition, availability_windows, timezone_confirmed, constraints, preferred_followup_channel, consent_to_followup, voicemail_left, needs_human_review, and evidence. Do not infer availability or consent from silence.`;
+}
+
+function buildPreview(request) {
+  const goal = buildGoal(request);
+  const previewArgs = ["calle", "call", "plan", "--to-phone", "<E164_PHONE>", "--goal", goal];
+  if (request.timezone) previewArgs.push("--timezone", request.timezone);
+  if (request.language) previewArgs.push("--language", request.language);
+  if (request.region) previewArgs.push("--region", request.region);
+
+  return {
+    dry_run: true,
+    would_place_call: false,
+    request_id: request.request_id,
+    candidate_name: request.candidate_name,
+    masked_to_phone: maskPhone(request.to_phone_e164),
+    call_goal: goal,
+    calle_cli_plan_command_preview: previewArgs.map(shellQuote).join(" "),
+    sensitive_command_note: "Dry-run output intentionally redacts --to-phone. Insert the reviewed E.164 number only at live planning time after explicit user authorization.",
+    disposition_options: [
+      "available",
+      "unavailable",
+      "voicemail",
+      "no_answer",
+      "wrong_number",
+      "declined",
+      "needs_human_review"
+    ],
+    expected_result_schema: {
+      disposition: "available | unavailable | voicemail | no_answer | wrong_number | declined | needs_human_review",
+      request_id: "string",
+      candidate_name: "string",
+      availability_windows: [
+        {
+          start: "string",
+          end: "string",
+          timezone: "string",
+          evidence: "string"
+        }
+      ],
+      timezone_confirmed: "string",
+      constraints: ["string"],
+      preferred_followup_channel: "phone | sms | email | none | unknown",
+      consent_to_followup: "boolean; true only when the candidate explicitly consents",
+      voicemail_left: false,
+      needs_human_review: true,
+      evidence: [
+        {
+          claim: "string",
+          transcript_span: "string"
+        }
+      ],
+      do_not_rely_on: ["string"],
+      notes: "string"
+    }
+  };
+}
+
+const args = process.argv.slice(2);
+const inputPath = args[0];
+const outputFlagIndex = args.indexOf("--output");
+const outputPath = outputFlagIndex >= 0 ? args[outputFlagIndex + 1] : undefined;
+
+if (!inputPath) {
+  console.error("Usage: node scripts/preview-candidate-call.mjs assets/sample-candidate-request.json [--output preview.json]");
+  process.exit(2);
+}
+
+const request = loadCandidateRequest(inputPath);
+const validation = validateCandidateRequest(request);
+if (!validation.valid) {
+  console.error(JSON.stringify(validation, null, 2));
+  process.exit(1);
+}
+
+const preview = buildPreview(request);
+const output = JSON.stringify(preview, null, 2);
+if (outputPath) {
+  writeFileSync(outputPath, `${output}\n`, "utf8");
+} else {
+  console.log(output);
+}

--- a/skills/candidate-availability-call/scripts/validate-candidate-input.mjs
+++ b/skills/candidate-availability-call/scripts/validate-candidate-input.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const REQUIRED_FIELDS = [
+  "request_id",
+  "candidate_name",
+  "to_phone_e164",
+  "role_label",
+  "company_name",
+  "coordinator_name",
+  "authorized_contact_reason",
+  "interview_duration_minutes",
+  "allowed_windows",
+  "timezone",
+  "followup_channels"
+];
+
+const E164_RE = /^\+[1-9]\d{7,14}$/;
+const BANNED_TEXT_RE = /\b(salary|compensation|benefits|visa|immigration|sponsor|sponsorship|age|children|pregnant|religion|race|disability|medical|health|background check|criminal|arrest|married)\b/i;
+
+function isValidTimeZone(timeZone) {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function loadCandidateRequest(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function validateCandidateRequest(request) {
+  const errors = [];
+  for (const field of REQUIRED_FIELDS) {
+    if (request[field] === undefined || request[field] === null || request[field] === "") {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  if (request.to_phone_e164 && !E164_RE.test(String(request.to_phone_e164))) {
+    errors.push("to_phone_e164 must be E.164, for example +15550101337");
+  }
+
+  if (!Number.isInteger(request.interview_duration_minutes) || request.interview_duration_minutes < 5 || request.interview_duration_minutes > 240) {
+    errors.push("interview_duration_minutes must be an integer between 5 and 240");
+  }
+
+  if (!Array.isArray(request.allowed_windows) || request.allowed_windows.length === 0) {
+    errors.push("allowed_windows must be a non-empty array");
+  } else {
+    request.allowed_windows.forEach((window, index) => {
+      if (!window || typeof window !== "object" || !window.start || !window.end) {
+        errors.push(`allowed_windows[${index}] must include start and end`);
+        return;
+      }
+      const start = Date.parse(window.start);
+      const end = Date.parse(window.end);
+      if (Number.isNaN(start) || Number.isNaN(end)) {
+        errors.push(`allowed_windows[${index}] start/end must be parseable dates`);
+      } else if (end <= start) {
+        errors.push(`allowed_windows[${index}] end must be after start`);
+      }
+    });
+  }
+
+  if (!Array.isArray(request.followup_channels) || request.followup_channels.length === 0) {
+    errors.push("followup_channels must be a non-empty array");
+  } else {
+    const allowed = new Set(["phone", "sms", "email"]);
+    for (const channel of request.followup_channels) {
+      if (!allowed.has(channel)) {
+        errors.push(`Unsupported followup channel: ${channel}`);
+      }
+    }
+  }
+
+  if (request.voicemail_allowed && !request.voicemail_message) {
+    errors.push("voicemail_message is required when voicemail_allowed is true");
+  }
+
+  if (request.timezone && !isValidTimeZone(String(request.timezone))) {
+    errors.push("timezone must be a valid IANA timezone, for example America/New_York");
+  }
+
+  const textFields = [
+    request.authorized_contact_reason,
+    request.candidate_context,
+    request.voicemail_message
+  ].filter(Boolean).join(" ");
+
+  if (BANNED_TEXT_RE.test(textFields)) {
+    errors.push("Request text appears to include sensitive recruiting topics; keep the call to availability coordination only");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors
+  };
+}
+
+export function maskPhone(phone) {
+  const text = String(phone);
+  if (text.length <= 6) return "***";
+  return `${text.slice(0, 3)}${"*".repeat(Math.max(3, text.length - 6))}${text.slice(-3)}`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("Usage: node scripts/validate-candidate-input.mjs assets/sample-candidate-request.json");
+    process.exit(2);
+  }
+
+  const request = loadCandidateRequest(path);
+  const result = validateCandidateRequest(request);
+  const summary = {
+    ...result,
+    request_id: request.request_id,
+    candidate_name: request.candidate_name,
+    masked_to_phone: request.to_phone_e164 ? maskPhone(request.to_phone_e164) : undefined,
+    allowed_window_count: Array.isArray(request.allowed_windows) ? request.allowed_windows.length : 0
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  process.exit(result.valid ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

Adds `candidate-availability-call`, a recruiting coordination Agent Skill for confirming candidate interview availability by phone. The skill is dry-run first, asks only scheduling questions, returns evidence-backed availability windows, and keeps final calendar or ATS changes behind human review.

## What Changed

- Adds `skills/candidate-availability-call/SKILL.md`.
- Adds safety guidance in `references/safety.md`.
- Adds safe and unsafe examples in `references/examples.md`.
- Adds a fictional sample request in `assets/sample-candidate-request.json`.
- Adds a no-call preview output in `assets/preview.example.json`.
- Adds no-network Node scripts for input validation and dry-run preview.
- Adds the skill to the README Skills list.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Validation

```bash
node skills/candidate-availability-call/scripts/validate-candidate-input.mjs skills/candidate-availability-call/assets/sample-candidate-request.json
node skills/candidate-availability-call/scripts/preview-candidate-call.mjs skills/candidate-availability-call/assets/sample-candidate-request.json --output skills/candidate-availability-call/assets/preview.example.json
C:\Users\47453\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe scripts\validate_repository.py
```

All commands pass locally. The Python command uses the local bundled Python runtime because this Windows environment does not expose `python3` on PATH.

## Safety Notes

- No live CALL-E calls are placed by the scripts.
- The sample uses a fictional reserved phone number.
- Dry-run command previews redact `--to-phone`.
- The skill refuses screening, compensation, protected-topic, and background-check questions.
- Consent is represented neutrally and is true only when explicitly stated.
- Recording/transcription disclosure and minimal retention are documented when applicable.
- Interview booking, cancellation, rescheduling, calendar invites, and ATS updates remain human-controlled.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior or are not recurring workflows.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes; validated locally with the bundled Python runtime.
