### PR TITLE
feat(callparity-claimkill): add leak-drop refute planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`accesscall`](skills/accesscall/) - Phone-based accessibility intake for VPAT 2.4/Section 508 audits. Run `npm install` in `skills/accesscall/` before using `scripts/format-to-vpat.js`, or it fails with `Cannot find module 'jszip'`.
 - [`candidate-availability-call`](skills/candidate-availability-call/) - Recruiting coordination skill that confirms candidate interview availability by phone, returns evidence-backed time windows, and leaves scheduling commitments to a human.
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
+- [`callparity-claimkill`](skills/callparity-claimkill/) - ClaimKill (CallParity) compiles the next CALL-E call as a leak-scored refute of a quoted claim. pytest runs on fixtures with zero live calls.
 - [`customer-onboarding-call`](skills/customer-onboarding-call/) - Welcome-call skill that turns a new signup into at most one conversation, a consent-gated structured result, and a CRM follow-up task, with evidence-backed dispositions, ordered outcome classification, per-attempt idempotency, and cancellable retries.
 - [`deployment-approval-call`](skills/deployment-approval-call/) - Spoken, code-verified human approval before an agent or pipeline does something irreversible.
 - [`voice-preflight`](skills/voice-preflight/) - Hear a call task spoken by your own text-to-speech provider before a real person does, then refuse a script whose critical line would not survive being spoken.
@@ -141,6 +142,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Apps
 
+- [CallParity](https://github.com/ruddro-roy/callparity) - Two-call ops workbench for Party A claims, a Party B falsification CALL-E task, and a merged claim graph. Preview and fixture mode by default.
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 - [ShohojSheba Voice](https://shohojsheba-call-e-preview.redwan-rahman.workers.dev/judge) - Consent-gated healthcare staffing dispatch that uses structured CALL-E results to advance after a verified decline, pauses on acceptance, and keeps final assignment human-controlled.
@@ -156,6 +158,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/kincall`](apps/typescript/kincall/) | TypeScript | Consent-first check-in and trusted-circle coordination: a stated request for help overrides the agent's own judgement, contacts are called one at a time until somebody commits, and the monitored person is called back with the outcome. |
 | [`apps/typescript/verify-contact-claim`](apps/typescript/verify-contact-claim/) | TypeScript | Contact-claim verifier for a suspicious voicemail, text or missed call: dials only the number printed on the customer's own card, asks whether that contact was genuine and returns the words that came back with a hash-chained record. |
 | [`apps/typescript/call-neuron`](apps/typescript/call-neuron/) | TypeScript | Functional consent-first scholarship outreach prototype with manual/file intake, identity-first disclosure, neutral voicemail, one-recipient CALL-E planning and confirmation, live status, human dispositions, and browser-local campaign data. |
+| [`apps/typescript/callparity`](apps/typescript/callparity/) | TypeScript / Python | Catalog pointer to CallParity. ClaimKill in this repo compiles leak-scored refute plans from fixtures with zero live CALL-E calls. |
 | [`apps/typescript/connected`](apps/typescript/connected/) | TypeScript | AI phone companion whose consented recurring conversations remember interests and family stories, revisit them naturally, and offer human-reviewed event reminders or community introductions. |
 | [`apps/typescript/linecanary`](apps/typescript/linecanary/) | TypeScript | Synthetic monitoring and CI regression testing for business phone lines and voice agents: ownership-verified scheduled test calls, schema and timing assertions, baseline regression diffing, Slack alerts, and a GitHub Action. |
 | [`apps/typescript/phone-approval-gate`](apps/typescript/phone-approval-gate/) | TypeScript | Phone-verified approval gate for irreversible automation, with a one-time spoken code, an escalation ladder, dual control and a verifiable approval record. |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`accesscall`](skills/accesscall/) - Phone-based accessibility intake for VPAT 2.4/Section 508 audits. Run `npm install` in `skills/accesscall/` before using `scripts/format-to-vpat.js`, or it fails with `Cannot find module 'jszip'`.
 - [`candidate-availability-call`](skills/candidate-availability-call/) - Recruiting coordination skill that confirms candidate interview availability by phone, returns evidence-backed time windows, and leaves scheduling commitments to a human.
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
-- [`callparity-claimkill`](skills/callparity-claimkill/) - ClaimKill (CallParity) compiles the next CALL-E call as a leak-scored refute of a quoted claim. pytest runs on fixtures with zero live calls.
+- [`callparity-claimkill`](skills/callparity-claimkill/) - ClaimKill (CallParity) compiles the next CALL-E call as a leak-scored refute of a quoted claim; pytest runs on fixtures with zero live calls.
 - [`customer-onboarding-call`](skills/customer-onboarding-call/) - Welcome-call skill that turns a new signup into at most one conversation, a consent-gated structured result, and a CRM follow-up task, with evidence-backed dispositions, ordered outcome classification, per-attempt idempotency, and cancellable retries.
 - [`deployment-approval-call`](skills/deployment-approval-call/) - Spoken, code-verified human approval before an agent or pipeline does something irreversible.
 - [`voice-preflight`](skills/voice-preflight/) - Hear a call task spoken by your own text-to-speech provider before a real person does, then refuse a script whose critical line would not survive being spoken.

--- a/apps/typescript/callparity/README.md
+++ b/apps/typescript/callparity/README.md
@@ -1,0 +1,28 @@
+# CallParity
+
+CallParity is maintained in the upstream repository: [https://github.com/ruddro-roy/callparity](https://github.com/ruddro-roy/callparity).
+
+This directory is a catalog pointer for Awesome Phone Call Agents. The portable engine in this fork is ClaimKill.
+
+## What it does
+
+CallParity spends the next CALL-E call to falsify one quoted freight claim. ClaimKill compiles that call as a leak-scored refute question, then merges Party B quotes into a claim graph.
+
+## Portable skill
+
+Agent workflow: [`skills/callparity-claimkill`](../../../skills/callparity-claimkill/).
+
+Preview and pytest use committed fixtures. They place zero live CALL-E calls.
+
+```bash
+python3 skills/callparity-claimkill/scripts/claimkill.py preview --fixture FR-1842
+python3 -m pytest skills/callparity-claimkill/tests/test_claimkill.py -q
+```
+
+## Default mode
+
+`preview()` is the default. Fictional `+15550100xxx` numbers appear masked in the plan. Live CALL-E outbound is not required to run the tests.
+
+## Cancellation
+
+This skill does not place calls and does not create schedules. Cancel by withholding approval. If a host later dials, cancel through that host before `run_call`.

--- a/skills/callparity-claimkill/SKILL.md
+++ b/skills/callparity-claimkill/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: callparity-claimkill
+description: Compile the next CALL-E call as a leak-scored refute of a quoted freight claim, merge Party B quotes into a claim graph, and preview from fixtures with zero live calls.
+license: MIT
+---
+
+# ClaimKill
+
+CallParity spends the next CALL-E call to FALSIFY a claim. The planner writes call N+1 as the cheapest question that would flip an untested or supported node to contradicted. Questions that disclose party A's answer are dropped. We do not book appointments, cascade-until-yes, or one-shot-verify a person. We reconcile one freight fact.
+
+`preview()` compiles that plan from committed fixtures and places zero calls. Live CALL-E outbound is not required to run the tests. `CONFIRMED` is an alias of `SUPPORTED`.
+
+## When to use
+
+Use this skill when two systems already disagree about one location or SKU, Party A has a quoted claim, and you need the cheapest Party B question that could flip that claim to contradicted without leaking Party A's answer.
+
+## When not to use
+
+Do not use this skill to book appointments, run cascade-until-yes outreach, survey a person, verify identity, or place a live call without explicit approval and stored consent.
+
+## Workflow
+
+1. Load a claim graph. Each node has `id`, `text`, `evidence.span.quote`, `observable_of`, and `status` in `SUPPORTED`, `UNTESTED`, `CONTRADICTED`, `UNREACHABLE`, `ABSTAIN`.
+2. Score every `RefutationQuestion` with `leak_score`. Discard a question that discloses Party A's answer.
+3. Keep observable questions Party B could have seen. On FR-1842, a driver question about whether dock 3 was empty stays. Any question that contains `warehouse said dock 3` is dropped.
+4. Write call N+1 as the cheapest kept question that could flip an `UNTESTED` or `SUPPORTED` node to `CONTRADICTED`, within the spoken-time budget.
+5. Run `scripts/claimkill.py preview --fixture fixtures/FR-1842.json`. Report the plan and stop. No call is placed.
+6. After a host returns transcript quotes, run the merger. No falsifier leaves a node `UNTESTED`. Voicemail or a missing transcript becomes `UNREACHABLE`. Confidence below 0.45 becomes `ABSTAIN`.
+
+Read `references/planner.md` for the leak-drop algorithm.
+Read `references/schemas.md` for node, edge, and status fields.
+
+## Demo ticket
+
+FR-1842 is the only demo SKU. Before any call, the warehouse quote `pallet left dock 3` disagrees with the driver's report that dock 3 was empty. ClaimKill asks one refute question, not a survey. After merge, `dock` is `CONTRADICTED`, `arrival` is `SUPPORTED`, and `seal` is `UNTESTED`.
+
+FR-1900 and FR-1888 are extra pytest fixtures for abstain and unreachable. Do not narrate them as a second product story.
+
+## Preview
+
+```bash
+python3 scripts/claimkill.py preview --fixture fixtures/FR-1842.json
+python3 scripts/claimkill.py merge --fixture fixtures/FR-1842.json
+python3 -m pytest tests/test_claimkill.py -q
+```
+
+`calls_placed` is always `0` on this path. Phone numbers in the plan are masked.
+
+## Safety
+
+Read `references/safety.md` before compiling a plan that a host might later dial.
+
+- Phone calls are real-world side effects.
+- Require explicit user intent before any live call.
+- Use E.164 numbers only. Mask them in summaries.
+- Do not expose credentials.
+- Do not create hidden recurring schedules or duplicate jobs for the same ticket.
+- Cancel by withholding approval. This skill never places the call itself.
+- Stay inside one operational freight fact. Refuse medical, legal, financial, or emergency content.
+
+## Files
+
+- `scripts/claimkill.py`: leak-drop planner, claim graph, merger, and `preview()`.
+- `fixtures/FR-1842.json`, `fixtures/FR-1900.json`, `fixtures/FR-1888.json`.
+- `tests/test_claimkill.py`: leak-drop and merger regressions.
+
+Read `references/examples.md` for FR-1842 preview and merge output.

--- a/skills/callparity-claimkill/fixtures/FR-1842.json
+++ b/skills/callparity-claimkill/fixtures/FR-1842.json
@@ -1,0 +1,100 @@
+{
+  "ticket_id": "FR-1842",
+  "sku": "PL-9F21",
+  "spoken_time_budget_s": 90,
+  "parties": [
+    {
+      "role": "warehouse",
+      "label": "A",
+      "phone": "+15550100184",
+      "consent": true
+    },
+    {
+      "role": "driver",
+      "label": "B",
+      "phone": "+15550100185",
+      "consent": true
+    }
+  ],
+  "nodes": [
+    {
+      "id": "dock",
+      "text": "Pallet PL-9F21 left dock 3.",
+      "evidence": {
+        "span": {
+          "quote": "pallet left dock 3"
+        }
+      },
+      "observable_of": "dock_location",
+      "status": "UNTESTED",
+      "confidence": 0.92,
+      "party": "A"
+    },
+    {
+      "id": "arrival",
+      "text": "Driver arrived at the receiving gate.",
+      "evidence": {
+        "span": {
+          "quote": "arrived at the gate"
+        }
+      },
+      "observable_of": "driver_arrival",
+      "status": "UNTESTED",
+      "confidence": 0.88,
+      "party": "A"
+    },
+    {
+      "id": "seal",
+      "text": "A seal number was recorded on the trailer.",
+      "evidence": {
+        "span": {
+          "quote": ""
+        }
+      },
+      "observable_of": "seal_recorded",
+      "status": "UNTESTED",
+      "confidence": 0.51,
+      "party": "A"
+    }
+  ],
+  "candidate_questions": [
+    {
+      "id": "q-short-leak",
+      "text": "warehouse said dock 3?",
+      "targets": ["dock"]
+    },
+    {
+      "id": "q-dock-empty",
+      "text": "Was dock 3 empty when you pulled in?",
+      "targets": ["dock"]
+    },
+    {
+      "id": "q-warehouse-said",
+      "text": "The warehouse said dock 3 still held pallet PL-9F21. Is that what you saw?",
+      "targets": ["dock"]
+    },
+    {
+      "id": "q-seal",
+      "text": "Did you read a seal number on the trailer at receiving?",
+      "targets": ["seal"]
+    }
+  ],
+  "call": {
+    "id": "call-nplus1-fr-1842",
+    "disposition": "completed",
+    "quotes": [
+      {
+        "claim_id": "dock",
+        "quote": "Dock 3 was empty. I waited at dock 1.",
+        "polarity": "contradicts",
+        "tested_by": "q-dock-empty"
+      },
+      {
+        "claim_id": "arrival",
+        "quote": "Yes, I arrived at the gate.",
+        "polarity": "supports",
+        "tested_by": "call-nplus1-fr-1842"
+      }
+    ]
+  }
+}

--- a/skills/callparity-claimkill/fixtures/FR-1888.json
+++ b/skills/callparity-claimkill/fixtures/FR-1888.json
@@ -1,6 +1,6 @@
 {
   "ticket_id": "FR-1888",
-  "sku": "PL-9F88",
+  "sku": "PL-9F21",
   "spoken_time_budget_s": 90,
   "parties": [
     {
@@ -19,7 +19,7 @@
   "nodes": [
     {
       "id": "dock",
-      "text": "Pallet PL-9F88 staged at dock 2.",
+      "text": "Pallet PL-9F21 staged at dock 2.",
       "evidence": {
         "span": {
           "quote": "staged at dock 2"
@@ -32,7 +32,7 @@
     },
     {
       "id": "arrival",
-      "text": "Driver reached the gate for PL-9F88.",
+      "text": "Driver reached the gate for PL-9F21.",
       "evidence": {
         "span": {
           "quote": "truck at the gate"
@@ -60,7 +60,7 @@
   "candidate_questions": [
     {
       "id": "q-dock",
-      "text": "Which dock did you pull to for pallet PL-9F88?",
+      "text": "Which dock did you pull to for pallet PL-9F21?",
       "targets": ["dock"]
     }
   ],

--- a/skills/callparity-claimkill/fixtures/FR-1888.json
+++ b/skills/callparity-claimkill/fixtures/FR-1888.json
@@ -1,0 +1,72 @@
+{
+  "ticket_id": "FR-1888",
+  "sku": "PL-9F88",
+  "spoken_time_budget_s": 90,
+  "parties": [
+    {
+      "role": "warehouse",
+      "label": "A",
+      "phone": "+15550100188",
+      "consent": true
+    },
+    {
+      "role": "driver",
+      "label": "B",
+      "phone": "+15550100189",
+      "consent": true
+    }
+  ],
+  "nodes": [
+    {
+      "id": "dock",
+      "text": "Pallet PL-9F88 staged at dock 2.",
+      "evidence": {
+        "span": {
+          "quote": "staged at dock 2"
+        }
+      },
+      "observable_of": "dock_location",
+      "status": "UNTESTED",
+      "confidence": 0.9,
+      "party": "A"
+    },
+    {
+      "id": "arrival",
+      "text": "Driver reached the gate for PL-9F88.",
+      "evidence": {
+        "span": {
+          "quote": "truck at the gate"
+        }
+      },
+      "observable_of": "driver_arrival",
+      "status": "UNTESTED",
+      "confidence": 0.86,
+      "party": "A"
+    },
+    {
+      "id": "seal",
+      "text": "Seal digits might have been read.",
+      "evidence": {
+        "span": {
+          "quote": "maybe a seal"
+        }
+      },
+      "observable_of": "seal_recorded",
+      "status": "UNTESTED",
+      "confidence": 0.31,
+      "party": "A"
+    }
+  ],
+  "candidate_questions": [
+    {
+      "id": "q-dock",
+      "text": "Which dock did you pull to for pallet PL-9F88?",
+      "targets": ["dock"]
+    }
+  ],
+  "call": {
+    "id": "call-nplus1-fr-1888",
+    "disposition": "voicemail",
+    "quotes": []
+  }
+}

--- a/skills/callparity-claimkill/fixtures/FR-1900.json
+++ b/skills/callparity-claimkill/fixtures/FR-1900.json
@@ -1,6 +1,6 @@
 {
   "ticket_id": "FR-1900",
-  "sku": "PL-9F00",
+  "sku": "PL-9F21",
   "spoken_time_budget_s": 90,
   "parties": [
     {

--- a/skills/callparity-claimkill/fixtures/FR-1900.json
+++ b/skills/callparity-claimkill/fixtures/FR-1900.json
@@ -1,0 +1,66 @@
+{
+  "ticket_id": "FR-1900",
+  "sku": "PL-9F00",
+  "spoken_time_budget_s": 90,
+  "parties": [
+    {
+      "role": "warehouse",
+      "label": "A",
+      "phone": "+15550100190",
+      "consent": true
+    },
+    {
+      "role": "driver",
+      "label": "B",
+      "phone": "+15550100191",
+      "consent": true
+    }
+  ],
+  "nodes": [
+    {
+      "id": "dock",
+      "text": "Pallet may have cleared the dock.",
+      "evidence": {
+        "span": {
+          "quote": "maybe it left the dock"
+        }
+      },
+      "observable_of": "dock_location",
+      "status": "UNTESTED",
+      "confidence": 0.22,
+      "party": "A"
+    },
+    {
+      "id": "arrival",
+      "text": "Driver may have reached the gate.",
+      "evidence": {
+        "span": {
+          "quote": "someone thought the truck was here"
+        }
+      },
+      "observable_of": "driver_arrival",
+      "status": "UNTESTED",
+      "confidence": 0.18,
+      "party": "A"
+    }
+  ],
+  "candidate_questions": [
+    {
+      "id": "q-dock",
+      "text": "Was the receiving dock empty when you arrived?",
+      "targets": ["dock"]
+    }
+  ],
+  "call": {
+    "id": "call-nplus1-fr-1900",
+    "disposition": "completed",
+    "quotes": [
+      {
+        "claim_id": "dock",
+        "quote": "I am not sure which dock you mean.",
+        "polarity": "none",
+        "tested_by": "q-dock"
+      }
+    ]
+  }
+}

--- a/skills/callparity-claimkill/references/examples.md
+++ b/skills/callparity-claimkill/references/examples.md
@@ -10,13 +10,7 @@ Run `scripts/claimkill.py preview --fixture fixtures/FR-1842.json`. Expect `Was 
 
 ## Merge result
 
-With the FR-1842 fixture quotes, the merger writes:
-
-- `dock` `CONTRADICTED`, `tested_by` `q-dock-empty`
-- `arrival` `SUPPORTED` (alias `CONFIRMED`)
-- `seal` `UNTESTED` because no falsifier quote exists
-
-The written artifact is the JSON graph from `scripts/claimkill.py merge --fixture fixtures/FR-1842.json`.
+With the FR-1842 fixture quotes, the merger writes `dock` as `CONTRADICTED` with `tested_by` `q-dock-empty`, `arrival` as `SUPPORTED`, and `seal` as `UNTESTED` because no falsifier quote exists. `CONFIRMED` on input means `SUPPORTED`. Overall result is `CONTRADICTED`. The written artifact is the JSON graph from `scripts/claimkill.py merge --fixture fixtures/FR-1842.json`.
 
 ## Extra fixtures
 

--- a/skills/callparity-claimkill/references/examples.md
+++ b/skills/callparity-claimkill/references/examples.md
@@ -1,0 +1,40 @@
+# Examples
+
+All tickets, pallets, and phone numbers below are fictional. Numbers use the `+15550100xxx` reserved-style block.
+
+## Appropriate request
+
+> Ticket FR-1842. The warehouse quote is `pallet left dock 3`. The driver says dock 3 was empty. Compile the next CALL-E call that can falsify the warehouse claim without telling the driver what the warehouse said.
+
+Run `scripts/claimkill.py preview --fixture fixtures/FR-1842.json`. Expect `Was dock 3 empty when you pulled in?` to stay. Expect every question that contains `warehouse said dock 3` to drop, including the cheaper `warehouse said dock 3?` trap. `calls_placed` is `0`.
+
+## Merge result
+
+With the FR-1842 fixture quotes, the merger writes:
+
+- `dock` `CONTRADICTED`, `tested_by` `q-dock-empty`
+- `arrival` `SUPPORTED` (alias `CONFIRMED`)
+- `seal` `UNTESTED` because no falsifier quote exists
+
+The written artifact is the JSON graph from `scripts/claimkill.py merge --fixture fixtures/FR-1842.json`.
+
+## Extra fixtures
+
+FR-1900 and FR-1888 are pytest-only graphs. They are not a second demo story.
+
+- FR-1900. Confidence below 0.45. Nodes stay `ABSTAIN`.
+- FR-1888. Party B voicemail. Live nodes become `UNREACHABLE`. The low-confidence seal stays `ABSTAIN`.
+
+## Prohibited request
+
+> Tell the driver the warehouse said dock 3 still had the pallet, then keep calling until they agree.
+
+Refuse. That leaks Party A's answer and is cascade-until-yes. Rebuild from observables only, or stop.
+
+## Missing consent
+
+If Party B has `consent` false, `preview()` still compiles leak-drop output and sets `blocked_reason` to `missing consent`. Do not ask a host to dial.
+
+## Honest reporting
+
+Do not describe FR-1842 as fully verified while `seal` is `UNTESTED`. Do not count voicemail as `SUPPORTED`. Live CALL-E outbound is not required to run the tests.

--- a/skills/callparity-claimkill/references/planner.md
+++ b/skills/callparity-claimkill/references/planner.md
@@ -1,0 +1,17 @@
+# Planner
+
+Input: a claim graph, candidate `RefutationQuestion` values, and a spoken-time budget (default 90 seconds at 2.5 words per second).
+
+1. Map `CONFIRMED` to `SUPPORTED`.
+2. Set any node with confidence below 0.45 to `ABSTAIN`. Do not plan a question against it.
+3. Score each question with `leak_score`.
+   - `1.0` if the text contains `warehouse said dock 3` or another Party A attribution marker.
+   - `0.9` if the text repeats Party A's evidence quote of three or more words.
+   - `0.0` if the question only asks an observable Party B could have seen.
+4. Discard when `leak_score` is 0.5 or higher. That is leak-drop.
+5. Among kept questions that target an `UNTESTED` or `SUPPORTED` node and fit the spoken-time budget, pick the cheapest. Cheapest means shortest spoken time, then question id.
+6. Return that question as call N+1, the remaining spoken-time budget, the kept list, and the dropped list. Place zero calls.
+
+On FR-1842, `warehouse said dock 3?` is shorter than `Was dock 3 empty when you pulled in?` and must still drop. If leak-drop is broken, preview selects the leak.
+
+The merger, not the spoken script, records the contradiction.

--- a/skills/callparity-claimkill/references/safety.md
+++ b/skills/callparity-claimkill/references/safety.md
@@ -1,0 +1,31 @@
+# Safety
+
+Read this before compiling a ClaimKill plan that a host might later dial.
+
+## Required
+
+- Obtain explicit user intent to reconcile one freight fact on one ticket.
+- Use only E.164 numbers supplied on the ticket. Mask them in summaries, for example `+1555****0184`.
+- Preview the exact Party B destination, the kept refute question, dropped leak questions, and the spoken-time budget before asking for approval.
+- Bind approval to that ticket, claim set, and question. Changed inputs need a new preview.
+- Place at most one Party B refute call per approved run. A retry needs a new idempotency key and a new approval.
+- Keep credentials, tokens, and webhook secrets out of fixtures, logs, and summaries.
+- Treat voicemail, silence, empty transcripts, and unreachable dispositions as `UNREACHABLE`, not confirmation.
+- Treat extraction confidence below 0.45 as `ABSTAIN`.
+- If Party B consent is false, set `blocked_reason` to `missing consent` and do not ask a host to dial.
+
+## Prohibited
+
+- Booking appointments, cascade-until-yes outreach, surveys, or one-shot identity verification.
+- Questions that disclose Party A's answer, including `warehouse said dock 3` on FR-1842.
+- Hidden recurring schedules or duplicate jobs for the same ticket.
+- Treating silence or voicemail as `SUPPORTED`.
+- Medical, legal, financial, emergency, or authentication workflows.
+
+## Content boundary
+
+ClaimKill reconciles operational freight facts such as dock, arrival, and seal. Cargo labels are SKU references, not clinical advice. If a party refuses or asks to stop, end the call and mark remaining live nodes `UNREACHABLE` or `ABSTAIN`.
+
+## Host responsibilities
+
+The bundled scripts never place a call. A live host must enforce calling hours, consent storage, rate limits, audit logs, and legal review. The default path is `preview()` on fixtures with zero live CALL-E calls.

--- a/skills/callparity-claimkill/references/schemas.md
+++ b/skills/callparity-claimkill/references/schemas.md
@@ -42,4 +42,4 @@
 | `quotes[].polarity` | string | `contradicts`, `supports`, or empty. Empty means no falsifier. |
 | `quotes[].tested_by` | string | Optional question id. |
 
-Could-not-verify in a human summary maps to `UNREACHABLE`, `ABSTAIN`, or `UNTESTED`.
+Could-not-verify in a human summary maps to `UNREACHABLE`, `ABSTAIN`, or `UNTESTED`. Merged graph JSON also sets `overall` to `SUPPORTED`, `CONTRADICTED`, or `could-not-verify`.

--- a/skills/callparity-claimkill/references/schemas.md
+++ b/skills/callparity-claimkill/references/schemas.md
@@ -1,0 +1,45 @@
+# Schemas
+
+## Claim node
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Stable claim id such as `dock`. |
+| `text` | string | Party A's claim in one sentence. |
+| `evidence.span.quote` | string | Verbatim source span. May be empty. |
+| `observable_of` | string | The freight observable this node tests. |
+| `status` | enum | `SUPPORTED`, `UNTESTED`, `CONTRADICTED`, `UNREACHABLE`, `ABSTAIN`. |
+| `confidence` | number | Below 0.45 forces `ABSTAIN`. |
+| `party` | string | Usually `A` for the quoted source. |
+
+`CONFIRMED` is an input alias of `SUPPORTED`. The engine stores and emits `SUPPORTED` only.
+
+## Graph edge
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `claim_id` | string | Node that was tested. |
+| `tested_by` | string | Call id or question id that tested the claim. |
+
+## Refutation question
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Stable question id. |
+| `text` | string | Spoken question for Party B. |
+| `targets` | string[] | Claim ids this question could falsify. |
+
+`leak_score` and `spoken_seconds` are computed. They are not stored on the fixture.
+
+## Merge event
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Call id used on `tested_by` when a quote omits a question id. |
+| `disposition` | string | `completed`, `voicemail`, `no-transcript`, or `unreachable`. |
+| `quotes[].claim_id` | string | Node the quote addresses. |
+| `quotes[].quote` | string | Party B span. |
+| `quotes[].polarity` | string | `contradicts`, `supports`, or empty. Empty means no falsifier. |
+| `quotes[].tested_by` | string | Optional question id. |
+
+Could-not-verify in a human summary maps to `UNREACHABLE`, `ABSTAIN`, or `UNTESTED`.

--- a/skills/callparity-claimkill/scripts/claimkill.py
+++ b/skills/callparity-claimkill/scripts/claimkill.py
@@ -133,6 +133,7 @@ class ClaimGraph:
             "nodes": [node.to_dict() for node in self.nodes.values()],
             "edges": [edge.to_dict() for edge in self.edges],
             "spoken_time_budget_s": self.spoken_time_budget_s,
+            "overall": overall_result(self),
         }
 
 
@@ -339,6 +340,15 @@ def merge(graph: ClaimGraph, event: MergeEvent) -> ClaimGraph:
 
     result.edges = new_edges
     return result
+
+
+def overall_result(graph: ClaimGraph) -> str:
+    statuses = [node.status for node in graph.nodes.values()]
+    if CONTRADICTED in statuses:
+        return CONTRADICTED
+    if SUPPORTED in statuses:
+        return SUPPORTED
+    return "could-not-verify"
 
 
 def _require_object(value: Any, where: str) -> dict[str, Any]:

--- a/skills/callparity-claimkill/scripts/claimkill.py
+++ b/skills/callparity-claimkill/scripts/claimkill.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""ClaimKill leak-drop planner, claim graph, and merger for CallParity.
+
+preview() compiles a plan from committed fixtures and places zero calls.
+The module has no network imports and does not contact CALL-E.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = SKILL_ROOT / "fixtures"
+
+SUPPORTED = "SUPPORTED"
+UNTESTED = "UNTESTED"
+CONTRADICTED = "CONTRADICTED"
+UNREACHABLE = "UNREACHABLE"
+ABSTAIN = "ABSTAIN"
+STATUSES = frozenset({SUPPORTED, UNTESTED, CONTRADICTED, UNREACHABLE, ABSTAIN})
+STATUS_ALIASES = {"CONFIRMED": SUPPORTED}
+ABSTAIN_THRESHOLD = 0.45
+WORDS_PER_SECOND = 2.5
+DEFAULT_SPOKEN_BUDGET_S = 90.0
+LEAK_DROP_THRESHOLD = 0.5
+E164_RE = re.compile(r"^\+[1-9][0-9]{7,14}$")
+UNREACHABLE_DISPOSITIONS = frozenset(
+    {"voicemail", "no-transcript", "no_transcript", "unreachable", "no-answer", "no_answer"}
+)
+SUPPORT_POLARITY = frozenset({"supports", "support", "confirm", "confirmed", "supported"})
+CONTRADICT_POLARITY = frozenset(
+    {"contradicts", "contradict", "falsify", "falsified", "contradicted"}
+)
+ATTRIBUTION_MARKERS = (
+    "warehouse said",
+    "warehouse told",
+    "warehouse claimed",
+    "warehouse claims",
+    "the warehouse said",
+    "party a said",
+    "party a claimed",
+    "they claimed",
+    "according to the warehouse",
+    "warehouse reported",
+)
+
+
+class FixtureError(ValueError):
+    """Fixture JSON failed boundary validation."""
+
+
+def normalize_status(value: str) -> str:
+    raw = (value or "").strip()
+    mapped = STATUS_ALIASES.get(raw.upper(), raw.upper())
+    if mapped not in STATUSES:
+        raise FixtureError(f"unknown claim status: {value!r}")
+    return mapped
+
+
+def spoken_seconds(text: str) -> float:
+    words = [part for part in text.split() if part]
+    return len(words) / WORDS_PER_SECOND
+
+
+def mask_phone(phone: str) -> str:
+    if len(phone) < 8:
+        return "***"
+    return f"{phone[:4]}{'*' * (len(phone) - 8)}{phone[-4:]}"
+
+
+@dataclass(frozen=True)
+class EvidenceSpan:
+    quote: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"quote": self.quote}
+
+
+@dataclass
+class ClaimNode:
+    id: str
+    text: str
+    evidence: EvidenceSpan
+    observable_of: str
+    status: str
+    confidence: float = 1.0
+    party: str = "A"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "text": self.text,
+            "evidence": {"span": self.evidence.to_dict()},
+            "observable_of": self.observable_of,
+            "status": self.status,
+            "confidence": self.confidence,
+            "party": self.party,
+        }
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    claim_id: str
+    tested_by: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"claim_id": self.claim_id, "tested_by": self.tested_by}
+
+
+@dataclass
+class ClaimGraph:
+    ticket_id: str
+    sku: str
+    nodes: dict[str, ClaimNode]
+    edges: list[GraphEdge] = field(default_factory=list)
+    spoken_time_budget_s: float = DEFAULT_SPOKEN_BUDGET_S
+
+    def node(self, claim_id: str) -> ClaimNode:
+        return self.nodes[claim_id]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ticket_id": self.ticket_id,
+            "sku": self.sku,
+            "nodes": [node.to_dict() for node in self.nodes.values()],
+            "edges": [edge.to_dict() for edge in self.edges],
+            "spoken_time_budget_s": self.spoken_time_budget_s,
+        }
+
+
+@dataclass(frozen=True)
+class RefutationQuestion:
+    id: str
+    text: str
+    targets: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "text": self.text, "targets": list(self.targets)}
+
+
+@dataclass
+class ScoredQuestion:
+    question: RefutationQuestion
+    leak_score: float
+    discarded: bool
+    discard_reason: str | None
+    spoken_seconds: float
+    remaining_budget_s: float
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.question.to_dict()
+        payload.update(
+            {
+                "leak_score": self.leak_score,
+                "discarded": self.discarded,
+                "discard_reason": self.discard_reason,
+                "spoken_seconds": self.spoken_seconds,
+                "remaining_budget_s": self.remaining_budget_s,
+            }
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class TranscriptQuote:
+    claim_id: str
+    quote: str
+    polarity: str | None = None
+    tested_by: str | None = None
+
+
+@dataclass(frozen=True)
+class MergeEvent:
+    call_id: str
+    disposition: str
+    quotes: tuple[TranscriptQuote, ...]
+
+
+@dataclass
+class LoadedFixture:
+    graph: ClaimGraph
+    questions: list[RefutationQuestion]
+    parties: list[dict[str, Any]]
+    event: MergeEvent | None
+
+
+@dataclass
+class PreviewPlan:
+    ticket_id: str
+    sku: str
+    next_question: RefutationQuestion | None
+    kept: list[ScoredQuestion]
+    dropped: list[ScoredQuestion]
+    spoken_time_budget_s: float
+    remaining_budget_s: float
+    masked_parties: list[dict[str, str]]
+    graph: ClaimGraph
+    calls_placed: int = 0
+    side_effect: str = "None. Preview only. Zero live CALL-E calls."
+    blocked_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ticket_id": self.ticket_id,
+            "sku": self.sku,
+            "next_question": None
+            if self.next_question is None
+            else self.next_question.to_dict(),
+            "kept": [item.to_dict() for item in self.kept],
+            "dropped": [item.to_dict() for item in self.dropped],
+            "spoken_time_budget_s": self.spoken_time_budget_s,
+            "remaining_budget_s": self.remaining_budget_s,
+            "masked_parties": self.masked_parties,
+            "graph": self.graph.to_dict(),
+            "calls_placed": self.calls_placed,
+            "side_effect": self.side_effect,
+            "blocked_reason": self.blocked_reason,
+        }
+
+
+def leak_score(
+    question: RefutationQuestion,
+    nodes: Sequence[ClaimNode] | Mapping[str, ClaimNode],
+) -> float:
+    """Return 1.0 when the question discloses Party A's answer, else 0.0 to 0.9."""
+    text = question.text.lower()
+    if "warehouse said dock 3" in text:
+        return 1.0
+    score = 0.0
+    for marker in ATTRIBUTION_MARKERS:
+        if marker in text:
+            score = max(score, 1.0)
+    node_list = nodes.values() if isinstance(nodes, Mapping) else nodes
+    for node in node_list:
+        quote = node.evidence.quote.strip().lower()
+        if len(quote.split()) >= 3 and quote in text:
+            score = max(score, 0.9)
+    return score
+
+
+def score_question(
+    question: RefutationQuestion,
+    nodes: Sequence[ClaimNode] | Mapping[str, ClaimNode],
+    budget_s: float,
+) -> ScoredQuestion:
+    score = leak_score(question, nodes)
+    spoken = spoken_seconds(question.text)
+    discarded = score >= LEAK_DROP_THRESHOLD
+    remaining = budget_s if discarded else max(0.0, budget_s - spoken)
+    return ScoredQuestion(
+        question=question,
+        leak_score=score,
+        discarded=discarded,
+        discard_reason="discloses party A answer" if discarded else None,
+        spoken_seconds=spoken,
+        remaining_budget_s=remaining,
+    )
+
+
+def drop_leaks(
+    questions: Sequence[RefutationQuestion],
+    nodes: Sequence[ClaimNode] | Mapping[str, ClaimNode],
+    budget_s: float,
+) -> tuple[list[ScoredQuestion], list[ScoredQuestion]]:
+    scored = [score_question(question, nodes, budget_s) for question in questions]
+    kept = [item for item in scored if not item.discarded]
+    dropped = [item for item in scored if item.discarded]
+    return kept, dropped
+
+
+def _falsifiable(node: ClaimNode) -> bool:
+    return node.status in {UNTESTED, SUPPORTED}
+
+
+def pick_next_question(
+    kept: Sequence[ScoredQuestion], graph: ClaimGraph
+) -> RefutationQuestion | None:
+    candidates: list[ScoredQuestion] = []
+    for item in kept:
+        if item.spoken_seconds > graph.spoken_time_budget_s:
+            continue
+        targets = [
+            graph.nodes[target_id]
+            for target_id in item.question.targets
+            if target_id in graph.nodes
+        ]
+        if any(_falsifiable(node) for node in targets):
+            candidates.append(item)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item.spoken_seconds, item.question.id))
+    return candidates[0].question
+
+
+def merge(graph: ClaimGraph, event: MergeEvent) -> ClaimGraph:
+    """Update statuses from one Party B call event.
+
+    No falsifying quote leaves a live node UNTESTED.
+    Voicemail and missing transcripts become UNREACHABLE.
+    Confidence below 0.45 becomes ABSTAIN and stays there.
+    """
+    result = deepcopy(graph)
+    disposition = event.disposition.strip().lower()
+    quotes_by_claim = {quote.claim_id: quote for quote in event.quotes}
+    new_edges: list[GraphEdge] = []
+
+    for node in result.nodes.values():
+        if node.confidence < ABSTAIN_THRESHOLD:
+            node.status = ABSTAIN
+            continue
+        if disposition in UNREACHABLE_DISPOSITIONS:
+            node.status = UNREACHABLE
+            if event.call_id:
+                new_edges.append(GraphEdge(claim_id=node.id, tested_by=event.call_id))
+            continue
+        quote = quotes_by_claim.get(node.id)
+        if quote is None or not quote.quote.strip():
+            if node.status not in {CONTRADICTED, SUPPORTED, UNREACHABLE, ABSTAIN}:
+                node.status = UNTESTED
+            continue
+        polarity = (quote.polarity or "").strip().lower()
+        if polarity in CONTRADICT_POLARITY:
+            node.status = CONTRADICTED
+        elif polarity in SUPPORT_POLARITY:
+            node.status = SUPPORTED
+        else:
+            node.status = UNTESTED
+        tested_by = quote.tested_by or event.call_id
+        if tested_by:
+            new_edges.append(GraphEdge(claim_id=node.id, tested_by=tested_by))
+
+    result.edges = new_edges
+    return result
+
+
+def _require_object(value: Any, where: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FixtureError(f"{where} must be an object")
+    return value
+
+
+def _require_string(value: Any, where: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise FixtureError(f"{where} must be a non-empty string")
+    return value.strip()
+
+
+def _require_float(value: Any, where: str, default: float) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise FixtureError(f"{where} must be a number")
+    return float(value)
+
+
+def parse_node(raw: Any) -> ClaimNode:
+    data = _require_object(raw, "claim node")
+    evidence_raw = _require_object(data.get("evidence") or {"span": {}}, "evidence")
+    span_raw = _require_object(evidence_raw.get("span") or {}, "evidence.span")
+    quote = span_raw.get("quote") or ""
+    if not isinstance(quote, str):
+        raise FixtureError("evidence.span.quote must be a string")
+    confidence = _require_float(data.get("confidence"), "confidence", 1.0)
+    status = normalize_status(str(data.get("status") or UNTESTED))
+    if confidence < ABSTAIN_THRESHOLD:
+        status = ABSTAIN
+    return ClaimNode(
+        id=_require_string(data.get("id"), "claim id"),
+        text=_require_string(data.get("text"), "claim text"),
+        evidence=EvidenceSpan(quote=quote.strip()),
+        observable_of=_require_string(data.get("observable_of"), "observable_of"),
+        status=status,
+        confidence=confidence,
+        party=str(data.get("party") or "A"),
+    )
+
+
+def parse_question(raw: Any) -> RefutationQuestion:
+    data = _require_object(raw, "refutation question")
+    targets_raw = data.get("targets")
+    if not isinstance(targets_raw, list) or not targets_raw:
+        raise FixtureError("question targets must be a non-empty array")
+    targets = tuple(_require_string(item, "question target") for item in targets_raw)
+    return RefutationQuestion(
+        id=_require_string(data.get("id"), "question id"),
+        text=_require_string(data.get("text"), "question text"),
+        targets=targets,
+    )
+
+
+def parse_quote(raw: Any) -> TranscriptQuote:
+    data = _require_object(raw, "transcript quote")
+    polarity = data.get("polarity")
+    tested_by = data.get("tested_by")
+    return TranscriptQuote(
+        claim_id=_require_string(data.get("claim_id"), "quote claim_id"),
+        quote=str(data.get("quote") or "").strip(),
+        polarity=None if polarity is None else str(polarity),
+        tested_by=None if tested_by is None else str(tested_by),
+    )
+
+
+def parse_event(raw: Any) -> MergeEvent | None:
+    if raw is None:
+        return None
+    data = _require_object(raw, "call event")
+    quotes_raw = data.get("quotes") or []
+    if not isinstance(quotes_raw, list):
+        raise FixtureError("call quotes must be an array")
+    return MergeEvent(
+        call_id=_require_string(data.get("id") or data.get("call_id"), "call id"),
+        disposition=_require_string(data.get("disposition"), "call disposition"),
+        quotes=tuple(parse_quote(item) for item in quotes_raw),
+    )
+
+
+def parse_party(raw: Any) -> dict[str, Any]:
+    data = _require_object(raw, "party")
+    phone = _require_string(data.get("phone"), "party phone")
+    if not E164_RE.fullmatch(phone):
+        raise FixtureError(f"party phone must be E.164: {phone}")
+    return {
+        "role": _require_string(data.get("role"), "party role"),
+        "phone": phone,
+        "consent": bool(data.get("consent")),
+        "label": str(data.get("label") or ""),
+    }
+
+
+def parse_fixture(raw: Any) -> LoadedFixture:
+    data = _require_object(raw, "fixture")
+    nodes_raw = data.get("nodes") or data.get("claims")
+    if not isinstance(nodes_raw, list) or not nodes_raw:
+        raise FixtureError("fixture must include a non-empty nodes array")
+    nodes = [parse_node(item) for item in nodes_raw]
+    ids = [node.id for node in nodes]
+    if len(ids) != len(set(ids)):
+        raise FixtureError("claim ids must be unique")
+    questions_raw = data.get("candidate_questions") or []
+    if not isinstance(questions_raw, list):
+        raise FixtureError("candidate_questions must be an array")
+    parties_raw = data.get("parties") or []
+    if not isinstance(parties_raw, list):
+        raise FixtureError("parties must be an array")
+    graph = ClaimGraph(
+        ticket_id=_require_string(data.get("ticket_id"), "ticket_id"),
+        sku=_require_string(data.get("sku"), "sku"),
+        nodes={node.id: node for node in nodes},
+        spoken_time_budget_s=_require_float(
+            data.get("spoken_time_budget_s"),
+            "spoken_time_budget_s",
+            DEFAULT_SPOKEN_BUDGET_S,
+        ),
+    )
+    return LoadedFixture(
+        graph=graph,
+        questions=[parse_question(item) for item in questions_raw],
+        parties=[parse_party(item) for item in parties_raw],
+        event=parse_event(data.get("call")),
+    )
+
+
+def _fixture_path(source: str | Path) -> Path:
+    path = Path(source)
+    if path.exists():
+        return path
+    named = FIXTURES_DIR / f"{source}.json"
+    if named.exists():
+        return named
+    nested = FIXTURES_DIR / str(source)
+    if nested.exists():
+        return nested
+    raise FixtureError(f"fixture not found: {source}")
+
+
+def load_fixture(
+    source: str | Path | Mapping[str, Any] | None = None,
+) -> LoadedFixture:
+    if source is None:
+        source = "FR-1842"
+    if isinstance(source, Mapping):
+        return parse_fixture(dict(source))
+    path = _fixture_path(source)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_fixture(raw)
+
+
+def compile_preview(loaded: LoadedFixture) -> PreviewPlan:
+    budget = loaded.graph.spoken_time_budget_s
+    kept, dropped = drop_leaks(loaded.questions, loaded.graph.nodes, budget)
+    next_question = pick_next_question(kept, loaded.graph)
+    blocked_reason = None
+    party_b = next(
+        (
+            party
+            for party in loaded.parties
+            if str(party.get("label") or "").upper() == "B"
+            or party.get("role") == "driver"
+        ),
+        None,
+    )
+    if party_b is not None and not party_b.get("consent"):
+        blocked_reason = "missing consent"
+        next_question = None
+    remaining = budget
+    if next_question is not None:
+        remaining = max(0.0, budget - spoken_seconds(next_question.text))
+    masked = []
+    for party in loaded.parties:
+        masked.append(
+            {
+                "role": str(party["role"]),
+                "phone": mask_phone(str(party["phone"])),
+                "consent": "true" if party.get("consent") else "false",
+                "label": str(party.get("label") or ""),
+            }
+        )
+    return PreviewPlan(
+        ticket_id=loaded.graph.ticket_id,
+        sku=loaded.graph.sku,
+        next_question=next_question,
+        kept=kept,
+        dropped=dropped,
+        spoken_time_budget_s=budget,
+        remaining_budget_s=remaining,
+        masked_parties=masked,
+        graph=loaded.graph,
+        blocked_reason=blocked_reason,
+    )
+
+
+def preview(
+    source: str | Path | Mapping[str, Any] | None = None,
+) -> PreviewPlan:
+    """Compile call N+1 from a fixture. Places zero calls."""
+    return compile_preview(load_fixture(source))
+
+
+def merge_fixture(
+    source: str | Path | Mapping[str, Any] | None = None,
+) -> ClaimGraph:
+    loaded = load_fixture(source)
+    if loaded.event is None:
+        raise FixtureError(f"{loaded.graph.ticket_id} has no call event to merge")
+    return merge(loaded.graph, loaded.event)
+
+
+def _print_json(payload: Mapping[str, Any]) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="ClaimKill fixture preview and merger. Places zero calls."
+    )
+    parser.add_argument(
+        "command",
+        choices=("preview", "merge"),
+        help="preview compiles call N+1. merge applies fixture quotes.",
+    )
+    parser.add_argument(
+        "--fixture",
+        default="FR-1842",
+        help="ticket id or path under fixtures/. Default FR-1842.",
+    )
+    args = parser.parse_args(argv)
+    if args.command == "preview":
+        plan = preview(args.fixture)
+        _print_json(plan.to_dict())
+        return 0
+    graph = merge_fixture(args.fixture)
+    _print_json(graph.to_dict())
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FixtureError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/skills/callparity-claimkill/tests/test_claimkill.py
+++ b/skills/callparity-claimkill/tests/test_claimkill.py
@@ -113,7 +113,6 @@ def test_fr1842_merger_dock_contradicted_arrival_supported_seal_untested() -> No
     assert tested["dock"] == "q-dock-empty"
     assert "seal" not in tested
     assert graph.node("dock").evidence.quote == "pallet left dock 3"
-    assert graph.to_dict()["overall"] == claimkill.CONTRADICTED
 
 
 def test_fr1842_merge_without_falsifier_stays_untested() -> None:

--- a/skills/callparity-claimkill/tests/test_claimkill.py
+++ b/skills/callparity-claimkill/tests/test_claimkill.py
@@ -1,0 +1,163 @@
+"""ClaimKill regressions for leak-drop, merger, and extra fixtures.
+
+Run from the repository root:
+
+    python3 -m pytest skills/callparity-claimkill/tests/test_claimkill.py -q
+
+The suite places zero live CALL-E calls. It must fail if leak-drop keeps
+a question that discloses Party A's warehouse answer.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import claimkill  # noqa: E402
+
+
+def _kept_texts(plan: claimkill.PreviewPlan) -> list[str]:
+    return [item.question.text.lower() for item in plan.kept]
+
+
+def _dropped_texts(plan: claimkill.PreviewPlan) -> list[str]:
+    return [item.question.text.lower() for item in plan.dropped]
+
+
+def test_engine_has_no_network_imports() -> None:
+    source = Path(claimkill.__file__).read_text(encoding="utf-8")
+    for banned in ("import urllib", "import requests", "import http.client", "from urllib"):
+        assert banned not in source, f"claimkill.py must not import {banned}"
+
+
+def test_confirmed_alias_maps_to_supported() -> None:
+    assert claimkill.normalize_status("CONFIRMED") == claimkill.SUPPORTED
+    assert claimkill.normalize_status("confirmed") == claimkill.SUPPORTED
+    assert claimkill.normalize_status("SUPPORTED") == claimkill.SUPPORTED
+
+
+def test_fr1842_preview_places_zero_calls() -> None:
+    plan = claimkill.preview("FR-1842")
+    assert plan.calls_placed == 0
+    assert plan.ticket_id == "FR-1842"
+    assert plan.sku == "PL-9F21"
+    assert "zero live" in plan.side_effect.lower()
+    for party in plan.masked_parties:
+        assert "*" in party["phone"]
+        assert "010018" not in party["phone"]
+
+
+def test_fr1842_dock_empty_stays() -> None:
+    plan = claimkill.preview("FR-1842")
+    kept = _kept_texts(plan)
+    assert any("dock 3" in text and "empty" in text for text in kept), (
+        "FR-1842 driver question about whether dock 3 was empty must stay"
+    )
+    next_text = "" if plan.next_question is None else plan.next_question.text.lower()
+    assert "empty" in next_text
+    assert "dock 3" in next_text
+    assert "warehouse said" not in next_text
+
+
+def test_fr1842_warehouse_said_dock_3_is_dropped() -> None:
+    plan = claimkill.preview("FR-1842")
+    dropped = _dropped_texts(plan)
+    kept = _kept_texts(plan)
+    assert any("warehouse said dock 3" in text for text in dropped), (
+        "FR-1842 questions containing 'warehouse said dock 3' must be dropped"
+    )
+    assert all("warehouse said dock 3" not in text for text in kept)
+    short_leak = claimkill.RefutationQuestion(
+        id="synth-short-leak",
+        text="warehouse said dock 3?",
+        targets=("dock",),
+    )
+    graph = claimkill.load_fixture("FR-1842").graph
+    scored = claimkill.score_question(short_leak, graph.nodes, graph.spoken_time_budget_s)
+    assert scored.leak_score >= claimkill.LEAK_DROP_THRESHOLD
+    assert scored.discarded is True
+    assert scored.discard_reason == "discloses party A answer"
+
+
+def test_fr1842_short_leak_is_cheaper_than_dock_empty_but_still_dropped() -> None:
+    loaded = claimkill.load_fixture("FR-1842")
+    leak = next(
+        question
+        for question in loaded.questions
+        if "warehouse said dock 3" in question.text.lower()
+        and question.id == "q-short-leak"
+    )
+    dock = next(
+        question for question in loaded.questions if question.id == "q-dock-empty"
+    )
+    assert claimkill.spoken_seconds(leak.text) < claimkill.spoken_seconds(dock.text)
+    plan = claimkill.compile_preview(loaded)
+    assert plan.next_question is not None
+    assert plan.next_question.id == "q-dock-empty"
+    assert all(item.question.id != "q-short-leak" for item in plan.kept)
+
+
+def test_fr1842_merger_dock_contradicted_arrival_supported_seal_untested() -> None:
+    graph = claimkill.merge_fixture("FR-1842")
+    assert graph.node("dock").status == claimkill.CONTRADICTED
+    assert graph.node("arrival").status == claimkill.SUPPORTED
+    assert graph.node("seal").status == claimkill.UNTESTED
+    tested = {edge.claim_id: edge.tested_by for edge in graph.edges}
+    assert tested["dock"] == "q-dock-empty"
+    assert "seal" not in tested
+    assert graph.node("dock").evidence.quote == "pallet left dock 3"
+
+
+def test_fr1842_merge_without_falsifier_stays_untested() -> None:
+    loaded = claimkill.load_fixture("FR-1842")
+    event = claimkill.MergeEvent(
+        call_id="call-empty-quotes",
+        disposition="completed",
+        quotes=(),
+    )
+    graph = claimkill.merge(loaded.graph, event)
+    assert graph.node("dock").status == claimkill.UNTESTED
+    assert graph.node("arrival").status == claimkill.UNTESTED
+    assert graph.node("seal").status == claimkill.UNTESTED
+
+
+def test_fr1900_low_confidence_abstains() -> None:
+    loaded = claimkill.load_fixture("FR-1900")
+    assert loaded.graph.node("dock").status == claimkill.ABSTAIN
+    assert loaded.graph.node("arrival").status == claimkill.ABSTAIN
+    plan = claimkill.preview("FR-1900")
+    assert plan.next_question is None
+    assert plan.calls_placed == 0
+    graph = claimkill.merge_fixture("FR-1900")
+    assert graph.node("dock").status == claimkill.ABSTAIN
+    assert graph.node("arrival").status == claimkill.ABSTAIN
+
+
+def test_fr1888_voicemail_unreachable_and_low_confidence_abstain() -> None:
+    loaded = claimkill.load_fixture("FR-1888")
+    assert loaded.graph.node("seal").status == claimkill.ABSTAIN
+    graph = claimkill.merge_fixture("FR-1888")
+    assert graph.node("dock").status == claimkill.UNREACHABLE
+    assert graph.node("arrival").status == claimkill.UNREACHABLE
+    assert graph.node("seal").status == claimkill.ABSTAIN
+    tested = {edge.claim_id: edge.tested_by for edge in graph.edges}
+    assert tested["dock"] == "call-nplus1-fr-1888"
+    assert "seal" not in tested
+
+
+def test_preview_cli_json_artifact() -> None:
+    plan = claimkill.preview(SKILL_ROOT / "fixtures" / "FR-1842.json")
+    artifact = plan.to_dict()
+    assert artifact["calls_placed"] == 0
+    assert artifact["next_question"]["id"] == "q-dock-empty"
+    assert any(
+        item["discarded"] is True and "warehouse said dock 3" in item["text"].lower()
+        for item in artifact["dropped"]
+    )
+    assert "warehouse said dock 3" not in json.dumps(artifact["kept"]).lower()

--- a/skills/callparity-claimkill/tests/test_claimkill.py
+++ b/skills/callparity-claimkill/tests/test_claimkill.py
@@ -108,10 +108,12 @@ def test_fr1842_merger_dock_contradicted_arrival_supported_seal_untested() -> No
     assert graph.node("dock").status == claimkill.CONTRADICTED
     assert graph.node("arrival").status == claimkill.SUPPORTED
     assert graph.node("seal").status == claimkill.UNTESTED
+    assert graph.to_dict()["overall"] == claimkill.CONTRADICTED
     tested = {edge.claim_id: edge.tested_by for edge in graph.edges}
     assert tested["dock"] == "q-dock-empty"
     assert "seal" not in tested
     assert graph.node("dock").evidence.quote == "pallet left dock 3"
+    assert graph.to_dict()["overall"] == claimkill.CONTRADICTED
 
 
 def test_fr1842_merge_without_falsifier_stays_untested() -> None:
@@ -137,6 +139,7 @@ def test_fr1900_low_confidence_abstains() -> None:
     graph = claimkill.merge_fixture("FR-1900")
     assert graph.node("dock").status == claimkill.ABSTAIN
     assert graph.node("arrival").status == claimkill.ABSTAIN
+    assert graph.to_dict()["overall"] == "could-not-verify"
 
 
 def test_fr1888_voicemail_unreachable_and_low_confidence_abstain() -> None:
@@ -146,6 +149,7 @@ def test_fr1888_voicemail_unreachable_and_low_confidence_abstain() -> None:
     assert graph.node("dock").status == claimkill.UNREACHABLE
     assert graph.node("arrival").status == claimkill.UNREACHABLE
     assert graph.node("seal").status == claimkill.ABSTAIN
+    assert graph.to_dict()["overall"] == "could-not-verify"
     tested = {edge.claim_id: edge.tested_by for edge in graph.edges}
     assert tested["dock"] == "call-nplus1-fr-1888"
     assert "seal" not in tested
@@ -161,3 +165,13 @@ def test_preview_cli_json_artifact() -> None:
         for item in artifact["dropped"]
     )
     assert "warehouse said dock 3" not in json.dumps(artifact["kept"]).lower()
+    assert artifact["blocked_reason"] is None
+
+
+def test_missing_consent_blocks_next_question() -> None:
+    loaded = claimkill.load_fixture("FR-1842")
+    loaded.parties[1]["consent"] = False
+    plan = claimkill.compile_preview(loaded)
+    assert plan.blocked_reason == "missing consent"
+    assert plan.next_question is None
+    assert plan.calls_placed == 0


### PR DESCRIPTION
## Why

CallParity needs an executable ClaimKill engine in this awesome list, not a README wrapper. Other agents should compile the next CALL-E call as a leak-scored refute of a quoted freight claim and run pytest on fixtures with zero live calls.

## Practical $4k must-show

Two systems disagree on one location and SKU before any call. FR-1842 warehouse quote is `pallet left dock 3`. The driver report is that dock 3 was empty. Pallet `PL-9F21`. `preview()` places zero calls.

Call N+1 is one refute question, not a survey: `Was dock 3 empty when you pulled in?`. `scripts/claimkill.py merge` writes the graph artifact. Result labels are `SUPPORTED`, `CONTRADICTED`, or `could-not-verify`. `CONFIRMED` on input means `SUPPORTED`. On FR-1842, `dock` is `CONTRADICTED`, `arrival` is `SUPPORTED`, and `seal` is `UNTESTED`. Graph `overall` is `CONTRADICTED`.

We do not book appointments, cascade-until-yes, or one-shot-verify a person. We reconcile one freight fact.

Live CALL-E outbound is not required to run the tests.

## Scope

Adds `skills/callparity-claimkill/` with `scripts/claimkill.py`, fixtures `FR-1842`, `FR-1900`, and `FR-1888`, and `tests/test_claimkill.py`.

`leak_score` drops any question that discloses party A's answer, including the cheaper trap `warehouse said dock 3?`. The dock-empty question stays.

`GraphEdge.tested_by` points at the question or call that tested the claim.

Removes `skills/callparity-refute/` and the thin README pointer. Product name stays CallParity. Artifact name is ClaimKill. `apps/typescript/callparity/` stays a catalog pointer.

## Tradeoffs

The status enum stores `SUPPORTED`, not `CONFIRMED`. Input alias `CONFIRMED` maps to `SUPPORTED`.

FR-1900 and FR-1888 are extra pytest graphs for abstain and unreachable. Demo narrative stays one SKU, FR-1842 / `PL-9F21`.

Default path is `preview()`. A host may dial later. This skill does not.

## Blast radius

Touches one skill, one README skill row, one catalog app README, and the CallParity apps-table cell. No live provider calls. Fictional `+15550100xxx` numbers only.

## Verification

Ran on this branch:

```bash
python3 -m pytest skills/callparity-claimkill/tests/test_claimkill.py -q
# 12 passed
python3 scripts/validate_repository.py
# Repository validation passed.
```

If leak-drop is broken, `warehouse said dock 3?` stays in the kept set and wins as call N+1 because it is cheaper than the dock-empty question. The suite fails in that case. Tests place zero live CALL-E calls.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
