### PR TITLE
feat(apps): add OdoSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Apps
 
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
+- [OdoSync](https://github.com/clinton-lynx/odo-sync) - Fleet-service reminder workbench that schedules 15-, 10-, and 5-day CALL-E calls, respects owner time windows, records structured outcomes, and supports a no-call dry-run.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.


### PR DESCRIPTION
## Summary

- add OdoSync to the community Apps list
- document its 15/10/5-day service reminders, preferred calling windows, structured outcomes, and no-call dry-run

OdoSync source and live demo:
- https://github.com/clinton-lynx/odo-sync
- https://odosync.vercel.app

## Validation

- `python3 scripts/validate_repository.py`
- `python3 scripts/check_branch_name.py --branch feat/add-odosync-app`
- `git diff --check`