### PR TITLE
docs(apps): add Cooldown Caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [Later, Me.](https://github.com/shirosenagi-design/later-me) - Windows CALL-E app for scheduling a real phone call to your future self, with a four-hour minimum, one pending reservation, and optional post-call Relationship Trace.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 - [ShohojSheba Voice](https://shohojsheba-call-e-preview.redwan-rahman.workers.dev/judge) - Consent-gated healthcare staffing dispatch that uses structured CALL-E results to advance after a verified decline, pauses on acceptance, and keeps final assignment human-controlled.
+- [Cooldown Caller](https://github.com/jayblast-spec/cooldown-caller) - Dashboard that evaluates rate-limited recurring actions on a daily cron or manual trigger, places a CALL-E call only when that check finds an item ready, prevents duplicate calls with cycle-scoped idempotency, and exposes only a privacy-redacted status log.
 
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.
 


### PR DESCRIPTION
## Summary
Adds **Cooldown Caller** to the Apps resource list.

Cooldown Caller evaluates recurring-action cooldowns on a documented daily Vercel Cron schedule or an explicit manual check. If that check finds an item ready, it can place a CALL-E call. Cycle-scoped idempotency prevents duplicate calls, missing destination configuration fails closed, and the public dashboard receives privacy-redacted call status rather than destination/provider identifiers or transcript evidence.

- Repo: https://github.com/jayblast-spec/cooldown-caller
- Live app: https://cooldown-caller.vercel.app

## Verification
- [x] Timing claim matches the daily/manual evaluation model
- [x] No destination fixtures, real-call artifacts, or personal contact data in this PR
- [x] PR branch rewritten to one clean commit
- [x] Linked repository is undergoing a complete public-history sanitation pass