### PR TITLE
docs: add SchemaRelay to apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Apps
 
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
+- [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.
 


### PR DESCRIPTION
## Summary

Add SchemaRelay to the Apps list. SchemaRelay uses consent-gated CALL-E owner interviews to turn data schema-change questions into human-review evidence packets, and defaults to a no-call dry run.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional. (No phone numbers are included in this change.)
- [x] Recurring workflows include cancellation behavior. (Not applicable; this entry is not a recurring workflow.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.