### PR TITLE
fix(ringer): update current unsigned webhook contract

### DIFF
--- a/apps/typescript/ringer/.env.example
+++ b/apps/typescript/ringer/.env.example
@@ -14,10 +14,11 @@ CALLE_BASE_URL=https://api.heycall-e.com
 # (entered once in Settings). Generate any long random string.
 CALLE_APP_SECRET=
 
-# Optional: enable signed webhook delivery for terminal call events.
-# When set, /api/calls auto-registers this deployment's /api/webhook URL.
-CALLE_WEBHOOK_SECRET=
-# CALLE_WEBHOOK_URL=https://your-deployment.vercel.app/api/webhook
+# Optional: opt into current unsigned terminal webhook delivery. CALL-E does
+# not send a secret or signature headers. This app validates event-ID
+# consistency and logs only bounded IDs; its live UI remains polling-based.
+# See https://docs.heycall-e.com/#/webhooks
+CALLE_WEBHOOK_URL=
 
 # Scheduled / recurring calls (optional).
 # These fire server-side via a cron, so they need a durable store (Vercel KV /

--- a/apps/typescript/ringer/README.md
+++ b/apps/typescript/ringer/README.md
@@ -12,7 +12,8 @@ confidence, quoted evidence, and the full transcript.
 - **Source:** https://github.com/DevJustinTech/ringer
 - **Language:** TypeScript (React + Vite front end, Vercel serverless functions)
 - **CALL-E surface used:** server SDK (`@call-e/calle`), REST API
-  (`/v1/calls`, `/v1/calls/{id}`, `/v1/calls/{id}/events`), signed webhooks
+  (`/v1/calls`, `/v1/calls/{id}`, `/v1/calls/{id}/events`), current unsigned
+  terminal webhooks
 
 ## Why not just use the CALL-E assistant?
 
@@ -102,8 +103,16 @@ pnpm dlx vercel dev
   when the scheduler is armed (KV + server key) it **requires `CRON_SECRET`** and
   a matching Bearer token and **fails closed** if the secret is unset — the
   dialer is never publicly triggerable.
-- Optional `CALLE_WEBHOOK_SECRET` enables signed-webhook verification via the
-  SDK's HMAC check on the raw request body.
+- Optional `CALLE_WEBHOOK_URL` opts calls into current unsigned terminal-event
+  delivery. `/api/webhook` requires `application/json`, validates that the
+  `CALL-E-Event-Id` header matches the bounded body event ID, accepts only the
+  documented terminal event types, and logs only bounded event/call IDs. This
+  consistency check is not sender authentication, so the endpoint performs no
+  business side effect and the live UI remains polling-based. A production
+  extension must durably deduplicate event IDs and reconcile through an
+  authenticated Calls API read before trusting a notification. Current CALL-E
+  deliveries do not include a webhook secret or signature headers; see the
+  [webhook guide](https://docs.heycall-e.com/#/webhooks).
 - A caller-supplied API base URL is honored only for the official
   `*.heycall-e.com` host (or loopback) and only alongside a BYOK key — the
   operator's server key is never redirected to a client-chosen host.

--- a/apps/typescript/ringer/api/_lib/calle.ts
+++ b/apps/typescript/ringer/api/_lib/calle.ts
@@ -101,11 +101,9 @@ export async function createCalleCall(
   return { id: call.id }
 }
 
-/** Derive the signed-webhook URL for this deployment, when configured. */
-export function deriveWebhookUrl(host?: string): string | undefined {
-  if (process.env.CALLE_WEBHOOK_URL) return process.env.CALLE_WEBHOOK_URL
-  if (process.env.CALLE_WEBHOOK_SECRET && host) return `https://${host}/api/webhook`
-  return undefined
+/** Return the explicitly configured current unsigned-webhook URL. */
+export function deriveWebhookUrl(): string | undefined {
+  return process.env.CALLE_WEBHOOK_URL?.trim() || undefined
 }
 
 /**

--- a/apps/typescript/ringer/api/calls.ts
+++ b/apps/typescript/ringer/api/calls.ts
@@ -44,7 +44,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         result_schema: body.result_schema ?? undefined,
         recipient_result_schema: body.recipient_result_schema ?? undefined,
         metadata: body.metadata,
-        webhook_url: body.webhook_url ?? deriveWebhookUrl(req.headers.host),
+        webhook_url: body.webhook_url ?? deriveWebhookUrl(),
       },
       idempotencyKey,
     )

--- a/apps/typescript/ringer/api/cron/run-due.ts
+++ b/apps/typescript/ringer/api/cron/run-due.ts
@@ -49,7 +49,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const creds = serverCreds()
   if (!creds) return res.status(200).json({ ok: true, note: 'no server CALL-E key', fired: 0 })
 
-  const webhookUrl = deriveWebhookUrl(req.headers.host)
+  const webhookUrl = deriveWebhookUrl()
   const due = await dueJobs(Date.now())
 
   let fired = 0

--- a/apps/typescript/ringer/api/health.ts
+++ b/apps/typescript/ringer/api/health.ts
@@ -25,7 +25,7 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     serverKeyLocked: keySet && !secretSet,
     // Scheduled calls fire server-side, so they need KV and a usable server key.
     hasScheduler: serverKeyUsable && kvConfigured(),
-    webhookConfigured: Boolean(process.env.CALLE_WEBHOOK_SECRET),
+    webhookConfigured: Boolean(process.env.CALLE_WEBHOOK_URL?.trim()),
     baseUrl: (process.env.CALLE_BASE_URL || 'https://api.heycall-e.com').replace(/\/$/, ''),
   })
 }

--- a/apps/typescript/ringer/api/webhook.ts
+++ b/apps/typescript/ringer/api/webhook.ts
@@ -1,18 +1,54 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { CalleClient } from '@call-e/calle'
 
 /**
  * POST /api/webhook — receive terminal CALL-E events (call.completed, etc).
  *
- * Demonstrates the SDK's signed-webhook verification. CALL-E signs each
- * delivery with HMAC-SHA256 over `timestamp + "." + raw_body`. We read the
- * RAW body (not the parsed one) so the signature check is byte-exact.
+ * Current CALL-E deliveries are unsigned. Validate the JSON envelope and
+ * require `CALL-E-Event-Id` to match the body event id. That consistency check
+ * is not sender authentication: this diagnostics-only endpoint performs no
+ * business side effect. A production extension must durably deduplicate the
+ * event id and reconcile the call through the authenticated Calls API before
+ * trusting the notification.
  *
- * The live UI polls for status, so this endpoint is optional — but wiring it
- * up (set CALLE_WEBHOOK_SECRET) shows the full terminal-event path.
+ * The live UI remains authoritative through polling, so this endpoint is
+ * optional. Set CALLE_WEBHOOK_URL to opt a deployment into delivery.
  */
 
-// Ask Vercel not to pre-parse the body so we can verify the exact bytes.
+const MAX_BODY_BYTES = 1_048_576
+const MAX_PROVIDER_ID_BYTES = 512
+const ISO_8601_TIMESTAMP =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/
+type TerminalEventType =
+  | 'call.completed'
+  | 'call.failed'
+  | 'call.result_validation_failed'
+const TERMINAL_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'call.completed',
+  'call.failed',
+  'call.result_validation_failed',
+])
+
+type HeaderMap = Record<string, string | string[] | undefined>
+
+export interface AcceptedWebhookNotification {
+  id: string
+  type: TerminalEventType
+  created_at: string
+  data: { id: string }
+}
+
+export class WebhookInputError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'WebhookInputError'
+  }
+}
+
+// Ask Vercel not to pre-parse the body so this route can enforce its own limit.
 export const config = { api: { bodyParser: false } }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -21,37 +57,136 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return
   }
 
-  const secret = process.env.CALLE_WEBHOOK_SECRET
-  if (!secret) {
-    // Nothing to verify against — accept but do nothing.
-    res.status(200).json({ ok: true, note: 'CALLE_WEBHOOK_SECRET not set; event ignored.' })
-    return
-  }
-
-  const rawBody = await readRawBody(req)
-  const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY ?? 'unused-for-webhook' })
-
   try {
-    const event = client.webhooks.unwrap({
-      rawBody,
-      headers: req.headers as Record<string, string | string[] | undefined>,
-      secret,
-    })
-    // In a full product you would persist event.data (the terminal call task)
-    // keyed by event.id for idempotency and notify the user. For the hackathon
-    // we log it; CALL-E treats any 2xx as delivered.
-    console.log(`[webhook] ${event.type} for call ${event.data?.id}`)
+    const rawBody = await readRawBody(req)
+    const event = parseWebhookEvent(rawBody, req.headers)
+    // Event and call IDs are attacker-controlled because current deliveries are
+    // unsigned. Log only the allowlisted type so diagnostic traffic cannot
+    // inject or reorder terminal output.
+    console.log(`[webhook] accepted ${event.type}`)
     res.status(200).json({ ok: true })
   } catch (err) {
-    console.warn('[webhook] signature verification failed:', (err as Error).message)
-    res.status(400).end()
+    if (err instanceof WebhookInputError) {
+      res.status(err.status).json({ error: { code: err.code, message: err.message } })
+      return
+    }
+    console.warn('[webhook] unexpected receiver error')
+    res.status(500).json({ error: { code: 'internal_error', message: 'Webhook processing failed.' } })
   }
+}
+
+export function parseWebhookEvent(
+  rawBody: string,
+  headers: HeaderMap,
+): AcceptedWebhookNotification {
+  const contentType = singleHeader(headers, 'content-type')
+  if (!contentType || contentType.split(';', 1)[0]?.trim().toLowerCase() !== 'application/json') {
+    throw new WebhookInputError(400, 'invalid_content_type', 'Content-Type must be application/json.')
+  }
+
+  const headerEventId = singleHeader(headers, 'call-e-event-id')
+  if (!headerEventId) {
+    throw new WebhookInputError(400, 'missing_event_id', 'CALL-E-Event-Id is required.')
+  }
+  if (!isSafeProviderId(headerEventId)) {
+    throw new WebhookInputError(400, 'invalid_event_id', 'CALL-E-Event-Id is invalid.')
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(rawBody)
+  } catch {
+    throw new WebhookInputError(400, 'invalid_json', 'Webhook body must be valid JSON.')
+  }
+  if (!isObject(value)) {
+    throw new WebhookInputError(400, 'invalid_event', 'Webhook body must be a JSON object.')
+  }
+
+  const eventId = value.id
+  if (!isSafeProviderId(eventId)) {
+    throw new WebhookInputError(400, 'invalid_event_id', 'Webhook event id is invalid.')
+  }
+  if (headerEventId !== eventId) {
+    throw new WebhookInputError(400, 'event_id_mismatch', 'CALL-E-Event-Id must match the body id.')
+  }
+  if (typeof value.type !== 'string' || !TERMINAL_EVENT_TYPES.has(value.type)) {
+    throw new WebhookInputError(400, 'unsupported_event_type', 'Webhook event type is not terminal.')
+  }
+  if (
+    typeof value.created_at !== 'string' ||
+    !isIso8601Timestamp(value.created_at)
+  ) {
+    throw new WebhookInputError(400, 'invalid_created_at', 'Webhook created_at must be an ISO timestamp.')
+  }
+  if (!isObject(value.data)) {
+    throw new WebhookInputError(400, 'invalid_call_data', 'Webhook data must be a call object.')
+  }
+  if (!isSafeProviderId(value.data.id)) {
+    throw new WebhookInputError(400, 'invalid_call_id', 'Webhook call id is invalid.')
+  }
+
+  return {
+    id: eventId,
+    type: value.type as TerminalEventType,
+    created_at: value.created_at,
+    data: { id: value.data.id },
+  }
+}
+
+function singleHeader(headers: HeaderMap, name: string): string | undefined {
+  const values = Object.entries(headers)
+    .filter(([key]) => key.toLowerCase() === name)
+    .flatMap(([, value]) => (Array.isArray(value) ? value : value === undefined ? [] : [value]))
+  if (values.length > 1) {
+    throw new WebhookInputError(400, 'duplicate_header', `Multiple ${name} headers are not allowed.`)
+  }
+  return values[0]
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isSafeProviderId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    Buffer.byteLength(value, 'utf8') <= MAX_PROVIDER_ID_BYTES &&
+    !hasUnsafeProviderIdCharacter(value)
+  )
+}
+
+function hasUnsafeProviderIdCharacter(value: string): boolean {
+  // Reject Unicode control, formatting, line-separator, and paragraph-separator
+  // characters. This covers C0/C1 controls plus bidi and zero-width controls.
+  return /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(value)
+}
+
+function isIso8601Timestamp(value: string): boolean {
+  const match = ISO_8601_TIMESTAMP.exec(value)
+  if (!match) return false
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = Number(secondText)
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) return false
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  return day >= 1 && day <= daysInMonth && Number.isFinite(Date.parse(value))
 }
 
 async function readRawBody(req: VercelRequest): Promise<string> {
   const chunks: Buffer[] = []
+  let bytes = 0
   for await (const chunk of req as AsyncIterable<Buffer>) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+    bytes += buffer.length
+    if (bytes > MAX_BODY_BYTES) {
+      throw new WebhookInputError(413, 'payload_too_large', 'Webhook body is too large.')
+    }
+    chunks.push(buffer)
   }
   return Buffer.concat(chunks).toString('utf8')
 }

--- a/apps/typescript/ringer/package.json
+++ b/apps/typescript/ringer/package.json
@@ -16,7 +16,7 @@
     "verify:all": "pnpm build && pnpm typecheck:api && pnpm verify && pnpm verify:api && pnpm verify:render"
   },
   "dependencies": {
-    "@call-e/calle": "^0.2.2",
+    "@call-e/calle": "^0.7.0",
     "@gsap/react": "^2.1.2",
     "@tailwindcss/vite": "^4.3.3",
     "clsx": "^2.1.1",

--- a/apps/typescript/ringer/pnpm-lock.yaml
+++ b/apps/typescript/ringer/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@call-e/calle':
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^0.7.0
+        version: 0.7.0
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.8)
@@ -84,8 +84,8 @@ packages:
   '@bytecodealliance/preview2-shim@0.17.6':
     resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
 
-  '@call-e/calle@0.2.2':
-    resolution: {integrity: sha512-o1cDf/mASU92luUbdiUj1E7AFtXK+mm4ikGwB3x+G9RaEZCezs7/vYKDMEydnRmM1b8FEzzQB+Z+ehoE5kKvGw==}
+  '@call-e/calle@0.7.0':
+    resolution: {integrity: sha512-SUOm42SaVvzboBbXlv7d8uGmbpPuQwZIX5rU9nWo5tr+JOgP36P8rfe1AI7ZVbMpLuX88XIxASm2BQ3qfAKyPg==}
     hasBin: true
 
   '@edge-runtime/format@2.2.1':
@@ -1702,7 +1702,7 @@ snapshots:
 
   '@bytecodealliance/preview2-shim@0.17.6': {}
 
-  '@call-e/calle@0.2.2':
+  '@call-e/calle@0.7.0':
     dependencies:
       openapi-fetch: 0.14.1
 

--- a/apps/typescript/ringer/scripts/verify-api.ts
+++ b/apps/typescript/ringer/scripts/verify-api.ts
@@ -10,9 +10,22 @@
  */
 import { pathToFileURL } from 'node:url'
 import path from 'node:path'
+import { createServer } from 'node:http'
 
 const mod: any = await import(pathToFileURL(path.resolve(process.cwd(), 'api/_lib/calle.ts')).href)
-const { contentIdempotencyKey, isAllowedBaseUrl, resolveCreds, requireKey, scheduleJobId } = mod
+const {
+  contentIdempotencyKey,
+  createCalleCall,
+  deriveWebhookUrl,
+  isAllowedBaseUrl,
+  resolveCreds,
+  requireKey,
+  scheduleJobId,
+} = mod
+const webhookMod: any = await import(
+  pathToFileURL(path.resolve(process.cwd(), 'api/webhook.ts')).href
+)
+const { default: webhookHandler, parseWebhookEvent } = webhookMod
 
 let pass = 0
 const ok = (name: string, cond: boolean) => {
@@ -122,5 +135,222 @@ ok('different occurrence (dueAt) → different job id', scheduleJobId({ dueAt: d
 ok('edited task → different job id', scheduleJobId({ dueAt: due1, body: schedBody }) !== scheduleJobId({ dueAt: due1, body: { ...schedBody, task: 'Cancel it.' } }))
 ok('client Idempotency-Key overrides content', scheduleJobId({ idempotencyKey: 'req-123', dueAt: due1, body: schedBody }) === scheduleJobId({ idempotencyKey: 'req-123', dueAt: due2, body: { ...schedBody, task: 'different' } }))
 ok('job id is namespaced', scheduleJobId({ dueAt: due1, body: schedBody }).startsWith('sched_'))
+
+console.log('\n[6] Current unsigned webhook contract')
+const webhookEvent = {
+  id: 'evt_test_123',
+  type: 'call.completed',
+  created_at: '2026-08-20T10:00:00.000Z',
+  data: { id: 'call_test_123', status: 'completed' },
+}
+const parsed = parseWebhookEvent(JSON.stringify(webhookEvent), {
+  'content-type': 'application/json',
+  'call-e-event-id': webhookEvent.id,
+})
+ok('unsigned terminal event is accepted', parsed.id === webhookEvent.id)
+ok('terminal call id is preserved', parsed.data.id === webhookEvent.data.id)
+const opaqueIdEvent = parseWebhookEvent(
+  JSON.stringify({ ...webhookEvent, id: 'evt:opaque.v1/@example', data: { id: 'call:opaque.v1/@example' } }),
+  {
+    'content-type': 'application/json',
+    'call-e-event-id': 'evt:opaque.v1/@example',
+  },
+)
+ok('bounded opaque provider ids are accepted', opaqueIdEvent.data.id === 'call:opaque.v1/@example')
+for (const type of ['call.failed', 'call.result_validation_failed']) {
+  const terminal = parseWebhookEvent(JSON.stringify({ ...webhookEvent, type }), {
+    'content-type': 'application/json; charset=utf-8',
+    'call-e-event-id': webhookEvent.id,
+  })
+  ok(`${type} is accepted`, terminal.type === type)
+}
+
+const expectWebhookError = (name: string, code: string, run: () => unknown) => {
+  try {
+    run()
+    ok(name, false)
+  } catch (error) {
+    ok(name, (error as { code?: string }).code === code)
+  }
+}
+
+expectWebhookError('missing event-id header is rejected', 'missing_event_id', () =>
+  parseWebhookEvent(JSON.stringify(webhookEvent), { 'content-type': 'application/json' }),
+)
+expectWebhookError('header/body event-id mismatch is rejected', 'event_id_mismatch', () =>
+  parseWebhookEvent(JSON.stringify(webhookEvent), {
+    'content-type': 'application/json',
+    'call-e-event-id': 'evt_other',
+  }),
+)
+expectWebhookError('malformed JSON is rejected', 'invalid_json', () =>
+  parseWebhookEvent('{', {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  }),
+)
+expectWebhookError('non-terminal event type is rejected', 'unsupported_event_type', () =>
+  parseWebhookEvent(JSON.stringify({ ...webhookEvent, type: 'call.in_progress' }), {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  }),
+)
+expectWebhookError('non-ISO created_at is rejected', 'invalid_created_at', () =>
+  parseWebhookEvent(JSON.stringify({ ...webhookEvent, created_at: 'August 20, 2026' }), {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  }),
+)
+expectWebhookError('impossible ISO calendar date is rejected', 'invalid_created_at', () =>
+  parseWebhookEvent(JSON.stringify({ ...webhookEvent, created_at: '2026-02-31T10:00:00Z' }), {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  }),
+)
+expectWebhookError('unsafe call id is rejected before logging', 'invalid_call_id', () =>
+  parseWebhookEvent(
+    JSON.stringify({ ...webhookEvent, data: { id: 'call_test\nforged-log', status: 'completed' } }),
+    { 'content-type': 'application/json', 'call-e-event-id': webhookEvent.id },
+  ),
+)
+expectWebhookError('C1 control in call id is rejected', 'invalid_call_id', () =>
+  parseWebhookEvent(
+    JSON.stringify({ ...webhookEvent, data: { id: 'call_test\u0085forged', status: 'completed' } }),
+    { 'content-type': 'application/json', 'call-e-event-id': webhookEvent.id },
+  ),
+)
+expectWebhookError('bidi control in call id is rejected', 'invalid_call_id', () =>
+  parseWebhookEvent(
+    JSON.stringify({ ...webhookEvent, data: { id: 'call_test\u202eforged', status: 'completed' } }),
+    { 'content-type': 'application/json', 'call-e-event-id': webhookEvent.id },
+  ),
+)
+expectWebhookError('duplicate event-id headers are rejected', 'duplicate_header', () =>
+  parseWebhookEvent(JSON.stringify(webhookEvent), {
+    'content-type': 'application/json',
+    'call-e-event-id': [webhookEvent.id, webhookEvent.id],
+  }),
+)
+
+f = fakeRes()
+await webhookHandler({ method: 'GET', headers: {} } as any, f.res)
+ok('non-POST webhook request is rejected', f.rec.status === 405)
+
+f = fakeRes()
+const oversizedReq = {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  },
+  async *[Symbol.asyncIterator]() {
+    yield Buffer.alloc(1_048_577)
+  },
+} as any
+await webhookHandler(oversizedReq, f.res)
+ok('webhook body over 1 MiB is rejected', f.rec.status === 413 && f.rec.code === 'payload_too_large')
+
+f = fakeRes()
+const validWebhookReq = {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'call-e-event-id': webhookEvent.id,
+  },
+  async *[Symbol.asyncIterator]() {
+    yield Buffer.from(JSON.stringify(webhookEvent))
+  },
+} as any
+const webhookLogs: string[] = []
+const previousConsoleLog = console.log
+try {
+  console.log = (...args: unknown[]) => webhookLogs.push(args.map(String).join(' '))
+  await webhookHandler(validWebhookReq, f.res)
+} finally {
+  console.log = previousConsoleLog
+}
+ok('valid streamed webhook request is accepted', f.rec.status === 200)
+ok(
+  'successful webhook log excludes attacker-controlled ids',
+  webhookLogs.length === 1 &&
+    webhookLogs[0]?.includes('call.completed') === true &&
+    webhookLogs[0]?.includes(webhookEvent.id) === false &&
+    webhookLogs[0]?.includes(webhookEvent.data.id) === false,
+)
+
+const prevWebhookUrl = process.env.CALLE_WEBHOOK_URL
+const prevWebhookSecret = process.env.CALLE_WEBHOOK_SECRET
+delete process.env.CALLE_WEBHOOK_URL
+delete process.env.CALLE_WEBHOOK_SECRET
+ok('webhook is opt-in without an explicit URL', deriveWebhookUrl() === undefined)
+process.env.CALLE_WEBHOOK_SECRET = 'legacy-secret'
+ok('legacy secret alone does not enable current delivery', deriveWebhookUrl() === undefined)
+process.env.CALLE_WEBHOOK_URL = 'https://ringer.example/api/webhook'
+ok('explicit webhook URL enables current delivery', deriveWebhookUrl() === process.env.CALLE_WEBHOOK_URL)
+if (prevWebhookUrl === undefined) delete process.env.CALLE_WEBHOOK_URL
+else process.env.CALLE_WEBHOOK_URL = prevWebhookUrl
+if (prevWebhookSecret === undefined) delete process.env.CALLE_WEBHOOK_SECRET
+else process.env.CALLE_WEBHOOK_SECRET = prevWebhookSecret
+
+console.log('\n[7] SDK 0.7 create-call mapping against a local fake server')
+let capturedSdkRequest: {
+  authorization?: string
+  idempotencyKey?: string
+  body?: Record<string, unknown>
+} = {}
+const sdkServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.from(chunk))
+  capturedSdkRequest = {
+    authorization: request.headers.authorization,
+    idempotencyKey: request.headers['idempotency-key'] as string | undefined,
+    body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
+  }
+  response.writeHead(201, { 'content-type': 'application/json' })
+  response.end(
+    JSON.stringify({
+      id: 'call_sdk_070',
+      object: 'call_task',
+      status: 'queued',
+      task: 'Synthetic mapping check.',
+      recipients: [],
+      structured_result: null,
+      summary: null,
+      task_completed: null,
+      completion_confidence: null,
+      evidence: [],
+      metadata: { app: 'ringer' },
+      failure_code: null,
+      failure_message: null,
+      created_at: '2026-08-20T10:00:00.000Z',
+      completed_at: null,
+    }),
+  )
+})
+await new Promise<void>((resolve) => sdkServer.listen(0, '127.0.0.1', resolve))
+const sdkAddress = sdkServer.address()
+if (!sdkAddress || typeof sdkAddress === 'string') throw new Error('Fake SDK server did not bind.')
+try {
+  const sdkResult = await createCalleCall(
+    { apiKey: 'synthetic-sdk-key', baseUrl: `http://127.0.0.1:${sdkAddress.port}` },
+    {
+      task: 'Synthetic mapping check.',
+      recipients: [{ phones: ['+14155550111'], region: 'US', locale: 'en-US' }],
+      result_schema: { type: 'object' },
+      metadata: { app: 'ringer' },
+      webhook_url: 'https://ringer.example/api/webhook',
+    },
+    'synthetic-idempotency-key',
+  )
+  ok('SDK response maps to the call id', sdkResult.id === 'call_sdk_070')
+  ok('SDK sends the server key only as bearer auth', capturedSdkRequest.authorization === 'Bearer synthetic-sdk-key')
+  ok('SDK forwards the stable idempotency key', capturedSdkRequest.idempotencyKey === 'synthetic-idempotency-key')
+  ok('SDK maps resultSchema to result_schema', (capturedSdkRequest.body?.result_schema as any)?.type === 'object')
+  ok('SDK maps webhookUrl to webhook_url', capturedSdkRequest.body?.webhook_url === 'https://ringer.example/api/webhook')
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    sdkServer.close((error) => (error ? reject(error) : resolve())),
+  )
+}
 
 console.log(`\n✅ All ${pass} API-safety checks passed.\n`)


### PR DESCRIPTION
## Summary

Update Ringer from the legacy SDK 0.2 signed-webhook path to the current CALL-E unsigned terminal-event contract.

- upgrade `@call-e/calle` to `^0.7.0`;
- require an explicit `CALLE_WEBHOOK_URL` to opt into delivery;
- validate JSON content type, a 1 MiB body limit, terminal event type, bounded opaque IDs, ISO timestamps, and `CALL-E-Event-Id`/body-ID equality;
- reject Unicode control/format characters and keep attacker-controlled IDs out of logs;
- keep the endpoint diagnostics-only and the existing authenticated polling UI authoritative;
- remove obsolete `CALLE_WEBHOOK_SECRET` setup guidance; and
- add credential-free webhook and SDK request-mapping regressions.

## Problem

Ringer was pinned to `@call-e/calle` `^0.2.2` and called `client.webhooks.unwrap`, which requires legacy `CALL-E-Timestamp` and `CALL-E-Signature` headers. Current CALL-E deliveries are unsigned and do not send those headers. A valid current-style event was therefore rejected before its JSON body could be processed.

This matches the current contract documented in #85 and the SDK. #91 separately tracks cryptographic signing as a future product capability.

## Trust boundary

Header/body event-ID equality is a consistency check, not authentication. The endpoint therefore logs only the allowlisted terminal event type and performs no business side effect. The README states that a future side-effecting extension must durably deduplicate event IDs and reconcile the call through an authenticated Calls API read before trusting the notification.

## Validation

All validation was credential-free and placed no call:

```text
corepack pnpm@10.28.2 verify:all      # passed: build, API typecheck, 98 logic, 49 API, 28 render
corepack pnpm@10.28.2 lint            # passed; four pre-existing warnings
python3 scripts/validate_repository.py # passed
git diff --check                      # passed
gitleaks redacted staged/tree/history scans # no leaks found
```

The API suite uses a loopback fake server to verify SDK 0.7 Bearer auth, idempotency-header forwarding, and `result_schema`/`webhook_url` mapping without contacting CALL-E.

## Scope

This PR does not add webhook-triggered product actions, durable event storage, or cryptographic sender verification. Ringer continues to obtain live product state through its existing authenticated polling path.
