### PR TITLE
fix(accesscall): use synthetic contact examples

### DIFF
--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -32,6 +32,18 @@ CLI_REFERENCE_SENTENCE = "CALL-E CLI parameters and command flags are documented
 TEXT_SUFFIXES = {".md", ".mjs", ".py", ".ts", ".json", ".toml", ".yaml", ".yml"}
 SKIP_TEXT_FILES = {"uv.lock"}
 SKIP_TEXT_DIRS = {".venv", "node_modules", ".pytest_cache", "__pycache__", ".mypy_cache", ".ruff_cache"}
+EMAIL_ADDRESS_RE = re.compile(
+    r"(?<![A-Za-z0-9.!#$%&'*+/=?^_`{|}~-])"
+    r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+    r"(?P<domain>[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+)"
+    r"(?![A-Za-z0-9-])"
+)
+ALLOWED_SKILL_EXAMPLE_EMAIL_DOMAINS = {
+    "example.com",
+    "example.net",
+    "example.org",
+}
 OUTBOUND_CALL_SKILL_CHECKER = ROOT / "skills" / "outbound-call-skill-creator" / "scripts" / "check-generated-skill.mjs"
 OUTBOUND_MCP_ROUTE = "https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth"
 OUTBOUND_SOURCE_FAMILY_README_TERMS = {
@@ -164,6 +176,112 @@ def iter_skill_dirs() -> list[Path]:
     if not skill_dirs:
         fail("No skills found in skills/.")
     return skill_dirs
+
+
+def find_disallowed_email_locations(text: str) -> list[tuple[int, int]]:
+    """Return line and column locations without retaining matched addresses."""
+    locations: list[tuple[int, int]] = []
+    for match in EMAIL_ADDRESS_RE.finditer(text):
+        domain = match.group("domain")
+        top_level_label = domain.rsplit(".", 1)[-1]
+        if not any(character.isalpha() for character in top_level_label):
+            continue
+        if domain.casefold() in ALLOWED_SKILL_EXAMPLE_EMAIL_DOMAINS:
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        previous_newline = text.rfind("\n", 0, match.start())
+        column = match.start() - previous_newline
+        locations.append((line, column))
+    return locations
+
+
+def iter_skill_example_and_script_text_files() -> list[tuple[Path, str]]:
+    files: list[tuple[Path, str]] = []
+    for skill_dir in iter_skill_dirs():
+        examples_path = skill_dir / "references" / "examples.md"
+        files.append((examples_path, read(examples_path)))
+
+        scripts_dir = skill_dir / "scripts"
+        if not scripts_dir.is_dir():
+            continue
+        for path in sorted(candidate for candidate in scripts_dir.rglob("*") if candidate.is_file()):
+            relative_parts = path.relative_to(scripts_dir).parts
+            if path.is_symlink() or any(part in SKIP_TEXT_DIRS for part in relative_parts):
+                continue
+            if path.name in SKIP_TEXT_FILES:
+                continue
+            try:
+                data = path.read_bytes()
+            except OSError:
+                fail(f"Could not read skill script: {path.relative_to(ROOT)}")
+            if b"\0" in data:
+                continue
+            try:
+                text = data.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            files.append((path, text))
+    return files
+
+
+def format_disallowed_email_failure(
+    locations: list[tuple[Path, int, int]],
+) -> str:
+    rendered_locations = "\n".join(
+        f"- {path.as_posix()}:{line}" for path, line, _column in locations
+    )
+    return (
+        "Non-example email address found in skill examples or scripts:\n"
+        f"{rendered_locations}\n"
+        "Skill examples and scripts may only use example.com, example.net, or example.org."
+    )
+
+
+def validate_skill_email_checker() -> None:
+    allowed_text = "\n".join(
+        [
+            "contact@example.com",
+            "SUPPORT@EXAMPLE.NET",
+            "first.last+followup@example.org",
+            "Multiple addresses: one@example.com and two@example.net.",
+            "Package reference: @scope/package",
+            "Version marker: package@1.2.3",
+        ]
+    )
+    if find_disallowed_email_locations(allowed_text):
+        fail("Skill email checker rejected an allowed example domain.")
+
+    disallowed_domain = "example." + "invalid"
+    disallowed_address = "contact@" + disallowed_domain
+    disallowed_cases = [
+        disallowed_address,
+        "contact@" + "sub.example.com",
+        "contact@" + "example.test",
+        disallowed_address.upper(),
+        f"safe@example.com and {disallowed_address}",
+    ]
+    for case in disallowed_cases:
+        if not find_disallowed_email_locations(case):
+            fail("Skill email checker accepted a disallowed example domain.")
+
+    locations = find_disallowed_email_locations(f"Header\n{disallowed_address}\n")
+    if locations != [(2, 1)]:
+        fail("Skill email checker reported an incorrect location.")
+
+    message = format_disallowed_email_failure(
+        [(Path("skills/example/scripts/check.js"), 2, 1)]
+    )
+    if disallowed_address in message:
+        fail("Skill email checker failure message exposed a matched address.")
+
+
+def validate_skill_example_and_script_emails() -> None:
+    violations: list[tuple[Path, int, int]] = []
+    for path, text in iter_skill_example_and_script_text_files():
+        for line, column in find_disallowed_email_locations(text):
+            violations.append((path.relative_to(ROOT), line, column))
+    if violations:
+        fail(format_disallowed_email_failure(violations))
 
 
 def validate_readme() -> None:
@@ -9299,6 +9417,8 @@ Runtime parameters still allowed: date window and approved source instance ident
 
 def main() -> None:
     validate_expected_files()
+    validate_skill_email_checker()
+    validate_skill_example_and_script_emails()
     validate_readme()
     validate_repository_name_references()
     validate_english_only()

--- a/skills/accesscall/references/examples.md
+++ b/skills/accesscall/references/examples.md
@@ -2,7 +2,7 @@
 
 [#accesscall-examples](#accesscall-examples)
 
-Setup, validation, and behavior scenarios for the `accesscall` skill, based on real end-to-end test calls.
+Setup, validation, and behavior scenarios for the `accesscall` skill.
 
 ## Setup Verification
 
@@ -37,19 +37,27 @@ Parsed result validates cleanly against `references/intake-result.schema.json`. 
 
 ## Scenario 2: Transcription error caught by contact confirmation
 
-[#scenario-2-transcription-error-caught](#scenario-2-transcription-error-caught)
+[#scenario-2-contact-confirmation](#scenario-2-contact-confirmation)
 
-Real test call transcript excerpt:
+This synthetic scenario demonstrates the required confirmation flow. The intended follow-up address is `contact@example.com`.
 
-```
-Bot: Please spell the email address letter by letter, including the domain.
-Caller: J-E-R-L-Y-N at D-E-S-I-G-N-L-A-D-Y dot com
-Bot: I heard an email starting with J-E-R-L-Y-N at A-T-D-E-S-I-G-N-L-A-D-Y dot com. Is that right?
-```
+Example exchange:
 
-The speech-to-text layer inserted a duplicate "at" into the domain. The bot's letter-by-letter read-back surfaced this for the caller to catch before the call ended, this is the confirmation mechanism working as designed.
+> **Bot:** Please spell your email address one character at a time.
+>
+> **Caller:** c-o-n-t-a-c-t at e-x-a-m-p-l-e dot c-o-m.
+>
+> **Bot:** I heard c-o-n-t-a-c-t-t at e-x-a-m-p-l-e dot c-o-m. Is that correct?
+>
+> **Caller:** No. It is c-o-n-t-a-c-t at e-x-a-m-p-l-e dot c-o-m.
+>
+> **Bot:** I heard c-o-n-t-a-c-t at e-x-a-m-p-l-e dot c-o-m. Is that correct?
+>
+> **Caller:** Yes, that is correct.
 
-**Known limitation, not a fix:** in one live test, the caller confirmed "correct" to a garbled domain without catching the error themselves. The mechanism prevents the bot from silently guessing wrong and moving on; it does not guarantee the human catches every error in a fast phone exchange. Document this to end users rather than presenting the mechanism as fully reliable.
+Set `followup_contact_confirmed: true` only after the caller explicitly confirms the final spell-back. Until then, keep it `false` and do not include the contact in a VPAT insertion.
+
+Letter-by-letter spell-back reduces transcription risk, but it does not guarantee that every address is captured correctly.
 
 ## Scenario 3: Ambiguous or unclear barrier category
 

--- a/skills/accesscall/scripts/redact-transcript.js
+++ b/skills/accesscall/scripts/redact-transcript.js
@@ -20,7 +20,7 @@
  *     order ID). That's an accepted tradeoff for a PII-redaction fallback --
  *     a missed real phone number is worse than an over-redacted non-number.
  *     Digit runs shorter than 7 (e.g. a bare 4-digit year) are left alone.
- *   - email addresses (e.g. "jerlyn@designlady.com" -> "[redacted email]")
+ *   - email addresses (e.g. "contact@example.com" -> "[redacted email]")
  *
  * KNOWN LIMITATION: this does not attempt to detect or redact spoken street
  * addresses. Unlike phone numbers and emails, mailing addresses have no


### PR DESCRIPTION
## Summary

- replace the AccessCall contact-confirmation and transcript-redaction examples with clearly synthetic reserved-domain data
- validate email addresses in every skill `references/examples.md` file and text-based skill script
- allow only `example.com`, `example.net`, and `example.org` in those examples and scripts
- report validation failures by file and line without echoing the matched address

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [x] Validation or tooling update

## Validation

- `python3 scripts/validate_repository.py`
- AccessCall transcript-redaction test with synthetic email addresses
- `python3 -m py_compile scripts/validate_repository.py`
- `git diff --check`
- branch-name validation

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. (Not applicable: this change adds no recurring workflow.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default. (The changed scripts do not place calls.)
- [x] `python3 scripts/validate_repository.py` passes.

Addresses #134
