### PR TITLE
feat(apps): add OpenGPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Apps
 
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
+- [OpenGPL](https://github.com/Arshgill01/opengpl) - Consent-first funeral price-survey workbench that calls only allowlisted recipients, qualifies phone observations against transcripts, and blocks contradictory CALL-E outcomes before human-reviewed export.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.


### PR DESCRIPTION
## What changed

Adds OpenGPL to the user-facing apps list.

OpenGPL is a Next.js funeral price-survey workbench built around CALL-E's
TypeScript SDK. Its default path is a no-call simulation. Live dispatch requires
a server-only API key, deployment-level number allowlist, recorded recipient
authorization, and exact operator confirmation.

## Why

Nonprofit funeral consumer advocates publish evidence that price surveys can
require repeated calls, email follow-up, and extensive volunteer review. OpenGPL
keeps phone observations separate from canonical General Price Lists, checks
structured results against transcript evidence, and routes uncertainty or
contradictory terminal outcomes to a human.

## User impact

The entry gives community users a runnable, deployed reference for a narrow
research workflow with explicit consent, dry-run fixtures, evidence gates, and
reviewer-approved export.

- Demo: https://opengpl.vercel.app
- Source and setup: https://github.com/Arshgill01/opengpl

## Validation

- `python3 scripts/validate_repository.py`
- OpenGPL: `npm run verify` (typecheck, 10 tests, production build)
- One owned, explicitly consenting number was exercised through the deployed
  CALL-E SDK path; the resulting contradictory terminal signals were blocked
  by the review gate rather than retried.
