### PR TITLE
feat(byggeklar-call-sheet): add supplier readiness workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`apps/typescript/byggeklar-call-sheet`](apps/typescript/byggeklar-call-sheet/) | TypeScript | Approval-gated construction supplier-readiness calls that return quantity, delivery, fee and substitution evidence while leaving every commercial commitment to a human. |
 | [`apps/typescript/asyncfounders`](apps/typescript/asyncfounders/) | TypeScript | Callback-first persistent team memory: consented CALL-E interviews capture updates, brief unseen company deltas, and resolve open questions into evidence-linked typed memory. |
 | [`apps/typescript/one-more-story`](apps/typescript/one-more-story/) | TypeScript | Consent-first oral-history call that discloses AI use, preserves the storyteller's correction, and creates no story until the corrected read-back is explicitly confirmed. |
 | [`apps/web/callproof`](apps/web/callproof/) | Ruby / Python | Closed-loop CALL-E workflow that checks transcript evidence against an immutable call contract and routes policy exceptions to persisted AgentKit human review. |

--- a/apps/typescript/byggeklar-call-sheet/.env.example
+++ b/apps/typescript/byggeklar-call-sheet/.env.example
@@ -1,0 +1,2 @@
+CALLE_API_KEY=calle_live_key
+CALLE_BASE_URL=https://api.heycall-e.com

--- a/apps/typescript/byggeklar-call-sheet/.gitignore
+++ b/apps/typescript/byggeklar-call-sheet/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+reports/

--- a/apps/typescript/byggeklar-call-sheet/README.md
+++ b/apps/typescript/byggeklar-call-sheet/README.md
@@ -1,0 +1,60 @@
+# Byggeklar Call Sheet
+
+Construction teams lose time when a quote says "available" but does not establish the full quantity, delivery date, excluded handling fees, or substitutions. Byggeklar Call Sheet turns one authorized supplier-readiness check into an inspectable CALL-E task and a structured evidence packet. It never places an order or accepts a commercial change.
+
+## Why this is phone work
+
+Small and regional suppliers often resolve stock and delivery exceptions by phone. The workflow asks a bounded set of project-specific questions, reads the answers back once, and returns evidence for a person to review. A voicemail, refusal, partial answer, substitution, fee or ambiguous date never becomes an approval.
+
+## Safety model
+
+- `preview` never contacts CALL-E or a recipient. It prints the exact task, masked destination, boundaries and a SHA-256 approval receipt.
+- `call` refuses unless `--confirm` exactly matches the current preview receipt. Editing any call detail invalidates approval.
+- The request must record contact consent or authorization and use a currently supported CALL-E region.
+- One stable idempotency key prevents a retry from creating a duplicate call.
+- The task prohibits negotiation, orders, substitutions, fee acceptance and unrelated disclosure.
+- The API key can only be sent to `https://api.heycall-e.com`.
+- Live reports are written with owner-only permissions and remain local.
+
+## Try it without a call
+
+Node 22 or later:
+
+```bash
+cd apps/typescript/byggeklar-call-sheet
+npm install
+npm run check
+npm test
+npm run demo
+```
+
+`npm run demo` uses a clearly labelled fixture result. It performs no network request and places no call.
+
+## Preview and run one authorized call
+
+Replace the fictional example with an authorized contact in a CALL-E-supported region.
+
+```bash
+npm run preview
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+npm run call -- --request examples/supplier-request.example.json \
+  --confirm <receipt-from-preview> \
+  --output reports/project-elm.json
+```
+
+The live path imports `@call-e/calle`, calls `client.calls.create(...)`, then polls the same call with `waitForResult(...)`. It does not contain a simulated success fallback.
+
+## Result contract
+
+The structured result keeps availability, delivery date, quote validity, excluded fees and substitutions separate. `human_review_required` remains explicit. Transcript evidence and provider confidence are retained in the private report; no answer is converted into an order.
+
+## Cancellation and recovery
+
+This app creates at most one call and no recurring job. Before `call`, stop by doing nothing. After CALL-E accepts a call, do not repeat the command with a new request ID: the stable idempotency key is designed to reconcile retries. Use the CALL-E dashboard for provider-supported cancellation and inspect the saved report before any procurement action.
+
+## Limits
+
+- The example number is fictional and must not be called.
+- CALL-E does not currently list Denmark as a supported destination, so the validator refuses `DK` rather than silently routing it elsewhere.
+- The workflow verifies statements made on the call; it does not verify the supplier's stock system, price, authority, identity or legal terms.
+- No automated call should be placed without applicable consent, disclosure and calling-time compliance.

--- a/apps/typescript/byggeklar-call-sheet/examples/supplier-request.example.json
+++ b/apps/typescript/byggeklar-call-sheet/examples/supplier-request.example.json
@@ -1,0 +1,18 @@
+{
+  "request_id": "project-elm-rfq-07",
+  "project_name": "Project Elm",
+  "supplier_name": "Northbridge Timber Demo Supplier",
+  "phone": "+442079460123",
+  "region": "GB",
+  "locale": "en-GB",
+  "consent_note": "Demo contact has consented to one automated supplier-readiness call.",
+  "material": "48 lengths of FSC-certified C24 timber, 47 x 150 mm",
+  "requested_delivery_date": "2026-09-02",
+  "questions": [
+    "Can you supply the full quantity by the requested delivery date?",
+    "Until what date is the quoted price valid?",
+    "Are delivery, unloading, or pallet fees excluded from the quote?",
+    "Is any substitution required?"
+  ],
+  "calling_window": "Weekdays 09:00-16:00 in the supplier's local time"
+}

--- a/apps/typescript/byggeklar-call-sheet/package.json
+++ b/apps/typescript/byggeklar-call-sheet/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "byggeklar-call-sheet",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Approval-gated CALL-E workflow for verifying construction supplier readiness without making commitments.",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "preview": "node --import tsx src/cli.ts preview --request examples/supplier-request.example.json",
+    "demo": "node --import tsx src/cli.ts demo --request examples/supplier-request.example.json",
+    "call": "node --import tsx src/cli.ts call"
+  },
+  "dependencies": {
+    "@call-e/calle": "0.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/typescript/byggeklar-call-sheet/pnpm-lock.yaml
+++ b/apps/typescript/byggeklar-call-sheet/pnpm-lock.yaml
@@ -1,0 +1,353 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@call-e/calle':
+        specifier: 0.2.2
+        version: 0.2.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.20.1
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.12
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+
+packages:
+
+  '@call-e/calle@0.2.2':
+    resolution: {integrity: sha512-o1cDf/mASU92luUbdiUj1E7AFtXK+mm4ikGwB3x+G9RaEZCezs7/vYKDMEydnRmM1b8FEzzQB+Z+ehoE5kKvGw==}
+    hasBin: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@call-e/calle@0.2.2':
+    dependencies:
+      openapi-fetch: 0.14.1
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  fsevents@2.3.3:
+    optional: true
+
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/apps/typescript/byggeklar-call-sheet/pnpm-workspace.yaml
+++ b/apps/typescript/byggeklar-call-sheet/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/apps/typescript/byggeklar-call-sheet/src/cli.ts
+++ b/apps/typescript/byggeklar-call-sheet/src/cli.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { buildPreview, DEMO_RESULT, renderPreview, validateRequest } from "./workflow.js";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function loadRequest(path: string) {
+  return validateRequest(JSON.parse(await readFile(resolve(path), "utf8")));
+}
+
+function renderResult(result: Record<string, unknown>): string {
+  return [
+    "BYGGEKLAR EVIDENCE PACKET",
+    `Status       ${String(result.status)}`,
+    `Completed    ${String(result.taskCompleted ?? result.task_completed)}`,
+    "",
+    "Structured result",
+    JSON.stringify(result.structuredResult ?? result.structured_result, null, 2),
+    "",
+    "Evidence",
+    ...((result.evidence as unknown[] | undefined) ?? []).map((line) => `- ${String(line)}`),
+    "",
+    "Decision: HUMAN REVIEW REQUIRED. No order or supplier commitment was created.",
+  ].join("\n");
+}
+
+async function main() {
+  const command = process.argv[2];
+  const requestPath = arg("--request");
+  if (!requestPath) throw new Error("Use --request <file.json>");
+  const preview = buildPreview(await loadRequest(requestPath));
+
+  if (command === "preview") {
+    console.log(renderPreview(preview));
+    return;
+  }
+  if (command === "demo") {
+    console.log(renderPreview(preview));
+    console.log("\n--- FIXTURE RESULT; NO CALL PLACED ---\n");
+    console.log(renderResult(DEMO_RESULT));
+    return;
+  }
+  if (command !== "call") throw new Error("Command must be preview, demo or call");
+
+  const receipt = arg("--confirm");
+  if (receipt !== preview.receipt) throw new Error("Refusing call: --confirm must match the current preview receipt");
+  const apiKey = process.env.CALLE_API_KEY;
+  if (!apiKey) throw new Error("CALLE_API_KEY is required for a live call");
+  const baseUrl = process.env.CALLE_BASE_URL ?? "https://api.heycall-e.com";
+  if (new URL(baseUrl).hostname !== "api.heycall-e.com" || new URL(baseUrl).protocol !== "https:") {
+    throw new Error("Refusing to send the API key anywhere except https://api.heycall-e.com");
+  }
+  const { CalleClient } = await import("@call-e/calle");
+  const client = new CalleClient({ apiKey, baseUrl });
+  const call = await client.calls.create(
+    {
+      task: preview.task,
+      recipients: [{ phones: [preview.request.phone], region: preview.request.region, locale: preview.request.locale }],
+      resultSchema: preview.resultSchema,
+      metadata: { workflow: "byggeklar-call-sheet", request_id: preview.request.request_id },
+    },
+    { idempotencyKey: `byggeklar:${preview.request.request_id}:${preview.receipt.slice(0, 16)}` },
+  );
+  const final = await client.calls.waitForResult(call.id, { timeoutMs: 300_000, intervalMs: 7_500 });
+  const output = arg("--output") ?? `reports/${preview.request.request_id}.json`;
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, `${JSON.stringify(final, null, 2)}\n`, { mode: 0o600 });
+  console.log(renderResult(final as unknown as Record<string, unknown>));
+  console.log(`\nSaved private report: ${output}`);
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/apps/typescript/byggeklar-call-sheet/src/workflow.ts
+++ b/apps/typescript/byggeklar-call-sheet/src/workflow.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+
+export const SUPPORTED_REGIONS = new Set([
+  "US", "SG", "MY", "IN", "AE", "AU", "CA", "GB", "VN", "DE", "JP", "FR", "MX", "BR",
+  "ID", "PH", "KE", "NL", "PL", "BD", "NG", "OM", "TH", "NA", "CM", "MZ", "SA", "FI",
+  "UA", "LK", "BW", "PK", "TR", "HN",
+]);
+
+export interface SupplierRequest {
+  request_id: string;
+  project_name: string;
+  supplier_name: string;
+  phone: string;
+  region: string;
+  locale: string;
+  consent_note: string;
+  material: string;
+  requested_delivery_date: string;
+  questions: string[];
+  calling_window: string;
+}
+
+export interface Preview {
+  request: SupplierRequest;
+  maskedPhone: string;
+  task: string;
+  resultSchema: Record<string, unknown>;
+  receipt: string;
+}
+
+function requiredText(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim().length < 2) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+export function validateRequest(value: unknown): SupplierRequest {
+  if (!value || typeof value !== "object") throw new Error("request must be an object");
+  const v = value as Record<string, unknown>;
+  const phone = requiredText(v.phone, "phone");
+  if (!/^\+[1-9]\d{7,14}$/.test(phone)) throw new Error("phone must use E.164 format");
+  const region = requiredText(v.region, "region").toUpperCase();
+  if (!SUPPORTED_REGIONS.has(region)) throw new Error(`region ${region} is not currently supported by CALL-E`);
+  if (!Array.isArray(v.questions) || v.questions.length < 1 || v.questions.length > 6) {
+    throw new Error("questions must contain 1 to 6 items");
+  }
+  const questions = v.questions.map((q, i) => requiredText(q, `questions[${i}]`));
+  const consent = requiredText(v.consent_note, "consent_note");
+  if (!/consent|authori[sz]ed|permission/i.test(consent)) {
+    throw new Error("consent_note must record permission or authorization for the call");
+  }
+  return {
+    request_id: requiredText(v.request_id, "request_id"),
+    project_name: requiredText(v.project_name, "project_name"),
+    supplier_name: requiredText(v.supplier_name, "supplier_name"),
+    phone,
+    region,
+    locale: requiredText(v.locale, "locale"),
+    consent_note: consent,
+    material: requiredText(v.material, "material"),
+    requested_delivery_date: requiredText(v.requested_delivery_date, "requested_delivery_date"),
+    questions,
+    calling_window: requiredText(v.calling_window, "calling_window"),
+  };
+}
+
+export function maskPhone(phone: string): string {
+  return `${phone.slice(0, 3)}${"*".repeat(Math.max(4, phone.length - 5))}${phone.slice(-2)}`;
+}
+
+export function buildPreview(request: SupplierRequest): Preview {
+  const task = [
+    `Call ${request.supplier_name} at ${request.phone}.`,
+    `Immediately disclose that you are an automated assistant calling for ${request.project_name}.`,
+    `Purpose: verify supplier readiness for ${request.material}, requested for ${request.requested_delivery_date}.`,
+    `Ask only these questions: ${request.questions.map((q, i) => `${i + 1}) ${q}`).join(" ")}`,
+    "Read back the factual answers once. Do not negotiate, place an order, accept a substitute, agree to fees, disclose unrelated project data, or create any commitment.",
+    "If the recipient refuses an automated call, record the refusal and end politely. If an answer is unclear, mark it unknown rather than guessing.",
+  ].join("\n");
+  const resultSchema = {
+    type: "object",
+    additionalProperties: false,
+    required: ["supplier_reached", "full_quantity_available", "delivery_date", "quote_valid_until", "excluded_fees", "substitution_required", "human_review_required"],
+    properties: {
+      supplier_reached: { type: "string", enum: ["yes", "no", "refused", "unknown"] },
+      full_quantity_available: { type: "string", enum: ["yes", "no", "partial", "unknown"] },
+      delivery_date: { type: ["string", "null"] },
+      quote_valid_until: { type: ["string", "null"] },
+      excluded_fees: { type: "array", items: { type: "string" } },
+      substitution_required: { type: ["string", "null"] },
+      human_review_required: { type: "boolean" },
+    },
+  };
+  const receipt = createHash("sha256").update(JSON.stringify({ request, task, resultSchema })).digest("hex");
+  return { request, maskedPhone: maskPhone(request.phone), task, resultSchema, receipt };
+}
+
+export function renderPreview(preview: Preview): string {
+  return [
+    "BYGGEKLAR CALL SHEET — NO CALL PLACED",
+    `Project      ${preview.request.project_name}`,
+    `Supplier     ${preview.request.supplier_name}`,
+    `Destination  ${preview.maskedPhone} (${preview.request.region}, ${preview.request.locale})`,
+    `Window       ${preview.request.calling_window}`,
+    "",
+    "The call may collect facts only. Ordering, negotiation, substitutions and fees remain human decisions.",
+    "",
+    preview.task,
+    "",
+    `Approval receipt: ${preview.receipt}`,
+  ].join("\n");
+}
+
+export const DEMO_RESULT = {
+  status: "completed",
+  taskCompleted: true,
+  completionConfidence: { score: 0.93, label: "high" },
+  structuredResult: {
+    supplier_reached: "yes",
+    full_quantity_available: "partial",
+    delivery_date: "2026-09-03",
+    quote_valid_until: "2026-08-28",
+    excluded_fees: ["unloading"],
+    substitution_required: "12 lengths would be substituted with 50 x 150 mm",
+    human_review_required: true,
+  },
+  evidence: [
+    "The supplier said 36 of 48 lengths are available in the specified size.",
+    "The supplier offered a dimensional substitution for the remaining 12 lengths.",
+    "The supplier said unloading is excluded and delivery would be 3 September.",
+  ],
+};

--- a/apps/typescript/byggeklar-call-sheet/src/workflow.ts
+++ b/apps/typescript/byggeklar-call-sheet/src/workflow.ts
@@ -104,7 +104,7 @@ export function renderPreview(preview: Preview): string {
     "",
     "The call may collect facts only. Ordering, negotiation, substitutions and fees remain human decisions.",
     "",
-    preview.task,
+    preview.task.replaceAll(preview.request.phone, preview.maskedPhone),
     "",
     `Approval receipt: ${preview.receipt}`,
   ].join("\n");

--- a/apps/typescript/byggeklar-call-sheet/test/workflow.test.ts
+++ b/apps/typescript/byggeklar-call-sheet/test/workflow.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildPreview, maskPhone, validateRequest } from "../src/workflow.js";
+
+const valid = {
+  request_id: "rfq-1", project_name: "Project Elm", supplier_name: "Demo Supplier",
+  phone: "+442079460123", region: "GB", locale: "en-GB",
+  consent_note: "The contact consented to one automated call.", material: "48 timber lengths",
+  requested_delivery_date: "2026-09-02", questions: ["Can you deliver the full quantity?"],
+  calling_window: "Weekdays 09:00-16:00 local time",
+};
+
+test("builds a stable approval receipt", () => {
+  const request = validateRequest(valid);
+  assert.equal(buildPreview(request).receipt, buildPreview(request).receipt);
+});
+
+test("changing the call changes the approval receipt", () => {
+  const a = buildPreview(validateRequest(valid)).receipt;
+  const b = buildPreview(validateRequest({ ...valid, material: "49 timber lengths" })).receipt;
+  assert.notEqual(a, b);
+});
+
+test("masks the destination", () => assert.equal(maskPhone("+442079460123"), "+44********23"));
+
+test("refuses unsupported regions", () => {
+  assert.throws(() => validateRequest({ ...valid, region: "DK" }), /not currently supported/);
+});
+
+test("refuses missing consent evidence", () => {
+  assert.throws(() => validateRequest({ ...valid, consent_note: "Public company number" }), /permission or authorization/);
+});
+
+test("task prohibits commitments", () => {
+  const task = buildPreview(validateRequest(valid)).task;
+  assert.match(task, /Do not negotiate, place an order/);
+  assert.match(task, /automated assistant/);
+});

--- a/apps/typescript/byggeklar-call-sheet/test/workflow.test.ts
+++ b/apps/typescript/byggeklar-call-sheet/test/workflow.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildPreview, maskPhone, validateRequest } from "../src/workflow.js";
+import { buildPreview, maskPhone, renderPreview, validateRequest } from "../src/workflow.js";
 
 const valid = {
   request_id: "rfq-1", project_name: "Project Elm", supplier_name: "Demo Supplier",
@@ -22,6 +22,15 @@ test("changing the call changes the approval receipt", () => {
 });
 
 test("masks the destination", () => assert.equal(maskPhone("+442079460123"), "+44********23"));
+
+test("rendered task masks the recipient without changing the approved payload", () => {
+  const preview = buildPreview(validateRequest(valid));
+  const receipt = preview.receipt;
+  assert.ok(!renderPreview(preview).includes(valid.phone));
+  assert.ok(renderPreview(preview).includes(preview.maskedPhone));
+  assert.ok(preview.task.includes(valid.phone));
+  assert.equal(preview.receipt, receipt);
+});
 
 test("refuses unsupported regions", () => {
   assert.throws(() => validateRequest({ ...valid, region: "DK" }), /not currently supported/);

--- a/apps/typescript/byggeklar-call-sheet/tsconfig.json
+++ b/apps/typescript/byggeklar-call-sheet/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds apps/typescript/byggeklar-call-sheet, an approval-gated construction supplier-readiness workflow built on the CALL-E TypeScript SDK.

- previews the exact task and creates a SHA-256 approval receipt before any call
- collects quantity, delivery, quote-validity, excluded-fee, and substitution evidence
- uses stable idempotency and refuses unsupported destinations or missing consent evidence
- leaves orders, substitutions, fees, and all commercial commitments to a human
- includes a no-call fixture demo and a clearly fictional example

## Type

- [x] New runnable app
- [x] README awesome-list entry
- [x] Safety or documentation update

## Validation

- [x] pnpm run check
- [x] pnpm test — 6/6 passing
- [x] pnpm run demo — fixture only; no call placed
- [x] python3 scripts/validate_repository.py — passed

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow docs/git-naming-conventions.md.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] The example phone number is fictional and documented as unsafe to dial.
- [x] Runnable code has a no-call path by default.
- [x] Cancellation, credential handling, retry behavior, and limits are documented.

## Live-call note

The live path imports @call-e/calle, invokes client.calls.create(...), and polls that same call with waitForResult(...). No real recipient was called while preparing this draft PR.