### PR TITLE
feat(fieldclose): ship reviewer-ready release

### DIFF
--- a/apps/web/fieldclose/README.md
+++ b/apps/web/fieldclose/README.md
@@ -18,25 +18,21 @@ protected-workspace operator UI, allow-listed protected-workspace provisioning
 with immutable administration evidence, and the durable, role-gated
 human-disposition closure through its browser and audit evidence.
 
-The fake-only judge environment is deployed at
-<https://fieldclose.dramaforge.icu/>. On 2026-08-06, one explicitly authorized
-CALL-E attempt was completed from a local protected workspace. CALL-E accepted
-and completed one provider task, but the call reached a Sonetel free-trial
-forwarding announcement instead of the intended participant. FieldClose kept
-all three HVAC answers as `not_asked`, routed the case to `human_follow_up` and
-`contact_review`, and required the operator to record the final
-`manual_follow_up_handoff`. The redacted private evidence records one attempt,
-one provider creation, one result, one disposition, and no retry or duplicate
-creation.
+The fake-only judge environment is available at
+<https://fieldclose.dramaforge.icu/>. Its publicly reviewable path is permanently
+fake-only and contains no CALL-E credential.
 
-That run verifies the live provider boundary, conservative normalization,
-idempotent creation, and human decision boundary. It does not verify a
-successful participant conversation or an isolated protected-staging
-deployment. Inspectable staging isolation, production authentication, and
-deployed CALL-E/SMTP evidence remain pending. The global live-call kill switch
-is paused and workspace live permission is disabled after the test. End-to-end
-deployed authentication-email delivery, GitHub OAuth, and general
-role-management UI are not claimed.
+This tree also describes maintainer-reported, redacted operational observations
+from one explicitly authorized local CALL-E attempt and a protected staging
+environment. Those private observations are not independently accessible and
+are not offered as public source, build, deployment, or validation provenance.
+They report one provider creation, conservative handling of a structured-result
+discrepancy, one human disposition, no retry, and a paused live-call gate after
+the test. They do not establish accurate structured capture of the participant's
+answers. The only public source provenance for this contribution is the
+`apps/web/fieldclose/` tree in this repository and its visible pull-request and
+CI history. Hosted Resend delivery, GitHub OAuth, and a general role-management
+UI are not claimed.
 
 ## Competition focus
 
@@ -226,15 +222,15 @@ credentials. All deployed authentication modes require a high-entropy
 The human-owned functional loop is complete: an authorized operator can persist
 a bounded disposition, resolve or cancel the human task, produce the final
 FieldClose case state, and audit the decision without mutating an external work
-order. The fake-only judge environment is deployed; protected-staging
-deployment, isolation, and production-authentication evidence remain pending.
-A redacted local evidence set now records one authorized CALL-E attempt with a
-contact exception and the resulting human disposition. The upstream
-contribution is open for review as
-[`apps/web/fieldclose/` PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96).
-Remaining submission gates are protected-staging verification, a stable
-sub-three-minute golden path, final upstream review fixes, and Devpost
-packaging. See the
+order. The fake-only judge environment is available for public review. Private
+staging and live-attempt observations are intentionally qualified as
+maintainer-reported operational evidence rather than public deployment
+provenance. The upstream
+[`apps/web/fieldclose/` PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96)
+was merged on 2026-08-10, and
+[PR #222](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/222)
+contains the focused reviewer-release update. Remaining submission gates are
+tracked in the
 [Hackathon submission plan](docs/hackathon-submission-plan.md) for status and
 acceptance gates. Submission-only drafts are kept under the local `submission/`
 directory and are ignored by Git.

--- a/apps/web/fieldclose/docs/architecture.md
+++ b/apps/web/fieldclose/docs/architecture.md
@@ -203,7 +203,14 @@ Authenticated bounded polling is the only result path. While the workbench is ac
 7. Route invalid results, mismatched identifiers, and unresolved 600-second attempts to `needs_attention` with one reconciliation task.
 8. Present the normalized result or explicit reconciliation state to the operator.
 
-Correctness must not depend on an in-memory timer. If scheduled reconciliation becomes necessary, due work is persisted in PostgreSQL and invoked by a hosted scheduler.
+The current MVP has no service worker, background poller, or hosted scheduler
+for accepted calls. The mounted case view schedules the first refresh after
+about five seconds and clears that timer when the view unmounts. Reopening the
+case reloads the persisted attempt and resumes the same bounded lookup loop when
+the attempt is still nonterminal. Correctness therefore depends on PostgreSQL
+state, the stored provider call ID, and `acceptedAt`, not on continuity of the
+browser timer. If unattended scheduled reconciliation is added later, its due
+work must be persisted in PostgreSQL and invoked by a hosted scheduler.
 
 ## Human disposition sequence
 
@@ -329,11 +336,47 @@ Do not place raw phone numbers, secrets, full transcripts, or unrestricted work-
 
 ## Deployment topology
 
-- The current hackathon deployment uses one Aliyun ECS host with isolated public-demo and protected-staging application environments behind Caddy HTTPS.
-- PostgreSQL is reachable only on the server network; it is not exposed publicly.
-- The public environment contains no CALL-E credentials and forces isolated fake-provider workspaces.
-- The protected environment permits only allow-listed operators and contains the live secrets.
-- The protected server retrieves CALL-E status through authenticated bounded polling and processes terminal results idempotently.
+The public URL and browser-visible fake-only boundary can be reviewed directly.
+The server, database, account, credential-presence, and protected-workspace
+details below are maintainer-reported private operational observations. They do
+not identify a publicly verifiable deployment revision and are not source or
+build provenance; the public source of truth is this repository tree and its
+visible pull-request history.
+
+- The current Aliyun ECS host serves the public demo and a separate
+  `fieldclose-staging` hostname behind Caddy HTTPS. The staging perimeter uses
+  HTTP Basic authentication; its DNS, valid hostname certificate, TLS 1.3
+  handshake, Caddy response, and `401` unauthenticated boundary were rechecked
+  on 2026-08-20.
+- A private 2026-08-04 preflight record identifies the protected release,
+  protected CALL-E workspace, recognized provider credential, and paused
+  durable kill switch that existed at that time.
+- The public application contains no CALL-E credentials and forces isolated
+  fake-provider workspaces.
+- A 2026-08-20 read-only server inspection verified distinct systemd services,
+  loopback ports, root-owned `0600` environment files, database URLs, Better
+  Auth secrets, field-encryption keys, and lookup keys. CALL-E credentials and
+  the protected-operator allowlist exist only in staging. The durable global
+  live-call switch was present and paused, and staging contained zero live
+  attempts.
+- The same-host PostgreSQL deployment uses distinct database names and roles,
+  aliases pinned to `127.0.0.1`, a loopback-only listener, and database-specific
+  host rules restricted to `127.0.0.1/32`. This is the documented equivalent to
+  certificate-verified transport for the current same-host topology; any
+  off-host database must use `sslmode=verify-full`.
+- On 2026-08-20 the Basic-auth credential was rotated and its bcrypt material
+  moved to a `root:caddy 0640` Caddy import. A dedicated protected access log
+  now removes IP, URI, and header fields and applies bounded rotation and
+  retention.
+- Public and staging share the same-owner QQ SMTP identity as an explicit,
+  documented operator-approved exception. On 2026-08-24 the unique verified
+  non-owner account received the existing protected workspace's `operator`
+  membership without changing the environment allowlist or live-call gates.
+  The operator then signed in and observed the protected workspace; the latest
+  bounded staging session row confirmed the verified non-owner operator role
+  and exact eight-hour duration. This completed W4 application-access evidence.
+- The protected server is designed to retrieve CALL-E status through
+  authenticated bounded polling and process terminal results idempotently.
 - Vercel and Neon remain a supported managed-hosting alternative.
 - `FIELDCLOSE_LIVE_CALLS_ENABLED` and a database-backed kill switch must both permit creation.
 - All timestamps are stored in UTC; each case retains its explicit IANA timezone.
@@ -395,7 +438,8 @@ The selected architecture remains subject to concrete implementation evidence. C
 - [x] Durable human disposition, task resolution, final case transition, and
   browser evidence
 - [x] An authorized asynchronous CALL-E creation smoke test, completed locally
-  with a contact exception and redacted evidence
+  with successful participant contact, a separately documented structured-result
+  discrepancy, and redacted evidence
 - [x] CALL-E lookup throttling, reconciliation, and late-recovery tests
 
 Failure of a spike may reopen the affected technology choice. It does not relax the product or safety invariants.

--- a/apps/web/fieldclose/docs/authentication-and-workspaces.md
+++ b/apps/web/fieldclose/docs/authentication-and-workspaces.md
@@ -7,20 +7,51 @@
 - Passwordless authentication: Six-digit email OTP for existing accounts
 - Secondary authentication: Optional GitHub OAuth
 - Session storage: PostgreSQL through the Better Auth Drizzle adapter
-- Public demo workspace - authenticated, per-user, and fake-only
+- Public demo workspace — Authenticated, per-user, and fake-only
 - Protected workspace provisioning: Implemented for server-allow-listed operators
 - SMTP email delivery: Implemented; STARTTLS authentication and self-delivery
-  verified with an operator-supplied provider configuration
-- Protected staging deployment and production access: Not yet verified
+  verified with an operator-supplied provider configuration; production signup
+  verification-code delivery and account verification were operator-verified on
+  2026-08-24
+- Protected staging endpoint and Basic-auth perimeter: Deployed and verified
+- Protected staging resource isolation: Verified with an operator-approved
+  same-owner SMTP exception
+- Protected staging application access: Basic-auth and minimum-privilege
+  operator workspace access verified on 2026-08-24
 - Hosted Resend delivery and GitHub OAuth verification: Not yet completed
+
+Deployment and account statements in this document are maintainer-reported
+private operational observations unless they are directly visible at the public
+URL. They do not identify a public deployment revision and are not offered as
+public source, build, or independent validation provenance.
 
 This document describes the implemented authentication boundary and workspace
 isolation rules. SMTP credentials remain external to this repository. The
 verification evidence confirms connection, TLS upgrade, authentication, and
-provider acceptance of one self-test message; it does not claim that a
-protected production deployment, deployed SMTP sender, hosted Resend sender, or
-GitHub OAuth application has been configured. Protected-staging isolation and
-allow-listed production access therefore remain open evidence gates.
+provider acceptance of one self-test message. The protected-staging hostname is
+deployed behind a valid TLS certificate and Caddy Basic-auth perimeter, and an
+earlier private preflight record identifies a protected application release and
+workspace. A later read-only server inspection verified separate public and
+staging services, database URLs, authentication secrets, encryption and lookup
+keys, and protected CALL-E/allowlist configuration. The environment files are
+root-owned mode `0600`. Follow-up remediation isolated and rotated the Basic-auth
+credential and added a dedicated, privacy-filtered, bounded-retention staging
+access log. PostgreSQL uses distinct databases and roles over a loopback-only
+same-host boundary. The operator accepted the shared QQ SMTP identity as a
+documented same-owner deployment exception. A verified non-owner `operator`
+subsequently signed in and observed the protected workspace; the bounded latest
+session record independently confirmed that role and the eight-hour session
+duration without retaining account identifiers.
+
+On 2026-08-24 the operator completed the deployed signup verification-code
+flow. A subsequent privacy-bounded query confirmed that the verified-user count
+increased from one to two without reading an email address, verification code,
+or account identifier. No active session remained at inspection time, and the
+newly verified account had not yet been assigned a protected-workspace
+membership at that inspection. Later on 2026-08-24, explicit operator authority
+was used to assign the unique verified non-owner account an idempotent
+`operator` membership. The environment administration allowlist and live-call
+gates were not changed.
 
 ## Authentication boundary
 
@@ -37,7 +68,13 @@ OAuth account tokens are encrypted by Better Auth before persistence. `BETTER_AU
 
 ### Credential and email-code flows
 
-Credential registration collects a display name, username, work email, and password. Usernames are normalized to lowercase, must contain 3–30 letters, numbers, dots, or underscores, and are unique. Passwords must contain 8–128 characters. A registration does not create a session until the email is verified, and duplicate registration responses remain generic to reduce account enumeration.
+Credential registration collects a display name, work email, and password. The
+browser derives an internal username from the normalized email so registration
+does not require a separate username field. Generated usernames contain 3–30
+lowercase letters, numbers, dots, or underscores and remain unique; the work
+email is the user-facing credential. Passwords must contain 8–128 characters. A
+registration does not create a session until the email is verified, and
+duplicate registration responses remain generic to reduce account enumeration.
 
 Email verification and passwordless sign-in use a six-digit OTP:
 
@@ -194,4 +231,7 @@ The workspace migration supports databases created by the prior persistence feat
 - Provisioning and actual live-gate changes create append-only workspace administration evidence without storing the actor email.
 - Unit and PostgreSQL tests cover every independent live-call switch.
 
-Hosted Resend delivery, GitHub OAuth login, secret configuration, secure-cookie behavior on HTTPS, and protected-environment access still require deployment verification.
+Hosted Resend delivery and GitHub OAuth login remain unverified. SMTP signup,
+secret configuration, secure-cookie behavior on HTTPS, and protected-environment
+access have maintainer-reported private operational evidence, but not independent
+public verification.

--- a/apps/web/fieldclose/docs/call-e-integration.md
+++ b/apps/web/fieldclose/docs/call-e-integration.md
@@ -83,6 +83,33 @@ Refresh never creates, retries, or redials a call. Provider state is handled as 
 
 The 600-second boundary is calculated from the persisted `acceptedAt` timestamp. Automatic refresh stops at a terminal result, reconciliation, navigation away from the active case, or component unmount. A human may still use `Refresh provider status` after timeout; a late terminal snapshot completes the normal result transaction and resolves the reconciliation task.
 
+### Browser close and reopen boundary
+
+The current MVP has no background worker, service worker, hosted poller, or
+server timer that continues CALL-E status lookup after the operator leaves the
+case. The five-second timer belongs to the mounted workbench only:
+
+1. Opening a case first loads its persisted detail from FieldClose.
+2. If that detail contains a live attempt with a stored provider call ID, no
+   result, and no reconciliation state, the workbench schedules its first
+   refresh for about five seconds later.
+3. Navigating to another case, opening the new-case form, signing out, closing
+   the tab, or unloading the workbench clears the browser timer. No CALL-E
+   request continues in the background.
+4. Reopening the same nonterminal case loads the same attempt from the database
+   and starts a new five-second timer. The refresh route looks up the stored
+   provider call ID; it does not execute call creation or mint a new attempt or
+   idempotency key.
+5. Time away from the page still counts toward the 600-second boundary because
+   the server compares the current time with persisted `acceptedAt`. If the
+   boundary elapsed while the page was closed, the first eligible refresh after
+   reopening performs the bounded final lookup. A terminal provider snapshot is
+   persisted normally; an unresolved snapshot creates one reconciliation task.
+
+Once the case is already in `needs_attention`, automatic refresh does not
+restart on reopen. The operator must use `Refresh provider status` to retrieve a
+late terminal snapshot from the same accepted call.
+
 ## Protected live path
 
 The authenticated HTTP API supports protected-workspace live mode without changing the fake public-demo default:
@@ -158,11 +185,12 @@ Failed-before-acceptance and ambiguous creation outcomes remain frozen.
 
 The SDK adapter, live application path, authenticated status refresh, protected
 operator UI, and protected-workspace provisioning boundary are implemented and
-covered through the injected HTTP boundary. A separately authorized local test
-also created exactly one real CALL-E task and retrieved its terminal result.
-The call reached a Sonetel free-trial forwarding announcement rather than the
-intended participant, so FieldClose preserved all approved HVAC questions as
-`not_asked` and routed the case to human follow-up. This verifies the provider
-boundary but not a successful conversation. The fake-only public environment is
-deployed; protected-staging isolation, production access, and deployed
-CALL-E/SMTP configuration still require inspectable verification.
+covered through the injected HTTP boundary. A maintainer-reported private record
+describes one separately authorized local CALL-E task, its terminal result, a
+structured-result discrepancy, and a dated operator correction. That record is
+redacted and not independently accessible, so it is not public validation or
+deployment provenance and does not establish accurate structured answer
+capture. The publicly reviewable environment is fake-only. Protected-staging,
+SMTP, and live-attempt statements elsewhere in this tree are likewise qualified
+as private operational observations unless a public artifact directly supports
+them.

--- a/apps/web/fieldclose/docs/hackathon-submission-plan.md
+++ b/apps/web/fieldclose/docs/hackathon-submission-plan.md
@@ -4,8 +4,15 @@
 
 - Objective: Compete for **Most Practical Use Case**
 - Scope: Frozen to one human-approved commercial HVAC closeout call
-- Last updated: 2026-08-06
-- Current phase: Close upstream review blockers, verify protected staging, and produce the final demonstration
+- Last updated: 2026-08-24
+- Current phase: Produce and verify the final demonstration and submission
+
+Publicly verifiable evidence is limited to this repository tree, visible pull
+request and CI history, the public fake-only URL, and published submission
+artifacts. Server configuration, protected accounts, local live-attempt records,
+and private validation logs are maintainer-reported operational evidence, not
+public source, build, or deployment provenance. This plan intentionally does not
+cite inaccessible revision identifiers.
 
 ## Submission thesis
 
@@ -29,7 +36,7 @@ workflow or an expansion of the UI information architecture.
 
 ## Current readiness snapshot
 
-As of 2026-08-06:
+As of 2026-08-24:
 
 - the workflow is implemented from case creation through normalized result,
   creation of a human next-action task, and role-gated final disposition;
@@ -44,30 +51,35 @@ As of 2026-08-06:
   state, so concurrent executions converge on one consistent recorded outcome;
 - the local demo secret writer narrows its target to owner-only permissions and
   refuses symlink and other non-regular targets before writing;
-- the repository validation gate has passed locally across type-check, lint,
-  unit tests, Drizzle schema validation, PostgreSQL integration tests,
-  production build, and Playwright;
+- the maintainer reports a complete local validation run across type-check,
+  lint, unit tests, Drizzle schema validation, PostgreSQL integration tests,
+  production build, and Playwright; the public repository validator is the
+  independently visible PR gate;
 - the fake-only judge environment is deployed at
   <https://fieldclose.dramaforge.icu/> and retains its build-time no-call gate;
-- protected-workspace provisioning and SMTP provider self-test evidence exist,
-  but protected-staging deployment, isolation, production access, and deployed
-  CALL-E/SMTP configuration have not been verified with inspectable evidence;
+- protected staging is deployed behind TLS and Basic authentication with
+  separate services, databases, roles, application secrets, and privacy-filtered
+  logs; deployed CALL-E/SMTP configuration and minimum-privilege operator access
+  have inspectable private evidence, with one same-owner SMTP identity exception
+  explicitly accepted by the operator;
 - one authorized local CALL-E attempt has a redacted private evidence bundle:
-  CALL-E accepted and completed one provider task, the Sonetel trial forwarding
-  announcement prevented participant connection, every HVAC answer remained
-  `not_asked`, and the result routed through human follow-up to one recorded
-  disposition without a retry or duplicate provider creation;
-- the current upstream contribution is open as
-  [PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96), with
-  final review-blocker fixes and validation still pending;
-- no successful participant conversation, protected-staging live execution, or
-  final sub-three-minute video is claimed.
+  CALL-E accepted and completed one provider task, reached the intended
+  participant, and completed a conversation; the structured result incorrectly
+  treated a Sonetel forwarding announcement as terminal, so every stored HVAC
+  answer remained `not_asked` and the case routed through human follow-up to one
+  recorded disposition without a retry or duplicate provider creation;
+- the operator-observed participant contact is recorded as a dated correction
+  beside the unchanged machine artifacts; no exact live-call answer values are
+  reconstructed without a retained transcript, recording, or participant
+  answer attestation;
+- [PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96) was
+  merged on 2026-08-10;
+- no accurate structured capture of the live answers, protected-staging live
+  execution, or final sub-three-minute video is claimed.
 
-P0A, the public deployment step, and one local authorized live-evidence run are
-complete. The local run does not replace the independent protected-staging
-gate. Remaining work begins with closing the upstream blockers and verifying
-protected staging, followed by demonstration and submission packaging. The only
-later product convenience is a preset
+P0A, the public deployment step, protected-staging verification, and one local
+authorized live-evidence run are complete. Remaining work centers on the final
+demonstration and submission packaging. The only later product convenience is a preset
 fictional work order for the demonstration; it must use the existing case
 workflow and must not create a new stage.
 
@@ -87,7 +99,7 @@ work-order mutation.
 | Implement the application service and API | Done | An owner/operator can atomically record one route-appropriate disposition; exact repeats are idempotent and stale or conflicting requests fail without mutation |
 | Implement the operator disposition UI | Done | Result and exception views provide the permitted action, bounded note, submitted state, final case state, resolved task, and visible audit evidence |
 | Add complete automated coverage | Done | Unit and PostgreSQL tests cover every outcome, permissions, route constraints, idempotency, stale state, audit redaction, and task/case atomicity; Playwright covers case creation through final human disposition |
-| Pass formal validation after closure | Done | `pnpm validate` passes with 107 unit, 64 PostgreSQL integration, and 15 Playwright tests plus type-check, lint, migration validation, and production build |
+| Pass formal validation after closure | Done, maintainer-reported | The maintainer reports a complete local `pnpm validate` run; the public PR separately exposes the repository validation check |
 
 Every P0A item now passes, so P0B deployment work may begin. No deployment should
 be treated as a release candidate unless it preserves the validated functional
@@ -98,16 +110,16 @@ loop and its safety boundaries.
 | Item | Status | Done when |
 | --- | --- | --- |
 | Deploy a judge-accessible fake-only public version | Done | The stable HTTPS deployment documented in [Public Fake-Only Deployment](public-demo-deployment.md) contains no CALL-E credentials and preserves the fake-only build gate |
-| Establish an isolated protected staging environment | Pending verification | Inspectable evidence proves separate data and secrets, production authentication for an allow-listed operator, and a paused live-call gate |
-| Complete one authorized real CALL-E test | Done locally with contact exception | One exact recipient, brief, timezone, and window were approved; CALL-E accepted and completed one task; the participant was not connected; uncertainty was preserved; one human disposition was recorded; and no duplicate provider creation occurred |
-| Preserve a redacted live-evidence bundle | Done privately | The gitignored bundle contains authorization, preflight, provider acceptance, terminal normalized result, human disposition, audit and duplicate evidence, cleanup state, and verified SHA-256 hashes without the full number, email, raw provider ID, transcript, recording, or credentials |
+| Establish an isolated protected staging environment | Done with documented SMTP exception | Private inspectable evidence proves separate data, roles and secrets, production authentication for a minimum-privilege operator, privacy-filtered logs, and a paused durable live-call gate; the same-owner SMTP identity is an explicitly accepted exception |
+| Complete one authorized real CALL-E test | Done locally with structured-result discrepancy | One exact recipient, brief, timezone, and window were approved; CALL-E accepted and completed one task; the intended participant was reached and a conversation occurred; the stored non-connection classification was preserved and corrected by dated operator clarification; one human disposition was recorded; and no duplicate provider creation occurred |
+| Preserve a redacted live-evidence bundle | Done privately | The gitignored bundle contains authorization, preflight, provider acceptance, unchanged terminal normalized result, human disposition, audit and duplicate evidence, cleanup state, a dated observation correction, and verified SHA-256 hashes without the full number, email, raw provider ID, transcript, recording, or credentials |
 | Stabilize the three-minute golden path | Pending rehearsal | The path uses a preset case, ends with a recorded disposition, completes within three minutes in three consecutive rehearsals, and labels every waiting-time edit accurately |
 
 ### P0 dependency order
 
-Steps 1–6 are complete. A separately authorized local protected-workspace run
-also completed steps 8–10 with a contact exception, but step 7 remains an
-independent deployment gate and must not be described as verified.
+Steps 1–7 are complete. A separately authorized local protected-workspace run
+also completed steps 8–10 and reached the intended participant, with a
+structured-result discrepancy documented by a dated correction.
 
 1. Add the human-disposition persistence contract and migration.
 2. Implement the authorized, idempotent application service and HTTP route.
@@ -132,11 +144,11 @@ P1 makes the project reviewable and acceptable as an upstream contribution.
 
 | Item | Status | Done when |
 | --- | --- | --- |
-| Package the contribution under `apps/web/fieldclose/` | Done; update pending | PR #96 contains the runnable app; the final concurrency and local-secret-writer fixes must be synchronized before review completion |
-| Complete the contribution README | Partial | The packaged README covers requirements, installation, fake/no-call default, credential handling, opt-in live side effects, cancellation limits, validation, and known limitations |
-| Run upstream repository validation | Rerun pending | The published PR snapshot passed; rerun `python3 scripts/validate_repository.py` after synchronizing the final blocker fixes |
-| Open the upstream pull request | Done; draft review active | [PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96) is the active contribution and supersedes PRs #93 and #72 |
-| Add the PR URL to Devpost | Pending | The submitted Devpost project contains the final PR #96 URL |
+| Package the contribution under `apps/web/fieldclose/` | Done; follow-up in review | PR #96 was merged with the safety fixes; [PR #222](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/222) contains the focused reviewer-release update |
+| Complete the contribution README | Done | The packaged README covers requirements, installation, fake/no-call default, credential handling, opt-in live side effects, cancellation limits, validation, known limitations, and the public/private evidence boundary |
+| Run upstream repository validation | Done for current branch | `python3 scripts/validate_repository.py` passes locally and the public PR exposes the repository validation check |
+| Open the upstream pull request | In review | [PR #222](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/222) follows the merged [PR #96](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/96) |
+| Add the PR URL to Devpost | Done | The Devpost submission references PR #222 |
 | Finish the English Devpost About text | Pending | The copy leads with the practical HVAC closeout problem, explains the human boundary and six mechanisms, and makes only evidence-supported claims |
 
 The packaging checklist follows the current
@@ -157,7 +169,7 @@ P2 improves comprehension without expanding the product.
 | Edit CALL-E waiting time accurately | Pending video | Nonessential waiting is shortened in editing and the video explicitly states that elapsed time was edited; it never implies instant completion |
 | Feature one memorable result | Pending evidence choice | The main story uses either a normal resolved report or one strong exception; other cases are mentioned, not toured |
 | Show audit and duplicate protection in the final 10 seconds | Pending script | One repeated action demonstrates the original attempt is reused, followed by the relevant audit evidence |
-| Capture domain or user feedback | Pending outreach | At least one consenting HVAC office, dispatcher, service manager, or adjacent domain reviewer provides a short, attributable or safely anonymized observation |
+| Capture domain or user feedback | Practitioner evidence unavailable; desk research complete | The current public-source brief is explicit that interviews are `n = 0`; this item becomes complete only if at least one consenting HVAC office, dispatcher, service manager, or adjacent domain reviewer provides a short, attributable or safely anonymized observation |
 
 ## Three-minute golden path
 
@@ -193,9 +205,11 @@ Do not submit until all of the following are true:
 - [ ] An owner or operator can complete the workflow from result review through
   persisted disposition, resolved task, final case state, and audit history.
 - [ ] The public fake-only URL passes the signed-out judge smoke test.
-- [ ] The protected staging environment is isolated from the public project.
-- [x] One authorized live CALL-E attempt has redacted, inspectable private
-  evidence and an explicitly documented contact exception.
+- [x] The protected staging environment has verified isolation evidence with a
+  documented operator-approved same-owner SMTP identity exception.
+- [x] One authorized live CALL-E attempt reached the intended participant and
+  has redacted, inspectable private evidence; its structured-result discrepancy
+  and later operator correction are both explicitly documented.
 - [ ] The video completes the fixed golden path in three minutes.
 - [ ] The upstream packaged app passes `scripts/validate_repository.py`.
 - [ ] The upstream PR URL is present in Devpost.

--- a/apps/web/fieldclose/docs/public-demo-deployment.md
+++ b/apps/web/fieldclose/docs/public-demo-deployment.md
@@ -4,12 +4,18 @@
 - Audience: Maintainers and hackathon reviewers
 - Target: A judge-accessible FieldClose deployment that cannot place a phone call
 
+The URL and its browser-visible fake-only behavior can be reviewed directly.
+Server configuration and deployment operations are maintainer-reported private
+observations; this document does not cite an inaccessible revision as public
+source, build, or validation provenance.
+
 ## Deployment boundary
 
-The P0A human-disposition workflow has passed unit, PostgreSQL integration,
-browser, and full repository validation. The P0B release must use that validated
-closure and demonstrate the complete case lifecycle, not stop at a displayed
-recommendation.
+The maintainer reports that the P0A human-disposition workflow passed unit,
+PostgreSQL integration, browser, and full local validation. Those private logs
+are not public provenance; the pull request exposes the repository-level check.
+The P0B release must preserve that closure and demonstrate the complete case
+lifecycle, not stop at a displayed recommendation.
 
 The public deployment is a standalone Next.js application backed by its own
 PostgreSQL database. It supports password, email-code, and account-registration
@@ -162,3 +168,10 @@ chat. Enter them directly in the selected service's secret manager.
 - [Vercel project configuration](https://vercel.com/docs/project-configuration/vercel-json)
 - [Vercel build configuration](https://vercel.com/docs/builds/configure-a-build)
 - [Neon connection pooling](https://neon.com/docs/connect/connection-pooling)
+
+## Latest smoke evidence
+
+The August 13, 2026 signed-out desktop and 375px public checks, isolated mobile
+fake-provider regression, and remaining authenticated-deployment gaps are
+recorded in
+[Public Demo Smoke Record](public-demo-smoke-2026-08-13.md).

--- a/apps/web/fieldclose/docs/public-demo-smoke-2026-08-13.md
+++ b/apps/web/fieldclose/docs/public-demo-smoke-2026-08-13.md
@@ -1,0 +1,206 @@
+# Public Demo Smoke Record — August 13, 2026
+
+- Target: <https://fieldclose.dramaforge.icu/>
+- Observation time: `2026-08-13T08:07:46Z`
+- Scope: Read-only signed-out smoke test plus isolated local fake-provider flow
+- Live calls placed: `0`
+- Accounts created: `0`
+
+## Deployed signed-out checks
+
+The public URL loaded over HTTPS in two independent Chromium sessions. The page
+title was `FieldClose`, the canonical URL remained on the expected domain, and
+the visible home page included `Public demo · No phone call placed`.
+
+Desktop observation:
+
+- viewport width: `1280px`;
+- document width: `1265px`;
+- public navigation, fake-only label, fixed fictional work-order preview, and
+  sign-in entry were present;
+- the sign-in entry opened `/?auth=signin` and displayed the account dialog with
+  `Public demo · fake only`.
+
+Mobile observation:
+
+- viewport: `375px × 812px`;
+- document width: `375px`, with no horizontal overflow;
+- compact navigation opened and exposed the sign-in and demo-workspace links;
+- the sign-in link opened `/?auth=signin` and the account dialog remained
+  readable at 375px;
+- the fake-only label remained present in the mobile accessibility snapshot.
+
+No credentials were entered and no account, case, approval, provider attempt,
+or disposition was created against the deployed environment.
+
+## Isolated fake-provider workflow check
+
+The repository's intercepted-browser workflow was run at `375px × 812px`. It
+covered:
+
+1. the fixed fictional case form;
+2. case creation;
+3. exact-brief review and three approval attestations;
+4. one approved fake simulation;
+5. normalized result review;
+6. human disposition;
+7. closed FieldClose case state; and
+8. append-only audit evidence.
+
+The regression also confirmed that an empty mobile queue keeps `.rail-empty`
+visible while the non-actionable right-side `.empty-workspace` is hidden. The
+empty-state `Create the first case` action remains available. No CSS change was
+required.
+
+Command:
+
+```text
+pnpm test:e2e -- tests/e2e/closeout-workflow.spec.ts
+```
+
+Result: `8 passed`, including the protected-live fixture, which intercepts the
+HTTP boundary and cannot place a phone call.
+
+## Open evidence gates
+
+This record does **not** complete the full deployed judge smoke test:
+
+- no dedicated reviewer account was used, so the deployed authenticated path
+  from case creation through audit was not exercised;
+- the deployed server environment and provider-request logs were not available,
+  so absence of CALL-E credentials and provider emissions was not independently
+  inspected during this run;
+- a direct command-line TLS/certificate probe failed at the current network
+  transport layer even though both Chromium sessions completed HTTPS
+  navigation, so certificate expiry monitoring is not verified;
+- no recurring availability or certificate-expiry monitor is configured by
+  this repository evidence;
+- the deployed commit identifier was not exposed to the signed-out client and
+  remains unverified.
+
+W5 must remain open until a maintainer supplies a private reviewer account,
+confirms the deployed build and environment boundary, runs the complete
+authenticated golden path in a fresh browser profile, and records ongoing
+availability and certificate monitoring.
+
+## Evidence boundary for later follow-ups
+
+The later sections combine browser-visible observations with
+maintainer-reported private operational checks. The public URL, repository tree,
+pull-request discussion, and visible CI result are independently reviewable.
+Private accounts, server configuration, deployment artifacts, and internal
+revision identifiers are not public provenance and must not be treated as such.
+
+## August 24 browser follow-up
+
+A direct in-app-browser follow-up rechecked the deployed signed-out experience
+without submitting a form or creating an account.
+
+- The desktop landing page exposed the public fake-only boundary with both
+  `Public demo · No phone call placed` and `Public demo · fake only` copy.
+- The account dialog exposed password and email-code sign-in methods.
+- The deployed signup dialog required name, username, work email, and password.
+  This differs from the newer repository UI, which derives the internal
+  username and no longer asks the user for a separate username; the deployed
+  smoke result therefore applies only to the deployment observed at that time.
+- At `375px × 812px`, the signup dialog occupied the viewport, retained all
+  fields and the submit action, and produced no horizontal overflow
+  (`scrollWidth=375`, `clientWidth=375`).
+- No email, password, verification code, account, case, provider request, or
+  live call was created.
+
+The authenticated golden path remains blocked on a dedicated reviewer account.
+Current signup requires an inbox that can receive the one-time verification
+code. The mailbox may be a dedicated test address or alias and does not need to
+represent a real person, but a nonexistent address cannot complete the deployed
+verification flow.
+
+## August 24 authenticated judge follow-up
+
+A dedicated judge mailbox completed public signup, one-time email verification,
+and the authenticated desktop golden path against the maintainer-operated
+deployment. The exact deployment revision is intentionally not cited because it
+is not publicly accessible and therefore cannot serve as public provenance. The
+mailbox address and generated account credential are private and are not
+recorded in this public smoke file.
+
+The observed workflow was:
+
+1. create the per-user demo workspace;
+2. restore and create the fixed `WO-DEMO-1042` fictional case;
+3. review the exact brief, masked reserved-range contact, three permitted
+   questions, AI disclosure, and hard authority boundaries;
+4. complete all three fake-only attestations and approve one exact digest;
+5. confirm `Provider fake`, `Live approved: no`, and `No phone call` before
+   execution;
+6. run the deterministic `Clear closeout` simulation;
+7. review the normalized `operating as expected`, no unresolved issue, and no
+   return-visit request result;
+8. record the human `Accept closeout review` disposition; and
+9. inspect the closed case and six append-only audit transitions covering case
+   creation, approval, request, fake-provider acceptance, normalization, and
+   human disposition.
+
+The UI continued to display `Simulation environment`, `Simulated calls only`,
+and the masked reserved-range number. Server-side verification found one
+verified judge account, one fake-only demo workspace, zero live workspaces,
+zero live attempts in both public and staging databases, and the durable live
+kill switch paused. No CALL-E phone call was placed.
+
+The signup attempt also exposed a deployment-configuration mismatch: the new
+runtime correctly rejected database host aliases as non-loopback URLs without
+`sslmode=verify-full`, even though both aliases resolved to `127.0.0.1` and
+PostgreSQL listened only on loopback. The deployed environment files were
+backed up and changed to use the literal `127.0.0.1` host while preserving each
+database, role, and credential. Both public and staging authentication health
+endpoints then returned `200`.
+
+This completes the authenticated desktop golden-path evidence.
+
+## August 24 judge-period monitoring follow-up
+
+A daily Codex heartbeat named `fieldclose-judge-period-monitor` is configured to
+run at 09:00 Asia/Shanghai through the judging-period cutoff at 17:00 SGT on
+October 13, 2026. It notifies the maintainer only on a failed run and performs
+read-only checks for:
+
+- public HTTP `200` plus the fake-only/no-call marker;
+- staging HTTP `401` without Basic Auth and `200` with the server-side credential
+  handoff, without printing the credential;
+- active public, staging, Caddy, and PostgreSQL services;
+- TLS expiry for both hostnames, failing when fewer than 21 days remain; and
+- the durable live kill switch remaining paused and the live-attempt count
+  remaining zero in both databases.
+
+The heartbeat is forbidden from remediation, sending email, or creating or
+approving a phone call. Its initial baseline completed successfully: both web
+status boundaries and the fake-only marker matched, all four services were
+active, both live gates were paused with zero live attempts, and both TLS
+certificates expired at `2026-11-01T23:59:59Z`, 69 days after the check.
+
+## August 24 authenticated 375 px follow-up
+
+The existing judge workspace was reused at a `375 px × 812 px` viewport for a
+second fake-only golden path. Reusing the fixed `WO-DEMO-1042` reference first
+exercised the workspace-scoped uniqueness guard: the server rejected the
+duplicate case, the UI stated that no call was placed, and aggregate database
+counts remained at one case, one contact, and six audit events.
+
+The work-order reference was then changed to the explicitly synthetic
+`WO-DEMO-1042-MOBILE`; all other fixed fictional fields remained unchanged. The
+mobile flow completed exact-brief review, all three attestations, one fake
+approval, deterministic clear-closeout execution, normalized result review,
+human disposition, closed case state, and six append-only audit transitions.
+The execution view displayed `Provider fake`, `Live approved: no`, and `No phone
+call` before the simulation ran.
+
+The final authenticated layout reported `innerWidth=375`, `clientWidth=360`,
+and `scrollWidth=360`, so no horizontal overflow was present. Read-only server
+verification then found two cases, two contacts, two attempts, two results, two
+human dispositions, and twelve audit events in the public database. Public and
+staging retained paused durable live gates and zero live attempts. No CALL-E
+phone call was placed.
+
+W5 remains open for a fresh-profile or incognito authenticated run and
+confirmation after the judging period that the public demo remained available
+through the cutoff.

--- a/apps/web/fieldclose/docs/real-world-impact-research.md
+++ b/apps/web/fieldclose/docs/real-world-impact-research.md
@@ -1,0 +1,180 @@
+# Real-World Impact Desk Research
+
+- Research date: August 13, 2026
+- Method: Public-source desk research
+- Direct practitioner interviews: `n = 0`
+- Quantitative field baseline: Not established
+
+## Purpose and evidence boundary
+
+This brief records public evidence for the administrative closeout problem that
+FieldClose addresses. It is not user research and must not be described as HVAC
+contractor feedback. The sources establish that commercial HVAC and adjacent
+field-service closeout depends on complete maintenance records, work summaries,
+required customer acknowledgements, equipment details, and explicit follow-up
+when work remains open. They do not establish how often these gaps occur, how
+long a typical contractor spends resolving them, or how much time or money
+FieldClose would save.
+
+The direct-practitioner evidence gate therefore remains open. Submission copy
+may cite the workflow observations below as desk research, but it must state
+that no contractor interviews or measured customer baseline were available.
+
+## Source-backed workflow observations
+
+### 1. Completion needs a traceable record and notification
+
+The U.S. Department of Energy's *Operations & Maintenance Best Practices Guide*
+lists work-order generation, prioritization, equipment-level tracking,
+historical work-order tracking, and technical-document storage as typical CMMS
+functions. Its needs assessment also asks how an organization verifies that
+work was done correctly and how completion is communicated. ASHRAE describes
+Standard 180 as minimum inspection and maintenance practice for HVAC systems in
+new and existing commercial buildings.
+
+**Supported observation:** technical work and administratively usable evidence
+are related but distinct concerns. A closeout workflow needs to preserve what
+was done, which equipment was involved, and what happened after completion.
+
+**FieldClose inference:** the product should consume a completed work order and
+produce bounded, auditable follow-up evidence. It should not replace the CMMS,
+maintenance standard, or technician record.
+
+Sources:
+
+- [U.S. Department of Energy, Operations & Maintenance Best Practices Guide, Chapter 4](https://www1.eere.energy.gov/femp/pdfs/OM_4.pdf)
+- [ASHRAE, Standards 180 and 211](https://www.ashrae.org/technical-resources/bookstore/standards-180-and-211)
+
+### 2. Closeout is a multi-role handoff with explicit blockers
+
+ServiceTitan's commercial-service workflow describes technicians entering
+timestamped work-performed logs, a lead technician checking whether tasks were
+completed, and an office manager using the work summary for the customer-facing
+work-order document. Its job-closeout documentation lists incomplete required
+forms, missing signatures, missing equipment details, and additional work that
+still needs scheduling as conditions that block completion.
+
+**Supported observation:** the end of a field appointment can still leave an
+office review, customer acknowledgement, or scheduling decision unresolved.
+The workflow crosses technician, lead or office staff, and customer roles.
+
+**FieldClose inference:** the initial operator should be an owner-dispatcher or
+service coordinator. A call result should create a recommended next action, not
+silently close the external work order.
+
+Sources:
+
+- [ServiceTitan, Capture daily job progress with work-performed logs and work summaries](https://help.servicetitan.com/release-hub/docs/capture-daily-job-progress-with-technicianwork-performed-logs-and-work-summaries)
+- [ServiceTitan, Complete a job in the Field Mobile App](https://help.servicetitan.com/how-to/complete-job-close-invoice)
+
+### 3. The authorized site contact may be unavailable at the point of service
+
+ServiceTitan documents a commercial rooftop-unit example in which a facility
+manager is in a meeting and cannot sign on site, and a commercial refrigeration
+example in which the store manager is away from the service interaction. The
+documented workflow sends a remote acknowledgement request and tracks its
+completion status.
+
+**Supported observation:** commercial service completion and authorized-site-
+contact availability do not always coincide. Some confirmation must therefore
+happen remotely or later.
+
+**FieldClose inference:** a narrowly scoped phone conversation can be one
+remote follow-up channel when the organization is authorized to call. This
+source does not prove that phone is more reliable than SMS, email, or a portal,
+and FieldClose must not make that comparative claim without field evidence.
+
+Source:
+
+- [ServiceTitan, Send required job signatures remotely](https://help.servicetitan.com/release-hub/docs/send-required-job-signatures-remotely-with-the-servicetitan-field-mobile-app)
+
+### 4. Missing information and unfinished visits require an explicit exception
+
+Jobber documents that an incomplete checklist can remain after a visit is
+marked complete and is then surfaced in the activity feed. It also prompts an
+operator to complete or remove unfinished visits when closing a job. ServiceTitan
+similarly exposes missing forms, signatures, equipment details, or scheduled
+work as closeout blockers.
+
+**Supported observation:** a safe system must represent incomplete information
+and remaining work rather than equating a completed visit with a fully closed
+job.
+
+**FieldClose inference:** `unknown`, refusal, no answer, an unresolved issue, or
+a return-visit request should remain visible and route to a human task. CALL-E
+must not diagnose the equipment, schedule the return visit, or make the final
+business disposition.
+
+Sources:
+
+- [Jobber, Checklists](https://help.getjobber.com/hc/en-us/articles/115009740048-Checklists)
+- [Jobber, Job Basics](https://help.getjobber.com/hc/en-us/articles/115009379027-Job-Basics)
+- [ServiceTitan, Complete a job in the Field Mobile App](https://help.servicetitan.com/how-to/complete-job-close-invoice)
+
+## Evidence-based current workflow model
+
+The sources support this generic sequence; it is a synthesis, not a transcript
+of one contractor's process:
+
+1. A technician finishes the on-site task and records work performed.
+2. A lead technician or office operator reviews the record for required forms,
+   equipment details, open work, and a usable customer-facing summary.
+3. An authorized site contact provides any required acknowledgement or missing
+   closeout information, either on site or through a remote channel.
+4. Missing information, an unavailable contact, or remaining work stays open
+   and creates a follow-up or scheduling decision.
+5. An authorized human records the final business disposition and completes the
+   external closeout process.
+
+FieldClose is intentionally limited to the approved follow-up and evidence
+handoff between steps 2 and 5. It does not perform the technician's work,
+invoice the customer, schedule a visit, or close the external system of record.
+
+## North-star metric
+
+**Time from technician completion to human-approved closeout evidence**
+
+For case `i`:
+
+```text
+closeout_evidence_latency_i = human_disposition_recorded_at_i
+                              - technician_completed_at_i
+```
+
+Report the median and 90th percentile only after both timestamps are collected
+from real, consented workflows. A case remains in the denominator when the
+contact is unreachable or the result needs attention; those outcomes must not
+be removed to improve the metric.
+
+For the current submission:
+
+- measured practitioner sample: `n = 0`;
+- real baseline: unavailable;
+- target improvement: not set;
+- demo measurements: simulated and not evidence of customer impact.
+
+Useful guardrail measures are actionable-closeout rate, human-escalation rate,
+unreachable rate, incorrect automatic-ready classifications, duplicate-call
+prevention rate, and audit completeness. Targets require a real baseline.
+
+## Claims allowed in the submission
+
+- Commercial HVAC closeout relies on documented maintenance information.
+- Field-service systems treat required forms, acknowledgements, equipment
+  details, and remaining appointments as explicit closeout concerns.
+- An authorized site contact is not always available during the service visit,
+  so later remote follow-up can be necessary.
+- FieldClose demonstrates one human-approved way to structure that follow-up
+  and preserve uncertainty.
+
+## Claims not supported by this research
+
+- A typical contractor loses a stated number of hours or dollars to closeout.
+- A stated percentage of HVAC jobs has missing customer confirmation.
+- Phone is more reliable than email, SMS, or a contractor portal.
+- HVAC contractors will accept an AI caller in this workflow.
+- FieldClose reduces closeout time, headcount, callbacks, or revenue leakage by
+  any stated amount.
+
+These claims require consented practitioner research or measured production
+evidence and must remain absent from submission materials until then.

--- a/apps/web/fieldclose/docs/safety-and-operations.md
+++ b/apps/web/fieldclose/docs/safety-and-operations.md
@@ -304,7 +304,7 @@ The application should have a server-side kill switch that prevents new live cal
 - [ ] An owner or operator can record a bounded, audited disposition that
   resolves the human task without performing an external scheduling, invoicing,
   or work-order action.
-- [ ] At least one authorized live test has inspectable evidence.
+- [x] At least one authorized live test has inspectable evidence.
 - [ ] The demo clearly distinguishes fixtures from live evidence.
 
 ## Known policy decisions still open

--- a/apps/web/fieldclose/docs/servicenow-inspired-ux-ui-direction.md
+++ b/apps/web/fieldclose/docs/servicenow-inspired-ux-ui-direction.md
@@ -15,7 +15,7 @@ human-approved commercial HVAC work-order closeout application.
 
 ### Visual thesis
 
-A calm, high-contrast operational workspace with deep blue-green navigation,
+A calm, high-contrast operational workspace — deep blue-green navigation,
 quiet light work surfaces, one vivid action accent, strong typography, and
 minimal decorative chrome.
 

--- a/apps/web/fieldclose/docs/technology-selection.md
+++ b/apps/web/fieldclose/docs/technology-selection.md
@@ -5,16 +5,21 @@
 - Status: Accepted for the hackathon MVP
 - Decision date: 2026-07-28
 - Product form: Web application
-- Implementation status: MVP implemented; fake-only public deployed; protected staging verification pending
-- Live-integration status: One authorized local CALL-E attempt verified with a contact exception; successful conversation and protected-staging execution remain unverified
+- Implementation status: MVP implemented; fake-only public and protected
+  staging verified
+- Live-integration status: One authorized local CALL-E attempt reached the intended participant and completed a conversation; structured answer capture was inaccurate, and protected-staging execution remains unverified
 - Review trigger: Revisit only if the CALL-E integration spike, hosting spike, or security controls fail
 
 This document records the implementation stack and operational shape selected
 for FieldClose. The public fake-only deployment and the authorized local CALL-E
-evidence are verified separately. The live run reached a Sonetel forwarding
-announcement rather than the participant, preserved every requested HVAC field
-as `not_asked`, and routed the result to a human. It is not evidence of a
-successful conversation or of the still-pending protected-staging deployment.
+evidence are verified separately. The live run reached the intended participant
+and completed a conversation, but the structured result incorrectly treated a
+Sonetel forwarding announcement in the connection path as terminal. FieldClose
+stored every requested HVAC field as `not_asked` and routed the result to a
+human. A dated operator correction records the successful contact
+without rewriting the original machine artifacts. The run is evidence of a
+successful conversation, but not of accurate structured answer capture or the
+still-pending protected-staging deployment.
 
 ## Decision
 
@@ -294,7 +299,7 @@ Two deployments have intentionally different capabilities:
 | Environment | Access | Provider | Live credentials |
 | --- | --- | --- | --- |
 | Public demo | Any authenticated user receives an isolated demo workspace; anonymous users see the sign-in experience | Fake only | Absent |
-| Protected live/staging | Allow-listed operator identities only | Fake by default; CALL-E only after explicit approval | Required only in protected server secret storage; deployment verification pending |
+| Protected live/staging | Allow-listed operator identities only | Fake by default; CALL-E only after explicit approval | Required only in protected server secret storage; configuration is not publicly verifiable |
 
 A live call requires both:
 
@@ -307,12 +312,14 @@ Both default to blocking live creation. Neither can be enabled from ordinary bro
 
 ### Current deployment evidence and target protected topology
 
-- The Aliyun ECS public demo runs behind Caddy HTTPS, contains no CALL-E
-  credential, and is forced to the fake provider.
+- The public demo is browser-visible at its HTTPS URL and exposes a fake-only
+  boundary. The absence of a CALL-E credential is additionally enforced by the
+  public build-time configuration check in this tree.
 - The protected target is a separate application environment with separate data
   and server-side CALL-E and authentication-email secrets.
-- Inspectable evidence for protected deployment, isolation, production
-  authentication, and deployed CALL-E/SMTP configuration is still pending.
+- Protected deployment, isolation, production authentication, and CALL-E/SMTP
+  statements have maintainer-reported private operational evidence only. No
+  inaccessible deployment revision is cited as public provenance.
 
 ### Supported managed topology
 

--- a/apps/web/fieldclose/docs/testing-and-evaluation.md
+++ b/apps/web/fieldclose/docs/testing-and-evaluation.md
@@ -156,6 +156,34 @@ The normalizer must prefer safe uncertainty over optimistic inference.
 - One operator cannot access another account's cases when multi-tenancy is enabled.
 - Public demo route exposes no administrative or private data.
 
+## Inspectable accepted-call recovery evidence
+
+The browser close/reopen boundary can be reviewed without placing a call. The
+evidence is intentionally split between client lifecycle code, persisted server
+policy, and existing automated coverage:
+
+| Claim | Inspectable evidence |
+| --- | --- |
+| Opening an accepted nonterminal case schedules a refresh after about five seconds | `FieldCloseWorkbench` first loads the selected case detail, then its accepted-live-attempt effect schedules `POST /api/attempts/<attemptId>/refresh` with `window.setTimeout(..., 5_000)` |
+| Leaving or closing the page stops automatic refresh | The same effect cleanup marks the loop inactive and calls `window.clearTimeout`; the repository has no service worker or hosted accepted-call polling worker |
+| Reopening resumes the existing call rather than redialing | The selected-case effect reloads persisted case detail; when the stored attempt is eligible, the refresh effect uses `detail.attempt.id`, while `refreshAcceptedLiveAttempt` accepts only an attempt with an existing CALL-E `providerCallId` and never calls provider creation |
+| Time away still counts toward the bound | `prepareLiveStatusRefresh` compares the request time with persisted `acceptedAt` using `liveStatusPollTimeoutMs` (`600_000`) |
+| A late terminal result can resolve reconciliation without another call | Integration case `times out to one reconciliation task and can recover on a later manual refresh` asserts one provider creation, one resolved reconciliation task, and later completion |
+| Five-second throttling and terminal idempotency survive repeated refresh | Integration cases `polls an accepted call without creating a result until the provider is terminal` and `allows only one provider lookup for concurrent refreshes` cover the persisted throttle and one-result boundary |
+
+For a manual browser inspection, use a fake or intercepted provider response:
+
+1. Open a case fixture whose persisted live attempt has a provider call ID and
+   no result, and observe the accepted-call status panel.
+2. Leave the case before the first five-second request and confirm that no
+   refresh request is emitted while the case is closed.
+3. Reopen that case and confirm one refresh request appears after about five
+   seconds with the same attempt ID.
+4. Confirm that no execute or provider-create request occurs during reopen.
+
+This inspection demonstrates lifecycle wiring only. It is not evidence of a
+real CALL-E call or unattended background execution.
+
 ## Accessibility and product tests
 
 - Approval cannot be triggered accidentally by loading a page.
@@ -280,9 +308,15 @@ the automated evidence for the P0A closure; live-provider verification remains
 a separate opt-in activity. On 2026-08-06, one separately authorized local
 CALL-E attempt produced redacted evidence of provider acceptance, terminal
 result retrieval, uncertainty-preserving normalization, human routing, final
-operator disposition, and duplicate protection. The call reached a Sonetel
-free-trial forwarding announcement, so the participant was not connected and
-all three HVAC questions remained `not_asked`.
+operator disposition, and duplicate protection. A correction recorded on
+2026-08-10 confirms that the intended participant was reached and a conversation
+occurred after the Sonetel forwarding announcement. The retained structured
+result incorrectly classified the announcement as terminal and stored all three
+HVAC questions as `not_asked`. The original machine artifacts remain unchanged;
+the dated correction is separate human-observation evidence. Without a retained
+transcript, recording, or participant answer attestation, the exact live answers
+are not reconstructed. The deterministic fictional fixture supplies the public
+demo values and is not live-call evidence.
 
 Markdown documentation is checked separately with `markdownlint-cli2`. Formatting is enforced through the lint and production-build toolchain; a dedicated formatter has not been added.
 

--- a/apps/web/fieldclose/docs/web-experience.md
+++ b/apps/web/fieldclose/docs/web-experience.md
@@ -128,6 +128,14 @@ without a second provider invocation. At 600 seconds, an unresolved
 final lookup moves the case to manual reconciliation; the operator can still
 refresh that same call later without redialing.
 
+Status polling is foreground-only. The first automatic check is scheduled about
+five seconds after the accepted case detail is displayed. Leaving or closing
+the page stops the timer because FieldClose has no background browser or server
+worker for this loop. Reopening a nonterminal case loads the persisted accepted
+attempt and resumes five-second status checks against that same provider call.
+If the case already reached manual reconciliation, reopen leaves automatic
+polling stopped and keeps the explicit `Refresh provider status` action.
+
 ### 6. Review the result
 
 The result keeps provider task status separate from business recommendation. It shows:
@@ -187,6 +195,10 @@ The Audit view shows append-only case transitions in order, including a human-re
 - Invalid case fields receive a field-specific message, `aria-invalid`, and
   focus. Safe not-found and access-denied states settle without leaving a
   loading indicator active.
+- Field and form validation stays beside the affected input or form. Approval,
+  execution, refresh, disposition, and sign-out failures use the single global
+  action alert. A visible multi-field registration summary is not a second live
+  region; the field-specific messages provide the alert announcements.
 - Disabled approval communicates the three required attestations structurally.
 - A skip link reaches the main content when focused.
 - Reduced-motion preferences disable entrance, drawer, route, spinner, and

--- a/apps/web/fieldclose/next-env.d.ts
+++ b/apps/web/fieldclose/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-e2e/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/fieldclose/src/app/globals.css
+++ b/apps/web/fieldclose/src/app/globals.css
@@ -498,20 +498,8 @@ button {
 }
 
 .rail-empty {
-  padding: 3rem 2rem 3rem 0;
+  padding: 0;
   color: var(--muted);
-}
-
-.rail-empty > span {
-  color: var(--line-dark);
-  font-family: var(--display);
-  font-size: 3rem;
-  font-weight: 750;
-}
-
-.rail-empty p {
-  margin: 0.5rem 0 1rem;
-  font-size: 0.84rem;
 }
 
 .workspace-panel {
@@ -764,6 +752,7 @@ button {
 .simulation-hero > p,
 .result-state > p,
 .empty-copy {
+  max-width: 30rem;
   color: var(--muted);
   font-size: 0.76rem;
   line-height: 1.6;
@@ -789,6 +778,14 @@ button {
   padding: 0.85rem 0;
   font-size: 0.71rem;
   line-height: 1.45;
+  transition:
+    padding 150ms ease,
+    background-color 150ms ease;
+}
+
+.attestation-list label:has(input:checked) {
+  padding-left: 0.6rem;
+  background: color-mix(in srgb, var(--safe) 6%, transparent);
 }
 
 input[type="checkbox"] {
@@ -801,7 +798,11 @@ input[type="checkbox"] {
 .primary-button,
 .secondary-button,
 .signin-button {
+  display: inline-flex;
   min-height: 2.8rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
   border: 1px solid var(--ink);
   border-radius: 0.1rem;
   padding: 0.75rem 1rem;
@@ -842,6 +843,17 @@ input[type="checkbox"] {
 .signin-button:disabled {
   cursor: not-allowed;
   opacity: 0.45;
+}
+
+.primary-button[aria-busy="true"]::before {
+  width: 0.82rem;
+  height: 0.82rem;
+  flex: 0 0 auto;
+  border: 2px solid color-mix(in srgb, currentColor 34%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: auth-button-spin 650ms linear infinite;
+  content: "";
 }
 
 .full-width {
@@ -1109,7 +1121,43 @@ textarea.field-control {
   padding-top: 1rem;
 }
 
+.disposition-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.disposition-mark {
+  display: grid;
+  width: 2.1rem;
+  height: 2.1rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent-dark) 28%, var(--line));
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--accent) 9%, var(--paper));
+  color: var(--accent-dark);
+}
+
+.disposition-mark svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
 .disposition-panel > span {
+  font-family: var(--display);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.disposition-panel-header > span {
+  display: block;
   font-family: var(--display);
   font-size: 0.68rem;
   font-weight: 750;
@@ -1147,7 +1195,7 @@ textarea.field-control {
   margin: 0;
   border-left: 1px solid var(--accent);
   padding-left: 0.8rem;
-  color: var(--ink-soft);
+  color: var(--muted);
   font-size: 0.72rem;
   line-height: 1.5;
 }
@@ -1219,12 +1267,26 @@ textarea.field-control {
 .notice-strip {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--safe) 8%, var(--paper));
   padding: 0.8rem 2rem;
   color: color-mix(in srgb, var(--safe) 82%, #143b2a);
   font-size: 0.7rem;
+}
+
+.notice-strip-copy {
+  min-width: min(100%, 24rem);
+  flex: 1 1 24rem;
+  line-height: 1.45;
+}
+
+.notice-strip-action {
+  margin-left: auto;
+  color: currentColor;
+  font-size: 0.68rem;
+  white-space: nowrap;
 }
 
 .notice-strip-live {
@@ -1443,11 +1505,86 @@ textarea.field-control {
   position: absolute;
   right: -1rem;
   bottom: -1.5rem;
-  color: var(--paper-deep);
+  color: color-mix(in srgb, var(--paper-deep) 72%, var(--line));
   font-family: var(--display);
   font-size: clamp(5rem, 13vw, 12rem);
   font-weight: 850;
   letter-spacing: -0.07em;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Shared empty-state recipe: every workspace no-data surface uses the same
+   icon / kicker / heading / copy / action stack so the states read as one
+   system. Tones keep unavailable states distinct from the brand accent. */
+.empty-state {
+  display: grid;
+  max-width: 34rem;
+  align-content: center;
+  justify-items: start;
+  gap: 0.9rem;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.empty-state-icon {
+  display: grid;
+  width: 3.5rem;
+  height: 3.5rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--empty-tone) 32%, var(--line));
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--empty-tone) 9%, var(--paper));
+  color: var(--empty-tone);
+  box-shadow: 0 0 0 0.5rem color-mix(in srgb, var(--empty-tone) 5%, transparent);
+  margin-bottom: 0.45rem;
+}
+
+.empty-state-icon svg {
+  width: 1.6rem;
+  height: 1.6rem;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.empty-state-eyebrow {
+  margin: 0;
+  color: var(--empty-tone);
+  font-family: var(--display);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.empty-state h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(1.7rem, 3vw, 2.7rem);
+  font-weight: 750;
+  letter-spacing: -0.045em;
+  line-height: 1;
+  text-wrap: balance;
+}
+
+.empty-state .empty-copy {
+  max-width: 30rem;
+}
+
+.empty-state--neutral {
+  --empty-tone: var(--accent-dark);
+}
+
+.empty-state--safe {
+  --empty-tone: var(--safe);
+}
+
+.empty-state--attention {
+  --empty-tone: var(--attention);
 }
 
 .workspace-loading,
@@ -2059,6 +2196,55 @@ textarea.field-control {
   font-weight: 650;
 }
 
+.password-requirements {
+  display: grid;
+  gap: 0.28rem;
+  margin: 0;
+  padding: 0;
+  color: var(--muted);
+  font-size: 0.63rem;
+  font-weight: 550;
+  letter-spacing: 0;
+  list-style: none;
+}
+
+.password-requirements li {
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.password-requirements li > span {
+  display: inline-grid;
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--line-dark);
+  border-radius: 50%;
+  color: transparent;
+  font-size: 0.55rem;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease;
+}
+
+.password-requirements li:not([data-met]) > span {
+  border-color: transparent;
+  color: var(--muted);
+}
+
+.password-requirements li[data-met="true"] {
+  color: var(--safe);
+}
+
+.password-requirements li[data-met="true"] > span {
+  border-color: var(--safe);
+  background: var(--safe);
+  color: #ffffff;
+}
+
 .auth-remember {
   display: flex;
   align-items: center;
@@ -2270,7 +2456,7 @@ textarea.field-control {
 
 .public-brand small {
   color: color-mix(in srgb, var(--canvas) 66%, transparent);
-  font-size: 0.61rem;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.075em;
   text-transform: uppercase;
@@ -2299,7 +2485,7 @@ textarea.field-control {
   border-bottom: 2px solid transparent;
   color: color-mix(in srgb, var(--canvas) 72%, transparent);
   padding: 0 1.15rem;
-  font-size: 0.68rem;
+  font-size: 0.76rem;
   font-weight: 750;
   letter-spacing: 0.055em;
   text-decoration: none;
@@ -2324,7 +2510,7 @@ textarea.field-control {
 .public-signin-link,
 .public-secondary-link {
   color: inherit;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 800;
   text-underline-offset: 0.3rem;
 }
@@ -2349,7 +2535,7 @@ textarea.field-control {
   background: var(--accent);
   color: #ffffff;
   padding: 0.72rem 1.2rem;
-  font-size: 0.68rem;
+  font-size: 0.76rem;
   font-weight: 850;
   letter-spacing: 0.035em;
   text-decoration: none;
@@ -2433,7 +2619,7 @@ textarea.field-control {
   display: grid;
   width: min(100%, 100rem);
   margin: 0 auto;
-  grid-template-columns: minmax(0, 1.04fr) minmax(24rem, 0.96fr);
+  grid-template-columns: minmax(0, 1.12fr) minmax(24rem, 0.88fr);
   align-items: end;
   gap: clamp(2rem, 4vw, 5rem);
   padding: clamp(2.5rem, 5vh, 4.5rem) clamp(1.25rem, 5vw, 5rem) clamp(3rem, 6vh, 5rem);
@@ -2442,7 +2628,7 @@ textarea.field-control {
 }
 
 .public-hero-copy-column {
-  max-width: 42rem;
+  max-width: 46rem;
 }
 
 .public-eyebrow {
@@ -2464,10 +2650,10 @@ textarea.field-control {
 }
 
 .public-hero h1 {
-  max-width: 38rem;
+  max-width: 44rem;
   margin: 0;
   font-family: var(--display);
-  font-size: clamp(3.2rem, 4.8vw, 5.6rem);
+  font-size: clamp(3.2rem, 4.35vw, 5.1rem);
   font-weight: 760;
   letter-spacing: -0.065em;
   line-height: 0.9;
@@ -2535,7 +2721,7 @@ textarea.field-control {
   gap: 0.6rem;
   margin: 1.5rem 0 0;
   color: color-mix(in srgb, var(--canvas) 68%, transparent);
-  font-size: 0.64rem;
+  font-size: 0.7rem;
   font-weight: 750;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -2557,7 +2743,7 @@ textarea.field-control {
   gap: 1.4rem;
   color: color-mix(in srgb, var(--canvas) 67%, transparent);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
-  font-size: 0.6rem;
+  font-size: 0.65rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -3094,19 +3280,19 @@ textarea.field-control {
   inset: 0;
   display: flex;
   justify-content: flex-end;
-  background: color-mix(in srgb, var(--ink) 62%, transparent);
-  backdrop-filter: blur(2px);
-  animation: auth-backdrop-enter 180ms ease-out both;
+  background: color-mix(in srgb, var(--ink) 44%, transparent);
+  backdrop-filter: blur(1px);
+  animation: auth-backdrop-enter 200ms ease-out both;
 }
 
 .auth-drawer {
-  width: min(32rem, 100vw);
+  width: min(30rem, 100vw);
   height: 100dvh;
   overflow-y: auto;
   border-left: 1px solid var(--line-dark);
   background: var(--paper);
-  box-shadow: -1.5rem 0 4rem color-mix(in srgb, var(--ink) 24%, transparent);
-  animation: auth-drawer-enter 260ms cubic-bezier(0.2, 0.75, 0.2, 1) both;
+  box-shadow: -1.25rem 0 3.5rem color-mix(in srgb, var(--ink) 20%, transparent);
+  animation: auth-drawer-enter 280ms cubic-bezier(0.2, 0.75, 0.2, 1) both;
 }
 
 .auth-drawer .auth-drawer-panel {
@@ -3183,11 +3369,12 @@ textarea.field-control {
 .auth-drawer .signin-shell {
   min-height: 0;
   place-items: start stretch;
-  padding: 2.7rem 1.75rem max(3.5rem, env(safe-area-inset-bottom));
+  padding: 2.35rem 1.75rem max(3rem, env(safe-area-inset-bottom));
 }
 
 .auth-drawer .signin-panel {
-  width: 100%;
+  width: min(100%, 27rem);
+  margin: 0 auto;
   animation: none;
 }
 
@@ -3195,7 +3382,7 @@ textarea.field-control {
   max-width: 25rem;
   margin: 0;
   font-family: var(--display);
-  font-size: clamp(2.35rem, 4.6vw, 3rem);
+  font-size: clamp(2.25rem, 4.2vw, 2.7rem);
   font-weight: 760;
   letter-spacing: -0.05em;
   line-height: 0.96;
@@ -3204,12 +3391,12 @@ textarea.field-control {
 
 .auth-drawer .signin-intro p {
   max-width: 26rem;
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   line-height: 1.55;
 }
 
 .auth-drawer .signin-auth {
-  margin-top: 1.65rem;
+  margin-top: 1.5rem;
   border-top: 0;
   border-radius: 0;
   padding-top: 0;
@@ -3241,7 +3428,28 @@ textarea.field-control {
 }
 
 .auth-drawer .auth-field input:focus {
+  border-color: var(--accent-dark);
   background: var(--paper);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.auth-trust-note {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: -0.15rem 0 0;
+  color: var(--muted);
+  font-size: 0.65rem;
+  line-height: 1.45;
+}
+
+.auth-trust-note > span {
+  width: 0.42rem;
+  height: 0.42rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--safe);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--safe) 13%, transparent);
 }
 
 .auth-drawer .auth-remember {
@@ -3325,6 +3533,12 @@ textarea.field-control {
 @keyframes auth-drawer-enter {
   from {
     transform: translateX(100%);
+  }
+}
+
+@keyframes auth-button-spin {
+  to {
+    transform: rotate(1turn);
   }
 }
 
@@ -3934,6 +4148,12 @@ textarea.field-control {
     font-size: clamp(2.25rem, 11.5vw, 2.65rem);
   }
 
+  .auth-drawer .auth-form > .primary-button {
+    position: sticky;
+    z-index: 2;
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+  }
+
   .auth-drawer .signin-auth {
     margin-top: 1.45rem;
   }
@@ -3975,5 +4195,9 @@ textarea.field-control {
   .workspace-loading div,
   .panel-loading span {
     border-top-color: var(--line);
+    border-right-color: var(--line);
+    border-bottom-color: var(--line);
+    border-left-color: var(--line);
+    transform: none;
   }
 }

--- a/apps/web/fieldclose/src/app/operations.css
+++ b/apps/web/fieldclose/src/app/operations.css
@@ -451,40 +451,65 @@ textarea {
   text-transform: none;
 }
 
+.rail-empty,
 .rail-empty-clear {
   display: grid;
-  min-height: calc(36rem - 4.35rem);
   grid-template-areas:
     "mark copy"
     ". action";
-  grid-template-columns: 5.25rem minmax(18rem, 31rem);
   align-content: center;
   justify-content: center;
+  gap: 1.1rem 1.5rem;
+}
+
+.rail-empty {
+  min-height: calc(36rem - 4.35rem);
+  grid-template-columns: 3.25rem minmax(0, 1fr);
+  padding: clamp(2.25rem, 5vw, 3.5rem) 1.5rem;
+}
+
+.rail-empty-clear {
+  min-height: calc(36rem - 4.35rem);
+  grid-template-columns: 5.25rem minmax(18rem, 31rem);
   gap: 1.3rem 2rem;
   padding: clamp(3.5rem, 7vw, 6.5rem);
 }
 
+.rail-empty .rail-empty-mark,
 .rail-empty-clear .rail-empty-mark {
   display: grid;
-  width: 5.25rem;
-  height: 5.25rem;
   grid-area: mark;
   place-items: center;
   border: 1px solid color-mix(in srgb, var(--safe) 38%, var(--line));
   border-radius: 50%;
   background: color-mix(in srgb, var(--safe) 8%, var(--paper));
   color: var(--safe);
-  box-shadow: 0 0 0 0.65rem color-mix(in srgb, var(--safe) 4%, transparent);
   animation: rail-empty-mark-enter 280ms cubic-bezier(0.2, 0.75, 0.2, 1) both;
 }
 
+.rail-empty .rail-empty-mark {
+  width: 3.25rem;
+  height: 3.25rem;
+}
+
+.rail-empty-clear .rail-empty-mark {
+  width: 5.25rem;
+  height: 5.25rem;
+  box-shadow: 0 0 0 0.65rem color-mix(in srgb, var(--safe) 4%, transparent);
+}
+
 .rail-empty-mark svg {
-  width: 2rem;
-  height: 2rem;
+  width: 1.7rem;
+  height: 1.7rem;
   stroke: currentColor;
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 1.7;
+}
+
+.rail-empty-clear .rail-empty-mark svg {
+  width: 2rem;
+  height: 2rem;
 }
 
 .rail-empty-copy {
@@ -513,7 +538,7 @@ textarea {
   text-wrap: balance;
 }
 
-.rail-empty-clear .rail-empty-copy p {
+.rail-empty-copy p {
   max-width: 30rem;
   margin: 0.8rem 0 0;
   color: var(--muted);
@@ -762,10 +787,16 @@ textarea {
 
 .route-list .empty-workspace {
   min-height: 26rem;
-  align-content: start;
+  padding: 1.2rem;
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--safe) 3%, var(--paper)), var(--paper));
-  padding: 1.2rem;
+}
+
+.route-list .empty-state {
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  margin: 0;
 }
 
 .route-list .empty-workspace .empty-index {
@@ -781,6 +812,17 @@ textarea {
   margin-top: 1.25rem;
   font-size: 1.35rem;
   line-height: 1.15;
+}
+
+.route-list .empty-state .empty-state-icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.route-list .empty-state .empty-state-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 .route-list .empty-workspace p {
@@ -1131,6 +1173,7 @@ textarea {
 
 .notice-strip {
   min-height: 3.5rem;
+  align-items: center;
   border-bottom-color: var(--line);
   background: color-mix(in srgb, var(--safe) 4%, var(--paper));
   padding: 0.75rem 1.25rem;
@@ -1142,7 +1185,30 @@ textarea {
 }
 
 .notice-mark {
-  border-radius: 0.4rem;
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--safe) 30%, var(--line));
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--safe) 10%, var(--paper));
+  color: var(--safe);
+}
+
+.notice-mark svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.notice-strip-live .notice-mark {
+  border-color: color-mix(in srgb, var(--attention) 34%, var(--line));
+  background: color-mix(in srgb, var(--attention) 12%, var(--paper));
+  color: var(--attention);
 }
 
 .form-progress {
@@ -1164,14 +1230,33 @@ textarea {
   padding: 0.6rem 0.8rem;
 }
 
+.form-progress li[aria-current="step"] {
+  background: color-mix(in srgb, var(--safe) 7%, var(--paper));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .form-progress li:last-child {
   border-right: 0;
 }
 
 .form-progress span {
+  display: grid;
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.35rem;
+  background: var(--paper);
   color: var(--accent-dark);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
-  font-size: 0.56rem;
+  font-size: 0.54rem;
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.form-progress li[aria-current="step"] span {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 .form-progress strong {
@@ -1187,11 +1272,12 @@ textarea {
 }
 
 .form-section legend {
+  position: relative;
   width: 100%;
   margin: 0;
   border-bottom: 1px solid var(--line);
   background: #f5f7fa;
-  padding: 0.7rem 0.9rem;
+  padding: 0.7rem 0.9rem 0.7rem 1rem;
   font-family: var(--display);
   font-size: 0.72rem;
   font-weight: 760;
@@ -1199,11 +1285,28 @@ textarea {
   text-transform: none;
 }
 
+.form-section legend::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--accent);
+  content: "";
+}
+
 .form-section legend span {
-  margin-right: 0.45rem;
+  display: inline-grid;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  margin-right: 0.55rem;
+  place-items: center;
+  border-radius: 0.35rem;
+  background: color-mix(in srgb, var(--accent) 12%, var(--paper));
   color: var(--accent-dark);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
-  font-size: 0.58rem;
+  font-size: 0.56rem;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .form-grid {
@@ -1257,6 +1360,9 @@ textarea {
   border-right: 1px solid var(--line);
   border-radius: 0;
   padding: 0.9rem;
+  transition:
+    background-color 150ms ease,
+    box-shadow 150ms ease;
 }
 
 .question-option:last-child {
@@ -1265,6 +1371,11 @@ textarea {
 
 .question-option:hover {
   background: color-mix(in srgb, var(--paper-deep) 50%, transparent);
+}
+
+.question-option:has(input:checked) {
+  background: color-mix(in srgb, var(--safe) 7%, var(--paper));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--safe) 30%, var(--line));
 }
 
 .question-option strong {
@@ -1279,14 +1390,15 @@ textarea {
 
 .form-actions {
   position: sticky;
-  z-index: 5;
+  z-index: 6;
   bottom: 0;
   justify-content: flex-end;
   gap: 0.65rem;
   margin-top: 1rem;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--line-dark);
   background: color-mix(in srgb, var(--paper) 96%, transparent);
   padding: 0.85rem 1rem;
+  box-shadow: 0 -0.6rem 1.2rem color-mix(in srgb, var(--ink) 6%, transparent);
   backdrop-filter: blur(12px);
 }
 
@@ -1662,6 +1774,7 @@ textarea {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .rail-empty,
   .rail-empty-clear {
     min-height: 24rem;
     grid-template-areas:
@@ -1675,6 +1788,7 @@ textarea {
     padding: 2.5rem 1.25rem;
   }
 
+  .rail-empty .rail-empty-mark,
   .rail-empty-clear .rail-empty-mark {
     width: 4.25rem;
     height: 4.25rem;
@@ -1896,7 +2010,9 @@ textarea {
     .audit-timeline p,
     .audit-timeline time,
     .task-list p,
-    .result-timestamp
+    .result-timestamp,
+    .empty-state-eyebrow,
+    .empty-state .empty-copy
   ) {
   font-size: var(--text-caption);
 }

--- a/apps/web/fieldclose/src/application/protected-workspaces.ts
+++ b/apps/web/fieldclose/src/application/protected-workspaces.ts
@@ -268,7 +268,7 @@ function requireLiveSettingConfirmation(
   }
 }
 
-function publicWorkspaceView(workspaceRecord: {
+function publicWorkspaceView(workspaceValue: {
   id: string;
   slug: string;
   displayName: string;
@@ -277,11 +277,11 @@ function publicWorkspaceView(workspaceRecord: {
   liveCallsAllowed: boolean;
 }) {
   return {
-    id: workspaceRecord.id,
-    slug: workspaceRecord.slug,
-    displayName: workspaceRecord.displayName,
-    kind: workspaceRecord.kind,
-    provider: workspaceRecord.provider,
-    liveCallsAllowed: workspaceRecord.liveCallsAllowed,
+    id: workspaceValue.id,
+    slug: workspaceValue.slug,
+    displayName: workspaceValue.displayName,
+    kind: workspaceValue.kind,
+    provider: workspaceValue.provider,
+    liveCallsAllowed: workspaceValue.liveCallsAllowed,
   };
 }

--- a/apps/web/fieldclose/src/components/fieldclose-workbench.tsx
+++ b/apps/web/fieldclose/src/components/fieldclose-workbench.tsx
@@ -15,7 +15,9 @@ import { useWorkspaceConfiguration } from "@/components/workspace-configuration"
 import { projectConfig } from "@/config/project";
 
 import {
+  createNewCaseWorkOrderReference,
   NewCaseForm,
+  PRESET_DEMO_WORK_ORDER,
   type NewCaseFieldErrors,
   type NewCaseInput,
 } from "./new-case-form";
@@ -297,7 +299,9 @@ function AuthenticatedWorkbench({
   const [cases, setCases] = useState<CaseSummary[]>([]);
   const [detail, setDetail] = useState<CaseDetail | null>(null);
   const [preview, setPreview] = useState<CallPreview | null>(null);
-  const [defaultWorkOrder, setDefaultWorkOrder] = useState("WO-DEMO-1042");
+  const [defaultWorkOrder, setDefaultWorkOrder] = useState<string>(
+    PRESET_DEMO_WORK_ORDER.workOrderRef,
+  );
   const [selectedScenario, setSelectedScenario] = useState("resolved_clear");
   const [attestations, setAttestations] = useState<Set<string>>(new Set());
   const [busyAction, setBusyAction] = useState<string | null>("bootstrap");
@@ -308,6 +312,7 @@ function AuthenticatedWorkbench({
     useState<WorkspaceLoadState>("loading");
   const [newCaseFieldErrors, setNewCaseFieldErrors] =
     useState<NewCaseFieldErrors>({});
+  const [newCaseFormError, setNewCaseFormError] = useState<string | null>(null);
   const view = route.view;
   const selectedCaseId = route.caseId ?? null;
   const showNewCase = Boolean(route.newCase);
@@ -353,7 +358,7 @@ function AuthenticatedWorkbench({
       try {
         setError(null);
         setWorkspaceLoadState("loading");
-        const demoResponse = await requestJson<{ workspace: Workspace }>(
+        const demoResponse = await requestJson<{ "workspace": Workspace }>(
           "/api/workspaces",
           { method: "POST" },
         );
@@ -407,7 +412,7 @@ function AuthenticatedWorkbench({
         setWorkspace(initialWorkspace);
         setWorkspaceLoadState("ready");
         setDefaultWorkOrder(
-          `WO-${workspaceMode(initialWorkspace) === "live" ? "LIVE" : "DEMO"}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+          createNewCaseWorkOrderReference(workspaceMode(initialWorkspace)),
         );
         window.localStorage.setItem(
           "fieldclose.last-workspace",
@@ -548,6 +553,7 @@ function AuthenticatedWorkbench({
     setBusyAction("create");
     setError(null);
     setNewCaseFieldErrors({});
+    setNewCaseFormError(null);
 
     try {
       const response = await requestJson<{ case: { id: string } }>(
@@ -568,8 +574,11 @@ function AuthenticatedWorkbench({
         `/workspace/${workspace.slug}/cases/${response.case.id}`,
       );
     } catch (caught) {
-      setNewCaseFieldErrors(newCaseErrors(caught));
-      setError(readableError(caught));
+      const fieldErrors = newCaseErrors(caught);
+      setNewCaseFieldErrors(fieldErrors);
+      setNewCaseFormError(
+        Object.keys(fieldErrors).length > 0 ? null : readableError(caught),
+      );
     } finally {
       setBusyAction(null);
     }
@@ -728,12 +737,12 @@ function AuthenticatedWorkbench({
   }
 
   function openNewCase() {
-    const suffix = crypto.randomUUID().slice(0, 8).toUpperCase();
     setDefaultWorkOrder(
-      `WO-${workspaceMode(workspace) === "live" ? "LIVE" : "DEMO"}-${suffix}`,
+      createNewCaseWorkOrderReference(workspaceMode(workspace)),
     );
     setError(null);
     setNewCaseFieldErrors({});
+    setNewCaseFormError(null);
     if (workspace) {
       router.push(`/workspace/${workspace.slug}/cases/new`);
     }
@@ -748,6 +757,8 @@ function AuthenticatedWorkbench({
 
     setBusyAction("workspace");
     setError(null);
+    setNewCaseFieldErrors({});
+    setNewCaseFormError(null);
     setDetail(null);
     setPreview(null);
     setAttestations(new Set());
@@ -756,7 +767,7 @@ function AuthenticatedWorkbench({
       nextWorkspace.slug,
     );
     setDefaultWorkOrder(
-      `WO-${workspaceMode(nextWorkspace) === "live" ? "LIVE" : "DEMO"}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+      createNewCaseWorkOrderReference(workspaceMode(nextWorkspace)),
     );
     router.push(`/workspace/${nextWorkspace.slug}/cases`);
   }
@@ -915,8 +926,8 @@ function AuthenticatedWorkbench({
               <NewCaseForm
                 busy={busyAction === "create"}
                 defaultWorkOrder={defaultWorkOrder}
-                error={error}
                 fieldErrors={newCaseFieldErrors}
+                formError={newCaseFormError}
                 key={workspace?.id ?? "workspace-loading"}
                 mode={workspaceMode(workspace)}
                 onCancel={() => {
@@ -925,10 +936,14 @@ function AuthenticatedWorkbench({
                   }
                 }}
                 onFieldErrorsChange={setNewCaseFieldErrors}
+                onFormErrorChange={setNewCaseFormError}
                 onSubmit={handleCreateCase}
               />
             ) : view === "audit" ? (
               <AuditView
+                casesHref={
+                  workspace ? `/workspace/${workspace.slug}/cases` : undefined
+                }
                 detail={activeDetail}
                 loadState={activeDetailLoadState}
                 loading={detailLoading}
@@ -945,6 +960,11 @@ function AuthenticatedWorkbench({
                 busyAction={busyAction}
                 canRecordDisposition={
                   workspace?.role === "owner" || workspace?.role === "operator"
+                }
+                casesHref={
+                  workspace
+                    ? `/workspace/${workspace.slug}/cases`
+                    : undefined
                 }
                 detail={activeDetail}
                 loadState={activeDetailLoadState}
@@ -1145,11 +1165,27 @@ function CaseRail({
             </>
           ) : (
             <>
-              <span aria-hidden="true">00</span>
-              <p>{emptyLabel}</p>
+              <span aria-hidden="true" className="rail-empty-mark">
+                <svg fill="none" viewBox="0 0 24 24">
+                  <path d="M8.5 4.5h7a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-7a1 1 0 0 1-1-1v-13a1 1 0 0 1 1-1Z" />
+                  <path d="M9.5 8h5M9.5 11.5h5M9.5 15h3" />
+                </svg>
+              </span>
+              <div className="rail-empty-copy">
+                <span className="rail-empty-kicker">Closeout queue</span>
+                <h2>{emptyLabel}</h2>
+                <p>
+                  Completed work orders land here once a closeout case is
+                  created and ready for review.
+                </p>
+              </div>
               {showNewAction ? (
-                <button className="text-button" onClick={onNewCase} type="button">
-                  Create the first case
+                <button
+                  className="rail-empty-action"
+                  onClick={onNewCase}
+                  type="button"
+                >
+                  Create the first case <span aria-hidden="true">→</span>
                 </button>
               ) : null}
             </>
@@ -1165,6 +1201,7 @@ function CaseWorkspace({
   attestations,
   busyAction,
   canRecordDisposition,
+  casesHref,
   detail,
   loadState,
   loading,
@@ -1184,6 +1221,7 @@ function CaseWorkspace({
   attestations: Set<string>;
   busyAction: string | null;
   canRecordDisposition: boolean;
+  casesHref: string | undefined;
   detail: CaseDetail | null;
   loadState: DetailLoadState;
   loading: boolean;
@@ -1216,15 +1254,29 @@ function CaseWorkspace({
 
   if (!detail) {
     return (
-      <section className="workspace-panel empty-workspace">
+      <section className="workspace-panel empty-workspace empty-state empty-state--neutral">
         <span aria-hidden="true" className="empty-index">
           FC / 01
         </span>
+        <div aria-hidden="true" className="empty-state-icon">
+          <svg fill="none" viewBox="0 0 24 24">
+            <path d="M8 4.5h8a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1v-13a1 1 0 0 1 1-1Z" />
+            <path d="M9 8h6M9 11.5h6M9 15h4" />
+          </svg>
+        </div>
+        <p className="empty-state-eyebrow">Case workspace</p>
         <h2>Select a case to begin.</h2>
-        <p>
+        <p className="empty-copy">
           Each case keeps the reviewed brief, one exact approval, provider state,
           normalized result, and human next action together.
         </p>
+        {casesHref ? (
+          <div className="empty-actions">
+            <Link className="secondary-button" href={casesHref}>
+              Browse closeout cases
+            </Link>
+          </div>
+        ) : null}
       </section>
     );
   }
@@ -1872,11 +1924,13 @@ function ExceptionView({
 }
 
 function AuditView({
+  casesHref,
   detail,
   loadState,
   loading,
   user,
 }: {
+  casesHref: string | undefined;
   detail: CaseDetail | null;
   loadState: DetailLoadState;
   loading: boolean;
@@ -1895,8 +1949,28 @@ function AuditView({
 
   if (!detail) {
     return (
-      <section className="workspace-panel empty-workspace">
+      <section className="workspace-panel empty-workspace empty-state empty-state--neutral">
+        <span aria-hidden="true" className="empty-index">
+          FC / 02
+        </span>
+        <div aria-hidden="true" className="empty-state-icon">
+          <svg fill="none" viewBox="0 0 24 24">
+            <path d="M4.5 6.5a1 1 0 0 1 1-1h13a1 1 0 0 1 1 1v11a1 1 0 0 1-1 1h-13a1 1 0 0 1-1-1v-11Z" />
+            <path d="M8.5 9.5h7M8.5 12.5h7M8.5 15.5h4" />
+          </svg>
+        </div>
+        <p className="empty-state-eyebrow">Append-only audit</p>
         <h2>Select a case to inspect its audit history.</h2>
+        <p className="empty-copy">
+          Open a case from the queue to review its immutable event timeline.
+        </p>
+        {casesHref ? (
+          <div className="empty-actions">
+            <Link className="secondary-button" href={casesHref}>
+              Browse closeout cases
+            </Link>
+          </div>
+        ) : null}
       </section>
     );
   }
@@ -2051,7 +2125,15 @@ function DispositionForm({
         });
       }}
     >
-      <span>Final human checkpoint</span>
+      <div className="disposition-panel-header">
+        <span aria-hidden="true" className="disposition-mark">
+          <svg fill="none" viewBox="0 0 24 24">
+            <path d="M7.5 5.5h9a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1v-12a1 1 0 0 1 1-1Z" />
+            <path d="m9.25 12.25 2 2 3.5-3.75" />
+          </svg>
+        </span>
+        <span>Final human checkpoint</span>
+      </div>
       <strong>Record the FieldClose disposition</strong>
       <p>
         This resolves the current FieldClose task only. It does not close an
@@ -2240,12 +2322,19 @@ function WorkspaceLoading() {
 
 function WorkspaceUnavailable() {
   return (
-    <section className="workspace-panel empty-workspace workspace-unavailable">
+    <section className="workspace-panel empty-workspace empty-state empty-state--attention workspace-unavailable">
       <span aria-hidden="true" className="empty-index">
         FC / 00
       </span>
+      <div aria-hidden="true" className="empty-state-icon">
+        <svg fill="none" viewBox="0 0 24 24">
+          <path d="M12 4.25 20.25 19H3.75L12 4.25Z" />
+          <path d="M12 9.75v4.5M12 17.25h.01" />
+        </svg>
+      </div>
+      <p className="empty-state-eyebrow">Workspace access</p>
       <h2>Workspace unavailable</h2>
-      <p>
+      <p className="empty-copy">
         Choose an available workspace or return to the public product page. No
         record details were disclosed.
       </p>
@@ -2267,12 +2356,20 @@ function CaseCreationUnavailable({
   showLocalSetupHint: boolean;
 }) {
   return (
-    <section className="workspace-panel empty-workspace">
+    <section className="workspace-panel empty-workspace empty-state empty-state--attention">
       <span aria-hidden="true" className="empty-index">
         FC / CFG
       </span>
+      <div aria-hidden="true" className="empty-state-icon">
+        <svg fill="none" viewBox="0 0 24 24">
+          <path d="M14.5 10.5h4l1.5 1.5v5a1 1 0 0 1-1 1h-6a1 1 0 0 1-1-1v-5l1.5-1.5h1Z" />
+          <circle cx="11.75" cy="14.5" r="0.75" />
+          <path d="M12.5 14.5v-2a1.75 1.75 0 0 0-3.5 0v2" />
+        </svg>
+      </div>
+      <p className="empty-state-eyebrow">Configuration required</p>
       <h2>Case protection setup required</h2>
-      <p>
+      <p className="empty-copy">
         Contact data cannot be accepted until separate encryption and lookup
         keys are configured.
         {showLocalSetupHint
@@ -2285,12 +2382,20 @@ function CaseCreationUnavailable({
 
 function CaseUnavailable() {
   return (
-    <section className="workspace-panel empty-workspace case-unavailable">
+    <section className="workspace-panel empty-workspace empty-state empty-state--attention case-unavailable">
       <span aria-hidden="true" className="empty-index">
         FC / 04
       </span>
+      <div aria-hidden="true" className="empty-state-icon">
+        <svg fill="none" viewBox="0 0 24 24">
+          <path d="M6.5 4.5h7L18 9v10a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-14a1 1 0 0 1 1-1Z" />
+          <path d="M13 4.5V9h4.5" />
+          <path d="m9.25 15.5 5.5-5.5M14.75 15.5l-5.5-5.5" />
+        </svg>
+      </div>
+      <p className="empty-state-eyebrow">Record access</p>
       <h2>Case unavailable</h2>
-      <p>
+      <p className="empty-copy">
         This record could not be opened. It may not exist or may be outside your
         workspace access.
       </p>
@@ -2440,10 +2545,10 @@ function createCallingWindow(timezone: string) {
   };
 }
 
-function workspaceMode(workspace: Workspace | null): "fake" | "live" {
-  return workspace?.kind === "protected" &&
-    workspace.provider === "call_e" &&
-    workspace.liveCallsAllowed
+function workspaceMode(workspaceValue: Workspace | null): "fake" | "live" {
+  return workspaceValue?.kind === "protected" &&
+    workspaceValue.provider === "call_e" &&
+    workspaceValue.liveCallsAllowed
     ? "live"
     : "fake";
 }

--- a/apps/web/fieldclose/src/components/new-case-form.tsx
+++ b/apps/web/fieldclose/src/components/new-case-form.tsx
@@ -17,11 +17,12 @@ export type NewCaseFieldErrors = Partial<
 type NewCaseFormProps = {
   busy: boolean;
   defaultWorkOrder: string;
-  error: string | null;
   fieldErrors: NewCaseFieldErrors;
+  formError: string | null;
   mode: "fake" | "live";
   onCancel: () => void;
   onFieldErrorsChange: (errors: NewCaseFieldErrors) => void;
+  onFormErrorChange: (error: string | null) => void;
   onSubmit: (input: NewCaseInput) => Promise<void>;
 };
 
@@ -43,21 +44,92 @@ const questionOptions = [
   },
 ] as const;
 
+export const PRESET_DEMO_WORK_ORDER = {
+  workOrderRef: "WO-DEMO-1042",
+  contractorDisplayName: "Example HVAC",
+  siteLabel: "Fictional North Store",
+  timezone: "America/Chicago",
+  contactRole: "site_manager",
+  phoneE164: "+12025550142",
+  serviceDate: "2026-07-27",
+  equipmentLabel: "Rooftop unit RTU-2",
+  technicianCompletionNote: "Filter replaced and unit restarted",
+  allowedReferenceText:
+    "A fictional technician visited to service rooftop unit RTU-2.",
+  requestedFields: [
+    "observed_operating_status",
+    "unresolved_issue",
+    "return_visit_request",
+  ],
+} as const satisfies {
+  workOrderRef: string;
+  contractorDisplayName: string;
+  siteLabel: string;
+  timezone: string;
+  contactRole: string;
+  phoneE164: string;
+  serviceDate: string;
+  equipmentLabel: string;
+  technicianCompletionNote: string;
+  allowedReferenceText: string;
+  requestedFields: readonly DemoCloseoutCaseInput["requestedFields"][number][];
+};
+
+export function createNewCaseWorkOrderReference(mode: "fake" | "live") {
+  if (mode === "fake") {
+    return PRESET_DEMO_WORK_ORDER.workOrderRef;
+  }
+
+  return `WO-LIVE-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export function formatDateInTimezone(date: Date, timezone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: timezone,
+    year: "numeric",
+  }).formatToParts(date);
+  const values = Object.fromEntries(
+    parts.map((part) => [part.type, part.value]),
+  );
+
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
 export function NewCaseForm({
   busy,
   defaultWorkOrder,
-  error,
   fieldErrors,
+  formError,
   mode,
   onCancel,
   onFieldErrorsChange,
+  onFormErrorChange,
   onSubmit,
 }: NewCaseFormProps) {
   const live = mode === "live";
+  const formRef = useRef<HTMLFormElement>(null);
   const phoneInputRef = useRef<HTMLInputElement>(null);
+  const serviceDateInputRef = useRef<HTMLInputElement>(null);
   const [selectedQuestions, setSelectedQuestions] = useState<Set<string>>(
-    new Set(questionOptions.map((question) => question.value)),
+    new Set(
+      live
+        ? questionOptions.map((question) => question.value)
+        : PRESET_DEMO_WORK_ORDER.requestedFields,
+    ),
   );
+
+  function restoreDemoPreset() {
+    if (live) {
+      return;
+    }
+
+    formRef.current?.reset();
+    setSelectedQuestions(new Set(PRESET_DEMO_WORK_ORDER.requestedFields));
+    onFieldErrorsChange({});
+    onFormErrorChange(null);
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -122,7 +194,16 @@ export function NewCaseForm({
   }
 
   return (
-    <form className="workspace-panel" onSubmit={handleSubmit}>
+    <form
+      className="workspace-panel"
+      onChange={() => {
+        if (formError) {
+          onFormErrorChange(null);
+        }
+      }}
+      onSubmit={handleSubmit}
+      ref={formRef}
+    >
       <div className="panel-heading">
         <div>
           <p className="eyebrow">
@@ -144,11 +225,32 @@ export function NewCaseForm({
         role="note"
       >
         <span aria-hidden="true" className="notice-mark">
-          {live ? "L" : "D"}
+          {live ? (
+            <svg fill="none" viewBox="0 0 24 24">
+              <path d="M12 4.25 20.25 19H3.75L12 4.25Z" />
+              <path d="M12 9.75v4.5M12 17.25h.01" />
+            </svg>
+          ) : (
+            <svg fill="none" viewBox="0 0 24 24">
+              <path d="M9 3.5h6M10 3.5V6l-4.5 6.5A1.5 1.5 0 0 0 6.7 15h10.6a1.5 1.5 0 0 0 1.2-2.5L14 6V3.5" />
+              <path d="M6.7 15a5 5 0 0 0 10.6 0" />
+            </svg>
+          )}
         </span>
-        {live
-          ? "Live mode can place one real CALL-E phone call after a separate exact approval. Enter only a contact and purpose your organization is authorized to use."
-          : "Demo data only. Use the fictional 555 number below; this workflow never places a real call."}
+        <span className="notice-strip-copy">
+          {live
+            ? "Live mode can place one real CALL-E phone call after a separate exact approval. Enter only a contact and purpose your organization is authorized to use."
+            : "Demo data only. Use the fixed fictional inputs below; this workflow never places a real call."}
+        </span>
+        {live ? null : (
+          <button
+            className="text-button notice-strip-action"
+            onClick={restoreDemoPreset}
+            type="button"
+          >
+            Restore fictional preset
+          </button>
+        )}
       </div>
 
       <ol className="form-progress" aria-label="Case preparation sections">
@@ -157,8 +259,8 @@ export function NewCaseForm({
           ["02", "Authorized contact"],
           ["03", "Visit evidence"],
           ["04", "Approved questions"],
-        ].map(([number, label]) => (
-          <li key={number}>
+        ].map(([number, label], index) => (
+          <li aria-current={index === 0 ? "step" : undefined} key={number}>
             <span>{number}</span>
             <strong>{label}</strong>
           </li>
@@ -174,7 +276,11 @@ export function NewCaseForm({
             Work-order reference
             <input
               className="field-control"
-              defaultValue={defaultWorkOrder}
+              defaultValue={
+                live
+                  ? defaultWorkOrder
+                  : PRESET_DEMO_WORK_ORDER.workOrderRef
+              }
               name="workOrderRef"
               required
             />
@@ -183,7 +289,9 @@ export function NewCaseForm({
             Contractor display name
             <input
               className="field-control"
-              defaultValue={live ? "" : "Example HVAC"}
+              defaultValue={
+                live ? "" : PRESET_DEMO_WORK_ORDER.contractorDisplayName
+              }
               name="contractorDisplayName"
               placeholder={live ? "Authorized contractor name" : undefined}
               required
@@ -193,7 +301,7 @@ export function NewCaseForm({
             {live ? "Site label" : "Fictional site label"}
             <input
               className="field-control"
-              defaultValue={live ? "" : "Fictional North Store"}
+              defaultValue={live ? "" : PRESET_DEMO_WORK_ORDER.siteLabel}
               name="siteLabel"
               placeholder={live ? "Customer-safe site label" : undefined}
               required
@@ -203,8 +311,18 @@ export function NewCaseForm({
             IANA timezone
             <select
               className="field-control"
-              defaultValue="America/Chicago"
+              defaultValue={
+                live ? "America/Chicago" : PRESET_DEMO_WORK_ORDER.timezone
+              }
               name="timezone"
+              onChange={(event) => {
+                if (live && serviceDateInputRef.current) {
+                  serviceDateInputRef.current.value = formatDateInTimezone(
+                    new Date(),
+                    event.target.value,
+                  );
+                }
+              }}
             >
               <option value="America/Chicago">America/Chicago</option>
               <option value="America/New_York">America/New_York</option>
@@ -238,7 +356,9 @@ export function NewCaseForm({
             Contact role
             <select
               className="field-control"
-              defaultValue="site_manager"
+              defaultValue={
+                live ? "site_manager" : PRESET_DEMO_WORK_ORDER.contactRole
+              }
               name="contactRole"
             >
               <option value="site_manager">Site manager</option>
@@ -259,7 +379,7 @@ export function NewCaseForm({
               }
               autoComplete="off"
               className="field-control font-mono"
-              defaultValue={live ? "" : "+12025550142"}
+              defaultValue={live ? "" : PRESET_DEMO_WORK_ORDER.phoneE164}
               id="phone-e164"
               inputMode="tel"
               name="phoneE164"
@@ -331,8 +451,13 @@ export function NewCaseForm({
             Service date
             <input
               className="field-control"
-              defaultValue={new Date().toISOString().slice(0, 10)}
+              defaultValue={
+                live
+                  ? formatDateInTimezone(new Date(), "America/Chicago")
+                  : PRESET_DEMO_WORK_ORDER.serviceDate
+              }
               name="serviceDate"
+              ref={serviceDateInputRef}
               required
               type="date"
             />
@@ -341,7 +466,9 @@ export function NewCaseForm({
             Equipment label
             <input
               className="field-control"
-              defaultValue={live ? "" : "Rooftop unit RTU-2"}
+              defaultValue={
+                live ? "" : PRESET_DEMO_WORK_ORDER.equipmentLabel
+              }
               name="equipmentLabel"
               placeholder={live ? "Equipment or serviced area" : undefined}
               required
@@ -351,7 +478,11 @@ export function NewCaseForm({
             Internal technician completion note
             <textarea
               className="field-control"
-              defaultValue={live ? "" : "Filter replaced and unit restarted"}
+              defaultValue={
+                live
+                  ? ""
+                  : PRESET_DEMO_WORK_ORDER.technicianCompletionNote
+              }
               name="technicianCompletionNote"
               required
               rows={2}
@@ -367,7 +498,7 @@ export function NewCaseForm({
               defaultValue={
                 live
                   ? ""
-                  : "A fictional technician visited to service rooftop unit RTU-2."
+                  : PRESET_DEMO_WORK_ORDER.allowedReferenceText
               }
               name="allowedReferenceText"
               placeholder={
@@ -415,9 +546,9 @@ export function NewCaseForm({
         </div>
       </fieldset>
 
-      {error ? (
+      {formError ? (
         <p className="form-error" role="alert">
-          {error}
+          {formError}
         </p>
       ) : null}
 

--- a/apps/web/fieldclose/src/components/public-home.tsx
+++ b/apps/web/fieldclose/src/components/public-home.tsx
@@ -120,7 +120,7 @@ const exceptionRows = [
 
 export function PublicHome({ signedIn }: PublicHomeProps) {
   const primaryHref = signedIn ? "/workspace" : "/?auth=signup";
-  const primaryLabel = signedIn ? "Open workspace" : "Explore demo workspace";
+  const primaryLabel = signedIn ? "Open workspace" : "Create demo workspace";
   const secondaryHref = signedIn ? "/workspace" : "/?auth=signin";
   const secondaryLabel = signedIn ? "View cases" : "Sign in";
 
@@ -163,7 +163,7 @@ export function PublicHome({ signedIn }: PublicHomeProps) {
             ) : (
               <>
                 <Link href="/?auth=signin">Sign in</Link>
-                <Link href="/?auth=signup">Explore demo workspace</Link>
+                <Link href="/?auth=signup">Create demo workspace</Link>
               </>
             )}
           </nav>

--- a/apps/web/fieldclose/src/components/sign-in-screen.tsx
+++ b/apps/web/fieldclose/src/components/sign-in-screen.tsx
@@ -7,24 +7,21 @@ import { authClient } from "@/auth-client";
 
 export type AuthView = "sign-in" | "sign-up";
 type SignInMethod = "password" | "email-code";
-type SignupField = "name" | "username" | "email" | "password";
+type SignupField = "name" | "email" | "password";
 type SignupFieldErrors = Partial<Record<SignupField, string>>;
 const pendingVerificationEmailKey = "fieldclose.pending-verification-email";
 const signupFieldOrder: SignupField[] = [
   "name",
-  "username",
   "email",
   "password",
 ];
 const signupFieldLabels: Record<SignupField, string> = {
   name: "Your name",
-  username: "Username",
   email: "Work email",
   password: "Password",
 };
 const signupFieldIds: Record<SignupField, string> = {
   name: "signup-name",
-  username: "signup-username",
   email: "signup-email",
   password: "signup-password",
 };
@@ -49,7 +46,6 @@ export function SignInScreen({
   const [code, setCode] = useState("");
   const [codeSent, setCodeSent] = useState(false);
   const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
   const [signupEmail, setSignupEmail] = useState("");
   const [signupPassword, setSignupPassword] = useState("");
   const [verificationEmail, setVerificationEmail] = useState<string | null>(
@@ -231,10 +227,8 @@ export function SignInScreen({
 
     const normalizedName = name.trim();
     const normalizedEmail = signupEmail.trim();
-    const normalizedUsername = username.trim();
     const fieldErrors = validateSignupFields({
       name: normalizedName,
-      username: normalizedUsername,
       email: normalizedEmail,
       password: signupPassword,
     });
@@ -249,14 +243,15 @@ export function SignInScreen({
     setSignupFieldErrors({});
     setBusy(true);
     rememberVerificationEmail(normalizedEmail);
+    const generatedUsername = createGeneratedUsername(normalizedEmail);
 
     try {
       const response = await authClient.signUp.email({
         name: normalizedName,
         email: normalizedEmail,
         password: signupPassword,
-        username: normalizedUsername,
-        displayUsername: normalizedUsername,
+        username: generatedUsername,
+        displayUsername: generatedUsername,
         callbackURL: returnTo,
       });
 
@@ -386,7 +381,7 @@ export function SignInScreen({
           <span className="mode-label">
             <i aria-hidden="true" /> Public demo · fake only
           </span>
-          <p>Account access</p>
+          <p>Workspace access</p>
         </div>
         <Link
           aria-label="Close account access"
@@ -438,7 +433,7 @@ export function SignInScreen({
                 tabIndex={view === "sign-up" ? 0 : -1}
                 type="button"
               >
-                Create account
+                Create workspace
               </button>
             </div>
 
@@ -519,6 +514,7 @@ export function SignInScreen({
                       <span>Keep me signed in on this device</span>
                     </label>
                     <button
+                      aria-busy={busy}
                       className="primary-button full-width"
                       disabled={busy}
                       type="submit"
@@ -546,6 +542,7 @@ export function SignInScreen({
                       />
                     </AuthField>
                     <button
+                      aria-busy={busy}
                       className="primary-button full-width"
                       disabled={busy}
                       type="submit"
@@ -577,6 +574,7 @@ export function SignInScreen({
                       />
                     </AuthField>
                     <button
+                      aria-busy={busy}
                       className="primary-button full-width"
                       disabled={busy}
                       type="submit"
@@ -588,7 +586,6 @@ export function SignInScreen({
                 </>
               ) : (
                 <form className="auth-form" noValidate onSubmit={createAccount}>
-                <div className="auth-form-row">
                   <AuthField
                     error={signupFieldErrors.name}
                     label="Your name"
@@ -618,37 +615,6 @@ export function SignInScreen({
                       value={name}
                     />
                   </AuthField>
-                  <AuthField
-                    error={signupFieldErrors.username}
-                    label="Username"
-                    htmlFor="signup-username"
-                  >
-                    <input
-                      aria-describedby={
-                        signupFieldErrors.username
-                          ? "signup-username-error"
-                          : undefined
-                      }
-                      aria-invalid={
-                        signupFieldErrors.username ? "true" : undefined
-                      }
-                      autoComplete="username"
-                      id="signup-username"
-                      maxLength={30}
-                      minLength={3}
-                      onChange={(event) =>
-                        updateSignupField(
-                          "username",
-                          event.target.value,
-                          setUsername,
-                        )
-                      }
-                      pattern="[A-Za-z0-9_.]+"
-                      required
-                      value={username}
-                    />
-                  </AuthField>
-                </div>
                 <AuthField
                   error={signupFieldErrors.email}
                   label="Work email"
@@ -706,33 +672,61 @@ export function SignInScreen({
                     type="password"
                     value={signupPassword}
                   />
-                  {signupFieldErrors.password ? null : (
-                    <small id="signup-password-help">
-                      Use 8–128 characters. Do not reuse a work-system password.
-                    </small>
-                  )}
+                  <ul
+                    aria-label="Password requirements"
+                    className="password-requirements"
+                    id="signup-password-help"
+                  >
+                    <li
+                      aria-live="polite"
+                      data-met={
+                        signupPassword.length >= 8 &&
+                        signupPassword.length <= 128
+                      }
+                    >
+                      <span aria-hidden="true">✓</span>
+                      8–128 characters
+                    </li>
+                    <li>
+                      <span aria-hidden="true">•</span>
+                      Do not reuse a work-system password
+                    </li>
+                  </ul>
                 </AuthField>
                 <button
+                  aria-busy={busy}
                   className="primary-button full-width"
                   disabled={busy}
                   type="submit"
                 >
-                  {busy ? "Creating account…" : "Create account"}
+                  {busy ? "Creating workspace…" : "Create demo workspace"}
                 </button>
+                <p className="auth-trust-note">
+                  <span aria-hidden="true" />
+                  Simulation only. No real customer data or calls.
+                </p>
                 </form>
               )}
 
               <div
-                aria-live="polite"
                 className="auth-feedback"
                 data-visible={Boolean(error || notice)}
               >
                 {error ? (
-                  <p className="signin-error" role="alert">
+                  <p
+                    className="signin-error"
+                    role={
+                      Object.keys(signupFieldErrors).length > 0
+                        ? undefined
+                        : "alert"
+                    }
+                  >
                     {error}
                   </p>
                 ) : notice ? (
-                  <p className="signin-notice">{notice}</p>
+                  <p className="signin-notice" role="status">
+                    {notice}
+                  </p>
                 ) : null}
               </div>
             </div>
@@ -783,6 +777,7 @@ function VerificationForm({
         />
       </AuthField>
       <button
+        aria-busy={busy}
         className="primary-button full-width"
         disabled={busy}
         type="submit"
@@ -827,7 +822,11 @@ function AuthField({
       <label htmlFor={htmlFor}>{label}</label>
       {children}
       {error ? (
-        <small className="auth-field-error" id={`${htmlFor}-error`}>
+        <small
+          className="auth-field-error"
+          id={`${htmlFor}-error`}
+          role="alert"
+        >
           {error}
         </small>
       ) : null}
@@ -837,12 +836,10 @@ function AuthField({
 
 function validateSignupFields({
   name,
-  username,
   email,
   password,
 }: {
   name: string;
-  username: string;
   email: string;
   password: string;
 }): SignupFieldErrors {
@@ -850,15 +847,6 @@ function validateSignupFields({
 
   if (name.length < 2 || name.length > 80) {
     errors.name = "Enter your name using 2–80 characters.";
-  }
-
-  if (
-    username.length < 3 ||
-    username.length > 30 ||
-    !/^[A-Za-z0-9_.]+$/u.test(username)
-  ) {
-    errors.username =
-      "Use 3–30 letters, numbers, dots, or underscores.";
   }
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(email)) {
@@ -883,12 +871,15 @@ function signupErrorDetails(error: {
 
   switch (error.code) {
     case "USERNAME_IS_ALREADY_TAKEN":
-      fields.username = "This username is already in use. Choose another.";
+      fields.email =
+        "An account identifier for this email is unavailable. Use another email.";
       break;
     case "INVALID_USERNAME":
-      fields.username =
-        "Use 3–30 letters, numbers, dots, or underscores.";
-      break;
+      return {
+        fields,
+        summary:
+          "The account service could not generate an account identifier. Try again in a moment.",
+      };
     case "INVALID_EMAIL":
       fields.email = "Enter a valid email address.";
       break;
@@ -930,7 +921,7 @@ function signupErrorSummary(errors: SignupFieldErrors) {
       ? `${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)}`
       : labels.length === 2
         ? `${labels[0]} and ${labels[1]}`
-      : labels[0];
+        : labels[0];
 
   return `Fix the highlighted ${
     labels.length === 1 ? "field" : "fields"
@@ -947,6 +938,23 @@ function focusFirstSignupError(errors: SignupFieldErrors) {
   queueMicrotask(() => {
     document.getElementById(signupFieldIds[firstInvalidField])?.focus();
   });
+}
+
+function createGeneratedUsername(email: string) {
+  const [localPart = "demo"] = email.toLowerCase().split("@");
+  const stem =
+    localPart
+      .replace(/[^a-z0-9_.]+/gu, "_")
+      .replace(/^[._]+|[._]+$/gu, "")
+      .slice(0, 20) || "demo";
+  let hash = 2166136261;
+
+  for (const character of email.toLowerCase()) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return `${stem}.${(hash >>> 0).toString(36)}`.slice(0, 30);
 }
 
 function authErrorMessage(

--- a/apps/web/fieldclose/tests/e2e/closeout-workflow.spec.ts
+++ b/apps/web/fieldclose/tests/e2e/closeout-workflow.spec.ts
@@ -12,6 +12,7 @@ test("creates, approves, simulates, and closes a fictional case through human di
   page,
 }) => {
   const fixtures = await installWorkflowFixtures(page);
+  await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/workspace/demo-e2e/cases/new");
 
   await expect(
@@ -31,6 +32,7 @@ test("creates, approves, simulates, and closes a fictional case through human di
     exactBrief.getByText("site manager · +*******0142", { exact: true }),
   ).toBeVisible();
   await expect(page.getByText("FAKE / NO NETWORK")).toBeVisible();
+  await expectNoHorizontalOverflow(page);
 
   await page
     .getByLabel("This fictional contact is authorized for the demo.")
@@ -65,6 +67,7 @@ test("creates, approves, simulates, and closes a fictional case through human di
   await expect(
     page.getByText("This resolves the current FieldClose task only."),
   ).toBeVisible();
+  await expectNoHorizontalOverflow(page);
   await page
     .getByRole("button", { name: "Record human disposition" })
     .click();
@@ -79,13 +82,8 @@ test("creates, approves, simulates, and closes a fictional case through human di
     page.locator(".case-heading-status").getByText("closed", { exact: true }),
   ).toBeVisible();
   expect(fixtures.getDispositionRequestCount()).toBe(1);
-  await page.setViewportSize({ width: 390, height: 844 });
   await expect(recordedDisposition).toBeVisible();
-  expect(
-    await page.evaluate(
-      () => document.documentElement.scrollWidth <= window.innerWidth,
-    ),
-  ).toBe(true);
+  await expectNoHorizontalOverflow(page);
 
   await page.getByRole("link", { name: "Open audit" }).click();
   await expect(page).toHaveURL(`/workspace/demo-e2e/audit/${caseId}`);
@@ -102,6 +100,7 @@ test("creates, approves, simulates, and closes a fictional case through human di
   await expect(
     auditTimeline.getByText("user-e2e", { exact: true }),
   ).toHaveCount(0);
+  await expectNoHorizontalOverflow(page);
   await page.goBack();
   await expect(page).toHaveURL(`/workspace/demo-e2e/cases/${caseId}`);
 });
@@ -124,34 +123,96 @@ test("identifies an invalid E.164 field before creating a case", async ({
   await expect(page).toHaveURL("/workspace/demo-e2e/cases/new");
 });
 
+test("restores the fixed fictional preset without creating or approving a case", async ({
+  page,
+}) => {
+  const fixtures = await installWorkflowFixtures(page);
+  await page.goto("/workspace/demo-e2e/cases/new");
+
+  const restorePreset = page.getByRole("button", {
+    name: "Restore fictional preset",
+  });
+  const operatingStatus = page.getByRole("checkbox", {
+    name: /Observed operating status/u,
+  });
+  const unresolvedIssue = page.getByRole("checkbox", {
+    name: /Unresolved issue/u,
+  });
+  const returnVisit = page.getByRole("checkbox", {
+    name: /Return-visit request/u,
+  });
+
+  await expect(restorePreset).toBeVisible();
+  await page.getByLabel("Work-order reference").fill("CHANGED-WORK-ORDER");
+  await page.getByLabel("Contractor display name").fill("Changed contractor");
+  await page.getByLabel("Fictional site label").fill("Changed site");
+  await page.getByLabel("IANA timezone").selectOption("Asia/Shanghai");
+  await page.getByLabel("Fictional E.164 number").fill("+12025550199");
+  await page.getByLabel("Service date").fill("2026-08-13");
+  await page.getByLabel("Equipment label").fill("Changed equipment");
+  await unresolvedIssue.uncheck();
+
+  await restorePreset.click();
+
+  await expect(page.getByLabel("Work-order reference")).toHaveValue(
+    "WO-DEMO-1042",
+  );
+  await expect(page.getByLabel("Contractor display name")).toHaveValue(
+    "Example HVAC",
+  );
+  await expect(page.getByLabel("Fictional site label")).toHaveValue(
+    "Fictional North Store",
+  );
+  await expect(page.getByLabel("IANA timezone")).toHaveValue(
+    "America/Chicago",
+  );
+  await expect(page.getByLabel("Fictional E.164 number")).toHaveValue(
+    "+12025550142",
+  );
+  await expect(page.getByLabel("Service date")).toHaveValue("2026-07-27");
+  await expect(page.getByLabel("Equipment label")).toHaveValue(
+    "Rooftop unit RTU-2",
+  );
+  await expect(operatingStatus).toBeChecked();
+  await expect(unresolvedIssue).toBeChecked();
+  await expect(returnVisit).toBeChecked();
+  await expect(page).toHaveURL("/workspace/demo-e2e/cases/new");
+  expect(fixtures.getCreateCaseRequestCount()).toBe(0);
+});
+
 test("keeps case creation available and readable on tablet and mobile", async ({
   page,
 }) => {
   await installWorkflowFixtures(page);
-  await page.goto("/workspace/demo-e2e/cases/new");
-  await page.getByRole("button", { name: "Create demo case" }).click();
-  await expect(page).toHaveURL(`/workspace/demo-e2e/cases/${caseId}`);
-
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/workspace/demo-e2e/cases");
-  const mobileNewCase = page.getByRole("button", { name: "New case" });
+  await expect(page.locator(".rail-empty")).toBeVisible();
+  await expect(page.locator(".empty-workspace")).toBeHidden();
+  const mobileNewCase = page.getByRole("button", {
+    name: "Create the first case",
+  });
   await expect(mobileNewCase).toBeVisible();
   await mobileNewCase.click();
   await expect(page).toHaveURL("/workspace/demo-e2e/cases/new");
+  await expect(page.getByLabel("Work-order reference")).toHaveValue(
+    "WO-DEMO-1042",
+  );
   await expect(
     page.getByRole("heading", { name: "Prepare the closeout brief" }),
   ).toBeVisible();
-  expect(
-    await page.evaluate(
-      () => document.documentElement.scrollWidth <= window.innerWidth,
-    ),
-  ).toBe(true);
+  await expectNoHorizontalOverflow(page);
 
   await page.setViewportSize({ width: 1024, height: 900 });
   const panelWidth = await page.locator(".workspace-panel").evaluate(
     (panel) => panel.getBoundingClientRect().width,
   );
   expect(panelWidth).toBeGreaterThan(800);
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.getByRole("button", { name: "Create demo case" }).click();
+  await expect(page).toHaveURL(`/workspace/demo-e2e/cases/${caseId}`);
+  await expect(page.getByText("Exact call brief")).toBeVisible();
+  await expectNoHorizontalOverflow(page);
 });
 
 test("presents an empty exceptions queue as a resolved operational state", async ({
@@ -179,13 +240,9 @@ test("presents an empty exceptions queue as a resolved operational state", async
     "/workspace/demo-e2e/cases",
   );
 
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize({ width: 375, height: 812 });
   await expect(allCasesLink).toBeVisible();
-  expect(
-    await page.evaluate(
-      () => document.documentElement.scrollWidth <= window.innerWidth,
-    ),
-  ).toBe(true);
+  await expectNoHorizontalOverflow(page);
 });
 
 test("keeps mobile sign-out available and returns to the public home", async ({
@@ -265,6 +322,12 @@ test("keeps a protected live call explicit from authorization through asynchrono
   await expect(page.getByText("Protected live calls")).toBeVisible();
   await page.getByRole("button", { name: "New case" }).click();
   await expect(page.getByText("Live mode can place one real CALL-E")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Restore fictional preset" }),
+  ).toHaveCount(0);
+  await expect(page.getByLabel("Work-order reference")).toHaveValue(
+    /^WO-LIVE-[A-F0-9]{8}$/u,
+  );
 
   await page.getByLabel("Work-order reference").fill("WO-LIVE-E2E");
   await page.getByLabel("Contractor display name").fill("Authorized HVAC");
@@ -273,7 +336,7 @@ test("keeps a protected live call explicit from authorization through asynchrono
   await page
     .getByLabel("Contact display name")
     .fill("Consenting site manager");
-  await page.getByLabel("Authorized E.164 number").fill("+861012345678");
+  await page.getByLabel("Authorized E.164 number").fill("+442079460000");
   await page
     .getByLabel("Authorization record")
     .fill("The consenting test participant confirmed this exact call.");
@@ -355,9 +418,18 @@ test("keeps a protected live call explicit from authorization through asynchrono
   ).toBe(true);
 });
 
+async function expectNoHorizontalOverflow(page: Page) {
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+}
+
 async function installWorkflowFixtures(page: Page) {
   let stage: "empty" | "draft" | "approved" | "completed" | "closed" =
     "empty";
+  let createCaseRequestCount = 0;
   let dispositionRequestCount = 0;
 
   await page.route("**/api/auth/**", async (route) => {
@@ -436,6 +508,7 @@ async function installWorkflowFixtures(page: Page) {
     const url = new URL(request.url());
 
     if (url.pathname === "/api/cases" && request.method() === "POST") {
+      createCaseRequestCount += 1;
       stage = "draft";
       await route.fulfill({
         contentType: "application/json",
@@ -567,6 +640,7 @@ async function installWorkflowFixtures(page: Page) {
   });
 
   return {
+    getCreateCaseRequestCount: () => createCaseRequestCount,
     getDispositionRequestCount: () => dispositionRequestCount,
   };
 }

--- a/apps/web/fieldclose/tests/e2e/foundation.spec.ts
+++ b/apps/web/fieldclose/tests/e2e/foundation.spec.ts
@@ -14,7 +14,7 @@ test("explains FieldClose before asking for an account", async ({ page }) => {
     page.getByText("Public demo · No phone call placed"),
   ).toBeVisible();
   await expect(
-    page.getByRole("link", { name: "Explore demo workspace" }).first(),
+    page.getByRole("link", { name: "Create demo workspace" }).first(),
   ).toBeVisible();
   await expect(
     page.getByRole("heading", {
@@ -119,7 +119,7 @@ test("offers password, email-code, and account-registration paths in the drawer"
   ).toHaveCount(0);
 
   const signInTab = page.getByRole("tab", { name: "Sign in" });
-  const createAccountTab = page.getByRole("tab", { name: "Create account" });
+  const createAccountTab = page.getByRole("tab", { name: "Create workspace" });
   const passwordMethod = page.getByRole("button", { name: "Password" });
   const emailCodeMethod = page.getByRole("button", { name: "Email code" });
 
@@ -171,14 +171,18 @@ test("offers password, email-code, and account-registration paths in the drawer"
   await expect(signInTab).toBeFocused();
   await expect(signInTab).toHaveAttribute("aria-selected", "true");
   await expect(page).toHaveURL("/?auth=signin");
-  await page.getByRole("tab", { name: "Create account" }).click();
+  await page.getByRole("tab", { name: "Create workspace" }).click();
   await expect(page).toHaveURL("/?auth=signin");
   await expect(page.getByLabel("Your name")).toBeVisible();
-  await expect(page.getByLabel("Username")).toBeVisible();
+  await expect(page.getByLabel("Username")).toHaveCount(0);
   await expect(page.getByLabel("Work email")).toBeVisible();
   await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
 
   await page.route("**/api/auth/sign-up/email", async (route) => {
+    const requestBody = route.request().postDataJSON() as {
+      username?: string;
+    };
+    expect(requestBody.username).toMatch(/^[a-z0-9_.]{3,30}$/u);
     await route.fulfill({
       contentType: "application/json",
       status: 200,
@@ -194,10 +198,12 @@ test("offers password, email-code, and account-registration paths in the drawer"
     });
   });
   await page.getByLabel("Your name").fill("Evaluator");
-  await page.getByLabel("Username").fill("evaluator");
   await page.getByLabel("Work email").fill("evaluator@example.com");
   await page.getByLabel("Password", { exact: true }).fill("ExamplePass123!");
-  await page.getByRole("button", { name: "Create account" }).click();
+  await expect(
+    page.getByLabel("Password requirements").getByText("8–128 characters"),
+  ).toHaveAttribute("data-met", "true");
+  await page.getByRole("button", { name: "Create demo workspace" }).click();
 
   await expect(page.getByLabel("Six-digit code")).toBeVisible();
   await expect(
@@ -253,19 +259,14 @@ test("identifies and highlights only the registration fields that need attention
   await page.goto("/?auth=signup");
 
   await page.getByLabel("Your name").fill("A");
-  await page.getByLabel("Username").fill("not allowed");
   await page.getByLabel("Work email").fill("not-an-email");
   await page.getByLabel("Password", { exact: true }).fill("short");
-  await page.getByRole("button", { name: "Create account" }).click();
+  await page.getByRole("button", { name: "Create demo workspace" }).click();
 
   await expect(page.locator(".signin-error")).toContainText(
-    "Your name, Username, Work email, and Password",
+    "Your name, Work email, and Password",
   );
   await expect(page.getByLabel("Your name")).toHaveAttribute(
-    "aria-invalid",
-    "true",
-  );
-  await expect(page.getByLabel("Username")).toHaveAttribute(
     "aria-invalid",
     "true",
   );
@@ -277,11 +278,8 @@ test("identifies and highlights only the registration fields that need attention
     "aria-invalid",
     "true",
   );
-  await expect(page.locator("#signup-password-help")).toHaveCount(0);
+  await expect(page.locator("#signup-password-help")).toBeVisible();
   await expect(page.locator("#signup-password-error")).toBeVisible();
-  await expect(page.locator("#signup-username-error")).toContainText(
-    "letters, numbers, dots, or underscores",
-  );
   await page.setViewportSize({ width: 390, height: 844 });
   expect(
     await page.evaluate(
@@ -290,7 +288,6 @@ test("identifies and highlights only the registration fields that need attention
   ).toBe(true);
 
   await page.getByLabel("Your name").fill("Evaluator");
-  await page.getByLabel("Username").fill("evaluator");
   await page.getByLabel("Work email").fill("evaluator@example.com");
   await page.getByLabel("Password", { exact: true }).fill("ExamplePass123!");
   await expect(page.locator("#signup-password-help")).toBeVisible();
@@ -305,22 +302,18 @@ test("identifies and highlights only the registration fields that need attention
       }),
     });
   });
-  await page.getByRole("button", { name: "Create account" }).click();
+  await page.getByRole("button", { name: "Create demo workspace" }).click();
 
-  await expect(page.getByLabel("Username")).toHaveAttribute(
+  await expect(page.getByLabel("Work email")).toHaveAttribute(
     "aria-invalid",
     "true",
   );
-  await expect(page.locator("#signup-username-error")).toHaveText(
-    "This username is already in use. Choose another.",
-  );
-  await expect(page.getByLabel("Work email")).not.toHaveAttribute(
-    "aria-invalid",
-    "true",
+  await expect(page.locator("#signup-email-error")).toHaveText(
+    "An account identifier for this email is unavailable. Use another email.",
   );
 
   await page.unroute("**/api/auth/sign-up/email");
-  await page.getByLabel("Username").fill("available_name");
+  await page.getByLabel("Work email").fill("another-evaluator@example.com");
   await page.route("**/api/auth/sign-up/email", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -331,7 +324,7 @@ test("identifies and highlights only the registration fields that need attention
       }),
     });
   });
-  await page.getByRole("button", { name: "Create account" }).click();
+  await page.getByRole("button", { name: "Create demo workspace" }).click();
 
   await expect(page.locator(".signin-error")).toHaveText(
     "The account service could not complete this request. Your details are still in the form; try again in a moment.",

--- a/apps/web/fieldclose/tests/integration/live-closeout-workflow.test.ts
+++ b/apps/web/fieldclose/tests/integration/live-closeout-workflow.test.ts
@@ -197,7 +197,7 @@ describe("protected live closeout workflow", () => {
         db,
         "live-owner",
         workspaceId,
-        protectedCaseInput("WO-LIVE-NON-US", "+861012345678"),
+        protectedCaseInput("WO-LIVE-NON-US", "+442079460000"),
         keys,
       ),
     ).rejects.toMatchObject({

--- a/apps/web/fieldclose/tests/unit/new-case-form.test.ts
+++ b/apps/web/fieldclose/tests/unit/new-case-form.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createNewCaseWorkOrderReference,
+  formatDateInTimezone,
+  PRESET_DEMO_WORK_ORDER,
+} from "@/components/new-case-form";
+
+describe("new case form defaults", () => {
+  it("keeps the demo work order fixed and explicitly fictional", () => {
+    expect(createNewCaseWorkOrderReference("fake")).toBe("WO-DEMO-1042");
+    expect(PRESET_DEMO_WORK_ORDER).toMatchObject({
+      contractorDisplayName: "Example HVAC",
+      siteLabel: "Fictional North Store",
+      phoneE164: "+12025550142",
+      serviceDate: "2026-07-27",
+      timezone: "America/Chicago",
+    });
+    expect(PRESET_DEMO_WORK_ORDER.requestedFields).toEqual([
+      "observed_operating_status",
+      "unresolved_issue",
+      "return_visit_request",
+    ]);
+  });
+
+  it("generates a bounded random reference only for live cases", () => {
+    const first = createNewCaseWorkOrderReference("live");
+    const second = createNewCaseWorkOrderReference("live");
+
+    expect(first).toMatch(/^WO-LIVE-[A-F0-9]{8}$/u);
+    expect(second).toMatch(/^WO-LIVE-[A-F0-9]{8}$/u);
+    expect(second).not.toBe(first);
+  });
+
+  it("derives the calendar date from the selected IANA timezone", () => {
+    const utcBoundary = new Date("2026-01-01T00:30:00.000Z");
+    const positiveOffsetBoundary = new Date("2026-01-01T23:30:00.000Z");
+
+    expect(formatDateInTimezone(utcBoundary, "America/Los_Angeles")).toBe(
+      "2025-12-31",
+    );
+    expect(formatDateInTimezone(positiveOffsetBoundary, "Asia/Shanghai")).toBe(
+      "2026-01-02",
+    );
+  });
+});

--- a/apps/web/fieldclose/tests/unit/phone-number.test.ts
+++ b/apps/web/fieldclose/tests/unit/phone-number.test.ts
@@ -12,7 +12,7 @@ describe("E.164 phone numbers", () => {
     expect(() => assertE164PhoneNumber("+12025550142")).not.toThrow();
   });
 
-  it.each(["123", "+0123456789", "+1202", "+1202555014212345"])(
+  it.each(["123", "+0123456789", "+1202", "+1-202-555-0142"])(
     "rejects invalid input %s with actionable copy",
     (value) => {
       expect(e164PhoneSchema.safeParse(value).error?.issues[0]).toMatchObject({
@@ -29,7 +29,7 @@ describe("US E.164 phone numbers", () => {
   });
 
   it("rejects a non-US E.164 number instead of pairing it with the US provider region", () => {
-    expect(usE164PhoneSchema.safeParse("+861012345678").error?.issues[0]).toMatchObject({
+    expect(usE164PhoneSchema.safeParse("+442079460000").error?.issues[0]).toMatchObject({
       message: "Enter an explicit US E.164 number beginning with +1.",
     });
   });


### PR DESCRIPTION
## Summary

- bring the packaged FieldClose app forward as a reviewer-ready public review tree
- improve the sign-in/sign-up flow, preset fictional work-order creation, actionable form feedback, and responsive reviewer UI
- document the fake-only public demo, protected staging controls, authentication/workspace boundaries, and evidence-limited HVAC desk research
- include the post-merge safety and operations updates already present in the FieldClose application

## Safety boundary

- the public demo remains fake-only and cannot create a CALL-E phone call
- live execution still requires exact human approval, a valid E.164 recipient, calling-window validation, a stable idempotency key, and the global live-call gate
- examples use fictional or masked contact data; this change contains no live credentials, private transcripts, recordings, or real phone numbers

## Public evidence boundary

- the authoritative reviewer-visible source is [`apps/web/fieldclose/` at PR HEAD `008d80e`](https://github.com/CALLE-AI/awesome-phone-call-agents/tree/008d80e30eba77e14cebcd895a2e4364c9ad6a98/apps/web/fieldclose)
- the public fake-only demo URL is independently browser-visible
- server configuration, protected accounts, staging observations, live-test records, deployment artifacts, private revisions, and local validation logs are maintainer-operated private evidence; they are not public source, build, deployment, or independent validation provenance
- this PR makes no exact private deployment-revision or private validation-result claim; the visible PR Checks result is the public CI signal

## Reviewer-blocker remediation

- the PR branch was rebased onto the latest `upstream/main` and rewritten as one clean commit, so the prior non-reserved fixture is absent from every reachable PR-unique commit
- the current tree uses standards-reserved fictional phone fixtures; a repository scan found no full E.164-like sample outside the documented reserved ranges
- inaccessible deployment-revision citations were removed, and deployment/account statements in the public docs are now explicitly qualified as maintainer-reported private operational observations
- the already-public base branch still contains the inherited prior fixture; this contributor PR cannot rewrite the upstream default branch, so repository-owned history remediation requires maintainer/security coordination without reproducing the value

## Review notes

The original FieldClose contribution was merged in #96. This focused follow-up updates only `apps/web/fieldclose/` and does not change shared repository infrastructure.