### PR TITLE
docs: add Later, Me. app entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Apps
 
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
+- [Later, Me.](https://github.com/shirosenagi-design/later-me) - Windows CALL-E app for scheduling a real phone call to your future self, with a four-hour minimum, one pending reservation, and optional post-call Relationship Trace.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 - [ShohojSheba Voice](https://shohojsheba-call-e-preview.redwan-rahman.workers.dev/judge) - Consent-gated healthcare staffing dispatch that uses structured CALL-E results to advance after a verified decline, pauses on acceptance, and keeps final assignment human-controlled.
 


### PR DESCRIPTION
## Summary

Adds [Later, Me.](https://github.com/shirosenagi-design/later-me) to the README Apps resource list.

Later, Me. is a Windows CALL-E app for scheduling a real phone call to your future self, with a four-hour minimum, one pending reservation, and optional post-call Relationship Trace.

This PR changes only the README awesome-list entry and does not add or modify runnable code in this repository.

## Type

- [x] README awesome-list entry

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit message, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described: the linked app schedules a real outbound phone call.
- [x] Phone-number fixture requirement is not applicable to this README-only change.
- [x] Recurring-workflow cancellation requirement is not applicable to this README-only change.
- [x] Runnable-code dry-run requirement is not applicable to this README-only change.
- [x] `python3 scripts/validate_repository.py` passes.