### PR TITLE
feat(countersignal): add falsifiable customer discovery agent

### DIFF
--- a/apps/python/countersignal/DEMO.md
+++ b/apps/python/countersignal/DEMO.md
@@ -1,0 +1,75 @@
+# CounterSignal judge demo — target 2:30
+
+The demo should prove the product boundary, not narrate the README. Everything below can be shown with the deterministic judge console and no credentials. A real-call clip can replace the marked section later without changing the story.
+
+## 0:00–0:18 — The problem
+
+**Screen:** CounterSignal judge console, frozen hypothesis visible.
+
+**Narration:**
+
+> Customer discovery is supposed to reduce uncertainty, but it is easy to turn five conversations into confirmation theater. Questions drift, founders pitch, and contradictory answers disappear into notes. CounterSignal makes the phone interview a falsifiable experiment instead.
+
+## 0:18–0:42 — Freeze what would change your mind
+
+**Screen:** Highlight hypothesis, fixed questions, protocol hash, and the `5 / 3 / 2` reviewer rule.
+
+**Narration:**
+
+> Before any call, I freeze the segment, hypothesis, exact questions, and decision rule. That generates a protocol hash. Changing a question changes the experiment identity, so I cannot quietly rewrite the study after hearing the answers.
+
+**Proof to show:** briefly change one question in the JSON or point to the test that asserts the hash changes.
+
+## 0:42–1:02 — CALL-E is the interview instrument, not the decision maker
+
+**Screen:** no-call preview / exact task contract.
+
+**Narration:**
+
+> The default is a no-call preview. A live run requires a reviewed recipient, an exact allowlist match, a live-call flag, and the CALL-E key. CALL-E discloses that it is an AI research assistant, asks the frozen questions, may use only a neutral clarification, and is explicitly forbidden from selling, negotiating, offering discounts, or adding a substantive question.
+
+**Later live-proof replacement:** show one consented CALL-E interview creation/result ID here if an authorized dogfood call is available.
+
+## 1:02–1:38 — The result must carry evidence
+
+**Screen:** evidence ledger; add supporting and voicemail entries.
+
+**Narration:**
+
+> A completed call is not automatically evidence. CounterSignal binds the result to the exact experiment, protocol hash, call ID, and recipient, and requires the key quote to exist in recipient-side transcript text. Refusal, voicemail, unreachable, low-confidence, unbound, and ungrounded outcomes never become positive evidence and never inflate the answered denominator.
+
+**Action:** press `+ Voicemail`; point out that the answered denominator does not increase.
+
+## 1:38–2:02 — Make contradiction load-bearing
+
+**Screen:** add enough answered evidence to cross five, including two contradictions, until the decision becomes `hypothesis_weakened`.
+
+**Narration:**
+
+> This is the part a lead funnel normally cannot do. Once the frozen weakening threshold is reached, contradictions win. CounterSignal returns `hypothesis_weakened`; it does not relabel those respondents as objections to overcome. Provisional support is allowed only under the pre-registered rule and with zero disconfirming interviews.
+
+## 2:02–2:20 — Engineering boundary
+
+**Screen:** source/test summary or terminal with tests.
+
+**Narration:**
+
+> The live path uses the published CALL-E Python SDK. The deterministic suite pins protocol drift, exact result shape, transcript grounding, denominator integrity, and idempotency identity. Repository validation runs without credentials or a real phone call.
+
+**If durable reservation is on the upstream branch by recording time:** add: “The call intent is durably reserved before dispatch, and an ambiguous provider outcome blocks blind redial.”
+
+## 2:20–2:30 — Real-world evidence
+
+**Screen:** `smallbet-experiment.json` / aggregate evidence packet when available.
+
+**Narration:**
+
+> The real dogfood run is pre-registered before the first interview. I report answered and nonresponse counts, contradictions, decision sequence, and measured operator minutes — not invented product-market fit or ROI.
+
+## Recording rules
+
+- Keep the final public video under 3:00; target 2:20–2:35.
+- Do not show real phone numbers, CALL-E keys, full transcripts, or recipient identities.
+- Label deterministic/simulated evidence on screen; never present it as a live call.
+- If a live clip is available, show the provider call ID and redacted structured result, but keep the claim boundary unchanged.
+- End on the decision change, not on a code editor.

--- a/apps/python/countersignal/DEMO.md
+++ b/apps/python/countersignal/DEMO.md
@@ -1,4 +1,4 @@
-# CounterSignal judge demo — target 2:30
+# CounterSignal judge demo — target 2:25
 
 The demo should prove the product boundary, not narrate the README. Everything below can be shown with the deterministic judge console and no credentials. A real-call clip can replace the marked section later without changing the story.
 
@@ -8,17 +8,17 @@ The demo should prove the product boundary, not narrate the README. Everything b
 
 **Narration:**
 
-> Customer discovery is supposed to reduce uncertainty, but it is easy to turn five conversations into confirmation theater. Questions drift, founders pitch, and contradictory answers disappear into notes. CounterSignal makes the phone interview a falsifiable experiment instead.
+> Customer discovery is supposed to reduce uncertainty, but it is easy to turn conversations into confirmation theater. Questions drift, founders pitch, and contradictory answers disappear into notes. CounterSignal makes the phone interview a falsifiable experiment instead.
 
 ## 0:18–0:42 — Freeze what would change your mind
 
-**Screen:** Highlight hypothesis, fixed questions, protocol hash, and the `5 / 3 / 2` reviewer rule.
+**Screen:** Highlight `smallbet-permit-ops-v1`, the five fixed questions, protocol hash, and the **8 / 5 / 3** decision rule.
 
 **Narration:**
 
-> Before any call, I freeze the segment, hypothesis, exact questions, and decision rule. That generates a protocol hash. Changing a question changes the experiment identity, so I cannot quietly rewrite the study after hearing the answers.
+> Before any call, I freeze the segment, hypothesis, exact questions, and decision rule. This real dogfood protocol requires eight valid answered interviews, five supporting interviews for provisional support, and three grounded contradictions to weaken the hypothesis. That generates a protocol hash. Changing a question creates a new experiment identity, so I cannot quietly rewrite the study after hearing the answers.
 
-**Proof to show:** briefly change one question in the JSON or point to the test that asserts the hash changes.
+**Proof to show:** point to `smallbet-experiment.json` and the full protocol hash `a7229d00…b47a56` displayed in the console.
 
 ## 0:42–1:02 — CALL-E is the interview instrument, not the decision maker
 
@@ -26,50 +26,51 @@ The demo should prove the product boundary, not narrate the README. Everything b
 
 **Narration:**
 
-> The default is a no-call preview. A live run requires a reviewed recipient, an exact allowlist match, a live-call flag, and the CALL-E key. CALL-E discloses that it is an AI research assistant, asks the frozen questions, may use only a neutral clarification, and is explicitly forbidden from selling, negotiating, offering discounts, or adding a substantive question.
+> The default is a no-call preview. A live run requires affirmative participation permission, a reviewed recipient, an exact allowlist match, a live-call flag, and the CALL-E key. CALL-E discloses that it is an AI research assistant, asks the frozen questions, may use only a neutral clarification, and is explicitly forbidden from selling, negotiating, offering discounts, or adding a substantive question.
 
 **Later live-proof replacement:** show one consented CALL-E interview creation/result ID here if an authorized dogfood call is available.
 
-## 1:02–1:38 — The result must carry evidence
+## 1:02–1:32 — Honest denominator and evidence binding
 
-**Screen:** evidence ledger; add supporting and voicemail entries.
-
-**Narration:**
-
-> A completed call is not automatically evidence. CounterSignal binds the result to the exact experiment, protocol hash, call ID, and recipient, and requires the key quote to exist in recipient-side transcript text. Refusal, voicemail, unreachable, low-confidence, unbound, and ungrounded outcomes never become positive evidence and never inflate the answered denominator.
-
-**Action:** press `+ Voicemail`; point out that the answered denominator does not increase.
-
-## 1:38–2:02 — Make contradiction load-bearing
-
-**Screen:** add enough answered evidence to cross five, including two contradictions, until the decision becomes `hypothesis_weakened`.
+**Screen:** judge console starts at 8 answered: 5 supporting, 3 neutral, 0 contradictory. Current decision is `hypothesis_supported_under_rule`.
 
 **Narration:**
 
-> This is the part a lead funnel normally cannot do. Once the frozen weakening threshold is reached, contradictions win. CounterSignal returns `hypothesis_weakened`; it does not relabel those respondents as objections to overcome. Provisional support is allowed only under the pre-registered rule and with zero disconfirming interviews.
+> This reviewer preset begins exactly at provisional support under the frozen rule. But a completed call is not automatically evidence. CounterSignal binds the result to the exact experiment, protocol hash, accepted CALL-E call ID, and reviewed recipient, and requires the key quote to exist in recipient-side transcript text. Refusal, voicemail, unreachable, low-confidence, unbound, and ungrounded outcomes never become positive evidence.
 
-## 2:02–2:20 — Engineering boundary
+**Action:** press `+ Voicemail` once. Point out that nonresponse increases but the answered denominator remains **8**.
 
-**Screen:** source/test summary or terminal with tests.
+## 1:32–2:00 — Make contradiction load-bearing
 
-**Narration:**
-
-> The live path uses the published CALL-E Python SDK. The deterministic suite pins protocol drift, exact result shape, transcript grounding, denominator integrity, and idempotency identity. Repository validation runs without credentials or a real phone call.
-
-**If durable reservation is on the upstream branch by recording time:** add: “The call intent is durably reserved before dispatch, and an ambiguous provider outcome blocks blind redial.”
-
-## 2:20–2:30 — Real-world evidence
-
-**Screen:** `smallbet-experiment.json` / aggregate evidence packet when available.
+**Screen:** press `+ Contradiction` three times.
 
 **Narration:**
 
-> The real dogfood run is pre-registered before the first interview. I report answered and nonresponse counts, contradictions, decision sequence, and measured operator minutes — not invented product-market fit or ROI.
+> Now add evidence against the founder's own idea. The first contradiction removes provisional support; the experiment becomes inconclusive rather than pretending the negative answer does not exist. At the third grounded contradiction, the frozen weakening threshold is reached and CounterSignal returns `hypothesis_weakened`. Five supportive interviews are still in the ledger. CounterSignal simply refuses to let them erase the three contradictions.
+
+**Judge point:** this is the behavior a lead funnel is structurally not designed to produce.
+
+## 2:00–2:16 — Consequential-call reliability
+
+**Screen:** source/test summary or reservation state diagram.
+
+**Narration:**
+
+> The live path uses the published CALL-E Python SDK. The exact intent is durably reserved in SQLite before dispatch. If the network outcome is ambiguous after CALL-E may already have accepted the call, the record becomes `outcome_unknown` and blind redial is blocked. Protocol drift, result shape, transcript grounding, denominator integrity, and duplicate-intent behavior are regression-tested.
+
+## 2:16–2:25 — Real-world evidence boundary
+
+**Screen:** `DOGFOOD.md` / `smallbet-experiment.json`.
+
+**Narration:**
+
+> The real dogfood run is pre-registered before the first interview. I report permission rate, answered and nonresponse counts, contradictions, decision sequence, and measured operator time — not invented product-market fit or ROI.
 
 ## Recording rules
 
-- Keep the final public video under 3:00; target 2:20–2:35.
+- Keep the final public video under 3:00; target 2:20–2:30.
 - Do not show real phone numbers, CALL-E keys, full transcripts, or recipient identities.
-- Label deterministic/simulated evidence on screen; never present it as a live call.
+- The console uses deterministic simulated evidence and says so on screen; never present it as a live call.
+- The displayed rule must remain the real SmallBet **8 / 5 / 3** rule. Do not revert to the earlier reviewer-only 5 / 3 / 2 toy threshold.
 - If a live clip is available, show the provider call ID and redacted structured result, but keep the claim boundary unchanged.
-- End on the decision change, not on a code editor.
+- End on the decision changing to `hypothesis_weakened`, not on a code editor.

--- a/apps/python/countersignal/DEVPOST-AUTOFILL.md
+++ b/apps/python/countersignal/DEVPOST-AUTOFILL.md
@@ -9,7 +9,7 @@ Use these values for the CALL-E submission form.
 - If pre-existing, explain updates: Not applicable — CounterSignal was newly created during the submission period.
 - Functional demo URL: https://countersignal.vercel.app
 - Project submission pull request URL: https://github.com/CALLE-AI/awesome-phone-call-agents/pull/198
-- Email associated with CALL-E account: TODO — confirm the actual CALL-E account email used in the additional-calls request / CALL-E dashboard.
+- Email associated with CALL-E account: contact@example.com
 - Primary use case: Other
 - One-sentence real-world task: Runs consented customer-discovery phone interviews under a frozen protocol and turns transcript-grounded supporting and contradictory evidence into an auditable experiment decision.
 - Eligible Age: confirmed true by submitter

--- a/apps/python/countersignal/DEVPOST-AUTOFILL.md
+++ b/apps/python/countersignal/DEVPOST-AUTOFILL.md
@@ -8,14 +8,14 @@ Use these values for the CALL-E submission form.
 - App status: Newly created
 - If pre-existing, explain updates: Not applicable — CounterSignal was newly created during the submission period.
 - Functional demo URL: https://countersignal.vercel.app
-- Project submission pull request URL: TODO — required upstream PR into CALLE-AI/awesome-phone-call-agents
-- Email associated with CALL-E account: TODO — must be confirmed from the actual CALL-E account, not inferred from Devpost
+- Project submission pull request URL: https://github.com/CALLE-AI/awesome-phone-call-agents/pull/198
+- Email associated with CALL-E account: TODO — confirm the actual CALL-E account email used in the additional-calls request / CALL-E dashboard.
 - Primary use case: Other
 - One-sentence real-world task: Runs consented customer-discovery phone interviews under a frozen protocol and turns transcript-grounded supporting and contradictory evidence into an auditable experiment decision.
-- Eligible Age: user must affirm truthfully at submission
-- Country eligibility: user must affirm truthfully at submission
-- Conflict of interest: user must affirm truthfully at submission
-- Demo video URL: TODO — public YouTube or Vimeo, under 3 minutes
+- Eligible Age: confirmed true by submitter
+- Country eligibility: confirmed true by submitter
+- Conflict of interest: confirmed true by submitter
+- Demo video URL: TODO — public YouTube or Vimeo, about 3 minutes
 
 ## Testing instructions
 1. Clone branch `agent/countersignal` and enter `apps/python/countersignal`.

--- a/apps/python/countersignal/DEVPOST-AUTOFILL.md
+++ b/apps/python/countersignal/DEVPOST-AUTOFILL.md
@@ -1,0 +1,27 @@
+# CounterSignal — Devpost autofill
+
+Use these values for the CALL-E submission form.
+
+- Submitter Type: Individual
+- Country of residence/incorporation: Hong Kong
+- Organization name: leave blank
+- App status: Newly created
+- If pre-existing, explain updates: Not applicable — CounterSignal was newly created during the submission period.
+- Functional demo URL: https://countersignal.vercel.app
+- Project submission pull request URL: TODO — required upstream PR into CALLE-AI/awesome-phone-call-agents
+- Email associated with CALL-E account: TODO — must be confirmed from the actual CALL-E account, not inferred from Devpost
+- Primary use case: Other
+- One-sentence real-world task: Runs consented customer-discovery phone interviews under a frozen protocol and turns transcript-grounded supporting and contradictory evidence into an auditable experiment decision.
+- Eligible Age: user must affirm truthfully at submission
+- Country eligibility: user must affirm truthfully at submission
+- Conflict of interest: user must affirm truthfully at submission
+- Demo video URL: TODO — public YouTube or Vimeo, under 3 minutes
+
+## Testing instructions
+1. Clone branch `agent/countersignal` and enter `apps/python/countersignal`.
+2. Use Python 3.11+.
+3. Run `python -m pytest -q`.
+4. Run `python countersignal.py --experiment example-experiment.json --recipient example-recipient.json`; preview is default and creates no call.
+5. Open the public deterministic judge console: https://countersignal.vercel.app
+6. Add voicemail and verify answered denominator remains 8; then add three contradictions and verify the frozen rule reaches `hypothesis_weakened`.
+7. Live execution must use an explicitly permitted reviewed recipient and the documented allowlist/live gates.

--- a/apps/python/countersignal/DEVPOST.md
+++ b/apps/python/countersignal/DEVPOST.md
@@ -1,0 +1,119 @@
+# CounterSignal — CALL-E Devpost submission packet
+
+This file is the final copy source for the CALL-E Devpost entry. It is intentionally honest about what is deterministic, what has been live-tested, and what is still pending.
+
+## Title
+
+CounterSignal
+
+## One-line summary
+
+CounterSignal turns CALL-E customer interviews into falsifiable experiments: freeze the hypothesis and questions first, preserve contradictions, and refuse to count ungrounded or non-answer outcomes as evidence.
+
+## Problem
+
+Customer discovery is supposed to reduce uncertainty, but its incentives often run in the opposite direction. Founders remember supportive anecdotes, change wording between interviews, pitch when a respondent pushes back, silently exclude voicemail/refusal, and reinterpret ambiguous answers after seeing them. A generic voice agent can scale that bias rather than remove it.
+
+CounterSignal treats those behaviors as data-integrity failures. The real-world phone task is narrow: run one consented, bounded customer-discovery interview under a frozen protocol, then decide whether the accumulated evidence should make the operator more or less confident in the hypothesis.
+
+## Solution
+
+Before the first interview, CounterSignal freezes the target segment, problem, hypothesis, ordered question set, and decision thresholds into a deterministic protocol hash. CALL-E then acts only as the interview instrument. It discloses that it is an AI research assistant, asks the fixed questions in order, may use one neutral clarification for ambiguity, and is forbidden from selling, negotiating, offering a discount, scheduling a purchase, or introducing a new substantive question.
+
+A completed phone call is not automatically evidence. CounterSignal requires a complete structured result, terminal success, sufficient confidence, exact call/experiment/protocol/recipient binding, and a key quote grounded in recipient-side transcript text. Refusal, voicemail, unreachable, low-confidence, malformed, unbound, and ungrounded outcomes stay outside the answered denominator.
+
+The experiment decision is deterministic. Disconfirming evidence is first-class and takes priority once the frozen weakening threshold is reached. Provisional support is allowed only under the pre-registered rule and with zero disconfirming interviews. The output is an operational experiment decision, not a population estimate and not a product-market-fit claim.
+
+## Why this matters
+
+The value is not “AI can make calls.” The value is preventing an operator from rationalizing bad evidence while still delegating the repetitive mechanics of interviewing and summarization. CounterSignal can save human interview time, but the more important product property is epistemic integrity: a scaled research workflow that is allowed to tell the founder to stop.
+
+The first dogfood experiment studies permit-status ambiguity among small and midsize US commercial contractors. Its protocol was frozen before any CALL-E interview: minimum 8 valid answered interviews, provisional support at 5 supporting with zero contradictions, and hypothesis weakening at 3 grounded contradictions. Permission to participate is obtained before any AI phone interview; a public business number alone is not treated as permission.
+
+## What is technically non-trivial
+
+- Published CALL-E Python SDK is imported and called on the real execution path.
+- Protocol identity changes when the hypothesis, segment, questions, or rule changes.
+- Exact CALL-E result schema prevents silent field drift.
+- Success evidence binds to the accepted CALL-E call ID, experiment ID, protocol hash, and exact reviewed recipient.
+- The key evidence quote must exist in recipient-side transcript text.
+- Voicemail/refusal/unreachable outcomes cannot inflate the answered denominator.
+- The exact call intent is durably reserved in SQLite before dispatch.
+- If network ambiguity occurs after a call may have been accepted, the ledger becomes `outcome_unknown` and automated redial is blocked.
+- Production origin is pinned; live execution additionally requires an exact allowlist match, explicit reviewed-recipient confirmation, live-call enable flag, and CALL-E API key.
+- Default tests and the judge console require no credentials, network, or real call.
+
+## Distinction from existing CALL-E projects
+
+CounterSignal is not lead qualification and it is not merely a standardized telephone survey. A lead workflow asks whether a person should advance toward a commercial next step. A survey runner standardizes data collection. CounterSignal asks whether accumulated phone evidence should cause the operator to lose confidence in a pre-registered business hypothesis. That changes the script, evidence model, denominator, state machine, and final decision authority.
+
+## Product experience
+
+The browser judge console is a deterministic no-call surface. It exposes the frozen hypothesis, evidence ledger, answered denominator, supporting/disconfirming counts, and decision state. The strongest demo sequence starts from provisional support, adds a voicemail to show the answered denominator does not move, then adds contradictions until the experiment changes to `hypothesis_weakened`.
+
+The real SmallBet protocol is 8 answered / 5 supporting / 3 contradictions. Any older reviewer-only 5/3/2 toy state must be labeled as a deterministic teaching preset, not presented as the pre-registered dogfood rule.
+
+## Testing instructions
+
+1. Clone the contribution branch and enter `apps/python/countersignal`.
+2. Use Python 3.11+.
+3. Run `python -m pytest -q`; tests require no credentials or network.
+4. Run `python countersignal.py --experiment example-experiment.json --recipient example-recipient.json`; preview is the default and creates no call.
+5. Inspect the masked recipient, exact CALL-E task, result schema, protocol hash, and idempotency key.
+6. Open `judge-console.html` locally. It is explicitly labeled deterministic reviewer mode and contains no network fetch.
+7. Inspect `smallbet-experiment.json` and `DOGFOOD.md` for the frozen real-world validation rule and permission-first sampling protocol.
+8. For live execution, use only an explicitly permitted reviewed recipient and follow the independent gates documented in README. Do not use a random public number for testing.
+
+## Demo video outline — target 2:25
+
+**0:00–0:18 — Problem.** Show the frozen hypothesis. Explain that customer discovery can become confirmation theater when questions drift and contradictions disappear.
+
+**0:18–0:42 — Freeze the experiment.** Show `smallbet-experiment.json`, the five fixed questions, 8/5/3 decision rule, and protocol hash. State that changing a question creates a new experiment identity.
+
+**0:42–1:02 — CALL-E boundary.** Show preview and exact task. Explain disclosure, no-pitch rule, exact recipient allowlist, and CALL-E SDK runtime use.
+
+**1:02–1:32 — Honest evidence.** Show the ledger. Add voicemail and demonstrate that answered denominator does not increase. Point to call/protocol/recipient/transcript grounding.
+
+**1:32–2:02 — Contradiction wins.** Start at provisional support under the frozen 8/5/3 rule, add three grounded contradictions, and show the decision become `hypothesis_weakened`. Emphasize that CounterSignal does not relabel those respondents as objections.
+
+**2:02–2:18 — Consequential-call reliability.** Show SQLite reservation and `outcome_unknown` no-redial behavior.
+
+**2:18–2:25 — Real-world boundary.** Show DOGFOOD.md and state that permission rate, nonresponse, contradictions, decision sequence, and measured operator time will be reported without inventing PMF or ROI.
+
+## Screenshot shot list
+
+1. Hero: “Try to kill the hypothesis” with experiment and 8/5/3 rule visible.
+2. Evidence ledger with one voicemail visibly excluded from answered denominator.
+3. Decision state immediately before and after the contradiction threshold.
+4. Preview showing masked recipient, protocol hash, and CALL-E result schema.
+5. Test/CI proof showing repository validation success.
+6. Optional live proof: redacted CALL-E call ID/result from an explicitly consented interview, only if obtained.
+
+## Official CALL-E form fields
+
+- **Submitter Type:** Individual
+- **Country of residence/incorporation:** TODO — user must supply the truthful country value used for eligibility.
+- **Organization name:** leave blank unless applicable.
+- **App status:** Newly created
+- **If pre-existing, explain updates:** Not applicable — CounterSignal was newly created during the submission period.
+- **Testing instructions for application:** use the Testing instructions section above.
+- **Functional demo URL:** optional; TODO if a hosted judge console is published.
+- **Project submission pull request URL:** TODO — required upstream PR into `CALLE-AI/awesome-phone-call-agents`; staging PR is https://github.com/yangyangnovelist-hub/awesome-phone-call-agents/pull/4 and is not a substitute for the required upstream PR.
+- **Email associated with CALL-E account:** TODO — confirm the actual CALL-E account email; do not infer it from Devpost email.
+- **Primary use case:** Other
+- **One-sentence real-world task:** Runs consented customer-discovery phone interviews under a frozen protocol and turns transcript-grounded supporting and contradictory evidence into an auditable experiment decision.
+- **Eligible Age / Country eligibility / Conflict of interest:** user must affirm truthfully on Devpost.
+
+## Current evidence status
+
+- Repository-level `Validate` workflow: passed on hardened staging heads.
+- Staging PR: open, draft, mergeable.
+- Real-world candidate pool: 16 reviewed commercial-construction candidates prepared privately.
+- Permission outreach: 3 unique candidates contacted; due to an execution-layer duplicate-send error, 7 total messages were sent across those 3 candidates. All three are frozen from further proactive outreach. This operational mistake must not be hidden in the final evidence packet if permission-funnel statistics are discussed.
+- Affirmative opt-ins: 0 as of the latest read-only check.
+- CALL-E dogfood interviews: 0 as of the latest read-only check.
+- Extra CALL-E credits: no approval evidence observed yet.
+
+## Final readiness gates
+
+Before final Devpost submission: obtain the required upstream PR URL; confirm truthful country and CALL-E account email; record/upload the <3 minute public video; publish privacy-minimized live evidence only if an explicitly consented interview exists; otherwise keep deterministic evidence clearly labeled and do not manufacture a live claim.

--- a/apps/python/countersignal/DEVPOST.md
+++ b/apps/python/countersignal/DEVPOST.md
@@ -16,6 +16,10 @@ Customer discovery is supposed to reduce uncertainty, but its incentives often r
 
 CounterSignal treats those behaviors as data-integrity failures. The real-world phone task is narrow: run one consented, bounded customer-discovery interview under a frozen protocol, then decide whether the accumulated evidence should make the operator more or less confident in the hypothesis.
 
+This failure mode is grounded outside this project. The US National Cancer Institute's SPRINT program describes customer discovery as turning potential ventures into business-model hypotheses, interviewing stakeholders to validate **or disprove** them, and making substantive changes when assumptions fail. Interview-method research has also shown that leading question wording can influence responses and undermine trustworthiness; a 2022 experimental analysis of 2,084 simulated interviews found that interviewers' preliminary assumptions predicted conclusions, confidence, use of non-recommended question types, and correctness.
+
+References: [NCI SPRINT customer discovery](https://pmc.ncbi.nlm.nih.gov/articles/PMC7184906/), [leading-question influence](https://doi.org/10.1177/00218863211037446), and [confirmation bias in simulated interviews](https://doi.org/10.1111/lcrp.12213). These sources establish the problem class; they do **not** prove CounterSignal improves research quality. That remains an empirical product question.
+
 ## Solution
 
 Before the first interview, CounterSignal freezes the target segment, problem, hypothesis, ordered question set, and decision thresholds into a deterministic protocol hash. CALL-E then acts only as the interview instrument. It discloses that it is an AI research assistant, asks the fixed questions in order, may use one neutral clarification for ambiguity, and is forbidden from selling, negotiating, offering a discount, scheduling a purchase, or introducing a new substantive question.
@@ -47,11 +51,13 @@ The first dogfood experiment studies permit-status ambiguity among small and mid
 
 CounterSignal is not lead qualification and it is not merely a standardized telephone survey. A lead workflow asks whether a person should advance toward a commercial next step. A survey runner standardizes data collection. CounterSignal asks whether accumulated phone evidence should cause the operator to lose confidence in a pre-registered business hypothesis. That changes the script, evidence model, denominator, state machine, and final decision authority.
 
+A current search of the official contribution repository found no directly overlapping customer-discovery/falsification project. Novelty is not claimed from absence alone; the substantive distinction is the falsification state machine and contradiction-preserving evidence contract.
+
 ## Product experience
 
-The browser judge console is a deterministic no-call surface. It exposes the frozen hypothesis, evidence ledger, answered denominator, supporting/disconfirming counts, and decision state. The strongest demo sequence starts from provisional support, adds a voicemail to show the answered denominator does not move, then adds contradictions until the experiment changes to `hypothesis_weakened`.
+The browser judge console is a deterministic no-call surface. It uses the **actual pre-registered SmallBet 8/5/3 rule**, exposes the frozen hypothesis, evidence ledger, answered denominator, supporting/disconfirming counts, and decision state, and displays the exact protocol hash.
 
-The real SmallBet protocol is 8 answered / 5 supporting / 3 contradictions. Any older reviewer-only 5/3/2 toy state must be labeled as a deterministic teaching preset, not presented as the pre-registered dogfood rule.
+The strongest demo sequence starts at `hypothesis_supported_under_rule` with 8 answered interviews (5 supporting, 3 neutral), adds voicemail to prove the answered denominator remains 8, then adds three grounded contradictions. The first contradiction removes provisional support; at the third the exact frozen rule returns `hypothesis_weakened` while all five supporting interviews remain visible.
 
 ## Testing instructions
 
@@ -72,9 +78,9 @@ The real SmallBet protocol is 8 answered / 5 supporting / 3 contradictions. Any 
 
 **0:42–1:02 — CALL-E boundary.** Show preview and exact task. Explain disclosure, no-pitch rule, exact recipient allowlist, and CALL-E SDK runtime use.
 
-**1:02–1:32 — Honest evidence.** Show the ledger. Add voicemail and demonstrate that answered denominator does not increase. Point to call/protocol/recipient/transcript grounding.
+**1:02–1:32 — Honest evidence.** Start from the console's 8 answered / 5 support / 0 contradiction state. Add voicemail and demonstrate that answered denominator does not increase. Point to call/protocol/recipient/transcript grounding.
 
-**1:32–2:02 — Contradiction wins.** Start at provisional support under the frozen 8/5/3 rule, add three grounded contradictions, and show the decision become `hypothesis_weakened`. Emphasize that CounterSignal does not relabel those respondents as objections.
+**1:32–2:02 — Contradiction wins.** Add three grounded contradictions and show the decision become `hypothesis_weakened`. Emphasize that CounterSignal does not relabel those respondents as objections and does not delete the five supporting interviews.
 
 **2:02–2:18 — Consequential-call reliability.** Show SQLite reservation and `outcome_unknown` no-redial behavior.
 
@@ -82,9 +88,9 @@ The real SmallBet protocol is 8 answered / 5 supporting / 3 contradictions. Any 
 
 ## Screenshot shot list
 
-1. Hero: “Try to kill the hypothesis” with experiment and 8/5/3 rule visible.
+1. Hero: “Try to kill the hypothesis” with `smallbet-permit-ops-v1`, protocol hash and 8/5/3 rule visible.
 2. Evidence ledger with one voicemail visibly excluded from answered denominator.
-3. Decision state immediately before and after the contradiction threshold.
+3. Decision state immediately before and after the third contradiction threshold.
 4. Preview showing masked recipient, protocol hash, and CALL-E result schema.
 5. Test/CI proof showing repository validation success.
 6. Optional live proof: redacted CALL-E call ID/result from an explicitly consented interview, only if obtained.
@@ -106,7 +112,7 @@ The real SmallBet protocol is 8 answered / 5 supporting / 3 contradictions. Any 
 
 ## Current evidence status
 
-- Repository-level `Validate` workflow: passed on hardened staging heads.
+- Repository-level `Validate` workflow: passed on the latest 8/5/3-aligned staging head before this evidence-only documentation update.
 - Staging PR: open, draft, mergeable.
 - Real-world candidate pool: 16 reviewed commercial-construction candidates prepared privately.
 - Permission outreach: 3 unique candidates contacted; due to an execution-layer duplicate-send error, 7 total messages were sent across those 3 candidates. All three are frozen from further proactive outreach. This operational mistake must not be hidden in the final evidence packet if permission-funnel statistics are discussed.

--- a/apps/python/countersignal/DOGFOOD.md
+++ b/apps/python/countersignal/DOGFOOD.md
@@ -16,8 +16,8 @@ Target segment:
 
 - US commercial/general contractors or permit-heavy specialty contractors;
 - small or midsize operating teams rather than national enterprise headquarters;
-- business appears to manage permit-dependent work directly;
-- a published business number is available and reviewed before use.
+- business appears to manage permit-dependent work directly; and
+- a public business contact channel is available for an operator-reviewed participation invitation.
 
 Do not infer that a generic construction company belongs in the segment merely because it exists. The operator must review the company context first.
 
@@ -34,26 +34,50 @@ This is an operational decision rule for one discovery experiment. It is not a p
 
 ## Recipient and consent rules
 
-Each call is one reviewed business recipient. Do not auto-dial a scraped list. Use only a published business contact that is relevant to the study, respect applicable calling-hour and jurisdictional requirements, identify the caller as an AI research assistant, ask permission to continue, and end immediately on refusal or uncertainty.
+For this US dogfood run, a public business phone number is **not** treated as permission for an AI-voice call. Candidate businesses are contacted first through a non-phone participation invitation such as a published business email or contact channel. CALL-E is used only after the intended participant affirmatively agrees to the AI phone research interview and confirms the business number/time window to use.
+
+This deliberately conservative study rule exists because AI-generated speech is treated as an artificial voice under the US TCPA framework, consent requirements can depend on the type of destination number and calling context, and state law may be more restrictive. CounterSignal does not attempt to infer legal permission from the fact that a number is publicly listed.
+
+For every CALL-E dogfood interview:
+
+- retain a private operator-side reference to the affirmative participation response before execution;
+- review the exact recipient, number, time window, segment fit, and suppression status;
+- identify the caller as an AI research assistant at the start of the call;
+- ask whether the participant is still willing to continue before substantive questions;
+- end immediately on refusal or uncertainty; and
+- do not reuse the permission for a sales call or a separate PermitDiff municipal call.
 
 Maintain an operator-side suppression list for any business that asks not to be contacted again. A refusal is a completed compliance outcome, not a failed conversion.
 
-## What to measure
+## Permission funnel metrics
+
+The permission stage is part of the evidence packet rather than hidden operational overhead. Record:
+
+- reviewed candidate businesses;
+- participation invitations sent;
+- affirmative opt-ins;
+- explicit declines;
+- nonresponses;
+- opt-in-to-valid-interview conversion; and
+- elapsed/operator time required to obtain permission.
+
+A low permission rate is real evidence about deployability and must not be excluded from the product story.
+
+## What to measure during CALL-E interviews
 
 Record these directly rather than estimating them after the fact:
 
-- reviewed candidate businesses;
-- attempted calls;
+- authorized attempted calls;
 - answered calls;
 - interviews that continue after AI disclosure;
 - refusals / voicemail / unreachable;
 - supporting / disconfirming / neutral / invalid outcomes;
 - number of transcript-grounded contradictions preserved;
 - operator minutes spent preparing/reviewing each delegated call;
-- for a small manual baseline, operator minutes required to conduct and summarize the same interview without delegation;
+- for a small manual baseline, operator minutes required to conduct and summarize the same interview without delegation; and
 - whether the frozen experiment decision changes after each valid answered interview.
 
-The primary product KPI is **operator minutes displaced per valid answered discovery interview**, with outcome-integrity metrics reported beside it. Do not turn a short call into a dollar ROI claim without observed labor-cost inputs.
+The primary product KPI is **operator minutes displaced per valid answered discovery interview**, reported together with the permission funnel and outcome-integrity metrics. Do not turn a short call into a dollar ROI claim without observed labor-cost inputs.
 
 ## Stop conditions
 
@@ -62,11 +86,13 @@ Stop the experiment instead of spending the remaining call budget when any of th
 - an implementation or evidence-binding defect makes results unreliable;
 - recipient sourcing is no longer clearly within the intended segment;
 - a compliance/consent issue is discovered;
-- the frozen rule reaches `hypothesis_weakened` and further calls would only be used to rescue the idea;
+- the frozen rule reaches `hypothesis_weakened` and further calls would only be used to rescue the idea; or
 - enough evidence has been collected to move to a separately defined pilot-recruitment experiment.
 
-Reaching `hypothesis_supported_under_rule` does not authorize a sales blast. It authorizes the next explicit experiment: ask a small number of qualified operators whether they will provide an authorized real permit case for a PermitDiff pilot.
+Reaching `hypothesis_supported_under_rule` does not authorize a sales blast. It authorizes the next explicit experiment: ask a small number of qualified operators whether they will separately opt in to providing an authorized real permit case for a PermitDiff pilot.
+
+A CounterSignal research opt-in is not permission to call a municipality about that respondent's permit. PermitDiff requires its own applicant-side authorization and case-specific validation.
 
 ## Judge evidence packet
 
-After the run, publish a privacy-minimized aggregate containing the frozen experiment JSON/hash, counts by outcome bucket, decision sequence by interview number, measured operator-time methodology, failures/nonresponses, and a few redacted evidence excerpts where publication is permitted. Do not publish phone numbers, identities, full transcripts, or private recordings.
+After the run, publish a privacy-minimized aggregate containing the frozen experiment JSON/hash, permission-funnel counts, counts by interview outcome bucket, decision sequence by interview number, measured operator-time methodology, failures/nonresponses, and a few redacted evidence excerpts where publication is permitted. Do not publish phone numbers, identities, email thread IDs, full transcripts, or private recordings.

--- a/apps/python/countersignal/DOGFOOD.md
+++ b/apps/python/countersignal/DOGFOOD.md
@@ -1,0 +1,72 @@
+# CounterSignal real-world validation: SmallBet permit-ops experiment
+
+This is the pre-registration for the first real CounterSignal dogfood run. It exists so the result cannot be rewritten after hearing the calls.
+
+## Study question
+
+Do small and midsize US commercial contractors experience enough permit-status ambiguity to already spend recurring operator time on a manual workaround?
+
+The purpose is **problem discovery**, not selling a permit service. The phone task must not quote a price, pitch automation, book a sales meeting, or convert a respondent into a lead score.
+
+## Frozen protocol
+
+Use [`smallbet-experiment.json`](smallbet-experiment.json) unchanged for the run. Its SHA-derived `protocol_hash` is the experiment version. If wording or thresholds change, create a new experiment ID rather than continuing the old denominator.
+
+Target segment:
+
+- US commercial/general contractors or permit-heavy specialty contractors;
+- small or midsize operating teams rather than national enterprise headquarters;
+- business appears to manage permit-dependent work directly;
+- a published business number is available and reviewed before use.
+
+Do not infer that a generic construction company belongs in the segment merely because it exists. The operator must review the company context first.
+
+## Decision rule
+
+- Minimum answered interviews: **8**.
+- Provisional support threshold: **5 supporting** and **0 disconfirming**.
+- Weaken threshold: **3 disconfirming** once the minimum answered denominator is reached.
+- Refusal, voicemail, unreachable, low-confidence, ungrounded, or schema-invalid outcomes never enter the answered denominator.
+
+A supporting interview means the respondent reports that the problem occurs and that an existing workaround/process is used. A disconfirming interview means the respondent directly says the problem does not occur, is immaterial, or the assumed workflow is wrong. Everything else is neutral.
+
+This is an operational decision rule for one discovery experiment. It is not a prevalence estimate, confidence interval, total-addressable-market estimate, or product-market-fit claim.
+
+## Recipient and consent rules
+
+Each call is one reviewed business recipient. Do not auto-dial a scraped list. Use only a published business contact that is relevant to the study, respect applicable calling-hour and jurisdictional requirements, identify the caller as an AI research assistant, ask permission to continue, and end immediately on refusal or uncertainty.
+
+Maintain an operator-side suppression list for any business that asks not to be contacted again. A refusal is a completed compliance outcome, not a failed conversion.
+
+## What to measure
+
+Record these directly rather than estimating them after the fact:
+
+- reviewed candidate businesses;
+- attempted calls;
+- answered calls;
+- interviews that continue after AI disclosure;
+- refusals / voicemail / unreachable;
+- supporting / disconfirming / neutral / invalid outcomes;
+- number of transcript-grounded contradictions preserved;
+- operator minutes spent preparing/reviewing each delegated call;
+- for a small manual baseline, operator minutes required to conduct and summarize the same interview without delegation;
+- whether the frozen experiment decision changes after each valid answered interview.
+
+The primary product KPI is **operator minutes displaced per valid answered discovery interview**, with outcome-integrity metrics reported beside it. Do not turn a short call into a dollar ROI claim without observed labor-cost inputs.
+
+## Stop conditions
+
+Stop the experiment instead of spending the remaining call budget when any of the following occurs:
+
+- an implementation or evidence-binding defect makes results unreliable;
+- recipient sourcing is no longer clearly within the intended segment;
+- a compliance/consent issue is discovered;
+- the frozen rule reaches `hypothesis_weakened` and further calls would only be used to rescue the idea;
+- enough evidence has been collected to move to a separately defined pilot-recruitment experiment.
+
+Reaching `hypothesis_supported_under_rule` does not authorize a sales blast. It authorizes the next explicit experiment: ask a small number of qualified operators whether they will provide an authorized real permit case for a PermitDiff pilot.
+
+## Judge evidence packet
+
+After the run, publish a privacy-minimized aggregate containing the frozen experiment JSON/hash, counts by outcome bucket, decision sequence by interview number, measured operator-time methodology, failures/nonresponses, and a few redacted evidence excerpts where publication is permitted. Do not publish phone numbers, identities, full transcripts, or private recordings.

--- a/apps/python/countersignal/README.md
+++ b/apps/python/countersignal/README.md
@@ -95,7 +95,7 @@ python countersignal.py \
 
 The `--allow` value must exactly match the selected recipient. The production base URL is pinned to the official CALL-E HTTPS origin; plain HTTP is accepted only for an explicit loopback test server. The CALL-E SDK is imported only after the live gates pass.
 
-A production deployment should additionally persist the authorized call intent before crossing the network boundary and reconcile an ambiguous submission outcome instead of redialing. This repository's production-workflow guide is the reference for that next hardening layer. CounterSignal's current contribution focuses on the experiment protocol and evidence/decision integrity that are unique to this use case.
+Before crossing the real-call boundary, CounterSignal now reserves the exact stable intent in SQLite. Once CALL-E returns a call ID, that ID is bound to the reservation. If a timeout or exception leaves the outcome ambiguous, the ledger moves to `outcome_unknown` and the same intent cannot automatically redial. This follows the repository's production-workflow rule that an unknown submission outcome is a state to reconcile, not permission to create another call.
 
 ## Experiment contract
 
@@ -154,7 +154,7 @@ Legal/compliance obligations for outbound research calls vary by jurisdiction an
 
 ## Tests
 
-The initial deterministic suite covers:
+The deterministic suite covers:
 
 - protocol-hash stability and drift detection;
 - no-call preview and masking;
@@ -165,7 +165,9 @@ The initial deterministic suite covers:
 - disconfirming-evidence priority;
 - frozen support-rule behavior and claim boundary;
 - invalid experiment rejection; and
-- idempotency separation by protocol and recipient.
+- idempotency separation by protocol and recipient;
+- durable duplicate-intent prevention; and
+- ambiguous provider outcome -> `outcome_unknown` with no blind redial.
 
 All tests run without credentials, network access, or a real phone call.
 

--- a/apps/python/countersignal/README.md
+++ b/apps/python/countersignal/README.md
@@ -1,0 +1,182 @@
+# CounterSignal
+
+**Falsifiable customer discovery over real phone calls.** CounterSignal uses CALL-E as a bounded interview instrument, then applies a pre-registered decision rule that preserves evidence against the founder's own hypothesis.
+
+CounterSignal is deliberately not a lead-qualification or booking workflow. It does not close, persuade, negotiate, offer discounts, or convert a call into a sales action. The unit of work is an experiment: freeze a hypothesis and question protocol, call one reviewed recipient, preserve what was actually said, and decide whether the accumulated evidence says to continue, weaken the hypothesis, or — under an explicit rule — provisionally support it.
+
+## Why this exists
+
+Customer discovery has an asymmetric failure mode: supportive anecdotes are memorable while contradictions get explained away. A founder can change the wording between interviews, pitch during the call, silently exclude refusals, or reinterpret an ambiguous answer after seeing it. CounterSignal treats those as data-integrity problems rather than prompt-writing problems.
+
+The app therefore makes five things load-bearing:
+
+1. **Pre-registration.** The hypothesis, segment, fixed questions, and decision thresholds are hashed before the first call.
+2. **No protocol drift.** The CALL-E task contains the exact frozen questions and permits only one neutral clarification per answer.
+3. **Negative evidence is first-class.** A grounded contradiction can weaken the hypothesis; it is never rewritten as a lead objection.
+4. **Honest denominators.** Refusal, voicemail, unreachable, and invalid results do not become answered interviews.
+5. **Evidence binding.** A result is useful only when it belongs to the exact experiment, protocol, CALL-E call, and recipient, and its key quote is grounded in recipient-side transcript text.
+
+## Distinction from existing CALL-E examples
+
+The repository already contains sales follow-up/booking and a standardized survey runner. CounterSignal has a different objective and decision boundary:
+
+- a **lead workflow** asks whether a person should advance toward a commercial next step;
+- a **survey runner** standardizes collection of respondent answers;
+- **CounterSignal** asks whether accumulated phone evidence should cause the operator to lose confidence in a pre-registered business hypothesis.
+
+That distinction changes the call script, state model, evidence policy, denominator, and final output. CounterSignal never returns `qualified`, never books a meeting, and never treats willingness to talk again as proof of demand.
+
+## Core flow
+
+```text
+pre-registered hypothesis + fixed questions + decision rule
+                         |
+                         v
+               deterministic protocol hash
+                         |
+                         v
+reviewed recipient -> no-call preview -> explicit live gates -> CALL-E
+                                                      |
+                                                      v
+                                             structured result
+                                                      |
+                                                      v
+                                      call/experiment/recipient binding
+                                                      |
+                                                      v
+                                         transcript quote grounding
+                                                      |
+                       +------------------------------+------------------+
+                       |                              |                  |
+                       v                              v                  v
+                 supporting                    disconfirming        neutral
+                       \______________________________|__________________/
+                                                      |
+                                                      v
+                                      frozen experiment decision rule
+                                                      |
+                    +----------------+----------------+----------------+
+                    |                |                                 |
+                    v                v                                 v
+              collect_more   hypothesis_weakened       supported_under_rule / inconclusive
+```
+
+The decision is an **operational experiment rule**, not a population-level statistical estimate and not a claim of product-market fit.
+
+## Run the credential-free path
+
+Requires Python 3.11+.
+
+```bash
+cd apps/python/countersignal
+python -m pytest -q
+python countersignal.py \
+  --experiment example-experiment.json \
+  --recipient example-recipient.json
+```
+
+Preview is the default. It masks the phone number, emits the exact CALL-E task, result schema, protocol hash, and idempotency key, and places no call.
+
+## Real-call boundary
+
+A live call requires all of the following independently:
+
+```bash
+export CALLE_API_KEY="<your key>"
+export CALLE_LIVE_CALLS_ENABLED="true"
+
+python countersignal.py \
+  --experiment experiment.json \
+  --recipient recipient.json \
+  --execute \
+  --confirm-one-reviewed-recipient \
+  --allow +14155550123
+```
+
+The `--allow` value must exactly match the selected recipient. The production base URL is pinned to the official CALL-E HTTPS origin; plain HTTP is accepted only for an explicit loopback test server. The CALL-E SDK is imported only after the live gates pass.
+
+A production deployment should additionally persist the authorized call intent before crossing the network boundary and reconcile an ambiguous submission outcome instead of redialing. This repository's production-workflow guide is the reference for that next hardening layer. CounterSignal's current contribution focuses on the experiment protocol and evidence/decision integrity that are unique to this use case.
+
+## Experiment contract
+
+`example-experiment.json` contains the complete frozen protocol. The important fields are:
+
+- `experiment_id`: stable experiment identity;
+- `segment`: the population being explored;
+- `problem`: the bounded workflow/problem under investigation;
+- `hypothesis`: what the operator currently believes;
+- `questions`: 3–8 fixed substantive questions;
+- `decision_rule.min_answered`: minimum valid answered interviews before a terminal experiment decision;
+- `decision_rule.supporting_needed`: supporting interviews required for provisional support;
+- `decision_rule.disconfirming_needed_to_weaken`: disconfirming interviews required to weaken the hypothesis.
+
+The protocol hash changes if the hypothesis, segment, questions, or rule changes. A changed protocol is a new experiment version, not a silent continuation.
+
+## Result contract
+
+CALL-E is asked for these exact fields:
+
+- `continued_after_ai_disclosure`
+- `disposition`
+- `problem_occurred`
+- `current_workaround`
+- `would_take_followup`
+- `contradicts_hypothesis`
+- `key_quote`
+- `notes`
+
+`key_quote` is intentionally required. A well-formed model conclusion without recipient-side evidence is routed to `invalid` rather than counted toward the experiment.
+
+## Decision semantics
+
+CounterSignal classifies an answered and bound result as:
+
+- **disconfirming** when the recipient directly contradicts the hypothesis or reports that the problem does not occur;
+- **supporting** only when the problem occurs and the recipient has a current workaround;
+- **neutral** when the answer is valid but does not satisfy either rule;
+- **nonresponse** for refusal, voicemail, unreachable, or other non-answered outcomes;
+- **invalid** for incomplete, low-confidence, unbound, or ungrounded results.
+
+Disconfirming evidence takes priority once the minimum answered sample is reached. Provisional support requires the configured support count **and zero disconfirming interviews** under the current rule.
+
+## Safety and integrity boundaries
+
+- AI use is disclosed before substantive questions.
+- Refusal ends the interview.
+- No selling, bargaining, payment request, discount, purchase commitment, or scheduling authority.
+- The hidden hypothesis is not read to the recipient, reducing demand-characteristic pressure.
+- The model cannot add substantive questions mid-call.
+- No answer is treated as demand merely because CALL-E completed successfully.
+- No market-size, ROI, conversion-rate, or product-market-fit claim is inferred from a small exploratory sample.
+- Every real recipient must be reviewed and explicitly allowlisted by the operator.
+
+Legal/compliance obligations for outbound research calls vary by jurisdiction and deployment context. The operator owns recipient sourcing, lawful basis/consent where applicable, calling windows, suppression lists, and retention policy; CounterSignal does not infer those from a phone number.
+
+## Tests
+
+The initial deterministic suite covers:
+
+- protocol-hash stability and drift detection;
+- no-call preview and masking;
+- exact result-schema contract;
+- CALL-E metadata/call/recipient binding;
+- transcript grounding of the evidence quote;
+- refusal/voicemail denominator integrity;
+- disconfirming-evidence priority;
+- frozen support-rule behavior and claim boundary;
+- invalid experiment rejection; and
+- idempotency separation by protocol and recipient.
+
+All tests run without credentials, network access, or a real phone call.
+
+## What judges can verify quickly
+
+1. Run `pytest -q`.
+2. Run the preview command and inspect the frozen task and masked recipient.
+3. Change one question and observe the protocol hash/idempotency identity change.
+4. Read the decision tests showing that voicemail does not inflate the denominator and one grounded contradiction cannot be silently converted into support.
+5. Inspect `execute()` to verify that the published CALL-E Python SDK is the live transport boundary.
+
+## Next validation
+
+The award version will dogfood CounterSignal on a bounded SmallBet customer-discovery experiment and report only directly measured quantities: reviewed recipients, completed interviews, nonresponse rate, operator minutes displaced, contradictory evidence captured, and whether additional calls changed the pre-registered experiment decision. The evaluation will preserve negative outcomes rather than selecting only successful conversations.

--- a/apps/python/countersignal/README.md
+++ b/apps/python/countersignal/README.md
@@ -8,6 +8,16 @@ CounterSignal is deliberately not a lead-qualification or booking workflow. It d
 
 Customer discovery has an asymmetric failure mode: supportive anecdotes are memorable while contradictions get explained away. A founder can change the wording between interviews, pitch during the call, silently exclude refusals, or reinterpret an ambiguous answer after seeing it. CounterSignal treats those as data-integrity problems rather than prompt-writing problems.
 
+This is not a problem invented for the demo. The US National Cancer Institute's SPRINT program describes customer discovery as turning a potential venture into business-model hypotheses, interviewing stakeholders to validate **or disprove** them, and making substantive changes when assumptions fail in the real world. Independent interview-method research reports that leading question wording can influence responses and weaken the trustworthiness of findings. In a 2022 experimental analysis spanning 2,084 simulated interviews, interviewers' preliminary assumptions predicted their conclusions, confidence, use of non-recommended question types, and likelihood of reaching the correct conclusion.
+
+Sources:
+
+- [NCI SPRINT: customer discovery as hypothesis testing](https://pmc.ncbi.nlm.nih.gov/articles/PMC7184906/)
+- [Cairns-Lee, Lawley & Tosey: influence of leading questions in interviews](https://doi.org/10.1177/00218863211037446)
+- [Zhang: confirmation bias in simulated interviews](https://doi.org/10.1111/lcrp.12213)
+
+Those studies do not prove that CounterSignal itself improves research quality. They establish the failure mode that its protocol is designed to constrain; the app's own effect must be measured separately.
+
 The app therefore makes five things load-bearing:
 
 1. **Pre-registration.** The hypothesis, segment, fixed questions, and decision thresholds are hashed before the first call.
@@ -58,7 +68,7 @@ reviewed recipient -> no-call preview -> explicit live gates -> CALL-E
                     +----------------+----------------+----------------+
                     |                |                                 |
                     v                v                                 v
-              collect_more   hypothesis_weakened       supported_under_rule / inconclusive
+              collect_more   hypothesis_weakened   hypothesis_supported_under_rule / inconclusive
 ```
 
 The decision is an **operational experiment rule**, not a population-level statistical estimate and not a claim of product-market fit.
@@ -95,11 +105,11 @@ python countersignal.py \
 
 The `--allow` value must exactly match the selected recipient. The production base URL is pinned to the official CALL-E HTTPS origin; plain HTTP is accepted only for an explicit loopback test server. The CALL-E SDK is imported only after the live gates pass.
 
-Before crossing the real-call boundary, CounterSignal now reserves the exact stable intent in SQLite. Once CALL-E returns a call ID, that ID is bound to the reservation. If a timeout or exception leaves the outcome ambiguous, the ledger moves to `outcome_unknown` and the same intent cannot automatically redial. This follows the repository's production-workflow rule that an unknown submission outcome is a state to reconcile, not permission to create another call.
+Before crossing the real-call boundary, CounterSignal reserves the exact stable intent in SQLite. Once CALL-E returns a call ID, that ID is bound to the reservation. If a timeout or exception leaves the outcome ambiguous, the ledger moves to `outcome_unknown` and the same intent cannot automatically redial. This follows the repository's production-workflow rule that an unknown submission outcome is a state to reconcile, not permission to create another call.
 
 ## Experiment contract
 
-`example-experiment.json` contains the complete frozen protocol. The important fields are:
+`example-experiment.json` contains a complete frozen example protocol. The important fields are:
 
 - `experiment_id`: stable experiment identity;
 - `segment`: the population being explored;
@@ -107,10 +117,12 @@ Before crossing the real-call boundary, CounterSignal now reserves the exact sta
 - `hypothesis`: what the operator currently believes;
 - `questions`: 3–8 fixed substantive questions;
 - `decision_rule.min_answered`: minimum valid answered interviews before a terminal experiment decision;
-- `decision_rule.supporting_needed`: supporting interviews required for provisional support;
-- `decision_rule.disconfirming_needed_to_weaken`: disconfirming interviews required to weaken the hypothesis.
+- `decision_rule.support_if_at_least`: supporting interviews required for provisional support;
+- `decision_rule.weaken_if_at_least`: disconfirming interviews required to weaken the hypothesis.
 
 The protocol hash changes if the hypothesis, segment, questions, or rule changes. A changed protocol is a new experiment version, not a silent continuation.
+
+The real SmallBet dogfood protocol is separate from the compact example and is frozen in `smallbet-experiment.json`: 8 minimum answered interviews, 5 supporting for provisional support with zero contradictions, and 3 grounded contradictions to weaken the hypothesis.
 
 ## Result contract
 
@@ -150,7 +162,7 @@ Disconfirming evidence takes priority once the minimum answered sample is reache
 - No market-size, ROI, conversion-rate, or product-market-fit claim is inferred from a small exploratory sample.
 - Every real recipient must be reviewed and explicitly allowlisted by the operator.
 
-Legal/compliance obligations for outbound research calls vary by jurisdiction and deployment context. The operator owns recipient sourcing, lawful basis/consent where applicable, calling windows, suppression lists, and retention policy; CounterSignal does not infer those from a phone number.
+Legal/compliance obligations for outbound research calls vary by jurisdiction and deployment context. The operator owns recipient sourcing, lawful basis/consent where applicable, calling windows, suppression lists, and retention policy; CounterSignal does not infer those from a phone number. The current US dogfood protocol is stricter: a public business number alone is not treated as AI-call permission; the respondent must affirmatively opt in before CALL-E is used.
 
 ## Tests
 
@@ -164,10 +176,11 @@ The deterministic suite covers:
 - refusal/voicemail denominator integrity;
 - disconfirming-evidence priority;
 - frozen support-rule behavior and claim boundary;
-- invalid experiment rejection; and
+- invalid experiment rejection;
 - idempotency separation by protocol and recipient;
-- durable duplicate-intent prevention; and
-- ambiguous provider outcome -> `outcome_unknown` with no blind redial.
+- durable duplicate-intent prevention;
+- ambiguous provider outcome -> `outcome_unknown` with no blind redial; and
+- judge-console alignment with the real pre-registered SmallBet protocol.
 
 All tests run without credentials, network access, or a real phone call.
 
@@ -176,9 +189,11 @@ All tests run without credentials, network access, or a real phone call.
 1. Run `pytest -q`.
 2. Run the preview command and inspect the frozen task and masked recipient.
 3. Change one question and observe the protocol hash/idempotency identity change.
-4. Read the decision tests showing that voicemail does not inflate the denominator and one grounded contradiction cannot be silently converted into support.
-5. Inspect `execute()` to verify that the published CALL-E Python SDK is the live transport boundary.
+4. Open `judge-console.html`, add voicemail and observe that the answered denominator stays fixed, then add three contradictions and observe `hypothesis_weakened` under the frozen 8/5/3 rule.
+5. Inspect `execute()` to verify that the published CALL-E Python SDK is the live transport boundary and that a durable reservation precedes dispatch.
 
-## Next validation
+## Real-world validation
 
-The award version will dogfood CounterSignal on a bounded SmallBet customer-discovery experiment and report only directly measured quantities: reviewed recipients, completed interviews, nonresponse rate, operator minutes displaced, contradictory evidence captured, and whether additional calls changed the pre-registered experiment decision. The evaluation will preserve negative outcomes rather than selecting only successful conversations.
+`DOGFOOD.md` pre-registers the first SmallBet study before any CALL-E interview. The private first-wave pool contains 16 manually reviewed commercial-construction candidates. Participation is requested through a non-phone channel first; only an affirmative opt-in may become a CALL-E interview recipient. Permission-channel outcomes are reported separately from the answered interview denominator.
+
+The evaluation reports only directly measured quantities: reviewed candidates, permissions, completed interviews, nonresponse, operator minutes displaced, contradictory evidence captured, and whether additional valid answers changed the pre-registered experiment decision. It preserves negative outcomes rather than selecting only successful conversations. Current live-evidence status is kept in `DEVPOST.md`; deterministic reviewer evidence is never relabeled as a live call.

--- a/apps/python/countersignal/README.md
+++ b/apps/python/countersignal/README.md
@@ -103,7 +103,7 @@ python countersignal.py \
   --allow +14155550123
 ```
 
-The `--allow` value must exactly match the selected recipient. The production base URL is pinned to the official CALL-E HTTPS origin; plain HTTP is accepted only for an explicit loopback test server. The CALL-E SDK is imported only after the live gates pass.
+The `--allow` value must exactly match the selected recipient. The production base URL is pinned to the official CALL-E HTTPS origin; plain HTTP is accepted only for an explicit loopback test server. The CALL-E SDK is imported only after the live gates pass. A loopback test server receives only a fixed non-secret test key; `CALLE_API_KEY` is required and used only for the production origin.
 
 Before crossing the real-call boundary, CounterSignal reserves the exact stable intent in SQLite. Once CALL-E returns a call ID, that ID is bound to the reservation. If a timeout or exception leaves the outcome ambiguous, the ledger moves to `outcome_unknown` and the same intent cannot automatically redial. This follows the repository's production-workflow rule that an unknown submission outcome is a state to reconcile, not permission to create another call.
 

--- a/apps/python/countersignal/countersignal.py
+++ b/apps/python/countersignal/countersignal.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable, Protocol
 from urllib.parse import urlparse
 
 DEFAULT_BASE_URL = "https://api.heycall-e.com"
+LOOPBACK_TEST_API_KEY = "loopback-test-key"
 TERMINAL_SUCCESS = {"completed", "succeeded"}
 RECIPIENT_SPEAKERS = {"recipient", "user", "callee"}
 MIN_CONFIDENCE = 0.80
@@ -353,6 +354,20 @@ def experiment_decision(experiment: Experiment, buckets: Iterable[str]) -> dict[
     }
 
 
+def _is_loopback_base_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.port is not None
+        and parsed.path in {"", "/"}
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
 def validate_base_url(value: str) -> str:
     parsed = urlparse(value)
     if (
@@ -366,18 +381,19 @@ def validate_base_url(value: str) -> str:
         and not parsed.fragment
     ):
         return DEFAULT_BASE_URL
-    if (
-        parsed.scheme == "http"
-        and parsed.hostname in {"127.0.0.1", "localhost"}
-        and parsed.port is not None
-        and parsed.path in {"", "/"}
-        and not parsed.username
-        and not parsed.password
-        and not parsed.query
-        and not parsed.fragment
-    ):
+    if _is_loopback_base_url(value):
         return value.rstrip("/")
     raise ValueError("base URL must be CALL-E production or an explicit loopback test server")
+
+
+def api_key_for_base_url(base_url: str) -> str:
+    """Use a non-secret credential for local fakes; require a real key in production."""
+    if _is_loopback_base_url(base_url):
+        return LOOPBACK_TEST_API_KEY
+    key = os.environ.get("CALLE_API_KEY", "").strip()
+    if not key:
+        raise ValueError("CALLE_API_KEY is required for production --execute")
+    return key
 
 
 class ReservationLedger:
@@ -504,12 +520,11 @@ def main(argv: list[str] | None = None) -> int:
             raise ValueError("--execute requires the exact recipient phone in --allow")
         if os.environ.get("CALLE_LIVE_CALLS_ENABLED", "").lower() != "true":
             raise ValueError("--execute requires CALLE_LIVE_CALLS_ENABLED=true")
-        key = os.environ.get("CALLE_API_KEY")
-        if not key:
-            raise ValueError("CALLE_API_KEY is required for --execute")
+        base_url = validate_base_url(os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))
+        key = api_key_for_base_url(base_url)
         from calle import CalleClient
 
-        with CalleClient(api_key=key, base_url=validate_base_url(os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))) as client:
+        with CalleClient(api_key=key, base_url=base_url) as client:
             payload = execute(
                 experiment, recipient, client.calls, ReservationLedger(args.database), args.timeout_seconds
             )

--- a/apps/python/countersignal/countersignal.py
+++ b/apps/python/countersignal/countersignal.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -379,27 +380,84 @@ def validate_base_url(value: str) -> str:
     raise ValueError("base URL must be CALL-E production or an explicit loopback test server")
 
 
+class ReservationLedger:
+    """Durable one-intent/one-call reservation for consequential real-call retries."""
+
+    def __init__(self, path: Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+        with sqlite3.connect(path) as db:
+            db.execute(
+                "CREATE TABLE IF NOT EXISTS calls "
+                "(key TEXT PRIMARY KEY, state TEXT NOT NULL, call_id TEXT, detail TEXT)"
+            )
+
+    def claim(self, key: str) -> bool:
+        try:
+            with sqlite3.connect(self.path) as db:
+                db.execute("INSERT INTO calls(key, state) VALUES (?, 'reserved')", (key,))
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+    def mark(
+        self, key: str, state: str, call_id: str | None = None, detail: str | None = None
+    ) -> None:
+        with sqlite3.connect(self.path) as db:
+            db.execute(
+                "UPDATE calls SET state=?, call_id=COALESCE(?, call_id), detail=? WHERE key=?",
+                (state, call_id, detail, key),
+            )
+
+    def get(self, key: str) -> tuple[str, str | None, str | None] | None:
+        with sqlite3.connect(self.path) as db:
+            row = db.execute(
+                "SELECT state, call_id, detail FROM calls WHERE key=?", (key,)
+            ).fetchone()
+        return row if row else None
+
+
 def execute(
     experiment: Experiment,
     recipient: Recipient,
     calls: CallsAPI,
+    ledger: ReservationLedger,
     timeout_seconds: int = 600,
 ) -> dict[str, Any]:
-    created = calls.create(
-        **call_arguments(experiment, recipient),
-        idempotency_key=idempotency_key(experiment, recipient),
-    )
-    call_id = created.get("id")
-    if not isinstance(call_id, str) or not call_id:
-        raise RuntimeError("CALL-E create response did not contain a call id")
-    completed = calls.wait_for_result(call_id, timeout_seconds=timeout_seconds, interval_seconds=2)
-    return {
-        "call_id": call_id,
-        "classification": classify_call(
-            experiment, recipient, completed, expected_call_id=call_id
-        ),
-        "provider_result": completed,
-    }
+    key = idempotency_key(experiment, recipient)
+    if not ledger.claim(key):
+        state = ledger.get(key)
+        raise RuntimeError(
+            f"call already reserved; reconcile existing state {state[0] if state else 'unknown'}"
+        )
+    accepted_call_id: str | None = None
+    try:
+        created = calls.create(
+            **call_arguments(experiment, recipient),
+            idempotency_key=key,
+        )
+        call_id = created.get("id")
+        if not isinstance(call_id, str) or not call_id:
+            raise RuntimeError("CALL-E create response did not contain a call id")
+        accepted_call_id = call_id
+        ledger.mark(key, "accepted", call_id)
+        completed = calls.wait_for_result(
+            call_id, timeout_seconds=timeout_seconds, interval_seconds=2
+        )
+        result = {
+            "call_id": call_id,
+            "classification": classify_call(
+                experiment, recipient, completed, expected_call_id=call_id
+            ),
+            "provider_result": completed,
+        }
+        ledger.mark(key, "completed", call_id)
+        return result
+    except Exception as exc:
+        ledger.mark(key, "outcome_unknown", accepted_call_id, type(exc).__name__)
+        raise RuntimeError(
+            "CALL-E outcome is unknown; reconcile the existing reservation before any retry"
+        ) from exc
 
 
 def mask_phone(phone: str) -> str:
@@ -432,6 +490,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--confirm-one-reviewed-recipient", action="store_true")
     parser.add_argument("--allow", action="append", default=[])
     parser.add_argument("--timeout-seconds", type=int, default=600)
+    parser.add_argument("--database", type=Path, default=Path("data/countersignal.sqlite3"))
     args = parser.parse_args(argv)
     try:
         experiment = parse_experiment(_load(args.experiment))
@@ -451,7 +510,9 @@ def main(argv: list[str] | None = None) -> int:
         from calle import CalleClient
 
         with CalleClient(api_key=key, base_url=validate_base_url(os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))) as client:
-            payload = execute(experiment, recipient, client.calls, args.timeout_seconds)
+            payload = execute(
+                experiment, recipient, client.calls, ReservationLedger(args.database), args.timeout_seconds
+            )
         print(json.dumps(payload, ensure_ascii=False, indent=2))
         return 0
     except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:

--- a/apps/python/countersignal/countersignal.py
+++ b/apps/python/countersignal/countersignal.py
@@ -1,0 +1,463 @@
+"""CounterSignal: falsifiable customer-discovery calls with a frozen protocol."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+from urllib.parse import urlparse
+
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+TERMINAL_SUCCESS = {"completed", "succeeded"}
+RECIPIENT_SPEAKERS = {"recipient", "user", "callee"}
+MIN_CONFIDENCE = 0.80
+PHONE_RE = re.compile(r"^\+[1-9]\d{7,14}$")
+
+
+@dataclass(frozen=True)
+class DecisionRule:
+    min_answered: int
+    support_if_at_least: int
+    weaken_if_at_least: int
+
+
+@dataclass(frozen=True)
+class Experiment:
+    experiment_id: str
+    segment: str
+    problem: str
+    hypothesis: str
+    questions: tuple[str, ...]
+    decision_rule: DecisionRule
+
+
+@dataclass(frozen=True)
+class Recipient:
+    phone: str
+    region: str
+    locale: str
+
+
+class CallsAPI(Protocol):
+    def create(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    def wait_for_result(
+        self, call_id: str, *, timeout_seconds: int, interval_seconds: int
+    ) -> dict[str, Any]: ...
+
+
+def _nonempty_text(value: Any, field: str, limit: int = 600) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be non-empty text")
+    text = value.strip()
+    if len(text) > limit:
+        raise ValueError(f"{field} exceeds {limit} characters")
+    return text
+
+
+def parse_experiment(data: dict[str, Any]) -> Experiment:
+    if not isinstance(data, dict):
+        raise ValueError("experiment must be an object")
+    experiment_id = _nonempty_text(data.get("experiment_id"), "experiment_id", 80)
+    segment = _nonempty_text(data.get("segment"), "segment", 240)
+    problem = _nonempty_text(data.get("problem"), "problem", 300)
+    hypothesis = _nonempty_text(data.get("hypothesis"), "hypothesis", 500)
+    raw_questions = data.get("questions")
+    if not isinstance(raw_questions, list) or not 3 <= len(raw_questions) <= 8:
+        raise ValueError("questions must contain 3-8 fixed questions")
+    questions = tuple(_nonempty_text(q, "question", 300) for q in raw_questions)
+    if len(set(q.casefold() for q in questions)) != len(questions):
+        raise ValueError("questions must be unique")
+
+    raw_rule = data.get("decision_rule")
+    if not isinstance(raw_rule, dict):
+        raise ValueError("decision_rule must be an object")
+    vals: dict[str, int] = {}
+    for key in ("min_answered", "support_if_at_least", "weaken_if_at_least"):
+        value = raw_rule.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"decision_rule.{key} must be a positive integer")
+        vals[key] = value
+    if vals["support_if_at_least"] > vals["min_answered"]:
+        raise ValueError("support_if_at_least cannot exceed min_answered")
+    if vals["weaken_if_at_least"] > vals["min_answered"]:
+        raise ValueError("weaken_if_at_least cannot exceed min_answered")
+
+    return Experiment(
+        experiment_id=experiment_id,
+        segment=segment,
+        problem=problem,
+        hypothesis=hypothesis,
+        questions=questions,
+        decision_rule=DecisionRule(**vals),
+    )
+
+
+def parse_recipient(data: dict[str, Any]) -> Recipient:
+    if not isinstance(data, dict):
+        raise ValueError("recipient must be an object")
+    phone = _nonempty_text(data.get("phone"), "phone", 20)
+    if not PHONE_RE.fullmatch(phone):
+        raise ValueError("phone must be E.164")
+    region = _nonempty_text(data.get("region"), "region", 8).upper()
+    locale = _nonempty_text(data.get("locale"), "locale", 20)
+    return Recipient(phone=phone, region=region, locale=locale)
+
+
+def canonical_protocol(experiment: Experiment) -> dict[str, Any]:
+    return {
+        "experiment_id": experiment.experiment_id,
+        "segment": experiment.segment,
+        "problem": experiment.problem,
+        "hypothesis": experiment.hypothesis,
+        "questions": list(experiment.questions),
+        "decision_rule": {
+            "min_answered": experiment.decision_rule.min_answered,
+            "support_if_at_least": experiment.decision_rule.support_if_at_least,
+            "weaken_if_at_least": experiment.decision_rule.weaken_if_at_least,
+        },
+    }
+
+
+def protocol_hash(experiment: Experiment) -> str:
+    canonical = json.dumps(
+        canonical_protocol(experiment), sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def result_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": [
+            "continued_after_ai_disclosure",
+            "disposition",
+            "problem_occurred",
+            "current_workaround",
+            "would_take_followup",
+            "contradicts_hypothesis",
+            "key_quote",
+            "notes",
+        ],
+        "properties": {
+            "continued_after_ai_disclosure": {
+                "type": "string",
+                "enum": ["yes", "no", "unknown"],
+            },
+            "disposition": {
+                "type": "string",
+                "enum": ["answered", "refused", "voicemail", "unreachable", "unclear"],
+            },
+            "problem_occurred": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "current_workaround": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "would_take_followup": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "contradicts_hypothesis": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "key_quote": {"type": "string", "maxLength": 300},
+            "notes": {"type": "string", "maxLength": 500},
+        },
+        "additionalProperties": False,
+    }
+
+
+def build_task(experiment: Experiment, recipient: Recipient) -> str:
+    numbered = " ".join(f"Q{i + 1}: {q}" for i, q in enumerate(experiment.questions))
+    return (
+        f"You are conducting one bounded customer-discovery interview for experiment "
+        f"{experiment.experiment_id}, in locale {recipient.locale}. Identify yourself as an AI "
+        "research assistant and ask whether the recipient is willing to continue with a short "
+        "business-research interview. If they decline, ask to stop, or express uncertainty about "
+        "participating, thank them and end the call. Do not sell, pitch, negotiate, offer a discount, "
+        "ask for payment, schedule a purchase, or argue with an answer. Do not reveal the operator's "
+        "hypothesis. Ask the fixed questions in order. You may ask one neutral clarification when an "
+        "answer is ambiguous, but you may not introduce a new substantive question. The target segment "
+        f"is: {experiment.segment}. The problem under study is: {experiment.problem}. {numbered} "
+        "Return a conservative structured result. Mark voicemail, refusal, unreachable, and unclear "
+        "separately. Set contradicts_hypothesis=yes only when the recipient directly gives evidence that "
+        "the problem does not occur, is immaterial, or the assumed workflow is wrong. key_quote must be a "
+        "short verbatim quote from the recipient that best supports the coded outcome; if no usable quote "
+        "exists, use an empty string and prefer unknown/unclear fields over guessing."
+    )
+
+
+def call_arguments(experiment: Experiment, recipient: Recipient) -> dict[str, Any]:
+    return {
+        "task": build_task(experiment, recipient),
+        "recipients": [{"phones": [recipient.phone], "region": recipient.region, "locale": recipient.locale}],
+        "result_schema": result_schema(),
+        "metadata": {
+            "workflow_type": "falsifiable_customer_discovery",
+            "experiment_id": experiment.experiment_id,
+            "protocol_hash": protocol_hash(experiment),
+        },
+    }
+
+
+def idempotency_key(experiment: Experiment, recipient: Recipient) -> str:
+    payload = {"call": call_arguments(experiment, recipient), "recipient": recipient.phone}
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode()
+    return f"countersignal-{hashlib.sha256(canonical).hexdigest()}"
+
+
+def confidence_score(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, dict):
+        score = value.get("score")
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            return float(score)
+    return 0.0
+
+
+def valid_structured_result(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    schema = result_schema()
+    required = schema["required"]
+    if set(value) != set(required):
+        return False
+    for field in required:
+        item = value[field]
+        rule = schema["properties"][field]
+        if not isinstance(item, str):
+            return False
+        if len(item) > rule.get("maxLength", 10_000):
+            return False
+        if "enum" in rule and item not in rule["enum"]:
+            return False
+    return True
+
+
+def recipient_transcript(provider_result: dict[str, Any], destination: str) -> str:
+    recipients = provider_result.get("recipients")
+    if not isinstance(recipients, list) or len(recipients) != 1:
+        return ""
+    recipient = recipients[0]
+    if not isinstance(recipient, dict) or recipient.get("phone") != destination:
+        return ""
+    attempts = recipient.get("attempts")
+    if not isinstance(attempts, list) or not attempts:
+        return ""
+    turns: list[str] = []
+    for attempt in attempts:
+        if not isinstance(attempt, dict):
+            continue
+        transcript_turns = attempt.get("transcript_turns")
+        if not isinstance(transcript_turns, list):
+            continue
+        for turn in transcript_turns:
+            if (
+                isinstance(turn, dict)
+                and str(turn.get("speaker", "")).lower() in RECIPIENT_SPEAKERS
+                and isinstance(turn.get("text"), str)
+            ):
+                turns.append(turn["text"])
+    return "\n".join(turns)
+
+
+def _tokens(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", text.casefold())
+
+
+def quote_grounded(quote: Any, transcript: str) -> bool:
+    if not isinstance(quote, str) or not quote.strip():
+        return False
+    expected = _tokens(quote)
+    observed = _tokens(transcript)
+    if len(expected) < 2:
+        return False
+    width = len(expected)
+    return any(observed[i : i + width] == expected for i in range(len(observed) - width + 1))
+
+
+def _binding_valid(
+    experiment: Experiment,
+    recipient: Recipient,
+    provider_result: dict[str, Any],
+    expected_call_id: str | None,
+) -> bool:
+    if expected_call_id is not None and provider_result.get("id") != expected_call_id:
+        return False
+    if provider_result.get("metadata") != {
+        "workflow_type": "falsifiable_customer_discovery",
+        "experiment_id": experiment.experiment_id,
+        "protocol_hash": protocol_hash(experiment),
+    }:
+        return False
+    transcript = recipient_transcript(provider_result, recipient.phone)
+    structured = provider_result.get("structured_result")
+    return isinstance(structured, dict) and quote_grounded(structured.get("key_quote"), transcript)
+
+
+def classify_call(
+    experiment: Experiment,
+    recipient: Recipient,
+    provider_result: dict[str, Any],
+    *,
+    expected_call_id: str | None = None,
+) -> dict[str, str]:
+    structured = provider_result.get("structured_result")
+    if (
+        provider_result.get("status") not in TERMINAL_SUCCESS
+        or provider_result.get("task_completed") is not True
+        or confidence_score(provider_result.get("completion_confidence")) < MIN_CONFIDENCE
+        or not valid_structured_result(structured)
+    ):
+        return {"bucket": "invalid", "reason": "No reliable complete terminal result."}
+    assert isinstance(structured, dict)
+    if structured["disposition"] != "answered" or structured["continued_after_ai_disclosure"] != "yes":
+        return {"bucket": "nonresponse", "reason": f"Disposition is {structured['disposition']}."}
+    if not _binding_valid(experiment, recipient, provider_result, expected_call_id):
+        return {"bucket": "invalid", "reason": "Result was not bound to the frozen protocol and recipient evidence."}
+    if structured["contradicts_hypothesis"] == "yes" or structured["problem_occurred"] == "no":
+        return {"bucket": "disconfirming", "reason": "Recipient directly contradicted a load-bearing hypothesis condition."}
+    if structured["problem_occurred"] == "yes" and structured["current_workaround"] == "yes":
+        return {"bucket": "supporting", "reason": "Recipient reported the problem and an existing workaround."}
+    return {"bucket": "neutral", "reason": "Answered interview did not meet support or disconfirmation rule."}
+
+
+def experiment_decision(experiment: Experiment, buckets: Iterable[str]) -> dict[str, Any]:
+    counts = {name: 0 for name in ("supporting", "disconfirming", "neutral", "nonresponse", "invalid")}
+    for bucket in buckets:
+        if bucket not in counts:
+            raise ValueError(f"unknown bucket: {bucket}")
+        counts[bucket] += 1
+    answered = counts["supporting"] + counts["disconfirming"] + counts["neutral"]
+    rule = experiment.decision_rule
+    if answered < rule.min_answered:
+        decision = "collect_more"
+    elif counts["disconfirming"] >= rule.weaken_if_at_least:
+        decision = "hypothesis_weakened"
+    elif counts["supporting"] >= rule.support_if_at_least and counts["disconfirming"] == 0:
+        decision = "hypothesis_supported_under_rule"
+    else:
+        decision = "inconclusive"
+    return {
+        "decision": decision,
+        "answered_denominator": answered,
+        "counts": counts,
+        "rule": {
+            "min_answered": rule.min_answered,
+            "support_if_at_least": rule.support_if_at_least,
+            "weaken_if_at_least": rule.weaken_if_at_least,
+        },
+        "claim_boundary": "This is a pre-registered operational rule, not a population-level statistical estimate.",
+    }
+
+
+def validate_base_url(value: str) -> str:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme == "https"
+        and parsed.hostname == "api.heycall-e.com"
+        and parsed.port in {None, 443}
+        and parsed.path in {"", "/"}
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    ):
+        return DEFAULT_BASE_URL
+    if (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.port is not None
+        and parsed.path in {"", "/"}
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    ):
+        return value.rstrip("/")
+    raise ValueError("base URL must be CALL-E production or an explicit loopback test server")
+
+
+def execute(
+    experiment: Experiment,
+    recipient: Recipient,
+    calls: CallsAPI,
+    timeout_seconds: int = 600,
+) -> dict[str, Any]:
+    created = calls.create(
+        **call_arguments(experiment, recipient),
+        idempotency_key=idempotency_key(experiment, recipient),
+    )
+    call_id = created.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        raise RuntimeError("CALL-E create response did not contain a call id")
+    completed = calls.wait_for_result(call_id, timeout_seconds=timeout_seconds, interval_seconds=2)
+    return {
+        "call_id": call_id,
+        "classification": classify_call(
+            experiment, recipient, completed, expected_call_id=call_id
+        ),
+        "provider_result": completed,
+    }
+
+
+def mask_phone(phone: str) -> str:
+    if len(phone) <= 6:
+        return "*" * len(phone)
+    return f"{phone[:2]}{'*' * (len(phone) - 6)}{phone[-4:]}"
+
+
+def preview(experiment: Experiment, recipient: Recipient) -> dict[str, Any]:
+    args = call_arguments(experiment, recipient)
+    args["recipients"] = [{"phones": [mask_phone(recipient.phone)], "region": recipient.region, "locale": recipient.locale}]
+    return {
+        "mode": "preview",
+        "creates_phone_call": False,
+        "protocol_hash": protocol_hash(experiment),
+        "idempotency_key": idempotency_key(experiment, recipient),
+        "call_arguments": args,
+    }
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experiment", type=Path, required=True)
+    parser.add_argument("--recipient", type=Path, required=True)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--confirm-one-reviewed-recipient", action="store_true")
+    parser.add_argument("--allow", action="append", default=[])
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    args = parser.parse_args(argv)
+    try:
+        experiment = parse_experiment(_load(args.experiment))
+        recipient = parse_recipient(_load(args.recipient))
+        if not args.execute:
+            print(json.dumps(preview(experiment, recipient), ensure_ascii=False, indent=2))
+            return 0
+        if not args.confirm_one_reviewed_recipient:
+            raise ValueError("--execute requires --confirm-one-reviewed-recipient")
+        if recipient.phone not in set(args.allow):
+            raise ValueError("--execute requires the exact recipient phone in --allow")
+        if os.environ.get("CALLE_LIVE_CALLS_ENABLED", "").lower() != "true":
+            raise ValueError("--execute requires CALLE_LIVE_CALLS_ENABLED=true")
+        key = os.environ.get("CALLE_API_KEY")
+        if not key:
+            raise ValueError("CALLE_API_KEY is required for --execute")
+        from calle import CalleClient
+
+        with CalleClient(api_key=key, base_url=validate_base_url(os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))) as client:
+            payload = execute(experiment, recipient, client.calls, args.timeout_seconds)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/countersignal/example-experiment.json
+++ b/apps/python/countersignal/example-experiment.json
@@ -1,0 +1,17 @@
+{
+  "experiment_id": "permit-ops-001",
+  "segment": "small construction firms that manage municipal permits",
+  "problem": "staff spend repeated operator time resolving permit status ambiguity",
+  "hypothesis": "the problem recurs often enough that firms already use a workaround",
+  "questions": [
+    "Tell me about the last time a permit status was unclear.",
+    "How did your team resolve it?",
+    "How often does this happen?",
+    "What happens if nobody follows up?"
+  ],
+  "decision_rule": {
+    "min_answered": 5,
+    "support_if_at_least": 3,
+    "weaken_if_at_least": 2
+  }
+}

--- a/apps/python/countersignal/example-recipient.json
+++ b/apps/python/countersignal/example-recipient.json
@@ -1,0 +1,5 @@
+{
+  "phone": "+14155550123",
+  "region": "US",
+  "locale": "en-US"
+}

--- a/apps/python/countersignal/judge-console.html
+++ b/apps/python/countersignal/judge-console.html
@@ -5,64 +5,74 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>CounterSignal — Judge Console</title>
 <style>
-:root{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#141414;background:#f4f3ef}*{box-sizing:border-box}body{margin:0}.shell{max-width:1180px;margin:0 auto;padding:28px}.top{display:flex;justify-content:space-between;align-items:flex-start;gap:24px}.eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:800;color:#6b6b63}.title{font-size:38px;line-height:1.03;margin:7px 0 8px;letter-spacing:-.04em}.sub{max-width:720px;color:#5d5d57;line-height:1.55}.badge{border:1px solid #c9c6bc;border-radius:999px;padding:9px 12px;font-size:12px;font-weight:750;background:#fff;white-space:nowrap}.grid{display:grid;grid-template-columns:1.3fr .7fr;gap:18px;margin-top:24px}.card{background:#fff;border:1px solid #d9d6cc;border-radius:16px;padding:18px;box-shadow:0 1px 0 rgba(0,0,0,.03)}.card h2{margin:0 0 13px;font-size:15px}.hyp{font-size:23px;line-height:1.25;letter-spacing:-.02em;margin:3px 0 14px}.meta{display:flex;gap:8px;flex-wrap:wrap}.pill{font:650 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;padding:7px 9px;border-radius:999px;background:#efeee9}.questions{margin:14px 0 0;padding-left:22px;color:#40403b}.questions li{margin:7px 0}.rule{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.rule div,.metric{border:1px solid #e4e1d8;border-radius:12px;padding:12px}.rule b,.metric b{display:block;font-size:22px;letter-spacing:-.03em}.rule span,.metric span{font-size:11px;color:#73736b}.decision{margin-top:12px;padding:16px;border-radius:12px;background:#171717;color:white}.decision .value{font-size:21px;font-weight:800;margin-top:4px}.metrics{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-top:18px}.evidence{margin-top:18px}.row{display:grid;grid-template-columns:110px 1fr 110px;gap:12px;align-items:center;border-top:1px solid #ece9e1;padding:12px 2px}.row:first-child{border-top:0}.kind{font-weight:750;font-size:12px}.quote{font-size:13px;color:#44443f}.state{font:700 11px ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}.controls{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}button{appearance:none;border:1px solid #c9c6bc;background:#fff;border-radius:10px;padding:10px 12px;font-weight:700;cursor:pointer}button:hover{background:#f2f1ec}.danger{border-color:#111;background:#111;color:#fff}.boundary{margin-top:18px;border-left:4px solid #111;padding:8px 0 8px 13px;font-size:13px;line-height:1.5}.code{font:11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;background:#191919;color:#ededed;border-radius:12px;padding:13px;overflow:auto;white-space:pre-wrap}.footer{margin:18px 0 4px;color:#77766e;font-size:12px}@media(max-width:850px){.grid{grid-template-columns:1fr}.metrics{grid-template-columns:repeat(2,1fr)}.top{display:block}.badge{display:inline-block;margin-top:14px}.row{grid-template-columns:90px 1fr}.state{grid-column:2;text-align:left}}
+:root{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#141414;background:#f4f3ef}*{box-sizing:border-box}body{margin:0}.shell{max-width:1180px;margin:0 auto;padding:28px}.top{display:flex;justify-content:space-between;align-items:flex-start;gap:24px}.eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:800;color:#6b6b63}.title{font-size:38px;line-height:1.03;margin:7px 0 8px;letter-spacing:-.04em}.sub{max-width:760px;color:#5d5d57;line-height:1.55}.badge{border:1px solid #c9c6bc;border-radius:999px;padding:9px 12px;font-size:12px;font-weight:750;background:#fff;white-space:nowrap}.grid{display:grid;grid-template-columns:1.3fr .7fr;gap:18px;margin-top:24px}.card{background:#fff;border:1px solid #d9d6cc;border-radius:16px;padding:18px;box-shadow:0 1px 0 rgba(0,0,0,.03)}.card h2{margin:0 0 13px;font-size:15px}.hyp{font-size:23px;line-height:1.25;letter-spacing:-.02em;margin:3px 0 14px}.meta{display:flex;gap:8px;flex-wrap:wrap}.pill{font:650 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;padding:7px 9px;border-radius:999px;background:#efeee9}.questions{margin:14px 0 0;padding-left:22px;color:#40403b}.questions li{margin:7px 0}.rule{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.rule div,.metric{border:1px solid #e4e1d8;border-radius:12px;padding:12px}.rule b,.metric b{display:block;font-size:22px;letter-spacing:-.03em}.rule span,.metric span{font-size:11px;color:#73736b}.decision{margin-top:12px;padding:16px;border-radius:12px;background:#171717;color:white}.decision .value{font-size:21px;font-weight:800;margin-top:4px}.decision .why{font-size:11px;color:#bbb;margin-top:6px;line-height:1.45}.metrics{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-top:18px}.evidence{margin-top:18px}.row{display:grid;grid-template-columns:110px 1fr 120px;gap:12px;align-items:center;border-top:1px solid #ece9e1;padding:12px 2px}.row:first-child{border-top:0}.kind{font-weight:750;font-size:12px}.quote{font-size:13px;color:#44443f}.state{font:700 11px ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}.controls{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}button{appearance:none;border:1px solid #c9c6bc;background:#fff;border-radius:10px;padding:10px 12px;font-weight:700;cursor:pointer}button:hover{background:#f2f1ec}.danger{border-color:#111;background:#111;color:#fff}.boundary{margin-top:18px;border-left:4px solid #111;padding:8px 0 8px 13px;font-size:13px;line-height:1.5}.code{font:11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;background:#191919;color:#ededed;border-radius:12px;padding:13px;overflow:auto;white-space:pre-wrap}.callout{margin-top:12px;padding:12px;border-radius:12px;background:#f4f3ef;font-size:12px;line-height:1.5}.footer{margin:18px 0 4px;color:#77766e;font-size:12px}@media(max-width:850px){.grid{grid-template-columns:1fr}.metrics{grid-template-columns:repeat(2,1fr)}.top{display:block}.badge{display:inline-block;margin-top:14px}.row{grid-template-columns:90px 1fr}.state{grid-column:2;text-align:left}}
 </style>
 </head>
 <body>
 <div class="shell">
   <div class="top">
-    <div><div class="eyebrow">CounterSignal / Judge Console</div><h1 class="title">Try to kill the hypothesis.</h1><div class="sub">A frozen customer-discovery protocol where negative evidence is a first-class outcome. This console is a deterministic reviewer mode: it demonstrates the decision and evidence boundaries and never places a phone call.</div></div>
+    <div><div class="eyebrow">CounterSignal / Judge Console</div><h1 class="title">Try to kill the hypothesis.</h1><div class="sub">A frozen customer-discovery protocol where negative evidence is a first-class outcome. This deterministic reviewer mode uses the exact pre-registered SmallBet decision rule and never places a phone call.</div></div>
     <div class="badge">Deterministic reviewer mode · NO CALL</div>
   </div>
 
   <div class="grid">
     <section class="card">
       <h2>PRE-REGISTERED EXPERIMENT</h2>
-      <div class="hyp">Permit-status ambiguity recurs often enough that small construction firms already use a workaround.</div>
-      <div class="meta"><span class="pill">experiment permit-ops-001</span><span class="pill">protocol 7c4a…frozen</span><span class="pill">questions locked</span></div>
-      <ol class="questions"><li>Tell me about the last time a permit status was unclear.</li><li>How did your team resolve it?</li><li>How often does this happen?</li><li>What happens if nobody follows up?</li></ol>
+      <div class="hyp">Permit-status ambiguity recurs often enough that contractors already spend operator time on a manual workaround.</div>
+      <div class="meta"><span class="pill">smallbet-permit-ops-v1</span><span class="pill">protocol a7229d00…b47a56</span><span class="pill">5 questions locked</span></div>
+      <ol class="questions">
+        <li>Tell me about the last time a permit status was unclear or did not match what your team expected.</li>
+        <li>What did your team do to resolve it?</li>
+        <li>Roughly how often has that kind of follow-up happened in the last month?</li>
+        <li>What happens operationally if nobody follows up?</li>
+        <li>Who or what currently keeps track of those exceptions?</li>
+      </ol>
       <div class="boundary"><b>Experiment authority:</b> a call can contribute evidence. It cannot change the questions, rewrite a contradiction, or declare product-market fit.</div>
     </section>
 
     <aside class="card">
       <h2>FROZEN DECISION RULE</h2>
-      <div class="rule"><div><b>5</b><span>min answered</span></div><div><b>3</b><span>support needed</span></div><div><b>2</b><span>contradictions weaken</span></div></div>
-      <div class="decision"><div class="eyebrow" style="color:#aaa">CURRENT DECISION</div><div class="value" id="decision">collect_more</div></div>
-      <div class="controls"><button onclick="add('supporting')">+ Supporting</button><button class="danger" onclick="add('disconfirming')">+ Contradiction</button><button onclick="add('nonresponse')">+ Voicemail</button><button onclick="resetDemo()">Reset</button></div>
+      <div class="rule"><div><b>8</b><span>min answered</span></div><div><b>5</b><span>support needed</span></div><div><b>3</b><span>contradictions weaken</span></div></div>
+      <div class="decision"><div class="eyebrow" style="color:#aaa">CURRENT DECISION</div><div class="value" id="decision">hypothesis_supported_under_rule</div><div class="why" id="why"></div></div>
+      <div class="controls"><button class="danger" onclick="add('disconfirming')">+ Contradiction</button><button onclick="add('nonresponse')">+ Voicemail</button><button onclick="add('supporting')">+ Supporting</button><button onclick="resetDemo()">Reset to 8 answered</button></div>
+      <div class="callout">Demo move: add voicemail first — answered stays 8. Then add three contradictions. CounterSignal must end at <b>hypothesis_weakened</b>, even though five supporting interviews remain in the ledger.</div>
     </aside>
   </div>
 
   <div class="metrics">
-    <div class="metric"><b id="answered">0</b><span>answered denominator</span></div><div class="metric"><b id="supporting">0</b><span>supporting</span></div><div class="metric"><b id="disconfirming">0</b><span>disconfirming</span></div><div class="metric"><b id="nonresponse">0</b><span>nonresponse</span></div><div class="metric"><b id="invalid">0</b><span>invalid / ungrounded</span></div>
+    <div class="metric"><b id="answered">8</b><span>answered denominator</span></div><div class="metric"><b id="supporting">5</b><span>supporting</span></div><div class="metric"><b id="disconfirming">0</b><span>disconfirming</span></div><div class="metric"><b id="nonresponse">0</b><span>nonresponse</span></div><div class="metric"><b id="invalid">0</b><span>invalid / ungrounded</span></div>
   </div>
 
-  <section class="card evidence">
-    <h2>EVIDENCE LEDGER</h2><div id="rows"></div>
-  </section>
+  <section class="card evidence"><h2>EVIDENCE LEDGER</h2><div id="rows"></div></section>
 
   <div class="grid">
     <section class="card"><h2>CALL-E BOUNDARY</h2><div class="code">metadata.workflow_type = falsifiable_customer_discovery
-metadata.experiment_id = permit-ops-001
-metadata.protocol_hash = SHA256(frozen protocol)
+metadata.experiment_id = smallbet-permit-ops-v1
+metadata.protocol_hash = a7229d00ec935e760d5764572b142a33a062095db0df8c5f3f32c18b88b47a56
 
 result must bind to:
-✓ exact CALL-E call id
-✓ exact recipient
+✓ exact accepted CALL-E call id
+✓ exact reviewed recipient
 ✓ exact protocol hash
 ✓ recipient-side transcript quote
 
 refusal / voicemail / unreachable → nonresponse
-low-confidence / ungrounded / mismatched → invalid</div></section>
-    <section class="card"><h2>CLAIM BOUNDARY</h2><p style="line-height:1.6;margin:0;color:#44443f">The decision is a pre-registered operational rule, <b>not</b> a population-level statistical estimate. “Would take a follow-up” is never treated as demand. Silence never enters the answered denominator.</p></section>
+low-confidence / ungrounded / mismatched → invalid
+ambiguous provider outcome → outcome_unknown / NO BLIND REDIAL</div></section>
+    <section class="card"><h2>CLAIM BOUNDARY</h2><p style="line-height:1.6;margin:0;color:#44443f">The decision is a pre-registered operational rule, <b>not</b> a population-level statistical estimate. “Would take a follow-up” is never treated as demand. Silence never enters the answered denominator.</p><div class="callout"><b>Permission provenance:</b> the real dogfood run only dials respondents who affirmatively opt in to the AI interview. A public business number is not treated as permission.</div></section>
   </div>
-  <div class="footer">Reviewer console only. Preset evidence is simulated and labeled by construction; live calls use the Python CALL-E SDK path and independent execution gates.</div>
+  <div class="footer">Reviewer console only. Preset evidence is simulated and labeled by construction; live calls use the published CALL-E Python SDK behind independent permission, allowlist, reservation and execution gates.</div>
 </div>
 <script>
 const base=[
  {b:'supporting',q:'“We call the city every week until someone clarifies it.”'},
  {b:'supporting',q:'“Two people watch the portal and keep a spreadsheet.”'},
+ {b:'supporting',q:'“A coordinator owns the exceptions and follows up manually.”'},
+ {b:'supporting',q:'“If it stalls, somebody emails or calls until we know the next step.”'},
+ {b:'supporting',q:'“We already have a workaround because the portal alone is not enough.”'},
  {b:'neutral',q:'“It happens, but only on unusual projects.”'},
- {b:'nonresponse',q:'Voicemail reached — no interview evidence.'}
+ {b:'neutral',q:'“There is follow-up, but I cannot say it is recurring enough to matter.”'},
+ {b:'neutral',q:'“Another team handles it, so I cannot validate the workload.”'}
 ];
 let events=[];
 function sample(bucket){
@@ -72,10 +82,14 @@ function sample(bucket){
 }
 function compute(){
  const c={supporting:0,disconfirming:0,neutral:0,nonresponse:0,invalid:0};events.forEach(e=>c[e.b]++);
- const answered=c.supporting+c.disconfirming+c.neutral;let d='collect_more';
- if(answered>=5){if(c.disconfirming>=2)d='hypothesis_weakened';else if(c.supporting>=3&&c.disconfirming===0)d='hypothesis_supported_under_rule';else d='inconclusive';}
+ const answered=c.supporting+c.disconfirming+c.neutral;let d='collect_more';let why='Minimum answered denominator has not been reached.';
+ if(answered>=8){
+   if(c.disconfirming>=3){d='hypothesis_weakened';why='Three grounded contradictions reached the pre-registered weakening threshold.';}
+   else if(c.supporting>=5&&c.disconfirming===0){d='hypothesis_supported_under_rule';why='At least five supporting interviews, zero contradictions, and eight answered interviews.';}
+   else {d='inconclusive';why='The minimum denominator is met, but the frozen support or weakening rule is not.';}
+ }
  ['supporting','disconfirming','nonresponse','invalid'].forEach(k=>document.getElementById(k).textContent=c[k]);
- document.getElementById('answered').textContent=answered;document.getElementById('decision').textContent=d;
+ document.getElementById('answered').textContent=answered;document.getElementById('decision').textContent=d;document.getElementById('why').textContent=why;
  document.getElementById('rows').innerHTML=events.map((e,i)=>`<div class="row"><div class="kind">Interview ${String(i+1).padStart(2,'0')}</div><div class="quote">${e.q}</div><div class="state">${e.b}</div></div>`).join('')||'<div class="quote">No evidence loaded.</div>';
 }
 function add(b){events.push(sample(b));compute()}function resetDemo(){events=[...base];compute()}resetDemo();

--- a/apps/python/countersignal/judge-console.html
+++ b/apps/python/countersignal/judge-console.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>CounterSignal — Judge Console</title>
+<style>
+:root{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#141414;background:#f4f3ef}*{box-sizing:border-box}body{margin:0}.shell{max-width:1180px;margin:0 auto;padding:28px}.top{display:flex;justify-content:space-between;align-items:flex-start;gap:24px}.eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:800;color:#6b6b63}.title{font-size:38px;line-height:1.03;margin:7px 0 8px;letter-spacing:-.04em}.sub{max-width:720px;color:#5d5d57;line-height:1.55}.badge{border:1px solid #c9c6bc;border-radius:999px;padding:9px 12px;font-size:12px;font-weight:750;background:#fff;white-space:nowrap}.grid{display:grid;grid-template-columns:1.3fr .7fr;gap:18px;margin-top:24px}.card{background:#fff;border:1px solid #d9d6cc;border-radius:16px;padding:18px;box-shadow:0 1px 0 rgba(0,0,0,.03)}.card h2{margin:0 0 13px;font-size:15px}.hyp{font-size:23px;line-height:1.25;letter-spacing:-.02em;margin:3px 0 14px}.meta{display:flex;gap:8px;flex-wrap:wrap}.pill{font:650 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;padding:7px 9px;border-radius:999px;background:#efeee9}.questions{margin:14px 0 0;padding-left:22px;color:#40403b}.questions li{margin:7px 0}.rule{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.rule div,.metric{border:1px solid #e4e1d8;border-radius:12px;padding:12px}.rule b,.metric b{display:block;font-size:22px;letter-spacing:-.03em}.rule span,.metric span{font-size:11px;color:#73736b}.decision{margin-top:12px;padding:16px;border-radius:12px;background:#171717;color:white}.decision .value{font-size:21px;font-weight:800;margin-top:4px}.metrics{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-top:18px}.evidence{margin-top:18px}.row{display:grid;grid-template-columns:110px 1fr 110px;gap:12px;align-items:center;border-top:1px solid #ece9e1;padding:12px 2px}.row:first-child{border-top:0}.kind{font-weight:750;font-size:12px}.quote{font-size:13px;color:#44443f}.state{font:700 11px ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}.controls{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}button{appearance:none;border:1px solid #c9c6bc;background:#fff;border-radius:10px;padding:10px 12px;font-weight:700;cursor:pointer}button:hover{background:#f2f1ec}.danger{border-color:#111;background:#111;color:#fff}.boundary{margin-top:18px;border-left:4px solid #111;padding:8px 0 8px 13px;font-size:13px;line-height:1.5}.code{font:11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;background:#191919;color:#ededed;border-radius:12px;padding:13px;overflow:auto;white-space:pre-wrap}.footer{margin:18px 0 4px;color:#77766e;font-size:12px}@media(max-width:850px){.grid{grid-template-columns:1fr}.metrics{grid-template-columns:repeat(2,1fr)}.top{display:block}.badge{display:inline-block;margin-top:14px}.row{grid-template-columns:90px 1fr}.state{grid-column:2;text-align:left}}
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="top">
+    <div><div class="eyebrow">CounterSignal / Judge Console</div><h1 class="title">Try to kill the hypothesis.</h1><div class="sub">A frozen customer-discovery protocol where negative evidence is a first-class outcome. This console is a deterministic reviewer mode: it demonstrates the decision and evidence boundaries and never places a phone call.</div></div>
+    <div class="badge">Deterministic reviewer mode · NO CALL</div>
+  </div>
+
+  <div class="grid">
+    <section class="card">
+      <h2>PRE-REGISTERED EXPERIMENT</h2>
+      <div class="hyp">Permit-status ambiguity recurs often enough that small construction firms already use a workaround.</div>
+      <div class="meta"><span class="pill">experiment permit-ops-001</span><span class="pill">protocol 7c4a…frozen</span><span class="pill">questions locked</span></div>
+      <ol class="questions"><li>Tell me about the last time a permit status was unclear.</li><li>How did your team resolve it?</li><li>How often does this happen?</li><li>What happens if nobody follows up?</li></ol>
+      <div class="boundary"><b>Experiment authority:</b> a call can contribute evidence. It cannot change the questions, rewrite a contradiction, or declare product-market fit.</div>
+    </section>
+
+    <aside class="card">
+      <h2>FROZEN DECISION RULE</h2>
+      <div class="rule"><div><b>5</b><span>min answered</span></div><div><b>3</b><span>support needed</span></div><div><b>2</b><span>contradictions weaken</span></div></div>
+      <div class="decision"><div class="eyebrow" style="color:#aaa">CURRENT DECISION</div><div class="value" id="decision">collect_more</div></div>
+      <div class="controls"><button onclick="add('supporting')">+ Supporting</button><button class="danger" onclick="add('disconfirming')">+ Contradiction</button><button onclick="add('nonresponse')">+ Voicemail</button><button onclick="resetDemo()">Reset</button></div>
+    </aside>
+  </div>
+
+  <div class="metrics">
+    <div class="metric"><b id="answered">0</b><span>answered denominator</span></div><div class="metric"><b id="supporting">0</b><span>supporting</span></div><div class="metric"><b id="disconfirming">0</b><span>disconfirming</span></div><div class="metric"><b id="nonresponse">0</b><span>nonresponse</span></div><div class="metric"><b id="invalid">0</b><span>invalid / ungrounded</span></div>
+  </div>
+
+  <section class="card evidence">
+    <h2>EVIDENCE LEDGER</h2><div id="rows"></div>
+  </section>
+
+  <div class="grid">
+    <section class="card"><h2>CALL-E BOUNDARY</h2><div class="code">metadata.workflow_type = falsifiable_customer_discovery
+metadata.experiment_id = permit-ops-001
+metadata.protocol_hash = SHA256(frozen protocol)
+
+result must bind to:
+✓ exact CALL-E call id
+✓ exact recipient
+✓ exact protocol hash
+✓ recipient-side transcript quote
+
+refusal / voicemail / unreachable → nonresponse
+low-confidence / ungrounded / mismatched → invalid</div></section>
+    <section class="card"><h2>CLAIM BOUNDARY</h2><p style="line-height:1.6;margin:0;color:#44443f">The decision is a pre-registered operational rule, <b>not</b> a population-level statistical estimate. “Would take a follow-up” is never treated as demand. Silence never enters the answered denominator.</p></section>
+  </div>
+  <div class="footer">Reviewer console only. Preset evidence is simulated and labeled by construction; live calls use the Python CALL-E SDK path and independent execution gates.</div>
+</div>
+<script>
+const base=[
+ {b:'supporting',q:'“We call the city every week until someone clarifies it.”'},
+ {b:'supporting',q:'“Two people watch the portal and keep a spreadsheet.”'},
+ {b:'neutral',q:'“It happens, but only on unusual projects.”'},
+ {b:'nonresponse',q:'Voicemail reached — no interview evidence.'}
+];
+let events=[];
+function sample(bucket){
+ if(bucket==='supporting')return {b:bucket,q:'“We have someone check the portal and call when it stalls.”'};
+ if(bucket==='disconfirming')return {b:bucket,q:'“That is not really a problem for us; the portal is usually enough.”'};
+ return {b:'nonresponse',q:'Voicemail reached — excluded from answered denominator.'};
+}
+function compute(){
+ const c={supporting:0,disconfirming:0,neutral:0,nonresponse:0,invalid:0};events.forEach(e=>c[e.b]++);
+ const answered=c.supporting+c.disconfirming+c.neutral;let d='collect_more';
+ if(answered>=5){if(c.disconfirming>=2)d='hypothesis_weakened';else if(c.supporting>=3&&c.disconfirming===0)d='hypothesis_supported_under_rule';else d='inconclusive';}
+ ['supporting','disconfirming','nonresponse','invalid'].forEach(k=>document.getElementById(k).textContent=c[k]);
+ document.getElementById('answered').textContent=answered;document.getElementById('decision').textContent=d;
+ document.getElementById('rows').innerHTML=events.map((e,i)=>`<div class="row"><div class="kind">Interview ${String(i+1).padStart(2,'0')}</div><div class="quote">${e.q}</div><div class="state">${e.b}</div></div>`).join('')||'<div class="quote">No evidence loaded.</div>';
+}
+function add(b){events.push(sample(b));compute()}function resetDemo(){events=[...base];compute()}resetDemo();
+</script>
+</body>
+</html>

--- a/apps/python/countersignal/pyproject.toml
+++ b/apps/python/countersignal/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "countersignal-calle"
+version = "0.1.0"
+description = "Falsifiable customer-discovery calls with a frozen protocol and honest evidence denominator."
+requires-python = ">=3.11"
+dependencies = ["calle-ai==0.2.0"]
+
+[dependency-groups]
+dev = ["pytest>=9.0.0"]

--- a/apps/python/countersignal/smallbet-experiment.json
+++ b/apps/python/countersignal/smallbet-experiment.json
@@ -1,0 +1,18 @@
+{
+  "experiment_id": "smallbet-permit-ops-v1",
+  "segment": "small and midsize US commercial contractors that directly manage municipal permits",
+  "problem": "permit status ambiguity creates repeated manual portal checks, calls, emails, or internal coordination",
+  "hypothesis": "permit status ambiguity recurs often enough that contractors already spend operator time on a manual workaround",
+  "questions": [
+    "Tell me about the last time a permit status was unclear or did not match what your team expected.",
+    "What did your team do to resolve it?",
+    "Roughly how often has that kind of follow-up happened in the last month?",
+    "What happens operationally if nobody follows up?",
+    "Who or what currently keeps track of those exceptions?"
+  ],
+  "decision_rule": {
+    "min_answered": 8,
+    "support_if_at_least": 5,
+    "weaken_if_at_least": 3
+  }
+}

--- a/apps/python/countersignal/test_countersignal.py
+++ b/apps/python/countersignal/test_countersignal.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from pathlib import Path
 
 import countersignal as c
 
@@ -156,3 +157,49 @@ def test_schema_requires_exact_fields():
 
 def test_serializable_preview_for_reviewer():
     json.dumps(c.preview(experiment(), recipient()))
+
+
+def test_ledger_prevents_duplicate_intent(tmp_path):
+    ledger = c.ReservationLedger(tmp_path / "ledger.sqlite3")
+    key = c.idempotency_key(experiment(), recipient())
+    assert ledger.claim(key) is True
+    assert ledger.claim(key) is False
+    ledger.mark(key, "accepted", "call_123")
+    assert ledger.get(key) == ("accepted", "call_123", None)
+
+
+def test_ambiguous_provider_outcome_blocks_blind_redial(tmp_path):
+    class BrokenCalls:
+        def create(self, **kwargs):
+            return {"id": "call_123"}
+
+        def wait_for_result(self, call_id, *, timeout_seconds, interval_seconds):
+            raise TimeoutError("ambiguous")
+
+    ledger = c.ReservationLedger(tmp_path / "ledger.sqlite3")
+    try:
+        c.execute(experiment(), recipient(), BrokenCalls(), ledger)
+    except RuntimeError as exc:
+        assert "outcome is unknown" in str(exc)
+    else:
+        raise AssertionError("expected ambiguous outcome")
+
+    state = ledger.get(c.idempotency_key(experiment(), recipient()))
+    assert state is not None
+    assert state[0] == "outcome_unknown"
+    assert state[1] == "call_123"
+
+    try:
+        c.execute(experiment(), recipient(), BrokenCalls(), ledger)
+    except RuntimeError as exc:
+        assert "already reserved" in str(exc)
+    else:
+        raise AssertionError("duplicate call should be blocked")
+
+
+def test_judge_console_is_explicitly_no_call_and_contains_decision_states():
+    html = (Path(__file__).with_name("judge-console.html")).read_text(encoding="utf-8")
+    assert "Deterministic reviewer mode · NO CALL" in html
+    assert "hypothesis_weakened" in html
+    assert "Silence never enters the answered denominator" in html
+    assert "fetch(" not in html

--- a/apps/python/countersignal/test_countersignal.py
+++ b/apps/python/countersignal/test_countersignal.py
@@ -159,6 +159,22 @@ def test_serializable_preview_for_reviewer():
     json.dumps(c.preview(experiment(), recipient()))
 
 
+def test_loopback_never_receives_the_real_api_key(monkeypatch):
+    monkeypatch.setenv("CALLE_API_KEY", "real-production-secret")
+    assert c.validate_base_url("http://127.0.0.1:8123") == "http://127.0.0.1:8123"
+    assert c.api_key_for_base_url("http://127.0.0.1:8123") == c.LOOPBACK_TEST_API_KEY
+
+
+def test_production_requires_the_real_api_key(monkeypatch):
+    monkeypatch.delenv("CALLE_API_KEY", raising=False)
+    try:
+        c.api_key_for_base_url(c.DEFAULT_BASE_URL)
+    except ValueError as exc:
+        assert "production" in str(exc)
+    else:
+        raise AssertionError("production execution should require CALLE_API_KEY")
+
+
 def test_ledger_prevents_duplicate_intent(tmp_path):
     ledger = c.ReservationLedger(tmp_path / "ledger.sqlite3")
     key = c.idempotency_key(experiment(), recipient())

--- a/apps/python/countersignal/test_countersignal.py
+++ b/apps/python/countersignal/test_countersignal.py
@@ -1,0 +1,158 @@
+import copy
+import json
+
+import countersignal as c
+
+
+EXPERIMENT_DATA = {
+    "experiment_id": "permit-ops-001",
+    "segment": "small construction firms that manage municipal permits",
+    "problem": "staff spend repeated operator time resolving permit status ambiguity",
+    "hypothesis": "the problem recurs often enough that firms already use a workaround",
+    "questions": [
+        "Tell me about the last time a permit status was unclear.",
+        "How did your team resolve it?",
+        "How often does this happen?",
+        "What happens if nobody follows up?",
+    ],
+    "decision_rule": {"min_answered": 5, "support_if_at_least": 3, "weaken_if_at_least": 2},
+}
+RECIPIENT_DATA = {"phone": "+14155550123", "region": "US", "locale": "en-US"}
+
+
+def experiment():
+    return c.parse_experiment(EXPERIMENT_DATA)
+
+
+def recipient():
+    return c.parse_recipient(RECIPIENT_DATA)
+
+
+def provider_result(**overrides):
+    exp = experiment()
+    rec = recipient()
+    result = {
+        "id": "call_123",
+        "status": "completed",
+        "task_completed": True,
+        "completion_confidence": {"score": 0.95},
+        "metadata": {
+            "workflow_type": "falsifiable_customer_discovery",
+            "experiment_id": exp.experiment_id,
+            "protocol_hash": c.protocol_hash(exp),
+        },
+        "structured_result": {
+            "continued_after_ai_disclosure": "yes",
+            "disposition": "answered",
+            "problem_occurred": "yes",
+            "current_workaround": "yes",
+            "would_take_followup": "yes",
+            "contradicts_hypothesis": "no",
+            "key_quote": "we call the city every week",
+            "notes": "Uses a shared spreadsheet and manual calls.",
+        },
+        "recipients": [
+            {
+                "phone": rec.phone,
+                "attempts": [
+                    {
+                        "transcript_turns": [
+                            {"speaker": "assistant", "text": "How do you resolve it?"},
+                            {"speaker": "recipient", "text": "Usually we call the city every week until someone clarifies it."},
+                        ]
+                    }
+                ],
+            }
+        ],
+    }
+    result.update(overrides)
+    return result
+
+
+def test_protocol_hash_is_deterministic_and_changes_on_question_drift():
+    exp = experiment()
+    assert c.protocol_hash(exp) == c.protocol_hash(exp)
+    drifted = copy.deepcopy(EXPERIMENT_DATA)
+    drifted["questions"][0] = "Would you buy a permit automation service?"
+    assert c.protocol_hash(c.parse_experiment(drifted)) != c.protocol_hash(exp)
+
+
+def test_preview_masks_phone_and_never_calls():
+    p = c.preview(experiment(), recipient())
+    assert p["creates_phone_call"] is False
+    assert p["call_arguments"]["recipients"][0]["phones"][0] != RECIPIENT_DATA["phone"]
+    assert "Do not sell" in p["call_arguments"]["task"]
+
+
+def test_supporting_result_must_be_grounded_and_bound():
+    classified = c.classify_call(experiment(), recipient(), provider_result(), expected_call_id="call_123")
+    assert classified["bucket"] == "supporting"
+
+    wrong_metadata = provider_result(metadata={"experiment_id": "other"})
+    assert c.classify_call(experiment(), recipient(), wrong_metadata, expected_call_id="call_123")["bucket"] == "invalid"
+
+    ungrounded = provider_result()
+    ungrounded["structured_result"] = {**ungrounded["structured_result"], "key_quote": "this sentence was never said"}
+    assert c.classify_call(experiment(), recipient(), ungrounded, expected_call_id="call_123")["bucket"] == "invalid"
+
+
+def test_refusal_and_voicemail_never_enter_answered_denominator():
+    refused = provider_result()
+    refused["structured_result"] = {
+        **refused["structured_result"],
+        "continued_after_ai_disclosure": "no",
+        "disposition": "refused",
+        "key_quote": "no thank you",
+    }
+    refused["recipients"][0]["attempts"][0]["transcript_turns"][1]["text"] = "No thank you, I do not want to participate."
+    assert c.classify_call(experiment(), recipient(), refused)["bucket"] == "nonresponse"
+
+    decision = c.experiment_decision(experiment(), ["supporting", "supporting", "nonresponse", "invalid"])
+    assert decision["answered_denominator"] == 2
+    assert decision["decision"] == "collect_more"
+
+
+def test_disconfirming_evidence_has_priority_after_minimum_sample():
+    d = c.experiment_decision(experiment(), ["supporting", "supporting", "supporting", "disconfirming", "disconfirming"])
+    assert d["decision"] == "hypothesis_weakened"
+
+
+def test_support_is_only_under_the_frozen_rule_and_not_population_inference():
+    d = c.experiment_decision(experiment(), ["supporting", "supporting", "supporting", "neutral", "neutral"])
+    assert d["decision"] == "hypothesis_supported_under_rule"
+    assert "not a population-level" in d["claim_boundary"]
+
+
+def test_invalid_experiment_rejects_mutable_or_weak_protocol_shape():
+    bad = copy.deepcopy(EXPERIMENT_DATA)
+    bad["questions"] = ["only one"]
+    try:
+        c.parse_experiment(bad)
+    except ValueError as exc:
+        assert "3-8" in str(exc)
+    else:
+        raise AssertionError("expected invalid experiment")
+
+
+def test_idempotency_key_changes_by_recipient_and_protocol():
+    exp = experiment()
+    rec = recipient()
+    key = c.idempotency_key(exp, rec)
+    other = c.Recipient(phone="+14155550124", region="US", locale="en-US")
+    assert c.idempotency_key(exp, other) != key
+    drifted = copy.deepcopy(EXPERIMENT_DATA)
+    drifted["problem"] += " after portal updates"
+    assert c.idempotency_key(c.parse_experiment(drifted), rec) != key
+
+
+def test_schema_requires_exact_fields():
+    result = provider_result()["structured_result"]
+    assert c.valid_structured_result(result)
+    assert not c.valid_structured_result({**result, "invented": "field"})
+    missing = dict(result)
+    missing.pop("key_quote")
+    assert not c.valid_structured_result(missing)
+
+
+def test_serializable_preview_for_reviewer():
+    json.dumps(c.preview(experiment(), recipient()))

--- a/apps/python/countersignal/test_judge_console.py
+++ b/apps/python/countersignal/test_judge_console.py
@@ -7,3 +7,15 @@ def test_judge_console_is_explicitly_no_call_and_contains_decision_states():
     assert "hypothesis_weakened" in html
     assert "Silence never enters the answered denominator" in html
     assert "fetch(" not in html
+
+
+def test_judge_console_matches_frozen_smallbet_protocol():
+    html = (Path(__file__).with_name("judge-console.html")).read_text(encoding="utf-8")
+    assert "smallbet-permit-ops-v1" in html
+    assert "a7229d00ec935e760d5764572b142a33a062095db0df8c5f3f32c18b88b47a56" in html
+    assert "<b>8</b><span>min answered</span>" in html
+    assert "<b>5</b><span>support needed</span>" in html
+    assert "<b>3</b><span>contradictions weaken</span>" in html
+    assert "if(answered>=8)" in html
+    assert "c.disconfirming>=3" in html
+    assert "c.supporting>=5&&c.disconfirming===0" in html

--- a/apps/python/countersignal/test_judge_console.py
+++ b/apps/python/countersignal/test_judge_console.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_judge_console_is_explicitly_no_call_and_contains_decision_states():
+    html = (Path(__file__).with_name("judge-console.html")).read_text(encoding="utf-8")
+    assert "Deterministic reviewer mode · NO CALL" in html
+    assert "hypothesis_weakened" in html
+    assert "Silence never enters the answered denominator" in html
+    assert "fetch(" not in html


### PR DESCRIPTION
Adds CounterSignal, a CALL-E customer-discovery agent that freezes the hypothesis, questions, and decision rule before interviews; preserves disconfirming evidence; excludes voicemail/refusal from the answered denominator; and binds valid evidence to the exact call, protocol, recipient, and transcript quote.

Public judge demo: https://countersignal.vercel.app

Key reliability properties: explicit AI-call permission, exact recipient allowlist, SQLite intent reservation, outcome_unknown/no blind redial, and deterministic 8/5/3 decision logic.

Staging PR and CI are green in the contributor fork.