### PR TITLE
docs(apps): point demo apps at the field-tested, actively maintained repos

### DIFF
--- a/apps/python/hungrycall-cascade/README.md
+++ b/apps/python/hungrycall-cascade/README.md
@@ -120,4 +120,4 @@ and the live CALL-E transport — lives at <https://github.com/ellmos-ai/hungryc
 since been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22),
 each call played out live by a human on the other end of the phone; its README carries a
 "How We Tested" section describing what was run, what broke, and what got fixed, and its
-test suite currently stands at 301 passing.
+test suite currently stands at 368 passing.

--- a/apps/python/hungrycall-cascade/README.md
+++ b/apps/python/hungrycall-cascade/README.md
@@ -120,4 +120,4 @@ and the live CALL-E transport — lives at <https://github.com/ellmos-ai/hungryc
 since been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22),
 each call played out live by a human on the other end of the phone; its README carries a
 "How We Tested" section describing what was run, what broke, and what got fixed, and its
-test suite currently stands at 368 passing.
+test suite currently stands at 407 passing.

--- a/apps/python/hungrycall-cascade/README.md
+++ b/apps/python/hungrycall-cascade/README.md
@@ -116,4 +116,8 @@ untouched, and no full number reaching any output.
 
 This is a focused, self-contained proof of the orchestration. The complete application —
 restaurant lookup, a second branch for table reservations, ordering chains, web interface
-and the live CALL-E transport — lives at <https://github.com/ellmos-ai/hungrycall>.
+and the live CALL-E transport — lives at <https://github.com/ellmos-ai/hungrycall>. It has
+since been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22),
+each call played out live by a human on the other end of the phone; its README carries a
+"How We Tested" section describing what was run, what broke, and what got fixed, and its
+test suite currently stands at 301 passing.

--- a/apps/python/hungrycall-cascade/cascade.py
+++ b/apps/python/hungrycall-cascade/cascade.py
@@ -19,7 +19,9 @@ yes does not count.
 
 This is the collection edition: fixture-driven, no network, no telephone, no
 credentials, no scheduler. The full application lives at
-https://github.com/ellmos-ai/hungrycall
+https://github.com/ellmos-ai/hungrycall, field-tested live against the real
+CALL-E service on 2026-08-11 and 2026-08-22 -- see its README's "How We
+Tested" section.
 """
 
 from __future__ import annotations

--- a/apps/python/researchcall-survey/README.md
+++ b/apps/python/researchcall-survey/README.md
@@ -146,4 +146,8 @@ hiding under a benign subject, and a full number reaching an output.
 
 This is a focused, self-contained proof of the instrument. The complete application —
 the eight-station workbench, form definitions, ethics configuration, web interface and the
-live CALL-E transport — lives at <https://github.com/ellmos-ai/researchcall>.
+live CALL-E transport — lives at <https://github.com/ellmos-ai/researchcall>. It has since
+been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22), with a
+live-verified withdrawal path -- a spoken deletion announcement, the local record actually
+cleared, the number added to a do-not-call registry; its README carries a "How We Tested"
+section, and its test suite currently stands at 263 passing.

--- a/apps/python/researchcall-survey/README.md
+++ b/apps/python/researchcall-survey/README.md
@@ -150,4 +150,4 @@ live CALL-E transport — lives at <https://github.com/ellmos-ai/researchcall>. 
 been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22), with a
 live-verified withdrawal path -- a spoken deletion announcement, the local record actually
 cleared, the number added to a do-not-call registry; its README carries a "How We Tested"
-section, and its test suite currently stands at 263 passing.
+section, and its test suite currently stands at 283 passing.

--- a/apps/python/researchcall-survey/README.md
+++ b/apps/python/researchcall-survey/README.md
@@ -150,4 +150,4 @@ live CALL-E transport — lives at <https://github.com/ellmos-ai/researchcall>. 
 been field-tested twice against the real CALL-E service (2026-08-11 and 2026-08-22), with a
 live-verified withdrawal path -- a spoken deletion announcement, the local record actually
 cleared, the number added to a do-not-call registry; its README carries a "How We Tested"
-section, and its test suite currently stands at 283 passing.
+section, and its test suite currently stands at 293 passing.

--- a/apps/python/researchcall-survey/survey.py
+++ b/apps/python/researchcall-survey/survey.py
@@ -30,7 +30,9 @@ in configuration does not have a consent requirement.
 
 This is the collection edition: fixture-driven, no network, no telephone, no
 credentials, no scheduler. The full application lives at
-https://github.com/ellmos-ai/researchcall
+https://github.com/ellmos-ai/researchcall, field-tested live against the
+real CALL-E service on 2026-08-11 and 2026-08-22 -- see its README's "How We
+Tested" section.
 """
 
 from __future__ import annotations

--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -160,4 +160,4 @@ call orchestration, the hash-chained record, web interface and the live CALL-E t
 lives at <https://github.com/ellmos-ai/ringedingeding>. It has since been field-tested
 twice against the real CALL-E service (2026-08-11 and 2026-08-22), including a live
 retest of a retry-idempotency bug found and fixed the same day; its README carries a
-"How We Tested" section, and its test suite currently stands at 567 passing.
+"How We Tested" section, and its test suite currently stands at 575 passing.

--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -160,4 +160,4 @@ call orchestration, the hash-chained record, web interface and the live CALL-E t
 lives at <https://github.com/ellmos-ai/ringedingeding>. It has since been field-tested
 twice against the real CALL-E service (2026-08-11 and 2026-08-22), including a live
 retest of a retry-idempotency bug found and fixed the same day; its README carries a
-"How We Tested" section, and its test suite currently stands at 498 passing.
+"How We Tested" section, and its test suite currently stands at 567 passing.

--- a/apps/python/ringedingeding/README.md
+++ b/apps/python/ringedingeding/README.md
@@ -157,4 +157,7 @@ an answer, and a full number reaching an output.
 
 This is a focused, self-contained proof of the aggregation. The complete application —
 call orchestration, the hash-chained record, web interface and the live CALL-E transport —
-lives at <https://github.com/ellmos-ai/ringedingeding>.
+lives at <https://github.com/ellmos-ai/ringedingeding>. It has since been field-tested
+twice against the real CALL-E service (2026-08-11 and 2026-08-22), including a live
+retest of a retry-idempotency bug found and fixed the same day; its README carries a
+"How We Tested" section, and its test suite currently stands at 498 passing.

--- a/apps/python/ringedingeding/aggregate.py
+++ b/apps/python/ringedingeding/aggregate.py
@@ -24,7 +24,9 @@ Three rules follow from that, and they are what the tests defend:
 
 This is the collection edition: fixture-driven, no network, no telephone, no
 credentials, no scheduler. The full application lives at
-https://github.com/ellmos-ai/ringedingeding
+https://github.com/ellmos-ai/ringedingeding, field-tested live against the
+real CALL-E service on 2026-08-11 and 2026-08-22 -- see its README's "How We
+Tested" section.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The three demo apps contributed in #73, #77 and #78 (with #99 updating their
organization links) are focused, self-contained proofs of one mechanism each.
Since those merges, all three full applications behind them went through two
live field-trial days against the real CALL-E service — real outbound calls,
a human playing every counterpart, findings written up honestly, fixed, and
re-verified live (2026-08-11 and 2026-08-22). Each repository now ships a
"How We Tested" section describing what was run, what broke, and what got
fixed, on top of the demo's existing pointer sentence.

This PR adds one factual sentence to each demo's README and module
docstring — repository, field-trial dates, and current test-suite size taken
from that repository's own README badge (407 / 575 / 293 passing). No code
changes to the demo apps themselves.

- Package tests re-run on this branch: hungrycall-cascade 24 passed,
  ringedingeding 26 passed, researchcall-survey 46 passed.
- `python scripts/validate_repository.py`: Repository validation passed.
- The linked repositories' reachable public branch histories were remediated
  on 2026-08-24. Public evidence now uses synthetic identifiers, contact
  examples, answers, timestamps, and transcript reconstructions; factual dates,
  aggregate outcomes, commands, and test counts remain intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
