### PR TITLE
feat(apps/web): add Locked Door, an emergency-directory phone verifier

### DIFF
--- a/apps/web/locked-door/LICENSE
+++ b/apps/web/locked-door/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CALL-E AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/web/locked-door/README.md
+++ b/apps/web/locked-door/README.md
@@ -1,0 +1,103 @@
+# Locked Door
+
+> A city PDF says the cooling center is open. This calls to check, cites the transcript for every fact, and says `unknown` rather than sending someone to a locked door.
+
+Locked Door is a web application for keeping **emergency resource directories** (cooling centers, heat-relief shelters, warming centers, food sites) truthful. It ingests a published directory, decides which facts are worth spending a phone call on, verifies them by phone, and publishes a time-stamped, human-approved delta instead of silently overwriting the source.
+
+The operational fact that matters in an emergency — *are you open right now, do you take pets, is the accessible entrance still on 3rd Street* — very often exists only behind a phone number. A search API cannot retrieve it. This is the policy layer around a call, not a voice bot.
+
+## Safety and provenance: no real calls are placed
+
+This is the most important thing to know before running it.
+
+The call transport is an interface with two implementations:
+
+| Implementation | State | Behaviour |
+| --- | --- | --- |
+| `CalleTelephonyAdapter` | **disabled** | Documents the real request shape. `placeCall()` **throws synchronously** if invoked. |
+| `SimulatedFacility` | active | Deterministic, seeded conversations with ground-truth state per facility. |
+
+`placeCall()` throws synchronously rather than returning a rejected promise, so an unawaited call cannot sail past the refusal and fail silently. On a boundary that must never be crossed quietly, "you only find out if you were listening" is not good enough.
+
+The UI states that calls are simulated at all times. A full session makes **zero external network requests**; the only external URL in the tree is a string constant that is never fetched. There is no credential handling of any kind, because there is nothing to authenticate.
+
+This is a dry-run-by-default app, as required by `CONTRIBUTING.md`.
+
+## What it does
+
+1. **Ingest** a realistic published directory — 64 facilities with the mess real ones have: 47 distinct hour formats, 109 missing verification timestamps, 5 facilities with no phone, 7 disconnected numbers, 4 duplicates.
+2. **Rank by risk.** Every `(facility, field)` pair is scored on **harm if stale x probability of being stale x observability by phone**, with documented volatility priors per field type. A greedy submodular selection then picks **facilities**, not fields, under an explicit call budget, because one call verifies several fields at once.
+3. **Call, within a budget**, with realistic outcomes: connected, IVR menu, voicemail, no answer, disconnected. Retry with backoff and a per-facility attempt cap.
+4. **Extract with citations.** Every typed field (`open_now`, `hours`, `pet_policy`, `accessibility`, `intake_requirements`, `capacity_status`) must point at a span of the transcript. **If no span supports it, the value is `unknown`** — enforced in code, with the citation visible on hover.
+5. **Route, do not guess.** Low-confidence or contradicted fields go to a review queue rather than to publication.
+6. **Publish a delta.** A time-stamped changeset (field, old, new, evidence, confidence, `verified_at`) awaiting human approval, with full per-field history and freshness decay.
+
+## Measured results
+
+Because the simulator carries ground truth, the app measures itself. From a 25-call batch (`node tools/smoke.mjs 25`, identical numbers in browser and headless):
+
+| Metric | Value |
+| --- | --- |
+| Precision | **94.4%** (67/71) |
+| Recall | 44.7% (67/150) |
+| Unknown rate | 52.7% |
+| **False-publish rate** | **0.00%** (0/37) |
+| Wrong values produced / held for review | 4 / 4 |
+| Harm reduction vs oldest-first baseline | **49.31 vs 39.35 (+25.3%)** |
+| Citation audit | **71/71 pass, 0 failures** |
+| Batch wall time | 22.0 s |
+
+The harm-reduction lift is *realized* against ground truth rather than planned, holds across budgets (+42.1% at budget 10, +32.4% at 15, +25.3% at 25), and correctly decays toward zero as the budget approaches the full directory.
+
+The citation audit is deliberately independent: it re-slices each stored span out of its retained transcript and compares it to the stored quote, rather than reusing the engine's own gate.
+
+## Honest limits
+
+- **Recall is 44.7%.** Over half of attempted facts stay `unknown`, driven by unreachable lines, staff who genuinely do not know, and ambiguous speech. That is the designed trade, and nobody should read it as a good number in isolation.
+- **The 0.00% false-publish rate is the rate at which the system publishes a wrong value on its own authority.** If a human blanket-approves all 34 review rows unread, it becomes 5.63%. Both figures are shown on screen, because `approveAll()` simulates exactly the rubber-stamping the review queue exists to prevent.
+- `capacity_status` recall is 24% — the most volatile field and the least reliably answered, so it burns budget for little return.
+- `open_now` precision is 84%, the weakest field: stale voicemail greetings get cited as evidence about today. They are correctly low-confidence and routed to review, but this is the softest part of the extractor.
+- The extractor is **rule-based, not a model**: deterministic and auditable, but it misses phrasings outside its rules — which surfaces as `unknown`, never as a wrong answer.
+- The directory is synthetic. The schema is realistic; the facilities are not. Do not drive anywhere based on it.
+
+## Run it
+
+Static files only. No build step, no CDN, no backend, no credentials.
+
+```bash
+cd apps/web/locked-door
+python3 -m http.server 8810
+# open http://127.0.0.1:8810/
+```
+
+Headless verification, which prints the same numbers as the browser:
+
+```bash
+node tools/smoke.mjs 25
+```
+
+## Layout
+
+```
+index.html          operator UI: call queue, live runner, review queue, evaluation
+css/app.css
+js/risk.js          harm x staleness x observability scoring
+js/planner.js       greedy submodular selection under a call budget
+js/transport.js     call transport interface: disabled real adapter + simulator
+js/dialogue.js      seeded facility personas, IVR, voicemail, hedging
+js/extract.js       typed extraction, citation enforcement, confidence
+js/publish.js       delta store, per-field history, freshness decay
+js/evaluate.js      precision/recall/unknown/false-publish, baseline comparison
+js/main.js          UI wiring and window.__demo hooks
+data/               synthetic directory + ground truth
+tools/smoke.mjs     headless run, identical codepath
+```
+
+## Upstream project
+
+Source repository: <https://github.com/rishabhcli/call-e-your-code-is-calling>
+Demo video: <https://youtu.be/iI-PyPrgk58>
+
+## License
+
+MIT, matching this repository.

--- a/apps/web/locked-door/css/app.css
+++ b/apps/web/locked-door/css/app.css
@@ -1,0 +1,349 @@
+/* Calm public-service ops console. Dense, low-chroma, no decoration that isn't
+   carrying information. Target viewport 1920x1080. */
+
+:root {
+  --ink-0: #0d1117;
+  --ink-1: #141a22;
+  --ink-2: #1b232d;
+  --ink-3: #232d3a;
+  --line: #2c3846;
+  --line-soft: #222c38;
+  --text: #dbe3ec;
+  --text-dim: #93a1b1;
+  --text-faint: #677484;
+  --heat: #e8963c;
+  --heat-soft: #4a3521;
+  --verified: #4fb3a4;
+  --review: #d8a13a;
+  --danger: #d9705f;
+  --plan: #6ea8d8;
+  --base: #6b7787;
+  --radius: 6px;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--ink-0);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 13px;
+  overflow: hidden;
+}
+
+#app {
+  height: 100vh;
+  display: grid;
+  /* 1920x1080: 62 topbar + 8 gap + main + 8 gap + 318 evaluation + 16 padding.
+     The evaluation row is fixed because its content is fixed (one hero tile,
+     six metric tiles, a six-row table and two charts); the centre column is the
+     only thing that should absorb a different viewport. */
+  grid-template-rows: 62px minmax(0, 1fr) 318px;
+  gap: 8px;
+  padding: 8px;
+}
+
+/* ============================== TOP BAR ============================== */
+.topbar {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  background: var(--ink-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0 14px;
+}
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand-mark {
+  width: 30px; height: 30px; border-radius: 5px; flex: none;
+  background: linear-gradient(150deg, var(--heat) 0%, #b5541f 100%);
+  position: relative;
+}
+.brand-mark::after {
+  content: ""; position: absolute; inset: 9px 8px;
+  border: 2px solid rgba(13, 17, 23, 0.72); border-radius: 2px; border-top: none;
+}
+.brand-text h1 { font-size: 14px; margin: 0; font-weight: 620; letter-spacing: -0.1px; }
+.brand-text p { margin: 1px 0 0; font-size: 10.5px; color: var(--text-faint); }
+
+.sim-banner {
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(232, 150, 60, 0.09);
+  border: 1px solid rgba(232, 150, 60, 0.38);
+  border-radius: var(--radius);
+  padding: 6px 11px;
+  font-size: 11px; line-height: 1.35;
+  color: #f0d3ad;
+  min-width: 0;
+}
+.sim-banner strong { color: var(--heat); letter-spacing: 0.35px; font-size: 10.5px; display: block; }
+.sim-banner span { color: #c8b294; }
+.sim-banner code { font-family: var(--mono); color: #e6c79c; font-size: 10px; }
+.sim-dot {
+  width: 8px; height: 8px; border-radius: 50%; background: var(--heat); flex: none;
+  box-shadow: 0 0 0 3px rgba(232, 150, 60, 0.2);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.42; } }
+
+.controls { display: flex; align-items: center; gap: 8px; }
+.budget { display: flex; flex-direction: column; gap: 2px; font-size: 9.5px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.5px; }
+.budget input, .budget select {
+  background: var(--ink-0); border: 1px solid var(--line); color: var(--text);
+  border-radius: 4px; padding: 4px 6px; font-size: 12px; font-family: var(--mono); width: 74px;
+}
+button {
+  font-family: var(--sans); font-size: 11.5px; border-radius: 4px; cursor: pointer;
+  padding: 7px 12px; border: 1px solid var(--line); background: var(--ink-3); color: var(--text);
+  transition: background 0.12s, border-color 0.12s;
+}
+button:hover { background: #2b3745; border-color: #3d4c5d; }
+button:disabled { opacity: 0.42; cursor: not-allowed; }
+button.primary { background: #234358; border-color: #2f5c78; color: #cfe6f4; }
+button.primary:hover { background: #2a5169; }
+button.ghost { background: transparent; }
+button.small { padding: 4px 8px; font-size: 10.5px; }
+
+/* ============================== LAYOUT =============================== */
+.grid {
+  display: grid;
+  grid-template-columns: 392px minmax(0, 1fr) 468px;
+  gap: 8px;
+  min-height: 0;
+}
+.panel {
+  background: var(--ink-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  display: flex; flex-direction: column;
+  min-height: 0; min-width: 0;
+}
+.panel-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 9px 12px; border-bottom: 1px solid var(--line-soft); flex: none;
+}
+.panel-head.second { border-top: 1px solid var(--line); }
+.panel-head h2 { font-size: 11.5px; margin: 0; font-weight: 600; letter-spacing: 0.3px; text-transform: uppercase; color: var(--text-dim); }
+.hint { font-size: 10.5px; color: var(--text-faint); font-family: var(--mono); }
+
+/* ============================ CALL QUEUE ============================= */
+.budget-box { padding: 10px 12px; border-bottom: 1px solid var(--line-soft); flex: none; }
+.bb-row { display: flex; justify-content: space-between; font-size: 11px; color: var(--text-dim); margin-bottom: 3px; }
+.bb-row b { font-family: var(--mono); color: var(--text); }
+.bb-bar { height: 6px; background: var(--ink-0); border-radius: 3px; overflow: hidden; margin: 6px 0 8px; border: 1px solid var(--line-soft); }
+.bb-bar i { display: block; height: 100%; background: linear-gradient(90deg, #2f6f88, var(--plan)); width: 0; transition: width 0.5s ease; }
+.bb-compare { display: grid; grid-template-columns: 1fr 1fr auto; gap: 6px; align-items: center; margin-bottom: 7px; }
+.bb-compare b { font-family: var(--mono); font-size: 13px; display: block; }
+.tag { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; padding: 1px 5px; border-radius: 3px; display: inline-block; margin-bottom: 2px; }
+.tag-plan { background: rgba(110, 168, 216, 0.16); color: var(--plan); }
+.tag-base { background: rgba(107, 119, 135, 0.18); color: var(--base); }
+.lift { text-align: right; }
+.lift b { color: var(--verified); font-size: 15px; }
+.lift span { font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.4px; }
+.bb-note { font-size: 10px; color: var(--text-faint); line-height: 1.45; margin: 0; }
+
+.queue { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; min-height: 0; }
+.qrow {
+  padding: 7px 12px; border-bottom: 1px solid var(--line-soft);
+  display: grid; grid-template-columns: 26px minmax(0, 1fr) 54px; gap: 8px; align-items: start;
+  cursor: default; transition: background 0.12s;
+}
+.qrow:hover { background: var(--ink-2); }
+.qrow.active { background: rgba(110, 168, 216, 0.1); box-shadow: inset 2px 0 0 var(--plan); }
+.qrow.done { opacity: 0.62; }
+.qrow.done.active { opacity: 1; }
+.qrank { font-family: var(--mono); font-size: 11px; color: var(--text-faint); padding-top: 1px; }
+.qname { font-size: 11.5px; font-weight: 550; line-height: 1.25; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.qsub { font-size: 10px; color: var(--text-faint); font-family: var(--mono); margin-top: 1px; }
+.qchips { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 4px; }
+.chip {
+  font-size: 8.5px; padding: 1px 4px; border-radius: 3px; font-family: var(--mono);
+  background: var(--ink-3); color: var(--text-dim); border: 1px solid transparent;
+}
+.chip.g { background: rgba(79, 179, 164, 0.15); color: var(--verified); border-color: rgba(79, 179, 164, 0.3); }
+.chip.u { background: rgba(107, 119, 135, 0.12); color: var(--text-faint); }
+.chip.r { background: rgba(216, 161, 58, 0.15); color: var(--review); border-color: rgba(216, 161, 58, 0.3); }
+.qscore { text-align: right; font-family: var(--mono); font-size: 12px; color: var(--heat); }
+.qscore small { display: block; font-size: 8.5px; color: var(--text-faint); }
+.qbar { height: 3px; background: var(--ink-0); border-radius: 2px; margin-top: 3px; overflow: hidden; }
+.qbar i { display: block; height: 100%; background: var(--heat); }
+.qstatus { font-size: 9px; font-family: var(--mono); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 3px; }
+.s-connected { color: var(--verified); }
+.s-voicemail { color: var(--review); }
+.s-no_answer, .s-busy { color: var(--text-faint); }
+.s-disconnected, .s-no_number, .s-ivr_dead_end { color: var(--danger); }
+
+/* ============================== RUNNER =============================== */
+.call-head {
+  padding: 10px 14px; border-bottom: 1px solid var(--line-soft); flex: none;
+  display: flex; justify-content: space-between; align-items: flex-start; gap: 12px;
+}
+.ch-main h3 { margin: 0; font-size: 14px; font-weight: 600; }
+.ch-main p { margin: 3px 0 0; font-size: 10.5px; color: var(--text-faint); font-family: var(--mono); }
+.ch-badges { display: flex; gap: 5px; flex-wrap: wrap; justify-content: flex-end; }
+.badge {
+  font-size: 9.5px; font-family: var(--mono); padding: 2px 7px; border-radius: 3px;
+  background: var(--ink-3); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.4px;
+  border: 1px solid var(--line);
+}
+.badge.ok { background: rgba(79, 179, 164, 0.14); color: var(--verified); border-color: rgba(79, 179, 164, 0.3); }
+.badge.warn { background: rgba(216, 161, 58, 0.14); color: var(--review); border-color: rgba(216, 161, 58, 0.3); }
+.badge.bad { background: rgba(217, 112, 95, 0.14); color: var(--danger); border-color: rgba(217, 112, 95, 0.3); }
+
+.runner-body { display: grid; grid-template-rows: minmax(0, 1fr) auto; min-height: 0; flex: 1; }
+.sub-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 6px 14px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+  color: var(--text-faint); border-bottom: 1px solid var(--line-soft);
+}
+.sub-head em { font-style: normal; color: var(--heat); }
+.transcript-wrap { display: flex; flex-direction: column; min-height: 0; }
+.transcript { overflow-y: auto; padding: 8px 14px 14px; flex: 1; min-height: 0; font-size: 12px; line-height: 1.5; }
+.turn { margin-bottom: 6px; display: grid; grid-template-columns: 62px minmax(0, 1fr); gap: 9px; }
+.turn .who {
+  font-family: var(--mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.5px;
+  padding-top: 2px; text-align: right; color: var(--text-faint);
+}
+.turn.agent .who { color: var(--plan); }
+.turn.staff .who { color: #c3cede; }
+.turn.system .who { color: var(--text-faint); }
+.turn .said { color: var(--text); }
+.turn.system .said { color: var(--text-faint); font-style: italic; font-size: 11px; }
+.turn.agent .said { color: #b9cfe2; }
+.turn mark { background: rgba(79, 179, 164, 0.26); color: #d6f2ec; border-radius: 2px; padding: 0 1px; box-shadow: 0 0 0 1px rgba(79, 179, 164, 0.4); }
+.turn mark.flash { animation: flash 1.1s ease; }
+@keyframes flash { 0% { background: rgba(232,150,60,0.6); } 100% { background: rgba(79,179,164,0.26); } }
+
+.fields-wrap { border-top: 1px solid var(--line); flex: none; }
+.fields { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; padding: 8px 14px 10px; }
+.fcard {
+  background: var(--ink-2); border: 1px solid var(--line-soft); border-radius: 5px;
+  padding: 6px 8px; min-height: 62px; position: relative; transition: border-color 0.25s, background 0.25s;
+}
+.fcard .fname { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-faint); font-family: var(--mono); }
+.fcard .fval { font-size: 13px; font-weight: 600; margin-top: 2px; font-family: var(--mono); color: var(--text-faint); }
+.fcard .fmeta { font-size: 9px; color: var(--text-faint); margin-top: 3px; font-family: var(--mono); }
+.fcard.grounded { border-color: rgba(79, 179, 164, 0.45); background: rgba(79, 179, 164, 0.07); }
+.fcard.grounded .fval { color: var(--verified); }
+.fcard.review { border-color: rgba(216, 161, 58, 0.45); background: rgba(216, 161, 58, 0.06); }
+.fcard.review .fval { color: var(--review); }
+.fcard.unknown .fval { color: var(--text-faint); }
+.fcard .cite {
+  margin-top: 4px; font-size: 9.5px; color: #9fd3c9; font-family: var(--mono);
+  border-left: 2px solid rgba(79, 179, 164, 0.5); padding-left: 5px; cursor: pointer;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.fcard.review .cite { color: #dcc189; border-left-color: rgba(216, 161, 58, 0.5); }
+.fcard .cite:hover { text-decoration: underline; }
+.fcard .no-cite { margin-top: 4px; font-size: 9.5px; color: var(--text-faint); font-family: var(--mono); font-style: italic; }
+
+/* ========================== REVIEW / DELTA =========================== */
+.review-list, .delta-list { overflow-y: auto; padding: 6px 10px 10px; min-height: 0; }
+.review-list { flex: 1.15; }
+.delta-list { flex: 1; }
+.empty { font-size: 10.5px; color: var(--text-faint); line-height: 1.5; padding: 4px 2px; margin: 0; }
+.rrow {
+  border: 1px solid var(--line-soft); border-radius: 5px; padding: 7px 9px; margin-bottom: 6px;
+  background: var(--ink-2); font-size: 11px;
+}
+.rrow.needs { border-left: 3px solid var(--review); }
+.rrow.auto { border-left: 3px solid var(--verified); }
+.rrow.human { border-left: 3px solid var(--plan); }
+.rr-top { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.rr-fac { font-size: 10px; color: var(--text-faint); font-family: var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rr-field { font-family: var(--mono); font-size: 11px; color: var(--text); font-weight: 600; }
+.rr-change { margin-top: 3px; font-family: var(--mono); font-size: 11px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.rr-old { color: var(--text-faint); text-decoration: line-through; }
+.rr-arrow { color: var(--text-faint); }
+.rr-new { color: var(--verified); font-weight: 600; }
+.rrow.needs .rr-new { color: var(--review); }
+.rr-why { margin-top: 3px; font-size: 10px; color: var(--text-dim); line-height: 1.4; }
+.rr-quote {
+  margin-top: 4px; font-size: 10px; color: #a8bccb; font-style: italic;
+  border-left: 2px solid var(--line); padding-left: 6px; line-height: 1.4;
+}
+.rr-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 5px; gap: 6px; }
+.rr-conf { font-family: var(--mono); font-size: 9.5px; color: var(--text-faint); }
+.rr-actions { display: flex; gap: 4px; }
+.rr-actions button { padding: 2px 8px; font-size: 10px; }
+.confbar { height: 3px; width: 52px; background: var(--ink-0); border-radius: 2px; overflow: hidden; display: inline-block; vertical-align: middle; margin-left: 5px; }
+.confbar i { display: block; height: 100%; }
+
+/* ============================ EVALUATION ============================= */
+.evalpanel { min-height: 0; }
+.eval-grid {
+  display: grid; grid-template-columns: 452px 400px minmax(0, 1fr);
+  gap: 14px; padding: 10px 14px; overflow: hidden; min-height: 0; flex: 1;
+}
+.tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; align-content: start; }
+.tile {
+  background: var(--ink-2); border: 1px solid var(--line-soft); border-radius: 5px; padding: 7px 9px;
+}
+.tile .tv { font-family: var(--mono); font-size: 19px; font-weight: 600; line-height: 1.05; }
+.tile .tl { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-faint); margin-top: 2px; }
+.tile .td { font-size: 9.5px; color: var(--text-faint); margin-top: 3px; font-family: var(--mono); }
+.tile.good .tv { color: var(--verified); }
+.tile.warn .tv { color: var(--review); }
+.tile.bad .tv { color: var(--danger); }
+.tile.neutral .tv { color: var(--text); }
+.tile.hero { grid-column: span 3; background: rgba(79, 179, 164, 0.07); border-color: rgba(79, 179, 164, 0.34); }
+.tile.hero .tv { font-size: 17px; color: var(--verified); }
+.tile.hero .tl { color: #8fb9b1; }
+.tile.hero .td { color: #9fd3c9; }
+
+.eval-table-wrap { overflow-y: auto; min-height: 0; }
+.eval-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 10.5px; }
+.eval-table th {
+  text-align: right; color: var(--text-faint); font-weight: 500; padding: 3px 6px;
+  border-bottom: 1px solid var(--line); position: sticky; top: 0; background: var(--ink-1);
+  text-transform: uppercase; font-size: 9px; letter-spacing: 0.4px;
+}
+.eval-table th:first-child, .eval-table td:first-child { text-align: left; }
+.eval-table td { padding: 3px 6px; border-bottom: 1px solid var(--line-soft); text-align: right; color: var(--text-dim); }
+.eval-table td.v { color: var(--text); }
+
+.eval-charts { display: grid; grid-template-rows: auto minmax(0, 1fr); gap: 8px; min-height: 0; }
+.chart-block h4 { margin: 0 0 5px; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-faint); font-weight: 500; }
+.chart-block h4 em { font-style: normal; color: var(--text-faint); text-transform: none; letter-spacing: 0; }
+.harm-bars { display: flex; flex-direction: column; gap: 5px; }
+.hb { display: grid; grid-template-columns: 96px minmax(0, 1fr) 62px; gap: 8px; align-items: center; font-size: 10px; }
+.hb-label { color: var(--text-dim); font-size: 10px; }
+.hb-track { height: 13px; background: var(--ink-0); border: 1px solid var(--line-soft); border-radius: 3px; overflow: hidden; }
+.hb-fill { height: 100%; transition: width 0.6s ease; }
+.hb-val { font-family: var(--mono); text-align: right; color: var(--text); font-size: 11px; }
+#decay-chart { width: 100%; height: 98px; display: block; }
+.decay-legend { display: flex; gap: 9px; flex-wrap: wrap; font-size: 9px; font-family: var(--mono); color: var(--text-faint); margin-top: 2px; }
+.decay-legend span { display: flex; align-items: center; gap: 3px; }
+.decay-legend i { width: 8px; height: 2px; display: inline-block; }
+
+/* ============================== MODAL =============================== */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(5, 8, 11, 0.76);
+  display: flex; align-items: center; justify-content: center; z-index: 40;
+}
+.modal-backdrop[hidden] { display: none; }
+.modal {
+  background: var(--ink-1); border: 1px solid var(--line); border-radius: 7px;
+  width: 860px; max-height: 80vh; display: flex; flex-direction: column; padding: 14px 16px;
+}
+.modal-head { display: flex; justify-content: space-between; align-items: center; }
+.modal-head h3 { margin: 0; font-size: 13px; color: var(--heat); }
+.modal-note { font-size: 11px; color: var(--text-dim); line-height: 1.5; margin: 8px 0; }
+.modal-note code { font-family: var(--mono); color: #e6c79c; font-size: 10.5px; }
+.modal pre {
+  background: var(--ink-0); border: 1px solid var(--line); border-radius: 5px;
+  padding: 11px; font-family: var(--mono); font-size: 11px; color: #b9cfe2;
+  overflow: auto; margin: 0; line-height: 1.55; white-space: pre-wrap; word-break: break-word;
+}
+
+/* scrollbars */
+::-webkit-scrollbar { width: 9px; height: 9px; }
+::-webkit-scrollbar-track { background: var(--ink-0); }
+::-webkit-scrollbar-thumb { background: #2b3541; border-radius: 5px; border: 2px solid var(--ink-0); }
+::-webkit-scrollbar-thumb:hover { background: #384552; }

--- a/apps/web/locked-door/data/directory.json
+++ b/apps/web/locked-door/data/directory.json
@@ -1,0 +1,3024 @@
+{
+ "dataset": "Simulated Maricopa County Heat Relief Network directory",
+ "note": "Synthetic. Names, addresses and 555-prefixed numbers are fictional. Modeled on the shape and failure modes of real published county heat-relief directories.",
+ "generated_at": "2026-08-26T16:00:00.000Z",
+ "as_of": "2026-08-26T16:00:00.000Z",
+ "field_schema": [
+  "open_now",
+  "hours",
+  "pet_policy",
+  "accessibility",
+  "intake_requirements",
+  "capacity_status"
+ ],
+ "facilities": [
+  {
+   "id": "MC-1001",
+   "name": "Sunnyslope Library Cooling Center",
+   "operator": "Maricopa County Human Services",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "7309 W Van Buren St, Phoenix, AZ 85090",
+   "address_is_po_box": false,
+   "phone": "(618) 555-1918",
+   "est_daily_visitors": 302,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-02T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "9am-3pm",
+     "last_verified": "2025-12-25T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "svc animals only",
+     "last_verified": "2025-09-19T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-01-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2026-03-10T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1002",
+   "name": "Maryvale Community Center",
+   "operator": "City of Phoenix Parks & Rec",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "4199 E Roosevelt St, Mesa, AZ 85273",
+   "address_is_po_box": false,
+   "phone": "(623) 555-1414",
+   "est_daily_visitors": 49,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "8:00 AM – 7:00 PM",
+     "last_verified": "2026-06-29T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-07-15T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-07T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1003",
+   "name": "Encanto Overnight Heat Respite",
+   "operator": "Salvation Army Valley Corps",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "7161 N Central Ave, Glendale, AZ 85384",
+   "address_is_po_box": false,
+   "phone": null,
+   "est_daily_visitors": 245,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-30T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "M-F 6-8",
+     "last_verified": "2025-12-27T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2025-11-19T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-06-20T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2026-06-03T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-07-23T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1004",
+   "name": "Desert Vista Hydration Station",
+   "operator": "St. Vincent de Paul",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "6654 S 7th Ave, Tempe, AZ 85268",
+   "address_is_po_box": false,
+   "phone": "(613) 555-1809",
+   "est_daily_visitors": 269,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-30T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 10 a.m. to 10 p.m.",
+     "last_verified": "2026-03-29T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "No pets",
+     "last_verified": "2025-09-23T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-07-13T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-17T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1005",
+   "name": "Ocotillo Faith-Based Relief Site",
+   "operator": "Phoenix Public Library",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "3903 W Indian School Rd, Chandler, AZ 85220",
+   "address_is_po_box": false,
+   "phone": "(607) 555-1754",
+   "est_daily_visitors": 39,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-10T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "1100-1700",
+     "last_verified": "2026-03-17T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "Pets OK",
+     "last_verified": "2026-07-25T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-12-25T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1006",
+   "name": "Papago Senior Center",
+   "operator": "Mesa Community Services",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "9657 E Thomas Rd, Peoria, AZ 85320",
+   "address_is_po_box": false,
+   "phone": "(605) 555-1054",
+   "est_daily_visitors": 207,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-09T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "Daily 9AM to 9PM",
+     "last_verified": "2025-07-30T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2025-10-07T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-07-05T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1007",
+   "name": "South Mountain Mobile Relief Unit",
+   "operator": "Glendale Neighborhood Services",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "PO Box 6511, Surprise, AZ 85312",
+   "address_is_po_box": true,
+   "phone": "(616) 555-1754",
+   "est_daily_visitors": 214,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-15T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Open 7:00-21:00 (closed holidays)",
+     "last_verified": "2026-04-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-02-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2025-09-08T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1008",
+   "name": "Cave Creek Municipal Lobby Site",
+   "operator": "Tempe Community Action Agency",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "930 W Camelback Rd, Avondale, AZ 85365",
+   "address_is_po_box": false,
+   "phone": "(615) 555-0152",
+   "est_daily_visitors": 339,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-08T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "9 am - 8 pm, weekdays only",
+     "last_verified": "2026-07-11T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Pet friendly",
+     "last_verified": "2026-04-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-08-23T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2026-02-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-08T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1009",
+   "name": "Estrella Library Cooling Center",
+   "operator": "Lutheran Social Services SW",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "1338 S Mill Ave, Scottsdale, AZ 85291",
+   "address_is_po_box": false,
+   "phone": "(615) 555-0149",
+   "est_daily_visitors": 298,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-01T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "9am-7pm",
+     "last_verified": "2026-03-15T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2026-04-09T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-07-21T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1010",
+   "name": "Palo Verde Community Center",
+   "operator": "Central Arizona Shelter Services",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "9407 E Broadway Rd, Gilbert, AZ 85229",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1026",
+   "est_daily_visitors": 81,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-05T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "10:00 AM – 4:00 PM",
+     "last_verified": "2025-08-13T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-06-16T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1011",
+   "name": "Camelback East Overnight Heat Respite",
+   "operator": "Chicanos Por La Causa",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "310 N Scottsdale Rd, Phoenix, AZ 85064",
+   "address_is_po_box": false,
+   "phone": "+1 623 555 1387",
+   "est_daily_visitors": 126,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-24T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "M-F 10-4",
+     "last_verified": "2025-08-08T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Pets OK",
+     "last_verified": "2026-05-20T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-01-26T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-07-09T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1012",
+   "name": "Deer Valley Hydration Station",
+   "operator": "Society of St. Vincent",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "4965 W Peoria Ave, Mesa, AZ 85236",
+   "address_is_po_box": false,
+   "phone": "(611) 555-1678",
+   "est_daily_visitors": 130,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-03T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 10 a.m. to 9 p.m.",
+     "last_verified": "2025-11-11T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2025-06-23T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-08-02T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1013",
+   "name": "Laveen Faith-Based Relief Site",
+   "operator": "Valley of the Sun United Way",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "PO Box 2962, Glendale, AZ 85326",
+   "address_is_po_box": true,
+   "phone": "(604) 555-1393",
+   "est_daily_visitors": 278,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-30T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "800-2000",
+     "last_verified": "2026-01-20T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Pets OK",
+     "last_verified": "2026-06-10T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-06-27T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2025-07-06T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-08-09T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1014",
+   "name": "Ahwatukee Senior Center",
+   "operator": "Native Health Phoenix",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "4273 N 35th Ave, Tempe, AZ 85223",
+   "address_is_po_box": false,
+   "phone": "(621) 555-1874",
+   "est_daily_visitors": 163,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-07T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "Daily 8AM to 8PM",
+     "last_verified": "2026-05-05T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2025-12-17T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-10-25T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2026-05-05T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-08-09T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1015",
+   "name": "Verrado Mobile Relief Unit",
+   "operator": "Justa Center",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "2888 W Bethany Home Rd, Chandler, AZ 85251",
+   "address_is_po_box": false,
+   "phone": "(613) 555-1414",
+   "est_daily_visitors": 297,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-09T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "Open 11:00-18:00 (closed holidays)",
+     "last_verified": "2025-12-27T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2026-02-23T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-06-03T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1016",
+   "name": "Agua Fria Municipal Lobby Site",
+   "operator": "Maricopa County Human Services",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "9396 S Country Club Dr, Peoria, AZ 85367",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1550",
+   "est_daily_visitors": 142,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-31T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "8 am - 9 pm, weekdays only",
+     "last_verified": "2026-07-08T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2026-01-26T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-01-09T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2025-09-14T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1017",
+   "name": "Copper Sky Library Cooling Center",
+   "operator": "City of Phoenix Parks & Rec",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "PO Box 6703, Surprise, AZ 85345",
+   "address_is_po_box": true,
+   "phone": "(602) 555-1483",
+   "est_daily_visitors": 277,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-01T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "pets welcome",
+     "last_verified": "2026-03-19T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-11-13T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-03-28T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-08-19T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1018",
+   "name": "Red Mountain Community Center",
+   "operator": "Salvation Army Valley Corps",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "8969 N 19th Ave, Avondale, AZ 85373",
+   "address_is_po_box": false,
+   "phone": "(619) 555-1855",
+   "est_daily_visitors": 231,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-18T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-03-27T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-03-21T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1019",
+   "name": "Dobson Ranch Overnight Heat Respite",
+   "operator": "St. Vincent de Paul",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "6227 W Dunlap Ave, Scottsdale, AZ 85253",
+   "address_is_po_box": false,
+   "phone": "(603) 555-1544",
+   "est_daily_visitors": 215,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": false,
+     "last_verified": "2026-07-31T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2025-06-22T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-06-04T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2026-04-22T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1020",
+   "name": "Val Vista Hydration Station",
+   "operator": "Phoenix Public Library",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "1663 E McDowell Rd, Gilbert, AZ 85254",
+   "address_is_po_box": false,
+   "phone": "(613) 555-0140",
+   "est_daily_visitors": 18,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-04T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 7 a.m. to 5 p.m.",
+     "last_verified": "2026-03-31T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-06-22T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1021",
+   "name": "Arrowhead Faith-Based Relief Site",
+   "operator": "Mesa Community Services",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "1503 W Van Buren St, Phoenix, AZ 85057",
+   "address_is_po_box": false,
+   "phone": "(622) 555-1596",
+   "est_daily_visitors": 215,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": false,
+     "last_verified": "2026-07-25T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "1100-2000",
+     "last_verified": "2025-12-24T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2026-06-09T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2024-10-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1022",
+   "name": "Litchfield Senior Center",
+   "operator": "Glendale Neighborhood Services",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "284 E Roosevelt St, Mesa, AZ 85230",
+   "address_is_po_box": false,
+   "phone": "(615) 555-1713",
+   "est_daily_visitors": 185,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-13T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "Daily 10AM to 5PM",
+     "last_verified": "2026-08-03T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Service animals only",
+     "last_verified": "2025-11-29T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-09-11T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1023",
+   "name": "Roosevelt Row Mobile Relief Unit",
+   "operator": "Tempe Community Action Agency",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "1927 N Central Ave, Glendale, AZ 85335",
+   "address_is_po_box": false,
+   "phone": "(622) 555-1665",
+   "est_daily_visitors": 284,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-21T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Open 7:00-21:00 (closed holidays)",
+     "last_verified": "2026-02-10T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-07-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2026-03-18T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1024",
+   "name": "Grant Park Municipal Lobby Site",
+   "operator": "Lutheran Social Services SW",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "1398 S 7th Ave, Tempe, AZ 85271",
+   "address_is_po_box": false,
+   "phone": "(623) 555-0155",
+   "est_daily_visitors": 257,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-03-29T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2025-07-13T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1025",
+   "name": "Coronado Library Cooling Center",
+   "operator": "Central Arizona Shelter Services",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "3646 W Indian School Rd, Chandler, AZ 85280",
+   "address_is_po_box": false,
+   "phone": "(606) 555-1540",
+   "est_daily_visitors": 39,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-29T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "10am-6pm",
+     "last_verified": "2025-12-21T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "No pets",
+     "last_verified": "2025-05-23T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-05-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-07-16T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1026",
+   "name": "Garfield Community Center",
+   "operator": "Chicanos Por La Causa",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "PO Box 8801, Peoria, AZ 85386",
+   "address_is_po_box": true,
+   "phone": "(619) 555-1840",
+   "est_daily_visitors": 275,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-24T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "8:00 AM – 8:00 PM",
+     "last_verified": "2025-10-01T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-09-02T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-06-29T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1027",
+   "name": "Eastlake Overnight Heat Respite",
+   "operator": "Society of St. Vincent",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "6984 N 51st Ave, Surprise, AZ 85321",
+   "address_is_po_box": false,
+   "phone": "(615) 555-1465",
+   "est_daily_visitors": 175,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-21T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "M-F 8-7",
+     "last_verified": "2026-05-08T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "pets welcome",
+     "last_verified": "2026-03-22T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-06-20T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-01-30T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-31T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1028",
+   "name": "Alhambra Hydration Station",
+   "operator": "Valley of the Sun United Way",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "1139 W Camelback Rd, Avondale, AZ 85355",
+   "address_is_po_box": false,
+   "phone": null,
+   "est_daily_visitors": 100,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-02T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 11 a.m. to 8 p.m.",
+     "last_verified": "2026-06-17T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-01-04T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-01-20T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2025-08-16T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1029",
+   "name": "North Gateway Faith-Based Relief Site",
+   "operator": "Native Health Phoenix",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "1118 S Mill Ave, Scottsdale, AZ 85222",
+   "address_is_po_box": false,
+   "phone": null,
+   "est_daily_visitors": 180,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-26T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "1100-2300",
+     "last_verified": "2025-07-31T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2025-04-10T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-08-06T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1030",
+   "name": "Rio Vista Senior Center",
+   "operator": "Justa Center",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "1066 E Broadway Rd, Gilbert, AZ 85244",
+   "address_is_po_box": false,
+   "phone": "(621) 555-1788",
+   "est_daily_visitors": 139,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-23T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Daily 9AM to 5PM",
+     "last_verified": "2026-07-12T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2025-10-01T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2024-10-30T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2026-01-24T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1031",
+   "name": "Tolleson Mobile Relief Unit",
+   "operator": "Maricopa County Human Services",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "3395 N Scottsdale Rd, Phoenix, AZ 85064",
+   "address_is_po_box": false,
+   "phone": "(611) 555-1582",
+   "est_daily_visitors": 211,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-02T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Open 9:00-21:00 (closed holidays)",
+     "last_verified": "2026-08-14T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2025-05-11T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-03-25T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2025-08-17T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1032",
+   "name": "Sun City Municipal Lobby Site",
+   "operator": "City of Phoenix Parks & Rec",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "Mesa, AZ",
+   "address_is_po_box": false,
+   "phone": "(623) 555-1102",
+   "est_daily_visitors": 33,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-29T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-03-20T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2025-08-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1033",
+   "name": "Youngtown Library Cooling Center",
+   "operator": "Salvation Army Valley Corps",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "6359 E Baseline Rd, Glendale, AZ 85323",
+   "address_is_po_box": false,
+   "phone": "(613) 555-1033",
+   "est_daily_visitors": 204,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-31T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "10am-6pm",
+     "last_verified": "2026-07-08T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-07-19T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2024-11-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-02-10T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1034",
+   "name": "El Mirage Community Center",
+   "operator": "St. Vincent de Paul",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "8727 N 35th Ave, Tempe, AZ 85237",
+   "address_is_po_box": false,
+   "phone": "617-555-1681 ext 573",
+   "est_daily_visitors": 108,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-23T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2025-12-25T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-02-04T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-07-06T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1035",
+   "name": "Guadalupe Overnight Heat Respite",
+   "operator": "Phoenix Public Library",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "1427 W Bethany Home Rd, Chandler, AZ 85295",
+   "address_is_po_box": false,
+   "phone": "(606) 555-1469",
+   "est_daily_visitors": 279,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-29T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "M-F 8-11",
+     "last_verified": "2025-09-17T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "Pet friendly",
+     "last_verified": "2026-07-10T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2024-10-03T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2026-02-09T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-08-02T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1036",
+   "name": "Buckeye Hydration Station",
+   "operator": "Mesa Community Services",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "9557 S Country Club Dr, Peoria, AZ 85356",
+   "address_is_po_box": false,
+   "phone": "(605) 555-1209",
+   "est_daily_visitors": 221,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-26T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 9 a.m. to 4 p.m.",
+     "last_verified": "2026-04-17T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "No pets",
+     "last_verified": "2025-09-28T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-24T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1037",
+   "name": "Anthem Faith-Based Relief Site",
+   "operator": "Glendale Neighborhood Services",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "7880 E Guadalupe Rd, Surprise, AZ 85311",
+   "address_is_po_box": false,
+   "phone": "618.555.1964",
+   "est_daily_visitors": 130,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-16T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "1000-2000",
+     "last_verified": "2025-11-01T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-08-10T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1038",
+   "name": "Cactus Park Senior Center",
+   "operator": "Tempe Community Action Agency",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "9434 N 19th Ave, Avondale, AZ 85374",
+   "address_is_po_box": false,
+   "phone": "(603) 555-1473",
+   "est_daily_visitors": 198,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-07-03T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "Daily 9AM to 9PM",
+     "last_verified": "2025-09-05T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1039",
+   "name": "Harmon Mobile Relief Unit",
+   "operator": "Lutheran Social Services SW",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "8206 W Dunlap Ave, Scottsdale, AZ 85230",
+   "address_is_po_box": false,
+   "phone": null,
+   "est_daily_visitors": 215,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-24T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "Open 7:00-16:00 (closed holidays)",
+     "last_verified": "2026-06-24T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-02-23T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-06-11T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1040",
+   "name": "Yucca Municipal Lobby Site",
+   "operator": "Central Arizona Shelter Services",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "3943 E McDowell Rd, Gilbert, AZ 85287",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1123",
+   "est_daily_visitors": 29,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-10T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "11 am - 7 pm, weekdays only",
+     "last_verified": "2026-08-11T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Pets OK",
+     "last_verified": "2026-07-10T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-05-19T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-08-17T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1041",
+   "name": "Ironwood Library Cooling Center",
+   "operator": "Chicanos Por La Causa",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "8929 W Van Buren St, Phoenix, AZ 85067",
+   "address_is_po_box": false,
+   "phone": "(617) 555-1777",
+   "est_daily_visitors": 278,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-23T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "8am-5pm",
+     "last_verified": "2025-11-19T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2026-02-02T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2025-10-19T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-08-21T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1042",
+   "name": "Saguaro Community Center",
+   "operator": "Society of St. Vincent",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "8302 E Roosevelt St, Mesa, AZ 85298",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1768",
+   "est_daily_visitors": 52,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-26T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "7:00 AM – 10:00 PM",
+     "last_verified": "2026-01-06T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2025-08-17T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-03-09T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2025-08-09T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1043",
+   "name": "Mesquite Overnight Heat Respite",
+   "operator": "Valley of the Sun United Way",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "3623 N Central Ave, Glendale, AZ 85358",
+   "address_is_po_box": false,
+   "phone": "(606) 555-1583",
+   "est_daily_visitors": 295,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-25T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "M-F 9-5",
+     "last_verified": "2026-02-24T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2026-01-20T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2026-05-13T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-07-17T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-06-27T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1044",
+   "name": "Chaparral Hydration Station",
+   "operator": "Native Health Phoenix",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "9404 S 7th Ave, Tempe, AZ 85228",
+   "address_is_po_box": false,
+   "phone": "(618) 555-0155",
+   "est_daily_visitors": 282,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-20T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 9 a.m. to 6 p.m.",
+     "last_verified": "2026-06-10T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "No pets",
+     "last_verified": "2026-04-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2025-10-29T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1045",
+   "name": "Pinnacle Peak Faith-Based Relief Site",
+   "operator": "Justa Center",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "7456 W Indian School Rd, Chandler, AZ 85294",
+   "address_is_po_box": false,
+   "phone": "+1 618 555 1845",
+   "est_daily_visitors": 63,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-03T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Service animals only",
+     "last_verified": "2026-01-15T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-01-18T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-08-15T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1046",
+   "name": "Thunderbird Senior Center",
+   "operator": "Maricopa County Human Services",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "9430 E Thomas Rd, Peoria, AZ 85387",
+   "address_is_po_box": false,
+   "phone": "(605) 555-1853",
+   "est_daily_visitors": 325,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-11T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "Daily 10AM to 8PM",
+     "last_verified": "2026-06-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-05-12T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-04-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-07-19T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1047",
+   "name": "Bell Road Mobile Relief Unit",
+   "operator": "City of Phoenix Parks & Rec",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "2779 N 51st Ave, Surprise, AZ 85311",
+   "address_is_po_box": false,
+   "phone": null,
+   "est_daily_visitors": 300,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-09T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Open 8:00-18:00 (closed holidays)",
+     "last_verified": "2026-05-18T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2025-05-11T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-06-01T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-07-26T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1048",
+   "name": "Greenway Municipal Lobby Site",
+   "operator": "Salvation Army Valley Corps",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "2726 W Camelback Rd, Avondale, AZ 85370",
+   "address_is_po_box": false,
+   "phone": "(605) 555-1347",
+   "est_daily_visitors": 337,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-10T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "8 am - 6 pm, weekdays only",
+     "last_verified": "2025-10-07T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2026-06-06T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "referral_required",
+     "last_verified": "2026-08-04T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-08-21T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1049",
+   "name": "Union Hills Library Cooling Center",
+   "operator": "St. Vincent de Paul",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "4184 S Mill Ave, Scottsdale, AZ 85237",
+   "address_is_po_box": false,
+   "phone": "(619) 555-1564",
+   "est_daily_visitors": 261,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-05-23T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-04-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2025-09-20T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1050",
+   "name": "Shea Community Center",
+   "operator": "Phoenix Public Library",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "528 E Broadway Rd, Gilbert, AZ 85281",
+   "address_is_po_box": false,
+   "phone": "(611) 555-1581",
+   "est_daily_visitors": 322,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "9:00 AM – 7:00 PM",
+     "last_verified": "2026-01-05T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "pets welcome",
+     "last_verified": "2025-10-11T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-12-24T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-08-17T16:00:00.000Z",
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1051",
+   "name": "Lone Butte Overnight Heat Respite",
+   "operator": "Mesa Community Services",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "9796 N Scottsdale Rd, Phoenix, AZ 85010",
+   "address_is_po_box": false,
+   "phone": "(617) 555-1868",
+   "est_daily_visitors": 116,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-11T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "M-F 10-9",
+     "last_verified": "2026-05-09T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2025-09-13T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "near_capacity",
+     "last_verified": "2026-07-10T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1052",
+   "name": "Sossaman Hydration Station",
+   "operator": "Glendale Neighborhood Services",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "3886 W Peoria Ave, Mesa, AZ 85279",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1764",
+   "est_daily_visitors": 52,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-25T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-01-17T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-06-29T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1053",
+   "name": "Higley Faith-Based Relief Site",
+   "operator": "Tempe Community Action Agency",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "5650 E Baseline Rd, Glendale, AZ 85362",
+   "address_is_po_box": false,
+   "phone": "(609) 555-1100",
+   "est_daily_visitors": 224,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-30T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "hours": {
+     "value": "700-1700",
+     "last_verified": "2025-07-28T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": "not_accessible",
+     "last_verified": "2026-03-18T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2026-03-29T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-07-04T16:00:00.000Z",
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-1054",
+   "name": "Recker Senior Center",
+   "operator": "Lutheran Social Services SW",
+   "kind": "senior_center",
+   "kind_label": "Senior Center",
+   "vulnerability_weight": 1.22,
+   "address": "7572 N 35th Ave, Tempe, AZ 85210",
+   "address_is_po_box": false,
+   "phone": "(610) 555-1460",
+   "est_daily_visitors": 30,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-22T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "Daily 8AM to 6PM",
+     "last_verified": "2025-12-25T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": "pets must be crated",
+     "last_verified": "2025-06-08T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2024-10-14T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-08-15T16:00:00.000Z",
+     "source": "self_reported"
+    }
+   }
+  },
+  {
+   "id": "MC-1055",
+   "name": "Signal Butte Mobile Relief Unit",
+   "operator": "Central Arizona Shelter Services",
+   "kind": "mobile_unit",
+   "kind_label": "Mobile Relief Unit",
+   "vulnerability_weight": 0.9,
+   "address": "869 W Bethany Home Rd, Chandler, AZ 85296",
+   "address_is_po_box": false,
+   "phone": "(604) 555-1035",
+   "est_daily_visitors": 130,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-06-16T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "Open 9:00-19:00 (closed holidays)",
+     "last_verified": "2026-01-23T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-03-19T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-04-16T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-07-08T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1056",
+   "name": "Crismon Municipal Lobby Site",
+   "operator": "Chicanos Por La Causa",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "PO Box 7356, Peoria, AZ 85347",
+   "address_is_po_box": true,
+   "phone": "(608) 555-1323",
+   "est_daily_visitors": 173,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-04-02",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-12T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-02-18T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1057",
+   "name": "Elliot Library Cooling Center",
+   "operator": "Society of St. Vincent",
+   "kind": "library_cooling_center",
+   "kind_label": "Library Cooling Center",
+   "vulnerability_weight": 1,
+   "address": "1776 E Guadalupe Rd, Surprise, AZ 85388",
+   "address_is_po_box": false,
+   "phone": "617.555.1819",
+   "est_daily_visitors": 230,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": false,
+     "last_verified": "2026-06-26T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "10am-3pm",
+     "last_verified": "2025-07-22T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "no animals permitted",
+     "last_verified": "2025-12-07T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2026-04-12T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "photo_id_required",
+     "last_verified": "2026-03-08T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": "space_available",
+     "last_verified": "2026-07-04T16:00:00.000Z",
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1058",
+   "name": "Warner Community Center",
+   "operator": "Valley of the Sun United Way",
+   "kind": "community_center",
+   "kind_label": "Community Center",
+   "vulnerability_weight": 1.05,
+   "address": "485 N 19th Ave, Avondale, AZ 85357",
+   "address_is_po_box": false,
+   "phone": "614-555-1654 ext 361",
+   "est_daily_visitors": 93,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-05-30",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-12T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": "8:00 AM – 4:00 PM",
+     "last_verified": "2025-09-10T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-10-01T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2026-01-03T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-1059",
+   "name": "Ray Road Overnight Heat Respite",
+   "operator": "Native Health Phoenix",
+   "kind": "overnight_respite",
+   "kind_label": "Overnight Heat Respite",
+   "vulnerability_weight": 1.3,
+   "address": "4366 W Dunlap Ave, Scottsdale, AZ 85269",
+   "address_is_po_box": false,
+   "phone": "(612) 555-1254",
+   "est_daily_visitors": 128,
+   "seasonal_activation_flag": "activated",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-01T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": "fully_accessible",
+     "last_verified": "2025-11-13T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "capacity_status": {
+     "value": "at_capacity",
+     "last_verified": "2026-07-09T16:00:00.000Z",
+     "source": "phone_2025"
+    }
+   }
+  },
+  {
+   "id": "MC-1060",
+   "name": "Chandler Heights Hydration Station",
+   "operator": "Justa Center",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "7599 E McDowell Rd, Gilbert, AZ 85239",
+   "address_is_po_box": false,
+   "phone": "+1 622 555 1740",
+   "est_daily_visitors": 94,
+   "seasonal_activation_flag": "standby",
+   "source_document": "Maricopa County Heat Relief Network directory, rev 2026-06-14",
+   "duplicate_of": null,
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-08-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 10 a.m. to 6 p.m.",
+     "last_verified": "2025-12-31T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "accessibility": {
+     "value": "ramp_only",
+     "last_verified": "2025-07-03T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "intake_requirements": {
+     "value": "no_id_required",
+     "last_verified": "2025-10-01T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    }
+   }
+  },
+  {
+   "id": "MC-9101",
+   "name": "Cave Creek Cooling Site (legacy listing)",
+   "operator": "211 Arizona import",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "930 W Camelback Rd, Avondale, AZ 85365",
+   "address_is_po_box": false,
+   "phone": "(615) 555-0152",
+   "est_daily_visitors": 339,
+   "seasonal_activation_flag": "unknown",
+   "source_document": "211 Arizona partner feed, rev 2026-03-11",
+   "duplicate_of": "MC-1008",
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-03-10T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "9 am - 8 pm, weekdays only",
+     "last_verified": "2026-07-11T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Pet friendly",
+     "last_verified": "2026-04-21T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2026-02-05T16:00:00.000Z",
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-9102",
+   "name": "Val Vista Cooling Site (legacy listing)",
+   "operator": "211 Arizona import",
+   "kind": "hydration_station",
+   "kind_label": "Hydration Station",
+   "vulnerability_weight": 0.78,
+   "address": "1663 E McDowell Rd, Gilbert, AZ 85254",
+   "address_is_po_box": false,
+   "phone": "(613) 555-0140",
+   "est_daily_visitors": 18,
+   "seasonal_activation_flag": "standby",
+   "source_document": "211 Arizona partner feed, rev 2026-03-11",
+   "duplicate_of": "MC-1020",
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-03-08T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": "Mon thru Fri, 7 a.m. to 5 p.m.",
+     "last_verified": "2026-03-31T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "Crated pets only",
+     "last_verified": "2026-06-22T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-9103",
+   "name": "Sun City Cooling Site (legacy listing)",
+   "operator": "211 Arizona import",
+   "kind": "municipal_office",
+   "kind_label": "Municipal Lobby Site",
+   "vulnerability_weight": 0.85,
+   "address": "Mesa, AZ",
+   "address_is_po_box": false,
+   "phone": "(623) 555-1102",
+   "est_daily_visitors": 33,
+   "seasonal_activation_flag": "activated",
+   "source_document": "211 Arizona partner feed, rev 2026-03-11",
+   "duplicate_of": "MC-1032",
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2025-12-10T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "self_reported"
+    },
+    "pet_policy": {
+     "value": "ADA service animals only",
+     "last_verified": "2026-03-20T16:00:00.000Z",
+     "source": "county_pdf"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": "id_requested_not_required",
+     "last_verified": "2025-08-20T16:00:00.000Z",
+     "source": "self_reported"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  },
+  {
+   "id": "MC-9104",
+   "name": "Pinnacle Peak Cooling Site (legacy listing)",
+   "operator": "211 Arizona import",
+   "kind": "faith_based_relief",
+   "kind_label": "Faith-Based Relief Site",
+   "vulnerability_weight": 1.12,
+   "address": "7456 W Indian School Rd, Chandler, AZ 85294",
+   "address_is_po_box": false,
+   "phone": "+1 618 555 1845",
+   "est_daily_visitors": 63,
+   "seasonal_activation_flag": "activated",
+   "source_document": "211 Arizona partner feed, rev 2026-03-11",
+   "duplicate_of": "MC-1045",
+   "fields": {
+    "open_now": {
+     "value": true,
+     "last_verified": "2026-03-27T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "hours": {
+     "value": null,
+     "last_verified": null,
+     "source": "county_pdf"
+    },
+    "pet_policy": {
+     "value": "Service animals only",
+     "last_verified": "2026-01-15T16:00:00.000Z",
+     "source": "partner_import"
+    },
+    "accessibility": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    },
+    "intake_requirements": {
+     "value": null,
+     "last_verified": null,
+     "source": "phone_2025"
+    },
+    "capacity_status": {
+     "value": null,
+     "last_verified": null,
+     "source": "partner_import"
+    }
+   }
+  }
+ ]
+}

--- a/apps/web/locked-door/data/ground-truth.json
+++ b/apps/web/locked-door/data/ground-truth.json
@@ -1,0 +1,1482 @@
+{
+ "note": "Ground truth for the DETERMINISTIC SIMULATED FACILITY transport. Used only by the simulator and by the evaluation panel. Never used by the planner or the extractor.",
+ "generated_at": "2026-08-26T16:00:00.000Z",
+ "facilities": [
+  {
+   "id": "MC-1001",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 394,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-16:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1002",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 604,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-19:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1003",
+   "line_type": "none",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 648,
+   "truth": {
+    "open_now": false,
+    "hours": "07:00-21:00",
+    "pet_policy": "no_pets",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1004",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 568,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1005",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 499,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-17:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "referral_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1006",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 363,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-21:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1007",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 227,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-21:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1008",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 575,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-20:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1009",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 453,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1010",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 276,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-16:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "not_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1011",
+   "line_type": "mobile",
+   "reachability": "unreachable_today",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 422,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-16:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1012",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 821,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-21:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1013",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 425,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1014",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 812,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1015",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 495,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-18:00",
+    "pet_policy": "no_pets",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1016",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 817,
+   "truth": {
+    "open_now": false,
+    "hours": "08:00-19:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1017",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 233,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-19:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1018",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 760,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-19:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1019",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 485,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-20:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1020",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 294,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-17:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1021",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 558,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1022",
+   "line_type": "ivr",
+   "reachability": "unreachable_today",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 718,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-17:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "referral_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1023",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 470,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-19:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1024",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 701,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-19:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1025",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 278,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-18:00",
+    "pet_policy": "no_pets",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1026",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 433,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-18:00",
+    "pet_policy": "no_pets",
+    "accessibility": "not_accessible",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1027",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 801,
+   "truth": {
+    "open_now": false,
+    "hours": "08:00-19:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1028",
+   "line_type": "none",
+   "reachability": "unreachable_today",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 225,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1029",
+   "line_type": "none",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 864,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-21:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1030",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 409,
+   "truth": {
+    "open_now": false,
+    "hours": "09:00-18:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1031",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 457,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-21:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1032",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 324,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-16:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "not_accessible",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1033",
+   "line_type": "main",
+   "reachability": "hard",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 361,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-18:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1034",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 522,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "no_pets",
+    "accessibility": "ramp_only",
+    "intake_requirements": "referral_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1035",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 824,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-21:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1036",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 788,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-16:00",
+    "pet_policy": "no_pets",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1037",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 445,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-20:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1038",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 297,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-21:00",
+    "pet_policy": "no_pets",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1039",
+   "line_type": "none",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 592,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-16:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1040",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 357,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-17:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1041",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 306,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-17:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1042",
+   "line_type": "ivr",
+   "reachability": "unreachable_today",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 886,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1043",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 587,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-17:00",
+    "pet_policy": "no_pets",
+    "accessibility": "not_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": false,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1044",
+   "line_type": "disconnected",
+   "reachability": "unreachable_today",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 432,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-16:00",
+    "pet_policy": "no_pets",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1045",
+   "line_type": "mobile",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 547,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1046",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 223,
+   "truth": {
+    "open_now": false,
+    "hours": "10:00-20:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1047",
+   "line_type": "none",
+   "reachability": "hard",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 882,
+   "truth": {
+    "open_now": true,
+    "hours": "08:00-18:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1048",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 476,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "no_pets",
+    "accessibility": "ramp_only",
+    "intake_requirements": "referral_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": false,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1049",
+   "line_type": "main",
+   "reachability": "unreachable_today",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 863,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-21:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1050",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 317,
+   "truth": {
+    "open_now": false,
+    "hours": "09:00-17:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1051",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 522,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-21:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1052",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 832,
+   "truth": {
+    "open_now": false,
+    "hours": "09:00-18:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1053",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 379,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "not_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": false,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1054",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 748,
+   "truth": {
+    "open_now": false,
+    "hours": "08:00-18:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1055",
+   "line_type": "ivr",
+   "reachability": "unreachable_today",
+   "persona": "knowledgeable_manager",
+   "answer_delay_ms": 699,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-19:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1056",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "front_desk_unsure",
+   "answer_delay_ms": 575,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-19:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1057",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 585,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-16:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": false,
+    "capacity_status": false
+   }
+  },
+  {
+   "id": "MC-1058",
+   "line_type": "ivr",
+   "reachability": "hard",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 618,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-16:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": false,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1059",
+   "line_type": "main",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 422,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-16:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-1060",
+   "line_type": "mobile",
+   "reachability": "unreachable_today",
+   "persona": "terse_maintenance",
+   "answer_delay_ms": 823,
+   "truth": {
+    "open_now": true,
+    "hours": "10:00-18:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "ramp_only",
+    "intake_requirements": "no_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   }
+  },
+  {
+   "id": "MC-9101",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 575,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-20:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": true,
+    "capacity_status": true
+   },
+   "shares_line_with": "MC-1008"
+  },
+  {
+   "id": "MC-9102",
+   "line_type": "disconnected",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 294,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-17:00",
+    "pet_policy": "crated_pets_only",
+    "accessibility": "fully_accessible",
+    "intake_requirements": "referral_required",
+    "capacity_status": "space_available"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": true,
+    "intake_requirements": false,
+    "capacity_status": true
+   },
+   "shares_line_with": "MC-1020"
+  },
+  {
+   "id": "MC-9103",
+   "line_type": "ivr",
+   "reachability": "normal",
+   "persona": "bilingual_handoff",
+   "answer_delay_ms": 324,
+   "truth": {
+    "open_now": true,
+    "hours": "09:00-16:00",
+    "pet_policy": "pets_allowed",
+    "accessibility": "not_accessible",
+    "intake_requirements": "id_requested_not_required",
+    "capacity_status": "at_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   },
+   "shares_line_with": "MC-1032"
+  },
+  {
+   "id": "MC-9104",
+   "line_type": "mobile",
+   "reachability": "normal",
+   "persona": "new_volunteer",
+   "answer_delay_ms": 547,
+   "truth": {
+    "open_now": true,
+    "hours": "07:00-18:00",
+    "pet_policy": "service_animals_only",
+    "accessibility": "ramp_only",
+    "intake_requirements": "photo_id_required",
+    "capacity_status": "near_capacity"
+   },
+   "knows": {
+    "open_now": true,
+    "hours": true,
+    "pet_policy": true,
+    "accessibility": false,
+    "intake_requirements": true,
+    "capacity_status": true
+   },
+   "shares_line_with": "MC-1045"
+  }
+ ]
+}

--- a/apps/web/locked-door/index.html
+++ b/apps/web/locked-door/index.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Heat Relief Directory Verification — evidence-backed phone verification</title>
+    <link rel="stylesheet" href="./css/app.css" />
+  </head>
+  <body>
+    <div id="app">
+      <!-- ============================ HEADER ============================ -->
+      <header class="topbar">
+        <div class="brand">
+          <div class="brand-mark" aria-hidden="true"></div>
+          <div class="brand-text">
+            <h1>Heat Relief Directory Verification</h1>
+            <p id="dataset-line">Loading directory…</p>
+          </div>
+        </div>
+
+        <div class="sim-banner" role="status">
+          <span class="sim-dot" aria-hidden="true"></span>
+          <div>
+            <strong>ALL CALLS ON THIS SCREEN ARE SIMULATED.</strong>
+            <span
+              >No telephone call is placed. Transport =
+              <code id="transport-name">deterministic simulated facility</code>. Real CALL-E adapter:
+              <em id="adapter-state">wired, disabled</em>.</span
+            >
+          </div>
+          <button id="btn-show-adapter" class="ghost small">Show the request it would send</button>
+        </div>
+
+        <div class="controls">
+          <label class="budget">
+            <span>Call budget</span>
+            <input id="budget-input" type="number" min="1" max="60" step="1" value="25" />
+          </label>
+          <label class="budget">
+            <span>Speed</span>
+            <select id="speed-input">
+              <option value="0.5">slow</option>
+              <option value="1" selected>normal</option>
+              <option value="4">fast</option>
+              <option value="instant">instant</option>
+            </select>
+          </label>
+          <button id="btn-plan" class="primary">Plan calls</button>
+          <button id="btn-run" class="primary">Run batch</button>
+          <button id="btn-approve" class="ghost">Approve all in review</button>
+        </div>
+      </header>
+
+      <!-- ============================= MAIN ============================= -->
+      <main class="grid">
+        <!-- ---------------------------- LEFT --------------------------- -->
+        <section class="panel col-queue" aria-labelledby="h-queue">
+          <div class="panel-head">
+            <h2 id="h-queue">Call queue</h2>
+            <span class="hint" id="queue-count">—</span>
+          </div>
+
+          <div class="budget-box" id="budget-box">
+            <div class="bb-row">
+              <span>Directory risk pool</span><b id="bb-total">—</b>
+            </div>
+            <div class="bb-row">
+              <span>Bought by this budget</span><b id="bb-bought">—</b>
+            </div>
+            <div class="bb-bar"><i id="bb-bar-fill"></i></div>
+            <div class="bb-compare">
+              <div>
+                <span class="tag tag-plan">risk-ranked</span>
+                <b id="bb-plan">—</b>
+              </div>
+              <div>
+                <span class="tag tag-base">oldest-first</span>
+                <b id="bb-base">—</b>
+              </div>
+              <div class="lift"><b id="bb-lift">—</b><span>planned lift</span></div>
+            </div>
+            <p class="bb-note" id="bb-note">
+              Greedy selection with diminishing returns: one call verifies several fields, later
+              questions in a call are worth less, and duplicate listings that share a phone line are
+              discounted after the first is queued.
+            </p>
+          </div>
+
+          <ol class="queue" id="queue"></ol>
+        </section>
+
+        <!-- --------------------------- CENTRE -------------------------- -->
+        <section class="panel col-runner" aria-labelledby="h-runner">
+          <div class="panel-head">
+            <h2 id="h-runner">Live call runner</h2>
+            <span class="hint" id="runner-progress">idle</span>
+          </div>
+
+          <div class="call-head" id="call-head">
+            <div class="ch-main">
+              <h3 id="ch-name">No call in progress</h3>
+              <p id="ch-meta">Plan a batch, then press Run.</p>
+            </div>
+            <div class="ch-badges" id="ch-badges"></div>
+          </div>
+
+          <div class="runner-body">
+            <div class="transcript-wrap">
+              <div class="sub-head">
+                <span>Transcript <em>(simulated)</em></span>
+                <span class="hint" id="transcript-hint">—</span>
+              </div>
+              <div class="transcript" id="transcript"></div>
+            </div>
+
+            <div class="fields-wrap">
+              <div class="sub-head">
+                <span>Grounded fields</span>
+                <span class="hint">a value exists only if a span supports it</span>
+              </div>
+              <div class="fields" id="fields"></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ---------------------------- RIGHT -------------------------- -->
+        <section class="panel col-review" aria-labelledby="h-review">
+          <div class="panel-head">
+            <h2 id="h-review">Review queue</h2>
+            <span class="hint" id="review-count">0 waiting</span>
+          </div>
+          <div class="review-list" id="review-list">
+            <p class="empty">Contradictions, hedged answers and low-confidence extractions land here
+              instead of in the directory.</p>
+          </div>
+
+          <div class="panel-head second">
+            <h2>Publishable delta</h2>
+            <span class="hint" id="delta-count">0 rows</span>
+          </div>
+          <div class="delta-list" id="delta-list">
+            <p class="empty">Approved changes append to a per-field history. Nothing is overwritten.</p>
+          </div>
+        </section>
+      </main>
+
+      <!-- =========================== EVALUATION ========================= -->
+      <footer class="panel evalpanel" aria-labelledby="h-eval">
+        <div class="panel-head">
+          <h2 id="h-eval">Evaluation — measured against simulator ground truth</h2>
+          <span class="hint" id="eval-state">run a batch to populate</span>
+        </div>
+        <div class="eval-grid">
+          <div class="tiles" id="eval-tiles"></div>
+          <div class="eval-table-wrap">
+            <table class="eval-table" id="eval-table">
+              <thead>
+                <tr>
+                  <th>field</th><th>att</th><th>grounded</th><th>precision</th><th>recall</th><th>unknown</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div class="eval-charts">
+            <div class="chart-block">
+              <h4>Harm reduction achieved <em>(realized, vs ground truth)</em></h4>
+              <div id="harm-bars" class="harm-bars"></div>
+            </div>
+            <div class="chart-block">
+              <h4>Freshness decay of what was just verified</h4>
+              <svg id="decay-chart" viewBox="0 0 460 118" preserveAspectRatio="none"></svg>
+              <div class="decay-legend" id="decay-legend"></div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <!-- adapter modal -->
+    <div class="modal-backdrop" id="adapter-modal" hidden>
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="adapter-title">
+        <div class="modal-head">
+          <h3 id="adapter-title">Real CALL-E telephony adapter — DISABLED</h3>
+          <button id="btn-close-adapter" class="ghost small">Close</button>
+        </div>
+        <p class="modal-note">
+          This is the exact request the real adapter would send for the top queued call. It is never
+          sent. <code>CalleTelephonyAdapter.placeCall()</code> throws
+          <code>REAL_TELEPHONY_DISABLED</code> before any network call is constructed, and this
+          codebase contains no fetch to a telephony host.
+        </p>
+        <pre id="adapter-body"></pre>
+      </div>
+    </div>
+
+    <script type="module" src="./js/main.js"></script>
+  </body>
+</html>

--- a/apps/web/locked-door/js/dialogue.js
+++ b/apps/web/locked-door/js/dialogue.js
@@ -1,0 +1,318 @@
+/**
+ * THE DETERMINISTIC SIMULATED FACILITY.
+ *
+ * Produces a realistic, IMPERFECT transcript from a facility's ground-truth
+ * state. It deliberately does not produce clean labelled data: staff hedge,
+ * misremember, hand the phone to someone else, answer a different question, or
+ * simply do not know. Some calls never reach a human at all.
+ *
+ * Nothing here is a real phone call. See transport.js for the disabled real
+ * adapter and the exact request shape it would send.
+ */
+
+import { streamFor } from './rng.js';
+
+const NUM_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve'];
+
+export const DISCLOSURE =
+  'Hi, this is an automated verification call from the Maricopa County Heat Relief Network directory team. ' +
+  'This call is recorded and I am an AI assistant. I have a few short questions to keep your public listing accurate. Is now an okay time?';
+
+/** How each persona behaves under questioning. */
+const PERSONA = {
+  knowledgeable_manager: { direct: 0.82, hedge: 0.12, ambiguous: 0.05, misinformed: 0.012, greeting: 'Front desk, this is Dana speaking.' },
+  front_desk_unsure:     { direct: 0.5,  hedge: 0.26, ambiguous: 0.14, misinformed: 0.03,  greeting: 'Hello, cooling center.' },
+  new_volunteer:         { direct: 0.42, hedge: 0.26, ambiguous: 0.16, misinformed: 0.06,  greeting: 'Uh, hi, hello? This is the front desk I think.' },
+  terse_maintenance:     { direct: 0.48, hedge: 0.08, ambiguous: 0.22, misinformed: 0.03,  greeting: 'Yeah.' },
+  bilingual_handoff:     { direct: 0.58, hedge: 0.18, ambiguous: 0.11, misinformed: 0.025, greeting: 'Buenas, un momento — let me get someone. Hold on.' },
+};
+
+const QUESTION_TEXT = {
+  open_now: 'First, is the cooling center open and accepting people right now?',
+  hours: 'What hours are you open today?',
+  pet_policy: 'Are pets allowed inside, or is it service animals only?',
+  accessibility: 'Is the entrance wheelchair accessible?',
+  intake_requirements: 'Does someone need to show a photo ID or a referral to come in?',
+  capacity_status: 'Do you have space available right now, or are you close to full?',
+};
+
+/* --------------------------------------------------------- answer text --- */
+
+function hoursPhrase(canonical, s) {
+  const [o, c] = canonical.split('-');
+  const oh = parseInt(o, 10);
+  const ch = parseInt(c, 10);
+  const c12 = ch > 12 ? ch - 12 : ch;
+  return s.pick([
+    `We're open ${oh} to ${c12} today.`,
+    `${oh}:00 in the morning until ${c12}:00 in the evening.`,
+    `We open at ${NUM_WORDS[oh] ?? oh} and we close at ${NUM_WORDS[c12] ?? c12}.`,
+    `Today it's ${oh} a.m. to ${c12} p.m., same as usual.`,
+    `Doors open ${oh}am, last entry is ${c12}pm.`,
+  ]);
+}
+
+const DIRECT = {
+  open_now: (v, s) =>
+    v
+      ? s.pick(["Yes, we're open right now, come on in.", "Yep, open and taking people.", "We are open, yes."])
+      : s.pick(["No, we're closed today.", "We're not open right now, no.", "Not today — we're closed."]),
+  hours: (v, s) => hoursPhrase(v, s),
+  pet_policy: (v, s) =>
+    ({
+      pets_allowed: s.pick(['Pets are allowed inside, yes.', 'Yeah, pets are welcome.']),
+      service_animals_only: s.pick(['Service animals only, I\'m afraid.', 'It\'s service animals only here.']),
+      crated_pets_only: s.pick(['Crated pets only — they have to be in a carrier.', 'Pets have to be crated.']),
+      no_pets: s.pick(['No pets, sorry.', 'We don\'t allow any animals inside.']),
+    })[v],
+  accessibility: (v, s) =>
+    ({
+      fully_accessible: s.pick(['Yes, the entrance is wheelchair accessible.', 'We\'re fully accessible, yes.']),
+      ramp_only: s.pick(['There\'s a ramp at the side entrance, but the main door has a step.', 'Ramp access only, around the side.']),
+      not_accessible: s.pick(['No, it\'s not wheelchair accessible unfortunately.', 'Not accessible, there\'s stairs.']),
+    })[v],
+  intake_requirements: (v, s) =>
+    ({
+      no_id_required: s.pick(['No ID required, anyone can come in.', 'You don\'t need any ID.']),
+      id_requested_not_required: s.pick(['We ask for ID but it\'s not required.', 'We request ID, but nobody is turned away without one.']),
+      photo_id_required: s.pick(['Photo ID is required, yes.', 'You need a photo ID to come in.']),
+      referral_required: s.pick(['You need a referral from a caseworker.', 'It\'s referral only through the county.']),
+    })[v],
+  capacity_status: (v, s) =>
+    ({
+      space_available: s.pick(['We have space available right now.', 'Plenty of room, yes.']),
+      near_capacity: s.pick(['We\'re close to full, honestly.', 'Near capacity right now.']),
+      at_capacity: s.pick(['We\'re at capacity, we can\'t take more right now.', 'We\'re full at the moment.']),
+    })[v],
+};
+
+const HEDGE_PREFIX = [
+  'I think ', 'Pretty sure ', 'As far as I know ', 'It should be — ', 'Last I heard ',
+];
+const HEDGE_SUFFIX = [
+  " but you'd want to double-check with the day manager.",
+  " though don't quote me on that.",
+  ' I think.',
+  " but that changed recently so I'm not certain.",
+];
+
+const AMBIGUOUS = {
+  open_now: ['We\'re around today, sort of — depends what you need.', 'Somebody\'s here, I couldn\'t tell you about the cooling side.'],
+  hours: ['We\'re open regular hours today.', 'Later than usual today because of the heat.', 'Depends on staffing, it varies.'],
+  pet_policy: ['Depends on the animal, really.', 'That\'s kind of case by case.'],
+  accessibility: ['There\'s a couple ways in, depends which door you use.', 'The building\'s old, so, you know.'],
+  intake_requirements: ['We usually just sign people in.', 'It depends who\'s working intake.'],
+  capacity_status: ['It comes and goes all day.', 'Busy, but I couldn\'t give you a number.'],
+};
+
+const UNKNOWN = [
+  "I honestly don't know, I'd have to ask the site manager.",
+  "That's not something I'd have in front of me, sorry.",
+  "You'd have to call back and speak with the coordinator on that one.",
+  "No idea, I just cover the desk on Tuesdays.",
+];
+
+/** Wrong-but-confident answers: the residual error the grounding rule cannot fix. */
+function misinform(field, truthValue, s) {
+  const alt = {
+    open_now: [!truthValue],
+    hours: ['08:00-17:00', '09:00-18:00', '07:00-19:00'].filter((h) => h !== truthValue),
+    pet_policy: ['pets_allowed', 'service_animals_only', 'crated_pets_only', 'no_pets'].filter((v) => v !== truthValue),
+    accessibility: ['fully_accessible', 'ramp_only', 'not_accessible'].filter((v) => v !== truthValue),
+    intake_requirements: ['no_id_required', 'id_requested_not_required', 'photo_id_required', 'referral_required'].filter((v) => v !== truthValue),
+    capacity_status: ['space_available', 'near_capacity', 'at_capacity'].filter((v) => v !== truthValue),
+  }[field];
+  return alt[Math.floor(s.next() * alt.length)];
+}
+
+/* ------------------------------------------------------------ outcomes --- */
+
+/**
+ * Decide the call outcome for a given attempt. Deterministic in
+ * (seed, facilityId, attempt).
+ */
+export function decideOutcome(gt, attempt, seed) {
+  const s = streamFor(seed, gt.id, 'outcome', attempt);
+  if (gt.line_type === 'none') return 'no_number';
+  if (gt.line_type === 'disconnected') return 'disconnected';
+
+  // Later attempts are more likely to connect (different time of day) -- but a
+  // facility that is structurally unreachable today stays unreachable, which is
+  // why the retry policy has a cap instead of a loop.
+  const reach = gt.reachability ?? 'normal';
+  if (reach === 'unreachable_today') {
+    return s.next() < 0.45 ? 'voicemail' : 'no_answer';
+  }
+  const bump = attempt * (reach === 'hard' ? 0.05 : 0.14);
+  // A 'hard' facility compresses the draw toward the failure thresholds.
+  const r = s.next() * (reach === 'hard' ? 0.7 : 1);
+  if (gt.line_type === 'ivr') {
+    if (r < 0.2 - bump * 0.4) return 'ivr_dead_end';
+    if (r < 0.34 - bump * 0.4) return 'voicemail';
+    if (r < 0.44 - bump * 0.5) return 'no_answer';
+    return 'connected_via_ivr';
+  }
+  if (gt.line_type === 'mobile') {
+    if (r < 0.24 - bump) return 'no_answer';
+    if (r < 0.4 - bump) return 'voicemail';
+    return 'connected';
+  }
+  if (r < 0.14 - bump) return 'no_answer';
+  if (r < 0.26 - bump) return 'voicemail';
+  if (r < 0.29 - bump) return 'busy';
+  return 'connected';
+}
+
+/* ---------------------------------------------------------- transcript --- */
+
+function T(speaker, text) {
+  return { speaker, text };
+}
+
+/**
+ * Build the full turn list for one attempt.
+ * `questions` is the ordered list of field names the plan approved for this call.
+ */
+export function buildTranscript(gt, facility, questions, attempt, seed, outcome) {
+  const s = streamFor(seed, gt.id, 'dialogue', attempt);
+  const turns = [];
+  const phone = facility.phone ?? 'no number on file';
+  turns.push(T('system', `[SIMULATED] Dialing ${phone} — attempt ${attempt + 1}. No real call is placed.`));
+
+  if (outcome === 'no_number') {
+    turns.push(T('system', 'No phone number published for this facility. Call cannot be attempted.'));
+    return turns;
+  }
+  if (outcome === 'disconnected') {
+    turns.push(T('system', 'Special information tone. "The number you have dialed is not in service. Please check the number and dial again."'));
+    return turns;
+  }
+  if (outcome === 'busy') {
+    turns.push(T('system', 'Busy signal. Line engaged.'));
+    return turns;
+  }
+  if (outcome === 'no_answer') {
+    turns.push(T('system', `Ringing… no answer after ${s.int(6, 9)} rings. Disconnected by caller.`));
+    return turns;
+  }
+  if (outcome === 'ivr_dead_end') {
+    turns.push(T('system', 'Automated menu answered.'));
+    turns.push(T('staff', 'Thank you for calling. For hours and locations press 1. For program eligibility press 2. To speak with staff press 0.'));
+    turns.push(T('agent', '[DTMF 0]'));
+    turns.push(T('staff', 'All representatives are assisting other callers. Please try your call again later.'));
+    turns.push(T('system', 'Menu returned to top level twice. No path to a human. Call ended.'));
+    return turns;
+  }
+  if (outcome === 'voicemail') {
+    // A voicemail greeting sometimes states hours or an activation status. That is
+    // real, citable evidence — at lower confidence, because a greeting can be old.
+    const greetingHasHours = s.chance(0.45);
+    const greetingHasClosure = s.chance(0.18);
+    let msg = `You've reached ${facility.name}. `;
+    if (greetingHasClosure) {
+      msg += 'We are currently closed for the season. Please call the county line for the nearest open site. ';
+    } else if (greetingHasHours) {
+      msg += hoursPhrase(gt.truth.hours, s).replace(/^We're /, 'We are ') + ' ';
+    }
+    msg += 'Please leave a message after the tone.';
+    turns.push(T('system', 'Call answered by voicemail.'));
+    turns.push(T('staff', msg));
+    turns.push(T('agent', 'This is an automated listing-verification call from the county heat relief directory. No message left. Thank you.'));
+    return turns;
+  }
+
+  /* ---- a human is on the line ---- */
+  const persona = PERSONA[gt.persona] ?? PERSONA.front_desk_unsure;
+
+  if (outcome === 'connected_via_ivr') {
+    turns.push(T('system', 'Automated menu answered.'));
+    turns.push(T('staff', 'Thank you for calling. For hours press 1, for staff press 0.'));
+    turns.push(T('agent', '[DTMF 0]'));
+    turns.push(T('system', `Held ${s.int(40, 190)} seconds. Transferred to staff.`));
+  }
+
+  turns.push(T('staff', persona.greeting));
+  turns.push(T('agent', DISCLOSURE));
+  turns.push(
+    T(
+      'staff',
+      s.pick(['Sure, go ahead.', 'Okay, quickly — it\'s busy in here.', 'Uh, okay. Yeah.', 'That\'s fine.']),
+    ),
+  );
+
+  if (gt.persona === 'bilingual_handoff') {
+    turns.push(T('system', `Hold ${s.int(20, 70)} seconds — phone handed to another staff member.`));
+    turns.push(T('staff', 'Hi, sorry, I\'m the one who handles the cooling program. What did you need?'));
+  }
+
+  let hangUp = false;
+  const asked = [];
+  for (let qi = 0; qi < questions.length; qi++) {
+    const field = questions[qi];
+    if (hangUp) break;
+
+    turns.push(T('agent', QUESTION_TEXT[field]));
+    asked.push(field);
+
+    const knows = gt.knows[field];
+    const r = s.next();
+    // fatigue: the further into the script, the more likely a shrug
+    const fatigue = qi * 0.038;
+
+    if (!knows || r < 0.1 + fatigue) {
+      turns.push(T('staff', s.pick(UNKNOWN)));
+    } else if (r < 0.1 + fatigue + persona.ambiguous) {
+      turns.push(T('staff', s.pick(AMBIGUOUS[field])));
+    } else if (r < 0.1 + fatigue + persona.ambiguous + persona.misinformed) {
+      const wrong = misinform(field, gt.truth[field], s);
+      turns.push(T('staff', DIRECT[field](wrong, s)));
+    } else if (r < 0.1 + fatigue + persona.ambiguous + persona.misinformed + persona.hedge) {
+      // Drop the statement's own full stop before appending the hedge, so the
+      // line reads as one spoken sentence ("...only here but you'd want to
+      // double-check") rather than two glued together ("...only here. but").
+      const stem = DIRECT[field](gt.truth[field], s).replace(/\.\s*$/, '');
+      turns.push(T('staff', s.pick(HEDGE_PREFIX) + stem.charAt(0).toLowerCase() + stem.slice(1) + s.pick(HEDGE_SUFFIX)));
+    } else {
+      turns.push(T('staff', DIRECT[field](gt.truth[field], s)));
+    }
+
+    // occasional early hang-up on long scripts
+    if (qi >= 3 && s.chance(0.12)) {
+      turns.push(T('staff', s.pick(['I\'ve got a line of people, I have to go.', 'Sorry, I need to go.'])));
+      turns.push(T('system', 'Caller hung up. Remaining questions not asked.'));
+      hangUp = true;
+    }
+  }
+
+  if (!hangUp) {
+    turns.push(T('agent', 'That\'s everything. Thank you for your time.'));
+    turns.push(T('staff', s.pick(['No problem.', 'Alright, bye.', 'Sure thing.'])));
+  }
+  turns.push(T('system', `Call ended. ${asked.length} of ${questions.length} planned questions asked.`));
+  return turns;
+}
+
+/** Join turns into one addressable string and attach absolute offsets. */
+export function materialize(turns) {
+  let cursor = 0;
+  const out = [];
+  const parts = [];
+  turns.forEach((t, i) => {
+    const prefix = t.speaker === 'agent' ? 'AGENT: ' : t.speaker === 'staff' ? 'STAFF: ' : 'SYSTEM: ';
+    const line = prefix + t.text;
+    out.push({
+      index: i,
+      speaker: t.speaker,
+      text: t.text,
+      prefix,
+      lineStart: cursor,
+      textStart: cursor + prefix.length,
+      textEnd: cursor + line.length,
+    });
+    parts.push(line);
+    cursor += line.length + 1; // +1 for the newline
+  });
+  return { turns: out, text: parts.join('\n') };
+}
+
+export { QUESTION_TEXT };

--- a/apps/web/locked-door/js/engine.js
+++ b/apps/web/locked-door/js/engine.js
@@ -1,0 +1,276 @@
+/**
+ * ORCHESTRATOR. Ingest -> risk -> plan -> simulated calls -> grounded extraction
+ * -> changeset -> review/publish -> evaluation.
+ *
+ * Runs identically headless (used to score the baseline counterfactually) and
+ * with UI hooks (used for the live runner).
+ */
+
+import { scoreDirectory, FIELDS, publishedLineClass } from './risk.js';
+import { planGreedy, planOldestFirst, totalAvailableHarm } from './planner.js';
+import {
+  SimulatedFacilityTransport,
+  CalleTelephonyAdapter,
+  buildCanonicalRequest,
+  toE164,
+  DISCLOSURE,
+  MAX_ATTEMPTS,
+} from './transport.js';
+import { extractFromAttempt, mergeAttempts } from './extract.js';
+import { buildChangeset, DirectoryStore, ROUTE, assertPublishable, verifySpansResolve } from './publish.js';
+import { evaluateRun, countUngroundedPublishes } from './evaluate.js';
+
+export const RESULT_SCHEMA_VERSION = 'heat-relief-verification/2026-08';
+
+export class VerificationEngine {
+  constructor(directory, groundTruth, { seed = 'calle-sim-v1', now = Date.now() } = {}) {
+    this.directory = directory;
+    this.facilities = directory.facilities;
+    this.now = now;
+    this.nowIso = new Date(now).toISOString();
+    this.seed = seed;
+
+    this.truthById = new Map(groundTruth.facilities.map((t) => [t.id, t]));
+    this.transport = new SimulatedFacilityTransport(this.truthById, seed);
+    this.realAdapter = new CalleTelephonyAdapter(); // present and disabled
+
+    // OBSERVABLE line class: derived from the published record only.
+    this.facilityById = new Map(this.facilities.map((f) => [f.id, f]));
+    this.lineClassById = (id) => publishedLineClass(this.facilityById.get(id));
+    // Duplicate listings that share a phone number are detectable from the
+    // directory itself (same digits), so collapsing them is fair game.
+    const phoneKey = new Map();
+    for (const f of this.facilities) {
+      const digits = String(f.phone ?? '').replace(/\D/g, '').slice(-10);
+      if (!digits) continue;
+      if (!phoneKey.has(digits)) phoneKey.set(digits, f.id);
+    }
+    this.lineKeyById = (id) => {
+      const f = this.facilityById.get(id);
+      const digits = String(f?.phone ?? '').replace(/\D/g, '').slice(-10);
+      return digits ? phoneKey.get(digits) : id;
+    };
+
+    this.riskRows = scoreDirectory(this.facilities, this.lineClassById, this.now);
+    this.riskIndex = new Map(this.riskRows.map((r) => [`${r.facilityId}:${r.field}`, r]));
+    this.rowFor = (id, field) => this.riskIndex.get(`${id}:${field}`);
+
+    this.ctx = {
+      rowFor: this.rowFor,
+      lineClassById: this.lineClassById,
+      lineKeyById: this.lineKeyById,
+    };
+
+    this.totalAvailableHarm = totalAvailableHarm(this.facilities, this.ctx);
+
+    this.reset();
+  }
+
+  reset() {
+    this.store = new DirectoryStore(this.facilities);
+    this.calls = [];
+    this.changeset = [];
+    this.reviewQueue = [];
+    this.transcripts = new Map();
+    this.plan = null;
+    this.baselinePlan = null;
+    this.baselineResult = null;
+    this.evaluation = null;
+    this.runId = `run_${new Date(this.now).toISOString().slice(0, 10)}_${Math.abs(hash(this.seed)).toString(36)}`;
+  }
+
+  /* ------------------------------------------------------------ plan ---- */
+  planCalls(budget = 25) {
+    this.plan = planGreedy(this.facilities, this.ctx, budget);
+    this.baselinePlan = planOldestFirst(this.facilities, this.ctx, budget);
+    return { plan: this.plan, baseline: this.baselinePlan };
+  }
+
+  /** The payload the real CALL-E adapter would receive for one queued call. */
+  buildCallPlan(entry) {
+    const facility = this.facilityById.get(entry.facilityId);
+    const questions = entry.questions.map((q) => q.field);
+    const payload = {
+      runId: this.runId,
+      facilityId: facility.id,
+      facility,
+      phoneE164: toE164(facility.phone),
+      disclosure: DISCLOSURE,
+      questions,
+      resultSchemaVersion: RESULT_SCHEMA_VERSION,
+      maximumAttempts: MAX_ATTEMPTS,
+      approvedPlanDigest: null,
+    };
+    const req = buildCanonicalRequest(payload);
+    payload.approvedPlanDigest = req.requestBodyDigest;
+    return { payload, request: buildCanonicalRequest(payload) };
+  }
+
+  /* ------------------------------------------------------------- run ---- */
+  /**
+   * Executes a plan through the simulated transport.
+   * hooks: { onCallStart, onTurn, onCallEnd, onBackoff, delay }
+   */
+  async runPlan(plan, { hooks = {}, store = this.store, collect = true } = {}) {
+    const calls = [];
+    for (const entry of plan.calls) {
+      const { payload, request } = this.buildCallPlan(entry);
+      const callId = `${this.runId}:${entry.facilityId}`;
+      const facility = payload.facility;
+
+      if (hooks.onCallStart) await hooks.onCallStart({ entry, payload, request, callId, facility });
+
+      const attempts = await this.transport.placeCall(payload, {
+        onTurn: hooks.onTurn ? (t, c) => hooks.onTurn(t, { ...c, callId, facility, entry }) : undefined,
+        onAttemptStart: hooks.onAttemptStart
+          ? (a) => hooks.onAttemptStart({ ...a, callId, facility, entry })
+          : undefined,
+        onBackoff: hooks.onBackoff,
+      });
+
+      const perAttempt = attempts.map((a) => extractFromAttempt(a, payload.questions));
+      const merged = mergeAttempts(perAttempt);
+      const used = attempts[attempts.length - 1];
+      const callMeta = {
+        callId,
+        attempts: attempts.length,
+        attemptUsed: used.attempt,
+        outcome: used.outcome,
+        connected: attempts.some((a) => a.connected),
+        idempotencyKey: request.idempotencyKey,
+      };
+
+      // A citation resolves against the transcript of the attempt that produced
+      // it, so every attempt is retained and addressed by callId#attempt.
+      for (const a of attempts) this.transcripts.set(`${callId}#${a.attempt}`, a.transcript);
+      const groundingAttempt =
+        attempts.find((a) => a.connected) ?? attempts.find((a) => a.outcome === 'voicemail') ?? used;
+
+      const rows = buildChangeset(facility, merged, callMeta, this.nowIso);
+
+      const call = {
+        callId,
+        facilityId: facility.id,
+        facility,
+        entry,
+        payload,
+        request,
+        attempts,
+        callMeta,
+        extractions: merged,
+        rows,
+        transcript: groundingAttempt.transcript,
+      };
+
+      // standing operator policy: high-confidence confirmations and blank-fills
+      // publish automatically; everything else waits for a human.
+      for (const r of rows) {
+        if (r.route === ROUTE.AUTO) {
+          r.publishedBy = 'auto-policy';
+          store.approve(r, 'auto-policy');
+        } else if (r.route === ROUTE.REVIEW && collect) {
+          this.reviewQueue.push(r);
+        }
+      }
+
+      if (collect) {
+        this.calls.push(call);
+        this.changeset.push(...rows);
+      }
+      calls.push(call);
+      if (hooks.onCallEnd) await hooks.onCallEnd(call);
+    }
+    return calls;
+  }
+
+  /** Counterfactual: what would the naive baseline actually have achieved? */
+  async runBaselineCounterfactual() {
+    const shadowStore = new DirectoryStore(this.facilities);
+    const savedReview = this.reviewQueue;
+    const savedTranscripts = this.transcripts;
+    this.reviewQueue = [];
+    this.transcripts = new Map();
+    const calls = await this.runPlan(this.baselinePlan, { store: shadowStore, collect: false });
+    const rows = calls.flatMap((c) => c.rows);
+    const result = evaluateRun({
+      rows,
+      truthById: this.truthById,
+      riskRowFor: this.rowFor,
+      publishedRows: shadowStore.published,
+      autoPublishedRows: shadowStore.published,
+    });
+    this.reviewQueue = savedReview;
+    this.transcripts = savedTranscripts;
+    this.baselineResult = {
+      ...result,
+      callsPlaced: calls.length,
+      connected: calls.filter((c) => c.callMeta.connected).length,
+    };
+    return this.baselineResult;
+  }
+
+  /* ------------------------------------------------------- evaluation ---- */
+  evaluate() {
+    const rows = this.changeset;
+    const published = this.store.published;
+    const autoOnly = published.filter((p) => p.approvedBy === 'auto-policy');
+    const result = evaluateRun({
+      rows,
+      truthById: this.truthById,
+      riskRowFor: this.rowFor,
+      publishedRows: published,
+      autoPublishedRows: autoOnly,
+    });
+
+    // enforced invariants, measured rather than asserted in prose
+    const gate = assertPublishable(published);
+    const spans = verifySpansResolve(published, this.transcripts);
+    const ungrounded = countUngroundedPublishes(published);
+
+    this.evaluation = {
+      ...result,
+      callsPlaced: this.calls.length,
+      connected: this.calls.filter((c) => c.callMeta.connected).length,
+      voicemail: this.calls.filter((c) => c.callMeta.outcome === 'voicemail').length,
+      noAnswer: this.calls.filter((c) => ['no_answer', 'busy'].includes(c.callMeta.outcome)).length,
+      deadLine: this.calls.filter((c) => ['disconnected', 'no_number', 'ivr_dead_end'].includes(c.callMeta.outcome)).length,
+      totalAttempts: this.calls.reduce((a, c) => a + c.attempts.length, 0),
+      attemptOutcomes: this.calls.reduce((acc, c) => {
+        for (const a of c.attempts) acc[a.outcome] = (acc[a.outcome] ?? 0) + 1;
+        return acc;
+      }, {}),
+      reviewQueueSize: this.reviewQueue.length,
+      publishedCount: published.length,
+      citationGate: { ...gate, ungroundedPublishes: ungrounded, spanCheck: spans },
+      plannedHarm: this.plan?.expectedHarmReduction ?? 0,
+      baselinePlannedHarm: this.baselinePlan?.expectedHarmReduction ?? 0,
+      baseline: this.baselineResult,
+      totalAvailableHarm: this.totalAvailableHarm,
+    };
+    return this.evaluation;
+  }
+
+  approveAll(approver = 'operator@county') {
+    const approved = [];
+    for (const row of this.reviewQueue) {
+      this.store.approve(row, approver);
+      row.publishedBy = approver;
+      approved.push(row);
+    }
+    this.reviewQueue = [];
+    return approved;
+  }
+
+  /* -------------------------------------------------------- accessors ---- */
+  fieldsExtracted() {
+    return this.changeset.filter((r) => r.newValue !== 'unknown').length;
+  }
+}
+
+function hash(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+export { FIELDS, ROUTE };

--- a/apps/web/locked-door/js/evaluate.js
+++ b/apps/web/locked-door/js/evaluate.js
@@ -1,0 +1,165 @@
+/**
+ * HONEST EVALUATION.
+ *
+ * The simulator knows the truth, so every number on the evaluation panel is a
+ * real measurement against it — not a self-report. Ground truth is read ONLY
+ * here and in the simulator; the planner, extractor and publisher never see it.
+ *
+ * Definitions, stated plainly because these terms get abused:
+ *
+ *   attempted   (facility, field) pairs the plan set out to verify on facilities
+ *               that were actually dialed. Includes calls that never connected.
+ *   grounded    attempted pairs where a transcript span produced a typed value.
+ *   correct     grounded pairs whose value matches ground truth after canonicalisation.
+ *   precision   correct / grounded          "when it speaks, is it right?"
+ *   recall      correct / attempted         "of the facts it set out to fix, how many did it fix?"
+ *   unknown     1 - grounded / attempted    "the price of refusing to guess"
+ *   false publish  published rows whose value contradicts ground truth / published rows
+ */
+
+import { canonicalize, ROUTE } from './publish.js';
+import { valuesEqual } from './extract.js';
+import { FIELDS } from './risk.js';
+
+export function evaluateRun({ rows, truthById, riskRowFor, publishedRows, autoPublishedRows }) {
+  const perField = {};
+  for (const f of FIELDS) perField[f] = { attempted: 0, grounded: 0, correct: 0, wrong: 0, unknown: 0 };
+
+  let attempted = 0;
+  let grounded = 0;
+  let correct = 0;
+  let wrong = 0;
+  let harmRealized = 0;
+  let harmForfeited = 0;
+
+  // Where did the WRONG values end up? This is the load-bearing safety claim:
+  // the extractor does make mistakes, and the router is supposed to catch every
+  // one of them before it can reach the directory on the machine's own
+  // authority. Measured, not asserted.
+  const wrongRouting = { total: 0, toReview: 0, toAuto: 0, examples: [] };
+
+  for (const r of rows) {
+    const t = truthById.get(r.facilityId);
+    if (!t) continue;
+    const truthCanon = canonicalize(r.field, t.truth[r.field]);
+    const pf = perField[r.field];
+    attempted++;
+    pf.attempted++;
+
+    if (r.newValue === 'unknown') {
+      pf.unknown++;
+      const risk = riskRowFor(r.facilityId, r.field);
+      harmForfeited += risk.harm * risk.pStale;
+      continue;
+    }
+    grounded++;
+    pf.grounded++;
+    const ok = truthCanon !== null && valuesEqual(r.newCanonical, truthCanon);
+    if (ok) {
+      correct++;
+      pf.correct++;
+      const risk = riskRowFor(r.facilityId, r.field);
+      harmRealized += risk.harm * risk.pStale;
+    } else {
+      wrong++;
+      pf.wrong++;
+      wrongRouting.total++;
+      if (r.route === ROUTE.REVIEW) wrongRouting.toReview++;
+      else if (r.route === ROUTE.AUTO) wrongRouting.toAuto++;
+      if (wrongRouting.examples.length < 8)
+        wrongRouting.examples.push({
+          facilityId: r.facilityId,
+          field: r.field,
+          extracted: r.newCanonical,
+          truth: truthCanon,
+          route: r.route,
+          confidence: r.confidence,
+          quote: r.evidence?.quote ?? null,
+        });
+    }
+  }
+
+  const falsePublish = countFalsePublishes(publishedRows, truthById);
+  const falseAuto = countFalsePublishes(autoPublishedRows, truthById);
+
+  return {
+    attempted,
+    grounded,
+    correct,
+    wrong,
+    unknown: attempted - grounded,
+    precision: grounded ? correct / grounded : 0,
+    recall: attempted ? correct / attempted : 0,
+    unknownRate: attempted ? (attempted - grounded) / attempted : 0,
+    harmRealized,
+    harmForfeited,
+    falsePublish: {
+      published: falsePublish.total,
+      wrong: falsePublish.wrong,
+      rate: falsePublish.total ? falsePublish.wrong / falsePublish.total : 0,
+      examples: falsePublish.examples,
+    },
+    falsePublishAutoOnly: {
+      published: falseAuto.total,
+      wrong: falseAuto.wrong,
+      rate: falseAuto.total ? falseAuto.wrong / falseAuto.total : 0,
+    },
+    wrongValueRouting: {
+      ...wrongRouting,
+      // 1.0 means every wrong value the extractor produced was held for a human.
+      caughtRate: wrongRouting.total ? wrongRouting.toReview / wrongRouting.total : 1,
+    },
+    perField: Object.fromEntries(
+      Object.entries(perField).map(([k, v]) => [
+        k,
+        {
+          ...v,
+          precision: v.grounded ? v.correct / v.grounded : null,
+          recall: v.attempted ? v.correct / v.attempted : null,
+          unknownRate: v.attempted ? v.unknown / v.attempted : null,
+        },
+      ]),
+    ),
+  };
+}
+
+function countFalsePublishes(publishedRows, truthById) {
+  let wrong = 0;
+  const examples = [];
+  for (const p of publishedRows) {
+    const t = truthById.get(p.facilityId);
+    if (!t) continue;
+    const truthCanon = canonicalize(p.field, t.truth[p.field]);
+    if (truthCanon === null) continue;
+    if (!valuesEqual(p.newCanonical, truthCanon)) {
+      wrong++;
+      if (examples.length < 6)
+        examples.push({
+          facilityId: p.facilityId,
+          field: p.field,
+          published: p.newCanonical,
+          truth: truthCanon,
+          confidence: p.confidence,
+          hedged: !!p.hedged,
+          quote: p.evidence?.quote ?? null,
+        });
+    }
+  }
+  return { total: publishedRows.length, wrong, examples };
+}
+
+/**
+ * Ungrounded-publish check: the property the citation rule is supposed to make
+ * impossible. Counted, not assumed.
+ */
+export function countUngroundedPublishes(publishedRows) {
+  return publishedRows.filter(
+    (p) =>
+      p.newValue === 'unknown' ||
+      !p.evidence ||
+      !p.evidence.span ||
+      typeof p.evidence.span.start !== 'number' ||
+      p.evidence.span.end <= p.evidence.span.start ||
+      !p.evidence.quote,
+  ).length;
+}

--- a/apps/web/locked-door/js/extract.js
+++ b/apps/web/locked-door/js/extract.js
@@ -1,0 +1,278 @@
+/**
+ * GROUNDED EXTRACTION.
+ *
+ * The rule this whole product rests on:
+ *
+ *      A field may hold a value ONLY IF a character span of the transcript
+ *      supports it. No span, no value. The value is `unknown`.
+ *
+ * `assertGrounded` enforces it at construction time and `assertPublishable`
+ * enforces it again at the publication gate, so an ungrounded value cannot
+ * reach the directory even if a later refactor forgets the rule.
+ *
+ * The extractor is deterministic and rule-based. It sees only transcript text —
+ * it has no access to ground truth. Ambiguous and hedged speech is *supposed*
+ * to fall through to `unknown`; that is the safety behaviour, not a bug.
+ */
+
+import { QUESTION_TEXT } from './dialogue.js';
+
+export const REVIEW_THRESHOLD = 0.62;
+
+const HEDGE_MARKERS = [
+  'i think', 'pretty sure', 'as far as i know', 'it should be', 'last i heard',
+  "don't quote me", 'not certain', 'double-check', 'i believe',
+];
+
+const NUM_WORD = {
+  one: 1, two: 2, three: 3, four: 4, five: 5, six: 6,
+  seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12,
+};
+
+/** Ordered rules per field. First match wins. */
+const RULES = {
+  open_now: [
+    [/\b(?:we(?:'re| are)\s+(?:currently\s+)?closed|we(?:'re| are)\s+not\s+open|not\s+open\s+right\s+now|we(?:'re| are)\s+not\s+open\s+right\s+now)\b/i, false],
+    [/\bnot\s+today\b/i, false],
+    [/\b(?:we(?:'re| are)\s+open|open\s+and\s+(?:taking|accepting))\b/i, true],
+  ],
+  pet_policy: [
+    [/\bno\s+pets\b|\bdon't\s+allow\s+any\s+animals\b|\bno\s+animals\b/i, 'no_pets'],
+    [/\bcrated?\b|\bin\s+a\s+carrier\b/i, 'crated_pets_only'],
+    [/\bservice\s+animals\s+only\b/i, 'service_animals_only'],
+    [/\bpets\s+are\s+(?:allowed|welcome)\b|\bpets\s+welcome\b/i, 'pets_allowed'],
+  ],
+  accessibility: [
+    [/\bnot\s+(?:wheelchair\s+)?accessible\b/i, 'not_accessible'],
+    [/\bramp\b/i, 'ramp_only'],
+    [/\b(?:wheelchair\s+accessible|fully\s+accessible)\b/i, 'fully_accessible'],
+  ],
+  intake_requirements: [
+    [/\breferral\b/i, 'referral_required'],
+    [/\bid\b[^.]{0,60}\bnot\s+required\b|\bnobody\s+is\s+turned\s+away\b/i, 'id_requested_not_required'],
+    [/\bno\s+id\s+required\b|\bdon't\s+need\s+any\s+id\b/i, 'no_id_required'],
+    [/\bphoto\s+id\s+is\s+required\b|\bneed\s+a\s+photo\s+id\b/i, 'photo_id_required'],
+  ],
+  capacity_status: [
+    [/\bnear\s+capacity\b|\bclose\s+to\s+full\b/i, 'near_capacity'],
+    [/\bat\s+capacity\b|\bwe(?:'re| are)\s+full\b/i, 'at_capacity'],
+    [/\bspace\s+available\b|\bplenty\s+of\s+room\b/i, 'space_available'],
+  ],
+};
+
+/** Hours needs numeric parsing rather than a lookup, so it gets its own matcher. */
+/**
+ * Spoken hours. Two things make this harder than a regex over "9am-5pm":
+ * people say the meridiem in words ("seven in the morning until nine in the
+ * evening"), and they often omit it entirely ("we're open eight to eight").
+ * A bare closing hour is read as PM, because a heat-relief site that opens at 8
+ * and closes at 8 is not closing at breakfast — and getting that wrong is a
+ * 12-hour error on the single most consequential field after open_now.
+ */
+function matchHours(text) {
+  const tokenRe =
+    /\b(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?|in the morning|in the evening|at night|tonight)?|\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b\s*(a\.?m\.?|p\.?m\.?|in the morning|in the evening|at night)?/gi;
+  const found = [];
+  let m;
+  while ((m = tokenRe.exec(text)) !== null) {
+    const hour = m[1] ? parseInt(m[1], 10) : m[4] ? NUM_WORD[m[4].toLowerCase()] : null;
+    if (!hour || hour > 12) continue;
+    found.push({ hour, mer: normalizeMeridiem(m[3] ?? m[5]), start: m.index, end: m.index + m[0].length });
+  }
+  if (found.length < 2) return null;
+  const a = found[0];
+  const b = found[1];
+  let open = a.hour;
+  if (a.mer === 'pm' && open < 12) open += 12;
+  let close = b.hour;
+  if (b.mer === 'pm' && close < 12) close += 12;
+  else if (b.mer === 'am') {
+    /* explicitly stated as morning: leave it */
+  } else if (close <= 12 && close + 12 > open) close += 12;
+  if (close <= open) return null;
+  const canonical = `${String(open).padStart(2, '0')}:00-${String(close).padStart(2, '0')}:00`;
+  return { value: canonical, start: a.start, end: b.end, tokens: found.length };
+}
+
+function normalizeMeridiem(raw) {
+  if (!raw) return null;
+  const s = raw.toLowerCase().replace(/\./g, '');
+  if (s === 'am' || s === 'in the morning') return 'am';
+  if (s === 'pm' || s === 'in the evening' || s === 'at night' || s === 'tonight') return 'pm';
+  return null;
+}
+
+function isHedged(text) {
+  const lower = text.toLowerCase();
+  return HEDGE_MARKERS.some((h) => lower.includes(h));
+}
+
+/**
+ * Build a grounded extraction. Returns value `unknown` with span `null` whenever
+ * no supporting span is found — never a guess.
+ */
+function ground(field, turn, matchInfo, opts) {
+  if (!matchInfo) {
+    return {
+      field,
+      value: 'unknown',
+      span: null,
+      quote: null,
+      confidence: 0,
+      hedged: false,
+      channel: opts.channel,
+      reason: opts.noMatchReason ?? 'no supporting span in transcript',
+    };
+  }
+  const abs = { start: turn.textStart + matchInfo.start, end: turn.textStart + matchInfo.end };
+  const hedged = isHedged(turn.text);
+  let conf = 0.92;
+  if (hedged) conf *= 0.62;
+  if (opts.channel === 'voicemail_greeting') conf *= 0.6;
+  if (opts.channel === 'ivr_transfer') conf *= 0.95;
+  if (matchInfo.tokens && matchInfo.tokens > 3) conf *= 0.85; // several clock numbers -> murkier
+  return {
+    field,
+    value: matchInfo.value,
+    span: { turnIndex: turn.index, start: abs.start, end: abs.end },
+    quote: turn.text.slice(matchInfo.start, matchInfo.end),
+    contextQuote: turn.text,
+    confidence: Math.max(0, Math.min(0.99, Number(conf.toFixed(3)))),
+    hedged,
+    channel: opts.channel,
+    reason: hedged ? 'grounded, speaker hedged' : 'grounded in transcript span',
+  };
+}
+
+/** THE HARD RULE. Throws rather than letting an ungrounded value exist. */
+export function assertGrounded(ex) {
+  if (ex.value !== 'unknown' && (!ex.span || typeof ex.span.start !== 'number')) {
+    throw new Error(
+      `CITATION_RULE_VIOLATION: field "${ex.field}" carries value ${JSON.stringify(ex.value)} with no transcript span.`,
+    );
+  }
+  return ex;
+}
+
+function findMatch(field, text) {
+  if (field === 'hours') return matchHours(text);
+  const rules = RULES[field] ?? [];
+  for (const [re, value] of rules) {
+    const m = re.exec(text);
+    if (m) return { value, start: m.index, end: m.index + m[0].length };
+  }
+  return null;
+}
+
+/**
+ * Extract every asked field from one attempt's transcript.
+ * Answers are scoped to the turns between the agent's question and the next
+ * agent turn, so a stray phrase elsewhere in the call cannot be cited as an
+ * answer to a question that was never asked.
+ */
+export function extractFromAttempt(attempt, questions) {
+  return extractInner(attempt, questions).map((ex) => ({ ...ex, attemptIndex: attempt.attempt }));
+}
+
+function extractInner(attempt, questions) {
+  const { turns } = attempt.transcript;
+  const out = [];
+  const channel = attempt.outcome === 'connected_via_ivr' ? 'ivr_transfer' : 'live_answer';
+
+  /* ---- voicemail: the greeting itself can be evidence, at low confidence ---- */
+  if (attempt.outcome === 'voicemail') {
+    const greeting = turns.find((t) => t.speaker === 'staff');
+    if (greeting) {
+      const closed = /\bcurrently\s+closed\b|\bclosed\s+for\s+the\s+season\b/i.exec(greeting.text);
+      if (closed) {
+        out.push(
+          assertGrounded(
+            ground('open_now', greeting, { value: false, start: closed.index, end: closed.index + closed[0].length }, {
+              channel: 'voicemail_greeting',
+            }),
+          ),
+        );
+      }
+      const hrs = matchHours(greeting.text);
+      if (hrs && questions.includes('hours')) {
+        out.push(assertGrounded(ground('hours', greeting, hrs, { channel: 'voicemail_greeting' })));
+      }
+    }
+    for (const f of questions) {
+      if (!out.some((o) => o.field === f)) {
+        out.push(
+          assertGrounded(
+            ground(f, null, null, { channel: 'voicemail', noMatchReason: 'voicemail — question never asked' }),
+          ),
+        );
+      }
+    }
+    return out;
+  }
+
+  if (!attempt.connected) {
+    return questions.map((f) =>
+      assertGrounded(
+        ground(f, null, null, { channel: attempt.outcome, noMatchReason: `call outcome: ${attempt.outcome}` }),
+      ),
+    );
+  }
+
+  for (const field of questions) {
+    const qIdx = turns.findIndex((t) => t.speaker === 'agent' && t.text === QUESTION_TEXT[field]);
+    if (qIdx < 0) {
+      out.push(
+        assertGrounded(ground(field, null, null, { channel, noMatchReason: 'question not reached before call ended' })),
+      );
+      continue;
+    }
+    let hit = null;
+    for (let i = qIdx + 1; i < turns.length && turns[i].speaker !== 'agent'; i++) {
+      if (turns[i].speaker !== 'staff') continue;
+      const m = findMatch(field, turns[i].text);
+      if (m) {
+        hit = ground(field, turns[i], m, { channel });
+        break;
+      }
+    }
+    out.push(assertGrounded(hit ?? ground(field, null, null, { channel, noMatchReason: 'answer did not resolve to a typed value' })));
+  }
+  return out;
+}
+
+/**
+ * Merge extractions across attempts for one facility. A later attempt that
+ * grounds a field that earlier attempts left unknown wins; two grounded answers
+ * that disagree with each other are demoted and sent to review.
+ */
+export function mergeAttempts(attemptExtractions) {
+  const byField = new Map();
+  for (const list of attemptExtractions) {
+    for (const ex of list) {
+      const prev = byField.get(ex.field);
+      if (!prev || prev.value === 'unknown') {
+        byField.set(ex.field, ex);
+      } else if (ex.value !== 'unknown' && !valuesEqual(ex.value, prev.value)) {
+        // Two attempts disagree. Keep the better-supported one -- a live human on
+        // a callback outranks a recorded greeting that may be months old -- but
+        // demote it hard and flag the conflict for a human either way.
+        const [win, lose] = ex.confidence > prev.confidence ? [ex, prev] : [prev, ex];
+        byField.set(ex.field, {
+          ...win,
+          confidence: win.confidence * 0.5,
+          internalConflict: { otherValue: lose.value, otherQuote: lose.quote, otherChannel: lose.channel },
+          reason: `attempts disagreed; kept ${win.channel} over ${lose.channel}`,
+        });
+      }
+    }
+  }
+  return [...byField.values()].map(assertGrounded);
+}
+
+export function valuesEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a === 'boolean' || typeof b === 'boolean') return String(a) === String(b);
+  return String(a).trim().toLowerCase() === String(b).trim().toLowerCase();
+}
+
+export { HEDGE_MARKERS };

--- a/apps/web/locked-door/js/main.js
+++ b/apps/web/locked-door/js/main.js
@@ -1,0 +1,1214 @@
+/**
+ * UI + DEMO HARNESS.
+ *
+ * This file is presentation and orchestration only. Every number it renders is
+ * computed by the engine modules at runtime from the ingested directory and the
+ * simulator's ground truth — nothing on this screen is a constant typed in by
+ * hand, and nothing is a placeholder.
+ *
+ * The exposed `window.__demo` surface drives an automated recorder.
+ */
+
+import { VerificationEngine, FIELDS, ROUTE } from './engine.js';
+import { extractFromAttempt } from './extract.js';
+import { freshness, halfLifeDays, REVIEW_THRESHOLD } from './publish.js';
+import { TAU_DAYS } from './risk.js';
+import { MAX_ATTEMPTS, BACKOFF_REAL_MINUTES, toE164 } from './transport.js';
+
+/* ===================================================================== */
+/* pacing                                                                */
+/* ===================================================================== */
+
+/**
+ * Wall-clock budget per call at speed = 1. 25 calls x 880ms = 22.0 seconds,
+ * which is the filmable window the recorder expects.
+ *
+ * Pacing is DEADLINE-BASED, not delay-based: each call gets a slice, turns
+ * inside it sleep a shrinking fraction of the time remaining in that slice, and
+ * the call sleeps off any surplus at the end. A call with 40 turns and a call
+ * with 8 turns therefore both take one slice, so total runtime stays ~= N x 880ms
+ * on a fast machine and on a slow one.
+ */
+const MS_PER_CALL_AT_SPEED_1 = 880;
+
+const sleep = (ms) => (ms > 0 ? new Promise((r) => setTimeout(r, ms)) : Promise.resolve());
+
+function makePacer(speed, callCount) {
+  const instant = speed === 'instant' || speed === 0 || speed === '0';
+  const mult = instant ? 0 : Number(speed) > 0 ? Number(speed) : 1;
+  const perCall = instant ? 0 : MS_PER_CALL_AT_SPEED_1 / mult;
+  const t0 = performance.now();
+  let index = 0;
+  let deadline = t0;
+  return {
+    instant,
+    perCall,
+    totalPlannedMs: perCall * callCount,
+    startCall() {
+      index += 1;
+      deadline = t0 + index * perCall;
+    },
+    /** Sleep a shrinking slice of the time left in this call. Never overruns. */
+    async turn() {
+      if (instant) return;
+      const left = deadline - performance.now();
+      if (left <= 0) return;
+      await sleep(Math.max(8, Math.min(78, left / 7)));
+    },
+    async endCall() {
+      if (instant) return;
+      await sleep(deadline - performance.now());
+    },
+    elapsed: () => performance.now() - t0,
+  };
+}
+
+/* ===================================================================== */
+/* tiny dom helpers                                                      */
+/* ===================================================================== */
+
+const $ = (id) => document.getElementById(id);
+
+function el(tag, className, text) {
+  const n = document.createElement(tag);
+  if (className) n.className = className;
+  if (text !== undefined && text !== null) n.textContent = String(text);
+  return n;
+}
+
+function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+const pct = (x, d = 1) => `${(x * 100).toFixed(d)}%`;
+const num = (x, d = 2) => Number(x).toFixed(d);
+
+/* ===================================================================== */
+/* value formatting                                                      */
+/* ===================================================================== */
+
+const FIELD_LABEL = {
+  open_now: 'open now',
+  hours: 'hours',
+  pet_policy: 'pets',
+  accessibility: 'accessibility',
+  intake_requirements: 'intake',
+  capacity_status: 'capacity',
+};
+
+const FIELD_COLOR = {
+  open_now: '#e8963c',
+  hours: '#6ea8d8',
+  capacity_status: '#d9705f',
+  intake_requirements: '#4fb3a4',
+  pet_policy: '#b58fd0',
+  accessibility: '#d8a13a',
+};
+
+const VALUE_LABEL = {
+  true: 'OPEN',
+  false: 'CLOSED',
+  no_pets: 'no pets',
+  crated_pets_only: 'crated only',
+  service_animals_only: 'service animals',
+  pets_allowed: 'pets allowed',
+  fully_accessible: 'fully accessible',
+  ramp_only: 'ramp only',
+  not_accessible: 'not accessible',
+  no_id_required: 'no ID needed',
+  id_requested_not_required: 'ID asked, optional',
+  photo_id_required: 'photo ID required',
+  referral_required: 'referral required',
+  space_available: 'space available',
+  near_capacity: 'near capacity',
+  at_capacity: 'at capacity',
+};
+
+function fmtValue(v) {
+  if (v === null || v === undefined || v === '') return '—';
+  return VALUE_LABEL[String(v)] ?? String(v);
+}
+
+const OUTCOME_LABEL = {
+  connected: 'connected',
+  connected_via_ivr: 'connected via IVR',
+  voicemail: 'voicemail',
+  no_answer: 'no answer',
+  busy: 'busy',
+  disconnected: 'disconnected',
+  no_number: 'no number',
+  ivr_dead_end: 'IVR dead end',
+};
+
+/* ===================================================================== */
+/* app state                                                             */
+/* ===================================================================== */
+
+const S = {
+  engine: null,
+  directory: null,
+  ran: false,
+  running: false,
+  /** facilityId -> { outcome, attempts, connected, rows } */
+  callState: new Map(),
+  /* live transcript render state for the centre panel.
+     A call can span up to MAX_ATTEMPTS attempts, and each attempt numbers its
+     turns from 0 again — so every rendered turn is keyed by `attempt:index`,
+     never by index alone. */
+  attempt: 0,
+  liveTurns: [], // turns of the CURRENT attempt (used for prefix extraction)
+  allTurns: new Map(), // "attempt:index" -> turn, for the whole call
+  liveMarks: new Map(), // "attempt:index" -> [{start,end,field}]
+  liveFields: new Map(), // field -> extraction
+  activeFacilityId: null,
+};
+
+const turnKey = (attempt, index) => `${attempt}:${index}`;
+
+/* ===================================================================== */
+/* boot                                                                  */
+/* ===================================================================== */
+
+async function boot() {
+  const [directory, groundTruth] = await Promise.all([
+    fetch('./data/directory.json').then((r) => r.json()),
+    fetch('./data/ground-truth.json').then((r) => r.json()),
+  ]);
+
+  S.directory = directory;
+  // "now" is pinned to the directory's as_of stamp so field ages — and therefore
+  // every risk score on screen — are reproducible rather than drifting with the
+  // wall clock of whoever opens the page.
+  S.engine = new VerificationEngine(directory, groundTruth, { now: Date.parse(directory.as_of) });
+
+  $('dataset-line').textContent =
+    `${directory.facilities.length} facilities · ${directory.dataset} · as of ` +
+    `${new Date(directory.as_of).toISOString().slice(0, 10)} · ` +
+    `${countMissing(directory)} missing field values · ${countDuplicates(directory)} duplicate listings`;
+
+  $('transport-name').textContent = S.engine.transport.name.toLowerCase();
+  $('adapter-state').textContent = `${S.engine.realAdapter.name}, enabled = ${S.engine.realAdapter.enabled}`;
+
+  wireControls();
+  doPlan(readBudget());
+  renderEmptyRunner();
+  renderReview();
+  renderDelta();
+  renderEvaluationPlaceholder();
+}
+
+function countMissing(directory) {
+  let n = 0;
+  for (const f of directory.facilities) for (const v of Object.values(f.fields)) if (v.value === null) n++;
+  return n;
+}
+function countDuplicates(directory) {
+  return directory.facilities.filter((f) => f.duplicate_of).length;
+}
+
+function readBudget() {
+  const v = parseInt($('budget-input').value, 10);
+  return Number.isFinite(v) && v > 0 ? Math.min(v, S.directory.facilities.length) : 25;
+}
+function readSpeed() {
+  const v = $('speed-input').value;
+  return v === 'instant' ? 'instant' : Number(v);
+}
+
+function wireControls() {
+  $('btn-plan').addEventListener('click', () => doPlan(readBudget()));
+  $('btn-run').addEventListener('click', () => {
+    if (!S.running) runBatch({ speed: readSpeed() });
+  });
+  $('btn-approve').addEventListener('click', () => approveAll());
+  $('budget-input').addEventListener('change', () => doPlan(readBudget()));
+  $('btn-show-adapter').addEventListener('click', showAdapterModal);
+  $('btn-close-adapter').addEventListener('click', () => ($('adapter-modal').hidden = true));
+  $('adapter-modal').addEventListener('click', (e) => {
+    if (e.target === $('adapter-modal')) $('adapter-modal').hidden = true;
+  });
+}
+
+/* ===================================================================== */
+/* PLAN                                                                  */
+/* ===================================================================== */
+
+function doPlan(budget) {
+  const { plan, baseline } = S.engine.planCalls(budget);
+  S.callState.clear();
+  S.ran = false;
+  renderQueue();
+  renderBudgetBox();
+  renderEvaluationPlaceholder();
+  return {
+    budget,
+    calls: plan.calls.length,
+    plannedHarmReduction: plan.expectedHarmReduction,
+    baselinePlannedHarmReduction: baseline.expectedHarmReduction,
+    totalAvailableHarm: S.engine.totalAvailableHarm,
+  };
+}
+
+function renderBudgetBox() {
+  const plan = S.engine.plan;
+  const base = S.engine.baselinePlan;
+  const total = S.engine.totalAvailableHarm;
+
+  $('bb-total').textContent = num(total, 1);
+  $('bb-bought').textContent = `${num(plan.expectedHarmReduction, 1)} (${pct(plan.expectedHarmReduction / total, 0)})`;
+  $('bb-bar-fill').style.width = `${Math.min(100, (plan.expectedHarmReduction / total) * 100)}%`;
+  $('bb-plan').textContent = num(plan.expectedHarmReduction, 2);
+  $('bb-base').textContent = num(base.expectedHarmReduction, 2);
+
+  const lift = plan.expectedHarmReduction / base.expectedHarmReduction - 1;
+  $('bb-lift').textContent = `+${pct(lift, 1)}`;
+
+  $('queue-count').textContent = `${plan.calls.length} of ${S.directory.facilities.length} · budget ${plan.budget}`;
+}
+
+function renderQueue() {
+  const list = $('queue');
+  clear(list);
+  const plan = S.engine.plan;
+  const top = plan.calls[0]?.expectedGain ?? 1;
+
+  for (const call of plan.calls) {
+    const f = S.engine.facilityById.get(call.facilityId);
+    const st = S.callState.get(call.facilityId);
+
+    const row = el('li', 'qrow');
+    row.dataset.fid = call.facilityId;
+    if (st) row.classList.add('done');
+    if (S.activeFacilityId === call.facilityId) row.classList.add('active');
+
+    row.appendChild(el('div', 'qrank', String(call.rank)));
+
+    const mid = el('div');
+    mid.appendChild(el('div', 'qname', f.name));
+    const sub = el('div', 'qsub');
+    sub.textContent = `${f.id} · ${f.phone ?? 'no number'} · ${call.line}`;
+    mid.appendChild(sub);
+
+    const chips = el('div', 'qchips');
+    for (const q of call.questions) {
+      const chip = el('span', 'chip', FIELD_LABEL[q.field]);
+      if (st) {
+        const r = st.rows.find((x) => x.field === q.field);
+        if (!r || r.newValue === 'unknown') chip.classList.add('u');
+        else if (r.route === ROUTE.REVIEW) chip.classList.add('r');
+        else chip.classList.add('g');
+      }
+      chip.title =
+        `${q.field}: harm ${num(q.harm ?? 0, 2)} x P(stale) ${num(q.pStale ?? 0, 2)} ` +
+        `x observability ${num(q.observability ?? 0, 2)} = EHR ${num(q.ehr ?? 0, 3)}` +
+        (q.staleReason ? ` · ${q.staleReason}` : '');
+      chips.appendChild(chip);
+    }
+    mid.appendChild(chips);
+
+    if (st) {
+      const s = el('div', `qstatus s-${st.outcome}`);
+      s.textContent = `${OUTCOME_LABEL[st.outcome] ?? st.outcome} · ${st.attempts} attempt${st.attempts > 1 ? 's' : ''}`;
+      mid.appendChild(s);
+    }
+    row.appendChild(mid);
+
+    const score = el('div', 'qscore');
+    score.textContent = num(call.expectedGain, 2);
+    score.appendChild(el('small', null, `p(conn) ${num(call.pConnect, 2)}`));
+    const bar = el('div', 'qbar');
+    const fill = el('i');
+    fill.style.width = `${Math.max(3, (call.expectedGain / top) * 100)}%`;
+    bar.appendChild(fill);
+    score.appendChild(bar);
+    row.appendChild(score);
+
+    list.appendChild(row);
+  }
+}
+
+function markQueueActive(facilityId) {
+  S.activeFacilityId = facilityId;
+  for (const row of $('queue').querySelectorAll('.qrow')) {
+    row.classList.toggle('active', row.dataset.fid === facilityId);
+  }
+  const active = $('queue').querySelector('.qrow.active');
+  if (active) active.scrollIntoView({ block: 'nearest' });
+}
+
+/* ===================================================================== */
+/* RUNNER (centre)                                                       */
+/* ===================================================================== */
+
+function renderEmptyRunner() {
+  $('ch-name').textContent = 'No call in progress';
+  $('ch-meta').textContent = 'Plan a batch, then press Run.';
+  clear($('ch-badges'));
+  clear($('transcript'));
+  $('transcript-hint').textContent = '—';
+  renderFieldCards([]);
+}
+
+function startCallUI(call) {
+  const f = call.facility;
+  S.attempt = 0;
+  S.liveTurns = [];
+  S.allTurns = new Map();
+  S.liveMarks = new Map();
+  S.liveFields = new Map();
+
+  $('ch-name').textContent = f.name;
+  $('ch-meta').textContent =
+    `${f.id} · ${f.phone ?? 'no number on file'} · ${toE164(f.phone) ?? 'unroutable'} · ` +
+    `${f.kind_label} · ~${f.est_daily_visitors} visitors/day · flag: ${f.seasonal_activation_flag}`;
+
+  clear($('ch-badges'));
+  addBadge('SIMULATED', 'warn');
+  addBadge(`rank ${call.entry.rank}`, null);
+  addBadge(`EHR ${num(call.entry.expectedGain, 2)}`, null);
+  addBadge(`${call.entry.questions.length} questions`, null);
+
+  clear($('transcript'));
+  $('transcript-hint').textContent = 'dialing…';
+  renderFieldCards(call.entry.questions.map((q) => q.field));
+  markQueueActive(f.id);
+}
+
+function addBadge(text, kind) {
+  const b = el('span', kind ? `badge ${kind}` : 'badge', text);
+  $('ch-badges').appendChild(b);
+  return b;
+}
+
+function appendTurn(turn, attempt = S.attempt, addressable = true) {
+  if (addressable) {
+    S.liveTurns.push(turn);
+    S.allTurns.set(turnKey(attempt, turn.index), turn);
+  }
+  const wrap = el('div', `turn ${turn.speaker}`);
+  if (addressable) wrap.dataset.turnKey = turnKey(attempt, turn.index);
+  wrap.appendChild(el('div', 'who', turn.speaker));
+  const said = el('div', 'said');
+  said.textContent = turn.text;
+  wrap.appendChild(said);
+  const tx = $('transcript');
+  tx.appendChild(wrap);
+  tx.scrollTop = tx.scrollHeight;
+}
+
+/** Re-render one turn's text with <mark> around every cited span. */
+function paintTurnMarks(key) {
+  const turn = S.allTurns.get(key);
+  if (!turn) return;
+  const node = $('transcript').querySelector(`[data-turn-key="${key}"] .said`);
+  if (!node) return;
+  const marks = (S.liveMarks.get(key) ?? [])
+    .slice()
+    .sort((a, b) => a.start - b.start)
+    .filter((m, i, arr) => i === 0 || m.start >= arr[i - 1].end);
+
+  clear(node);
+  let cursor = 0;
+  for (const m of marks) {
+    const rs = m.start - turn.textStart;
+    const re = m.end - turn.textStart;
+    if (rs < cursor || re > turn.text.length) continue;
+    if (rs > cursor) node.appendChild(document.createTextNode(turn.text.slice(cursor, rs)));
+    const mark = el('mark', 'flash', turn.text.slice(rs, re));
+    mark.dataset.field = m.field;
+    node.appendChild(mark);
+    cursor = re;
+  }
+  if (cursor < turn.text.length) node.appendChild(document.createTextNode(turn.text.slice(cursor)));
+}
+
+function renderFieldCards(fields, extractions = new Map()) {
+  const wrap = $('fields');
+  clear(wrap);
+  const list = fields.length ? fields : FIELDS;
+
+  for (const field of list) {
+    const ex = extractions.get(field);
+    const card = el('div', 'fcard');
+    card.dataset.field = field;
+    card.appendChild(el('div', 'fname', FIELD_LABEL[field]));
+
+    if (!ex || ex.value === 'unknown') {
+      card.classList.add('unknown');
+      card.appendChild(el('div', 'fval', ex ? 'unknown' : '—'));
+      card.appendChild(el('div', 'fmeta', ex ? '' : 'awaiting answer'));
+      if (ex) {
+        const nc = el('div', 'no-cite', 'no supporting span → unknown');
+        nc.title = ex.reason;
+        card.appendChild(nc);
+      }
+    } else {
+      const low = ex.confidence < REVIEW_THRESHOLD || ex.internalConflict;
+      card.classList.add(low ? 'review' : 'grounded');
+      card.appendChild(el('div', 'fval', fmtValue(ex.value)));
+      card.appendChild(
+        el('div', 'fmeta', `conf ${num(ex.confidence, 2)}${ex.hedged ? ' · hedged' : ''} · ${ex.channel}`),
+      );
+      const cite = el('div', 'cite', `“${ex.quote}”`);
+      cite.title = 'jump to the cited span in the transcript';
+      cite.addEventListener('click', () => jumpToSpan(field));
+      card.appendChild(cite);
+    }
+    wrap.appendChild(card);
+  }
+}
+
+function jumpToSpan(field) {
+  const mark = $('transcript').querySelector(`mark[data-field="${field}"]`);
+  if (!mark) return;
+  mark.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  mark.classList.remove('flash');
+  void mark.offsetWidth;
+  mark.classList.add('flash');
+}
+
+/* ===================================================================== */
+/* RUN BATCH                                                             */
+/* ===================================================================== */
+
+async function runBatch({ speed } = {}) {
+  if (S.running) return null;
+  S.running = true;
+  $('btn-run').disabled = true;
+  $('btn-plan').disabled = true;
+
+  const spd = speed === undefined ? readSpeed() : speed;
+
+  // Preserve the plan across the engine reset so re-running is idempotent.
+  const plan = S.engine.plan ?? S.engine.planCalls(readBudget()).plan;
+  const baselinePlan = S.engine.baselinePlan;
+  S.engine.reset();
+  S.engine.plan = plan;
+  S.engine.baselinePlan = baselinePlan;
+  S.callState.clear();
+
+  const pacer = makePacer(spd, plan.calls.length);
+  let done = 0;
+
+  const hooks = {
+    onCallStart: async (call) => {
+      pacer.startCall();
+      startCallUI(call);
+      $('runner-progress').textContent = `call ${done + 1} / ${plan.calls.length}`;
+      await pacer.turn();
+    },
+
+    onAttemptStart: async ({ attempt, outcome }) => {
+      // Each attempt is a fresh transcript with its own turn numbering.
+      S.attempt = attempt;
+      S.liveTurns = [];
+      $('transcript-hint').textContent =
+        `attempt ${attempt + 1} of ${MAX_ATTEMPTS} · outcome ${OUTCOME_LABEL[outcome] ?? outcome}`;
+    },
+
+    onTurn: async (turn, ctx) => {
+      appendTurn(turn);
+      // Live grounding: re-run the REAL extractor over the transcript prefix so
+      // a field lights up at the moment its answer is spoken, using exactly the
+      // same code path that produces the published value.
+      if (turn.speaker === 'staff') {
+        liveExtract(ctx);
+      }
+      await pacer.turn();
+    },
+
+    onBackoff: async ({ attempt, nextInMinutes }) => {
+      appendTurn(
+        {
+          index: -1,
+          speaker: 'system',
+          text: `No usable answer on attempt ${attempt + 1}. Backing off ${nextInMinutes} minutes before retry (simulated — no wait is actually served).`,
+          textStart: 0,
+        },
+        attempt,
+        false,
+      );
+      await pacer.turn();
+    },
+
+    onCallEnd: async (call) => {
+      done += 1;
+      S.callState.set(call.facilityId, {
+        outcome: call.callMeta.outcome,
+        attempts: call.attempts.length,
+        connected: call.callMeta.connected,
+        rows: call.rows,
+      });
+      finalizeCallUI(call);
+      renderQueue();
+      renderReview();
+      renderDelta();
+      renderEvaluation({ live: true });
+      $('runner-progress').textContent = `call ${done} / ${plan.calls.length} complete`;
+      await pacer.endCall();
+    },
+  };
+
+  await S.engine.runPlan(plan, { hooks });
+
+  // Counterfactual baseline: same simulator, same seeds, naive ordering.
+  await S.engine.runBaselineCounterfactual();
+
+  S.ran = true;
+  S.running = false;
+  $('btn-run').disabled = false;
+  $('btn-plan').disabled = false;
+  $('runner-progress').textContent = `${done} calls complete in ${(pacer.elapsed() / 1000).toFixed(1)}s`;
+
+  renderQueue();
+  renderReview();
+  renderDelta();
+  renderEvaluation();
+
+  return stats();
+}
+
+/** Run the real extractor over the streamed prefix of the current attempt. */
+function liveExtract(ctx) {
+  const questions = ctx.plan.questions;
+  const turns = S.liveTurns;
+  if (!turns.length) return;
+  const text = turns.map((t) => t.prefix + t.text).join('\n');
+  const synthetic = {
+    attempt: ctx.attempt,
+    outcome: ctx.outcome,
+    connected: ctx.outcome === 'connected' || ctx.outcome === 'connected_via_ivr',
+    transcript: { turns, text },
+  };
+
+  let extractions;
+  try {
+    // The engine's own extractor, on a transcript PREFIX. If an answer has not
+    // been spoken yet it returns unknown, which is the correct behaviour rather
+    // than an error — so the card stays dark until a span actually supports it.
+    extractions = extractFromAttempt(synthetic, questions);
+  } catch {
+    return;
+  }
+
+  let changed = false;
+  for (const ex of extractions) {
+    if (ex.value === 'unknown') continue;
+    const prev = S.liveFields.get(ex.field);
+    if (prev && prev.value === ex.value) continue;
+    S.liveFields.set(ex.field, ex);
+    changed = true;
+    if (ex.span) {
+      const key = turnKey(ctx.attempt, ex.span.turnIndex);
+      const arr = S.liveMarks.get(key) ?? [];
+      if (!arr.some((m) => m.start === ex.span.start && m.field === ex.field)) {
+        arr.push({ start: ex.span.start, end: ex.span.end, field: ex.field });
+        S.liveMarks.set(key, arr);
+        paintTurnMarks(key);
+      }
+    }
+  }
+  if (changed) renderFieldCards(questions, S.liveFields);
+}
+
+function finalizeCallUI(call) {
+  // Replace the live view with the authoritative merged extraction.
+  const merged = new Map(call.extractions.map((e) => [e.field, e]));
+  S.liveFields = merged;
+  S.liveMarks = new Map();
+  for (const ex of call.extractions) {
+    if (!ex.span) continue;
+    // A merged extraction remembers which attempt produced it, so the citation
+    // is painted on the right attempt's transcript.
+    const key = turnKey(ex.attemptIndex ?? 0, ex.span.turnIndex);
+    const arr = S.liveMarks.get(key) ?? [];
+    if (!arr.some((m) => m.start === ex.span.start && m.field === ex.field)) {
+      arr.push({ start: ex.span.start, end: ex.span.end, field: ex.field });
+    }
+    S.liveMarks.set(key, arr);
+  }
+  for (const key of S.liveMarks.keys()) paintTurnMarks(key);
+  renderFieldCards(
+    call.entry.questions.map((q) => q.field),
+    merged,
+  );
+
+  clear($('ch-badges'));
+  addBadge('SIMULATED', 'warn');
+  const oc = call.callMeta.outcome;
+  addBadge(
+    OUTCOME_LABEL[oc] ?? oc,
+    call.callMeta.connected ? 'ok' : oc === 'voicemail' ? 'warn' : 'bad',
+  );
+  addBadge(`${call.attempts.length}/${MAX_ATTEMPTS} attempts`, null);
+  const grounded = call.rows.filter((r) => r.newValue !== 'unknown').length;
+  addBadge(`${grounded}/${call.rows.length} grounded`, grounded ? 'ok' : null);
+  const rev = call.rows.filter((r) => r.route === ROUTE.REVIEW).length;
+  if (rev) addBadge(`${rev} to review`, 'warn');
+
+  $('transcript-hint').textContent =
+    `${call.attempts.length} attempt(s) · backoff ${call.attempts.map((a) => BACKOFF_REAL_MINUTES[a.attempt]).join('/')} min · ` +
+    `idempotency ${call.callMeta.idempotencyKey.slice(-12)}`;
+}
+
+/* ===================================================================== */
+/* REVIEW + DELTA (right)                                                */
+/* ===================================================================== */
+
+function renderReview() {
+  const wrap = $('review-list');
+  clear(wrap);
+  const q = S.engine.reviewQueue;
+  $('review-count').textContent = `${q.length} waiting`;
+
+  if (!q.length) {
+    wrap.appendChild(
+      el(
+        'p',
+        'empty',
+        'Contradictions, hedged answers and low-confidence extractions land here instead of in the directory.',
+      ),
+    );
+    return;
+  }
+
+  // Highest-risk contradictions first: a human reviewing 30 rows should see the
+  // one that sends someone to a locked door before the one about pets.
+  const sorted = [...q].sort((a, b) => {
+    const ra = S.engine.rowFor(a.facilityId, a.field);
+    const rb = S.engine.rowFor(b.facilityId, b.field);
+    return rb.harm * rb.pStale - ra.harm * ra.pStale;
+  });
+
+  for (const row of sorted) wrap.appendChild(reviewRow(row));
+}
+
+function reviewRow(row) {
+  const box = el('div', 'rrow needs');
+
+  const top = el('div', 'rr-top');
+  top.appendChild(el('div', 'rr-field', FIELD_LABEL[row.field]));
+  top.appendChild(el('div', 'rr-fac', `${row.facilityId} · ${row.facilityName}`));
+  box.appendChild(top);
+
+  const chg = el('div', 'rr-change');
+  chg.appendChild(el('span', 'rr-old', fmtValue(row.oldCanonical)));
+  chg.appendChild(el('span', 'rr-arrow', '→'));
+  chg.appendChild(el('span', 'rr-new', fmtValue(row.newCanonical)));
+  box.appendChild(chg);
+
+  box.appendChild(el('div', 'rr-why', row.reason));
+
+  if (row.evidence?.quote) {
+    const q = el('div', 'rr-quote', `“${row.evidence.contextQuote ?? row.evidence.quote}”`);
+    q.title = `cited span ${row.evidence.span.start}–${row.evidence.span.end} of attempt ${row.evidence.attempt + 1} transcript`;
+    box.appendChild(q);
+  }
+
+  const foot = el('div', 'rr-foot');
+  const conf = el('div', 'rr-conf');
+  conf.textContent = `conf ${num(row.confidence, 2)}`;
+  const bar = el('span', 'confbar');
+  const fill = el('i');
+  fill.style.width = `${Math.round(row.confidence * 100)}%`;
+  fill.style.background = row.confidence >= REVIEW_THRESHOLD ? 'var(--verified)' : 'var(--review)';
+  bar.appendChild(fill);
+  conf.appendChild(bar);
+  foot.appendChild(conf);
+
+  const actions = el('div', 'rr-actions');
+  const ok = el('button', 'primary', 'Approve');
+  ok.addEventListener('click', () => {
+    S.engine.store.approve(row, 'operator@county');
+    row.publishedBy = 'operator@county';
+    S.engine.reviewQueue = S.engine.reviewQueue.filter((r) => r !== row);
+    renderReview();
+    renderDelta();
+    if (S.ran) renderEvaluation();
+  });
+  const no = el('button', 'ghost', 'Reject');
+  no.addEventListener('click', () => {
+    S.engine.store.reject(row, 'operator@county');
+    S.engine.reviewQueue = S.engine.reviewQueue.filter((r) => r !== row);
+    renderReview();
+    if (S.ran) renderEvaluation();
+  });
+  actions.appendChild(ok);
+  actions.appendChild(no);
+  foot.appendChild(actions);
+  box.appendChild(foot);
+
+  return box;
+}
+
+function renderDelta() {
+  const wrap = $('delta-list');
+  clear(wrap);
+  const published = S.engine.store.published;
+  $('delta-count').textContent = `${published.length} rows`;
+
+  if (!published.length) {
+    wrap.appendChild(
+      el('p', 'empty', 'Approved changes append to a per-field history. Nothing is overwritten.'),
+    );
+    return;
+  }
+
+  const recent = [...published].reverse().slice(0, 60);
+  for (const row of recent) {
+    const box = el('div', `rrow ${row.approvedBy === 'auto-policy' ? 'auto' : 'human'}`);
+
+    const top = el('div', 'rr-top');
+    top.appendChild(el('div', 'rr-field', FIELD_LABEL[row.field]));
+    top.appendChild(el('div', 'rr-fac', `${row.facilityId} · ${row.status}`));
+    box.appendChild(top);
+
+    const chg = el('div', 'rr-change');
+    if (row.status === 'confirmed') {
+      // Old and new are the same value: showing "X → X" with a strikethrough
+      // would imply a change that did not happen. A re-verification is still a
+      // new version, because its freshness clock restarts.
+      chg.appendChild(el('span', 'rr-new', fmtValue(row.newCanonical)));
+      chg.appendChild(el('span', 'rr-arrow', 're-verified, unchanged'));
+    } else {
+      chg.appendChild(el('span', 'rr-old', fmtValue(row.oldCanonical)));
+      chg.appendChild(el('span', 'rr-arrow', '→'));
+      chg.appendChild(el('span', 'rr-new', fmtValue(row.newCanonical)));
+    }
+    const v = S.engine.store.versionCount(row.facilityId, row.field);
+    chg.appendChild(el('span', 'rr-conf', `v${v}`));
+    box.appendChild(chg);
+
+    const q = el('div', 'rr-quote', `“${row.evidence.quote}”`);
+    q.title =
+      `span ${row.evidence.span.start}–${row.evidence.span.end} · turn ${row.evidence.turnIndex} · ` +
+      `${row.evidence.channel} · attempt ${row.evidence.attempt + 1}`;
+    box.appendChild(q);
+
+    const foot = el('div', 'rr-foot');
+    foot.appendChild(
+      el(
+        'div',
+        'rr-conf',
+        `conf ${num(row.confidence, 2)} · fresh ${pct(freshness(row.field, row.verifiedAt, S.engine.now), 0)} · ` +
+          `50% in ${halfLifeDays(row.field).toFixed(0)}d`,
+      ),
+    );
+    foot.appendChild(el('div', 'rr-conf', row.approvedBy === 'auto-policy' ? 'auto-policy' : row.approvedBy));
+    box.appendChild(foot);
+
+    const ts = el('div', 'rr-why');
+    ts.textContent = `verified_at ${row.verifiedAt}`;
+    box.appendChild(ts);
+
+    wrap.appendChild(box);
+  }
+}
+
+function approveAll() {
+  const approved = S.engine.approveAll('operator@county');
+  renderReview();
+  renderDelta();
+  if (S.ran) renderEvaluation();
+  return approved.length;
+}
+
+/* ===================================================================== */
+/* EVALUATION (bottom)                                                   */
+/* ===================================================================== */
+
+function renderEvaluationPlaceholder() {
+  $('eval-state').textContent = 'run a batch to populate';
+  clear($('eval-tiles'));
+  clear($('eval-table').querySelector('tbody'));
+  clear($('harm-bars'));
+  clear($('decay-legend'));
+  clear($('decay-chart'));
+}
+
+function tile(value, label, detail, kind = 'neutral') {
+  const t = el('div', `tile ${kind}`);
+  t.appendChild(el('div', 'tv', value));
+  t.appendChild(el('div', 'tl', label));
+  if (detail) t.appendChild(el('div', 'td', detail));
+  return t;
+}
+
+/**
+ * `live` renders the same measurements mid-batch. Everything shown is real and
+ * final for the calls completed SO FAR — the only thing missing is the baseline
+ * counterfactual, which cannot exist until the batch finishes, so the headline
+ * comparison is replaced by progress rather than by a placeholder number.
+ */
+function renderEvaluation({ live = false } = {}) {
+  const ev = S.engine.evaluate();
+  const hasBaseline = !!ev.baseline;
+
+  $('eval-state').textContent = live
+    ? `LIVE · ${ev.callsPlaced}/${S.engine.plan.calls.length} calls · ${ev.attempted} field-facts so far · ` +
+      `baseline counterfactual runs when the batch completes`
+    : `${ev.callsPlaced} calls · ${ev.totalAttempts} attempts · ${ev.attempted} field-facts attempted · ` +
+      `measured against ${S.engine.truthById.size} ground-truth records`;
+
+  /* ---- tiles ---- */
+  const tiles = $('eval-tiles');
+  clear(tiles);
+
+  // The headline comparison leads, because it is the claim the product makes.
+  if (hasBaseline) {
+    const lift = ev.harmRealized / ev.baseline.harmRealized - 1;
+    tiles.appendChild(
+      tile(
+        `${num(ev.harmRealized, 1)} vs ${num(ev.baseline.harmRealized, 1)} harm units  ·  +${pct(lift, 1)}`,
+        'risk-ranked plan vs naive oldest-first, realized against ground truth',
+        `same budget (${ev.callsPlaced} calls), same simulator, same seeds · ` +
+          `${num(ev.harmForfeited, 1)} units forfeited to "unknown" rather than guessed`,
+        'hero',
+      ),
+    );
+  } else {
+    tiles.appendChild(
+      tile(
+        `${num(ev.harmRealized, 1)} harm units recovered so far`,
+        `batch running — ${ev.callsPlaced} of ${S.engine.plan.calls.length} calls placed`,
+        `the naive oldest-first counterfactual is replayed through the same simulator ` +
+          `once this batch finishes, so no comparison is shown yet`,
+        'hero',
+      ),
+    );
+  }
+
+  tiles.appendChild(
+    tile(pct(ev.precision), 'precision', `${ev.correct}/${ev.grounded} grounded correct`, ev.precision >= 0.9 ? 'good' : 'warn'),
+  );
+  tiles.appendChild(
+    tile(pct(ev.recall), 'recall', `${ev.correct}/${ev.attempted} attempted · ${ev.connected}/${ev.callsPlaced} connected`, 'neutral'),
+  );
+  tiles.appendChild(
+    tile(pct(ev.unknownRate), 'unknown rate', `the price of not guessing · vm ${ev.voicemail} · no-ans ${ev.noAnswer}`, 'warn'),
+  );
+
+  tiles.appendChild(
+    tile(
+      pct(ev.falsePublishAutoOnly.rate, 2),
+      'false publish (machine)',
+      `${ev.falsePublishAutoOnly.wrong}/${ev.falsePublishAutoOnly.published} on machine authority · ` +
+        `incl. human-approved rows ${pct(ev.falsePublish.rate, 1)} (${ev.falsePublish.wrong}/${ev.falsePublish.published})`,
+      ev.falsePublishAutoOnly.wrong === 0 ? 'good' : 'bad',
+    ),
+  );
+  tiles.appendChild(
+    tile(
+      String(ev.citationGate.ungroundedPublishes),
+      'ungrounded publishes',
+      `${ev.citationGate.spanCheck.resolved}/${ev.citationGate.spanCheck.total} spans re-resolve to their quote`,
+      ev.citationGate.ungroundedPublishes === 0 ? 'good' : 'bad',
+    ),
+  );
+
+  const wr = ev.wrongValueRouting;
+  tiles.appendChild(
+    tile(
+      `${wr.toReview}/${wr.total}`,
+      'wrong values caught',
+      wr.total
+        ? `router held ${pct(wr.caughtRate, 0)} of its own errors · ${ev.reviewQueueSize} in queue`
+        : `no wrong values produced · ${ev.reviewQueueSize} in queue`,
+      wr.toAuto === 0 ? 'good' : 'bad',
+    ),
+  );
+
+  /* ---- per-field table ---- */
+  const tbody = $('eval-table').querySelector('tbody');
+  clear(tbody);
+  for (const [field, v] of Object.entries(ev.perField)) {
+    const tr = el('tr');
+    tr.appendChild(el('td', null, field));
+    tr.appendChild(el('td', null, String(v.attempted)));
+    tr.appendChild(el('td', 'v', String(v.grounded)));
+    tr.appendChild(el('td', 'v', v.precision === null ? 'n/a' : pct(v.precision, 0)));
+    tr.appendChild(el('td', null, v.recall === null ? 'n/a' : pct(v.recall, 0)));
+    tr.appendChild(el('td', null, v.unknownRate === null ? 'n/a' : pct(v.unknownRate, 0)));
+    tbody.appendChild(tr);
+  }
+
+  /* ---- harm bars ---- */
+  const bars = $('harm-bars');
+  clear(bars);
+  const maxHarm = Math.max(
+    ev.harmRealized,
+    ev.baseline?.harmRealized ?? 0,
+    ev.harmForfeited,
+    ev.plannedHarm,
+  );
+  const rows = [
+    ['risk-ranked (realized)', ev.harmRealized, 'var(--verified)'],
+    ...(hasBaseline ? [['oldest-first (realized)', ev.baseline.harmRealized, 'var(--base)']] : []),
+    ['risk-ranked (planned)', ev.plannedHarm, 'var(--plan)'],
+    ['forfeited to unknown', ev.harmForfeited, 'var(--review)'],
+  ];
+  for (const [label, value, color] of rows) {
+    const hb = el('div', 'hb');
+    hb.appendChild(el('div', 'hb-label', label));
+    const track = el('div', 'hb-track');
+    const fill = el('div', 'hb-fill');
+    fill.style.width = `${maxHarm ? (value / maxHarm) * 100 : 0}%`;
+    fill.style.background = color;
+    track.appendChild(fill);
+    hb.appendChild(track);
+    hb.appendChild(el('div', 'hb-val', num(value, 2)));
+    bars.appendChild(hb);
+  }
+
+  renderDecayChart();
+}
+
+/**
+ * Freshness decay of what was just verified, per field, over the next 21 days.
+ * Drawn from the same tau priors the risk model uses, so the chart is the model
+ * rather than an illustration of it.
+ */
+function renderDecayChart() {
+  const svg = $('decay-chart');
+  const W = 460;
+  const H = 118;
+  const pad = { l: 26, r: 16, t: 8, b: 16 };
+  const DAYS = 21;
+  clear(svg);
+
+  const ns = 'http://www.w3.org/2000/svg';
+  const mk = (tag, attrs) => {
+    const n = document.createElementNS(ns, tag);
+    for (const [k, v] of Object.entries(attrs)) n.setAttribute(k, String(v));
+    return n;
+  };
+
+  const x = (d) => pad.l + (d / DAYS) * (W - pad.l - pad.r);
+  const y = (v) => pad.t + (1 - v) * (H - pad.t - pad.b);
+
+  for (const v of [0, 0.5, 1]) {
+    svg.appendChild(mk('line', { x1: pad.l, x2: W - pad.r, y1: y(v), y2: y(v), stroke: '#232d3a', 'stroke-width': 1 }));
+    const t = mk('text', { x: 2, y: y(v) + 3, fill: '#677484', 'font-size': 8, 'font-family': 'ui-monospace, monospace' });
+    t.textContent = v === 1 ? '100%' : v === 0.5 ? '50%' : '0';
+    svg.appendChild(t);
+  }
+  for (const d of [0, 7, 14, 21]) {
+    const t = mk('text', { x: x(d), y: H - 4, fill: '#677484', 'font-size': 8, 'font-family': 'ui-monospace, monospace', 'text-anchor': 'middle' });
+    t.textContent = `${d}d`;
+    svg.appendChild(t);
+  }
+
+  // Only chart fields that were actually published in this run.
+  const publishedFields = new Set(S.engine.store.published.map((p) => p.field));
+  const fields = FIELDS.filter((f) => publishedFields.has(f));
+  const list = fields.length ? fields : FIELDS;
+
+  for (const field of list) {
+    const pts = [];
+    for (let d = 0; d <= DAYS; d += 0.5) {
+      pts.push(`${x(d).toFixed(1)},${y(Math.exp(-d / TAU_DAYS[field])).toFixed(1)}`);
+    }
+    svg.appendChild(
+      mk('polyline', { points: pts.join(' '), fill: 'none', stroke: FIELD_COLOR[field], 'stroke-width': 1.6, opacity: 0.9 }),
+    );
+  }
+
+  const legend = $('decay-legend');
+  clear(legend);
+  for (const field of list) {
+    const s = el('span');
+    const i = el('i');
+    i.style.background = FIELD_COLOR[field];
+    s.appendChild(i);
+    s.appendChild(document.createTextNode(`${FIELD_LABEL[field]} τ${TAU_DAYS[field]}d`));
+    legend.appendChild(s);
+  }
+}
+
+/* ===================================================================== */
+/* adapter modal                                                         */
+/* ===================================================================== */
+
+function showAdapterModal() {
+  const entry = S.engine.plan?.calls[0];
+  const body = $('adapter-body');
+  if (!entry) {
+    body.textContent = 'Plan a batch first.';
+    $('adapter-modal').hidden = false;
+    return;
+  }
+  const { payload, request } = S.engine.buildCallPlan(entry);
+
+  let refusal;
+  try {
+    // Proves the refusal is real by actually calling it.
+    S.engine.realAdapter.placeCall(payload);
+    refusal = 'NO ERROR THROWN — this would be a bug.';
+  } catch (e) {
+    refusal = e.message;
+  }
+
+  body.textContent =
+    `${request.method} ${request.url}\n` +
+    Object.entries(request.headers)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n') +
+    `\n\n${JSON.stringify(JSON.parse(request.canonicalBody), null, 2)}\n\n` +
+    `request-body-digest: ${request.requestBodyDigest}\n` +
+    `idempotency-key:     ${request.idempotencyKey}\n\n` +
+    `--- what happens when placeCall() is invoked ---\n${refusal}\n\n` +
+    `--- disclosure read at the top of every call ---\n${payload.disclosure}`;
+
+  $('adapter-modal').hidden = false;
+}
+
+/* ===================================================================== */
+/* stats + demo surface                                                  */
+/* ===================================================================== */
+
+function stats() {
+  const ev = S.ran ? S.engine.evaluate() : null;
+  const plan = S.engine.plan;
+
+  return {
+    facilities: S.directory ? S.directory.facilities.length : 0,
+    budget: plan ? plan.budget : 0,
+    callsPlaced: ev ? ev.callsPlaced : 0,
+    connected: ev ? ev.connected : 0,
+    voicemail: ev ? ev.voicemail : 0,
+    noAnswer: ev ? ev.noAnswer : 0,
+    fieldsExtracted: S.engine ? S.engine.fieldsExtracted() : 0,
+    unknownRate: ev ? ev.unknownRate : 0,
+    precision: ev ? ev.precision : 0,
+    recall: ev ? ev.recall : 0,
+    // The rate at which the SYSTEM publishes a wrong value on its own authority.
+    // Rows a human pulled out of the review queue are that human's decision, and
+    // are reported separately below rather than being folded in silently.
+    falsePublishRate: ev ? ev.falsePublishAutoOnly.rate : 0,
+    harmReduction: ev ? ev.harmRealized : plan ? plan.expectedHarmReduction : 0,
+    baselineHarmReduction: ev
+      ? (ev.baseline?.harmRealized ?? 0)
+      : S.engine?.baselinePlan?.expectedHarmReduction ?? 0,
+    reviewQueueSize: S.engine ? S.engine.reviewQueue.length : 0,
+
+    /* ---- additional measured detail, beyond the required keys ---- */
+    deadLine: ev ? ev.deadLine : 0,
+    totalAttempts: ev ? ev.totalAttempts : 0,
+    attempted: ev ? ev.attempted : 0,
+    grounded: ev ? ev.grounded : 0,
+    publishedCount: ev ? ev.publishedCount : 0,
+    autoPublished: ev ? ev.falsePublishAutoOnly.published : 0,
+    falsePublishRateAllPublished: ev ? ev.falsePublish.rate : 0,
+    wrongValuesProduced: ev ? ev.wrongValueRouting.total : 0,
+    wrongValuesHeldForReview: ev ? ev.wrongValueRouting.toReview : 0,
+    wrongValuesAutoPublished: ev ? ev.wrongValueRouting.toAuto : 0,
+    ungroundedPublishes: ev ? ev.citationGate.ungroundedPublishes : 0,
+    spansResolved: ev ? ev.citationGate.spanCheck.resolved : 0,
+    spansChecked: ev ? ev.citationGate.spanCheck.total : 0,
+    plannedHarmReduction: plan ? plan.expectedHarmReduction : 0,
+    plannedBaselineHarmReduction: S.engine?.baselinePlan?.expectedHarmReduction ?? 0,
+    totalAvailableHarm: S.engine ? S.engine.totalAvailableHarm : 0,
+    harmForfeitedToUnknown: ev ? ev.harmForfeited : 0,
+    realCallsPlaced: 0,
+    transportIsReal: S.engine ? S.engine.transport.isReal : false,
+    realAdapterEnabled: S.engine ? S.engine.realAdapter.enabled : false,
+  };
+}
+
+function flash(node) {
+  node.style.transition = 'box-shadow 0.3s';
+  node.style.boxShadow = '0 0 0 2px rgba(110,168,216,0.65)';
+  setTimeout(() => {
+    node.style.boxShadow = '';
+  }, 1100);
+}
+
+const ready = boot();
+
+window.__demo = {
+  ready,
+
+  async planCalls(budget = 25) {
+    await ready;
+    $('budget-input').value = String(budget);
+    return doPlan(budget);
+  },
+
+  async runBatch(opts = {}) {
+    await ready;
+    return runBatch(opts);
+  },
+
+  async openReview() {
+    await ready;
+    const panel = $('review-list').closest('.panel');
+    $('review-list').scrollTop = 0;
+    flash(panel);
+    await sleep(320);
+    return { reviewQueueSize: S.engine.reviewQueue.length };
+  },
+
+  async approveAll() {
+    await ready;
+    const n = approveAll();
+    await sleep(220);
+    return { approved: n, published: S.engine.store.published.length };
+  },
+
+  async showEvaluation() {
+    await ready;
+    if (S.ran) renderEvaluation();
+    flash(document.querySelector('.evalpanel'));
+    await sleep(320);
+    return stats();
+  },
+
+  stats,
+
+  /* escape hatches used by the verification harness */
+  _engine: () => S.engine,
+  _citationAudit: citationAudit,
+};
+
+/**
+ * INDEPENDENT CITATION AUDIT.
+ *
+ * Re-derives, from scratch, the claim the whole product rests on: every
+ * published field carries a transcript span, and that span still contains
+ * exactly the quoted text. Deliberately does not reuse the engine's own gate.
+ */
+function citationAudit() {
+  const published = S.engine.store.published;
+  const failures = [];
+  let withSpan = 0;
+
+  for (const p of published) {
+    if (p.newValue === 'unknown') {
+      failures.push(`${p.facilityId}/${p.field}: value is "unknown" but was published`);
+      continue;
+    }
+    const sp = p.evidence?.span;
+    if (!sp || typeof sp.start !== 'number' || typeof sp.end !== 'number' || sp.end <= sp.start) {
+      failures.push(`${p.facilityId}/${p.field}: no usable span`);
+      continue;
+    }
+    const tx = S.engine.transcripts.get(`${p.callMeta.callId}#${p.evidence.attempt}`);
+    if (!tx) {
+      failures.push(`${p.facilityId}/${p.field}: transcript not retained`);
+      continue;
+    }
+    const slice = tx.text.slice(sp.start, sp.end);
+    if (slice !== p.evidence.quote) {
+      failures.push(`${p.facilityId}/${p.field}: span "${slice}" != quote "${p.evidence.quote}"`);
+      continue;
+    }
+    withSpan++;
+  }
+
+  return {
+    publishedRows: published.length,
+    rowsWithResolvingSpan: withSpan,
+    failures,
+    pass: failures.length === 0 && withSpan === published.length,
+  };
+}

--- a/apps/web/locked-door/js/planner.js
+++ b/apps/web/locked-door/js/planner.js
@@ -1,0 +1,168 @@
+/**
+ * THE PLANNER — turning per-field risk into a bounded call queue.
+ *
+ * This is not a sort. Two things make it an optimisation:
+ *
+ *  1. ONE CALL VERIFIES SEVERAL FIELDS. The unit of cost is a call, not a field,
+ *     so the value of a facility is a *set* value, and the set has diminishing
+ *     returns inside it: a caller gets a clean answer to question 1, a decent
+ *     answer to question 3, and by question 6 the staff member is done. That is
+ *     modelled by an explicit per-question decay, so the 6th question on a
+ *     high-risk facility can be worth less than the 1st question on a lower one.
+ *
+ *  2. FACILITIES OVERLAP. Duplicate listings share a phone line, so calling one
+ *     already answers most of the other's questions. Selecting a facility
+ *     therefore *changes the value of other facilities*, which is what forces
+ *     re-evaluation each round instead of a single ranking pass.
+ *
+ * The objective is monotone and submodular, so greedy carries the standard
+ * (1 - 1/e) guarantee against the optimal bounded set. We do not claim optimality.
+ */
+
+import { FIELDS, LINE_PROFILE } from './risk.js';
+
+/** Value retained by the k-th question asked in a single call (k is 0-based). */
+export const QUESTION_DECAY = 0.82;
+/** Hard cap on questions per call: a disclosed script that runs long gets hung up on. */
+export const MAX_QUESTIONS_PER_CALL = 6;
+/** Residual value of a field already covered by a selected facility on the same line. */
+export const SHARED_LINE_RESIDUAL = 0.25;
+
+/**
+ * Marginal expected harm reduction of calling `facilityId` given already-selected set.
+ * `covered` maps "facilityKey:field" -> true for fields a selected call already reaches.
+ */
+export function marginalGain(facilityId, ctx, covered) {
+  const line = ctx.lineClassById(facilityId);
+  const profile = LINE_PROFILE[line] ?? LINE_PROFILE.direct;
+  const pConnect = profile.connect;
+  if (pConnect <= 0) return { gain: 0, questions: [], pConnect: 0, line };
+
+  const lineKey = ctx.lineKeyById(facilityId);
+
+  const scored = FIELDS.map((field) => {
+    const row = ctx.rowFor(facilityId, field);
+    const residual = covered.has(`${lineKey}:${field}`) ? SHARED_LINE_RESIDUAL : 1;
+    return { field, base: row.ehr, residual, value: row.ehr * residual, row };
+  })
+    .filter((q) => q.value > 0)
+    .sort((a, b) => b.value - a.value)
+    .slice(0, MAX_QUESTIONS_PER_CALL);
+
+  let gain = 0;
+  const questions = scored.map((q, k) => {
+    const decay = Math.pow(QUESTION_DECAY, k);
+    const contribution = q.value * decay;
+    gain += contribution;
+    return { ...q, rank: k, decay, contribution };
+  });
+
+  return { gain: gain * pConnect, questions, pConnect, line };
+}
+
+/**
+ * Greedy-with-diminishing-returns selection under a hard call budget.
+ * Re-scores every remaining candidate on every round because selection mutates
+ * the value of the rest.
+ */
+export function planGreedy(facilities, ctx, budget) {
+  const covered = new Set();
+  const chosen = [];
+  const remaining = new Map(facilities.map((f) => [f.id, f]));
+  const rounds = [];
+
+  while (chosen.length < budget && remaining.size > 0) {
+    let best = null;
+    for (const id of remaining.keys()) {
+      const m = marginalGain(id, ctx, covered);
+      if (!best || m.gain > best.m.gain) best = { id, m };
+    }
+    if (!best || best.m.gain <= 1e-9) break; // nothing left worth a call
+    remaining.delete(best.id);
+    const lineKey = ctx.lineKeyById(best.id);
+    for (const q of best.m.questions) covered.add(`${lineKey}:${q.field}`);
+    chosen.push({
+      facilityId: best.id,
+      rank: chosen.length + 1,
+      expectedGain: best.m.gain,
+      pConnect: best.m.pConnect,
+      line: best.m.line,
+      questions: best.m.questions.map((q) => ({
+        field: q.field,
+        ehr: q.base,
+        residual: q.residual,
+        decay: q.decay,
+        contribution: q.contribution,
+        pStale: q.row.pStale,
+        harm: q.row.harm,
+        observability: q.row.observability,
+        ageDays: q.row.ageDays,
+        staleReason: q.row.staleReason,
+        publishedValue: q.row.publishedValue,
+      })),
+    });
+    rounds.push({ round: chosen.length, picked: best.id, gain: best.m.gain });
+  }
+
+  return {
+    strategy: 'risk_greedy',
+    budget,
+    calls: chosen,
+    expectedHarmReduction: chosen.reduce((a, c) => a + c.expectedGain, 0),
+    rounds,
+  };
+}
+
+/**
+ * BASELINE: "call the oldest listings first" — what a directory team actually
+ * does today. Ranks facilities by the age of their oldest published field and
+ * takes the first `budget`. It is scored with the *same* objective so the
+ * comparison is apples to apples; it loses because age alone ignores harm,
+ * ignores whether a phone call can even observe the field, and spends budget on
+ * duplicate listings and dead lines.
+ */
+export function planOldestFirst(facilities, ctx, budget) {
+  const withPhone = facilities.filter((f) => f.phone); // a human would skip blank numbers
+  const ranked = [...withPhone].sort((a, b) => oldestAge(b, ctx) - oldestAge(a, ctx));
+  const chosen = [];
+  const covered = new Set();
+  for (const f of ranked) {
+    if (chosen.length >= budget) break;
+    const m = marginalGain(f.id, ctx, covered);
+    const lineKey = ctx.lineKeyById(f.id);
+    for (const q of m.questions) covered.add(`${lineKey}:${q.field}`);
+    chosen.push({
+      facilityId: f.id,
+      rank: chosen.length + 1,
+      expectedGain: m.gain,
+      pConnect: m.pConnect,
+      line: m.line,
+      questions: m.questions.map((q) => ({ field: q.field, contribution: q.contribution })),
+    });
+  }
+  return {
+    strategy: 'naive_oldest_first',
+    budget,
+    calls: chosen,
+    expectedHarmReduction: chosen.reduce((a, c) => a + c.expectedGain, 0),
+  };
+}
+
+function oldestAge(facility, ctx) {
+  let max = -1;
+  for (const field of FIELDS) {
+    const row = ctx.rowFor(facility.id, field);
+    const a = row.ageDays === null ? 9999 : row.ageDays;
+    if (a > max) max = a;
+  }
+  return max;
+}
+
+/** Total EHR available in the directory if every facility could be called. */
+export function totalAvailableHarm(facilities, ctx) {
+  let total = 0;
+  for (const f of facilities) {
+    for (const field of FIELDS) total += ctx.rowFor(f.id, field).ehr;
+  }
+  return total;
+}

--- a/apps/web/locked-door/js/publish.js
+++ b/apps/web/locked-door/js/publish.js
@@ -1,0 +1,278 @@
+/**
+ * PUBLICATION — a delta, never an overwrite.
+ *
+ * A verified call does not write into the directory. It produces a proposed
+ * changeset row carrying (field, old, new, evidence, confidence, verified_at).
+ * A human approves or rejects each row. Approved rows append to a per-field
+ * history; nothing is ever destroyed, and every historical value keeps the
+ * evidence that produced it.
+ *
+ * Freshness is modelled explicitly, because a verified fact is not verified
+ * forever: freshness(t) = exp(-age / tau_field), with the same tau priors the
+ * risk model uses. A field verified today is already only ~64% fresh tomorrow
+ * if it is `capacity_status`.
+ */
+
+import { TAU_DAYS } from './risk.js';
+import { valuesEqual } from './extract.js';
+import { REVIEW_THRESHOLD } from './extract.js';
+
+/* ------------------------------------------------------ canonicalising --- */
+
+const NUM_WORD = { one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12 };
+
+/** Turns any of the 8 published hour formats into HH:00-HH:00. */
+export function canonicalizeHours(raw) {
+  if (raw === null || raw === undefined) return null;
+  const str = String(raw);
+  const mil = /\b(\d{3,4})\s*-\s*(\d{3,4})\b/.exec(str);
+  if (mil) {
+    const o = Math.floor(parseInt(mil[1], 10) / 100);
+    const c = Math.floor(parseInt(mil[2], 10) / 100);
+    if (o < 24 && c < 24 && c > o) return `${String(o).padStart(2, '0')}:00-${String(c).padStart(2, '0')}:00`;
+  }
+  const re = /\b(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)?|\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b/gi;
+  const found = [];
+  let m;
+  while ((m = re.exec(str)) !== null) {
+    const h = m[1] ? parseInt(m[1], 10) : NUM_WORD[m[4].toLowerCase()];
+    if (h === undefined || h > 23) continue;
+    found.push({ h, mer: m[3] ? m[3].toLowerCase().replace(/\./g, '') : null });
+  }
+  if (found.length < 2) return null;
+  let open = found[0].h;
+  let close = found[1].h;
+  if (found[0].mer === 'pm' && open < 12) open += 12;
+  if (found[1].mer === 'pm' && close < 12) close += 12;
+  else if (found[1].mer === 'am') {
+    /* explicitly morning */
+  } else if (close <= 12 && close + 12 > open) close += 12;
+  if (close <= open) return null;
+  return `${String(open).padStart(2, '0')}:00-${String(close).padStart(2, '0')}:00`;
+}
+
+export function canonicalizePet(raw) {
+  if (raw === null || raw === undefined) return null;
+  const s = String(raw).toLowerCase();
+  if (/no pets|no animals/.test(s)) return 'no_pets';
+  if (/crat/.test(s)) return 'crated_pets_only';
+  if (/service animals|svc animals/.test(s)) return 'service_animals_only';
+  if (/pets ok|pets welcome|pet friendly|pets_allowed/.test(s)) return 'pets_allowed';
+  return s;
+}
+
+/** One canonical form per field so published, extracted and truth are comparable. */
+export function canonicalize(field, value) {
+  if (value === null || value === undefined) return null;
+  if (field === 'hours') return canonicalizeHours(value);
+  if (field === 'pet_policy') return canonicalizePet(value);
+  if (field === 'open_now') return value === true || value === 'true' ? true : value === false || value === 'false' ? false : null;
+  return String(value);
+}
+
+/* ----------------------------------------------------------- routing ----- */
+
+export const ROUTE = {
+  AUTO: 'auto_publishable',
+  REVIEW: 'needs_review',
+  NONE: 'no_change_proposed',
+};
+
+/**
+ * Build the changeset for one facility from its merged extractions.
+ * Nothing here writes to the directory.
+ */
+export function buildChangeset(facility, extractions, callMeta, nowIso) {
+  const rows = [];
+  for (const ex of extractions) {
+    const published = facility.fields[ex.field];
+    const oldCanon = canonicalize(ex.field, published?.value ?? null);
+
+    if (ex.value === 'unknown') {
+      rows.push({
+        facilityId: facility.id,
+        facilityName: facility.name,
+        field: ex.field,
+        oldValue: published?.value ?? null,
+        oldCanonical: oldCanon,
+        newValue: 'unknown',
+        newCanonical: null,
+        evidence: null,
+        confidence: 0,
+        verifiedAt: null,
+        status: 'unknown',
+        route: ROUTE.NONE,
+        reason: ex.reason,
+        callMeta,
+      });
+      continue;
+    }
+
+    const newCanon = canonicalize(ex.field, ex.value);
+    const same = oldCanon !== null && valuesEqual(oldCanon, newCanon);
+    const status = oldCanon === null ? 'filled' : same ? 'confirmed' : 'changed';
+
+    let route;
+    let reason;
+    if (ex.confidence < REVIEW_THRESHOLD) {
+      route = ROUTE.REVIEW;
+      reason = `confidence ${ex.confidence.toFixed(2)} below ${REVIEW_THRESHOLD} threshold${ex.hedged ? ' (speaker hedged)' : ''}`;
+    } else if (ex.internalConflict) {
+      route = ROUTE.REVIEW;
+      reason = `attempts disagreed: "${ex.value}" vs "${ex.internalConflict.otherValue}"`;
+    } else if (status === 'changed') {
+      route = ROUTE.REVIEW;
+      reason = `contradicts published record (${String(oldCanon)} -> ${String(newCanon)})`;
+    } else {
+      route = ROUTE.AUTO;
+      reason = status === 'filled' ? 'fills a blank field, no contradiction' : 'confirms published value';
+    }
+
+    rows.push({
+      facilityId: facility.id,
+      facilityName: facility.name,
+      field: ex.field,
+      oldValue: published?.value ?? null,
+      oldCanonical: oldCanon,
+      newValue: ex.value,
+      newCanonical: newCanon,
+      evidence: {
+        quote: ex.quote,
+        contextQuote: ex.contextQuote,
+        span: ex.span,
+        turnIndex: ex.span.turnIndex,
+        channel: ex.channel,
+        attempt: ex.attemptIndex ?? callMeta.attemptUsed,
+        outcome: callMeta.outcome,
+      },
+      confidence: ex.confidence,
+      hedged: ex.hedged,
+      verifiedAt: nowIso,
+      status,
+      route,
+      reason,
+      callMeta,
+    });
+  }
+  return rows;
+}
+
+/** THE PUBLICATION GATE. Refuses to publish anything without a transcript span. */
+export function assertPublishable(rows) {
+  const violations = [];
+  for (const r of rows) {
+    if (r.newValue === 'unknown') {
+      violations.push({ row: r, why: 'unknown value reached the publication gate' });
+      continue;
+    }
+    const sp = r.evidence?.span;
+    if (!r.evidence || !sp || typeof sp.start !== 'number' || typeof sp.end !== 'number' || sp.end <= sp.start) {
+      violations.push({ row: r, why: 'no transcript span' });
+    }
+    if (!r.evidence?.quote || String(r.evidence.quote).length === 0) {
+      violations.push({ row: r, why: 'empty evidence quote' });
+    }
+  }
+  if (violations.length) {
+    throw new Error(
+      `CITATION_RULE_VIOLATION: ${violations.length} row(s) reached publication without evidence: ` +
+        violations.slice(0, 3).map((v) => `${v.row.facilityId}/${v.row.field} (${v.why})`).join('; '),
+    );
+  }
+  return { checked: rows.length, violations: 0 };
+}
+
+/**
+ * Verifies the citation span actually points at text supporting the value —
+ * not just that a span object exists. A span that does not resolve inside its
+ * transcript is treated as a violation.
+ */
+export function verifySpansResolve(rows, transcriptsByCallId) {
+  let resolved = 0;
+  const failures = [];
+  for (const r of rows) {
+    const tx = transcriptsByCallId.get(`${r.callMeta.callId}#${r.evidence.attempt}`);
+    if (!tx) {
+      failures.push(`${r.facilityId}/${r.field}: transcript missing`);
+      continue;
+    }
+    const slice = tx.text.slice(r.evidence.span.start, r.evidence.span.end);
+    if (slice.length > 0 && slice === r.evidence.quote) resolved++;
+    else failures.push(`${r.facilityId}/${r.field}: span text "${slice}" != quote "${r.evidence.quote}"`);
+  }
+  return { total: rows.length, resolved, failures };
+}
+
+/* ---------------------------------------------------------- freshness ---- */
+
+export function freshness(field, verifiedAtIso, nowMs) {
+  if (!verifiedAtIso) return 0;
+  const age = Math.max(0, (nowMs - Date.parse(verifiedAtIso)) / 86400000);
+  return Math.exp(-age / TAU_DAYS[field]);
+}
+
+/** Days until a freshly-verified field decays below `floor` (default 50%). */
+export function halfLifeDays(field, floor = 0.5) {
+  return TAU_DAYS[field] * Math.log(1 / floor);
+}
+
+/* ------------------------------------------------------------ history ---- */
+
+export class DirectoryStore {
+  constructor(facilities) {
+    this.facilities = new Map(facilities.map((f) => [f.id, f]));
+    /** key `${facilityId}:${field}` -> array of versions, oldest first */
+    this.history = new Map();
+    for (const f of facilities) {
+      for (const [field, v] of Object.entries(f.fields)) {
+        this.history.set(`${f.id}:${field}`, [
+          {
+            value: v.value,
+            canonical: canonicalize(field, v.value),
+            verifiedAt: v.last_verified,
+            source: v.source,
+            evidence: null,
+            approvedBy: null,
+          },
+        ]);
+      }
+    }
+    this.published = [];
+    this.rejected = [];
+  }
+
+  /** Apply an approved changeset row. Appends; never overwrites. */
+  approve(row, approver = 'operator@county') {
+    assertPublishable([row]);
+    const key = `${row.facilityId}:${row.field}`;
+    const versions = this.history.get(key) ?? [];
+    versions.push({
+      value: row.newValue,
+      canonical: row.newCanonical,
+      verifiedAt: row.verifiedAt,
+      source: 'simulated_phone_verification',
+      evidence: row.evidence,
+      confidence: row.confidence,
+      approvedBy: approver,
+      status: row.status,
+    });
+    this.history.set(key, versions);
+    this.published.push({ ...row, approvedBy: approver, approvedAt: new Date().toISOString() });
+    return row;
+  }
+
+  reject(row, approver = 'operator@county', note = 'rejected in review') {
+    this.rejected.push({ ...row, rejectedBy: approver, note });
+  }
+
+  currentValue(facilityId, field) {
+    const v = this.history.get(`${facilityId}:${field}`);
+    return v ? v[v.length - 1] : null;
+  }
+
+  versionCount(facilityId, field) {
+    return (this.history.get(`${facilityId}:${field}`) ?? []).length;
+  }
+}
+
+export { REVIEW_THRESHOLD };

--- a/apps/web/locked-door/js/risk.js
+++ b/apps/web/locked-door/js/risk.js
@@ -1,0 +1,166 @@
+/**
+ * THE RISK MODEL — "which facts matter today"
+ *
+ * Every (facility, field) pair is scored on three independent axes and the
+ * product is an *expected harm reduction in units of harm*:
+ *
+ *     EHR(f, k) = harm_if_stale(f, k) x P(stale | k, age, source) x P(observable by phone | k, line)
+ *
+ * All three terms are defined here with their priors written down, because a
+ * risk model whose constants live in someone's head is not a risk model.
+ */
+
+/* -------------------------------------------------------- HARM PRIORS ---- */
+/**
+ * harm_if_stale: what happens to a person who acts on this field when it is wrong.
+ * Anchored at 1.0 = "arrives at a locked door during an excessive-heat warning".
+ */
+export const HARM_BASE = {
+  open_now: 1.0, // locked door in 112F. the whole reason this product exists
+  hours: 0.82, // arrives 40 minutes after close
+  accessibility: 0.7, // wheelchair user cannot get in and has no fallback
+  capacity_status: 0.6, // turned away at the door, must travel again
+  intake_requirements: 0.55, // has no photo ID, is refused, will not come back
+  pet_policy: 0.45, // will not abandon a dog, so stays outside in the heat
+};
+
+/* --------------------------------------------------- VOLATILITY PRIORS --- */
+/**
+ * Mean life of a fact, in days, before it should be assumed stale.
+ * P(stale) = 1 - exp(-age_days / tau). These are the load-bearing assumptions:
+ *
+ *  open_now (1.5d)            activation flips with each heat advisory
+ *  capacity_status (2.0d)     changes within a single day; nearly always stale
+ *  hours (45d)                seasonal + staffing changes
+ *  intake_requirements (90d)  policy changes at the program level
+ *  pet_policy (140d)          changes rarely, usually after an incident
+ *  accessibility (300d)       changes only with construction
+ */
+export const TAU_DAYS = {
+  open_now: 1.5,
+  capacity_status: 2.0,
+  hours: 45,
+  intake_requirements: 90,
+  pet_policy: 140,
+  accessibility: 300,
+};
+
+/** Source credibility multiplier on P(stale). Self-reported rots faster. */
+export const SOURCE_STALENESS_MULT = {
+  county_pdf: 1.0,
+  phone_2025: 0.85, // last verified by a human on the phone: decays slower
+  self_reported: 1.25,
+  partner_import: 1.4, // 211 feed of a feed
+};
+
+/* ------------------------------------------------- OBSERVABILITY PRIORS -- */
+/**
+ * P(a phone call to this facility yields a groundable answer for this field).
+ * Front-desk staff reliably know if they are open; almost nobody can speak to
+ * ADA compliance without checking.
+ */
+export const OBSERVABILITY = {
+  open_now: 0.95,
+  hours: 0.92,
+  pet_policy: 0.75,
+  intake_requirements: 0.7,
+  accessibility: 0.6,
+  capacity_status: 0.55,
+};
+
+/**
+ * Line profile, keyed on what the PUBLISHED RECORD reveals — not on what the
+ * line actually is. The planner cannot know a number is disconnected until it
+ * is dialed, and modelling it as if it could would quietly inflate every result
+ * on this page. All the planner sees is: is there a number, and does it look
+ * like a direct line or a switchboard extension.
+ */
+export const LINE_PROFILE = {
+  direct: { observability: 1.0, connect: 0.72 },
+  switchboard: { observability: 0.85, connect: 0.55 },
+  none: { observability: 0.0, connect: 0.0 },
+};
+
+/** Derived from the directory record alone. Ground truth is not consulted. */
+export function publishedLineClass(facility) {
+  if (!facility.phone) return 'none';
+  if (/\bext\b|\bx\d/i.test(facility.phone)) return 'switchboard';
+  return 'direct';
+}
+
+export const FIELDS = Object.keys(HARM_BASE);
+
+/* ------------------------------------------------------------- model ---- */
+
+export function ageDays(lastVerifiedIso, nowMs) {
+  if (!lastVerifiedIso) return null;
+  return Math.max(0, (nowMs - Date.parse(lastVerifiedIso)) / 86400000);
+}
+
+/**
+ * P(this published value no longer matches reality).
+ * A missing value is not "fresh" — it is maximally unknown, so it gets a high
+ * fixed prior rather than being skipped.
+ */
+export function probabilityStale(field, published, nowMs) {
+  if (!published || published.value === null || published.value === undefined) {
+    return { p: 0.88, reason: 'no published value', age: null };
+  }
+  const age = ageDays(published.last_verified, nowMs);
+  if (age === null) return { p: 0.88, reason: 'no verification timestamp', age: null };
+  const tau = TAU_DAYS[field];
+  const mult = SOURCE_STALENESS_MULT[published.source] ?? 1.0;
+  const raw = 1 - Math.exp(-age / tau);
+  const p = Math.min(0.97, raw * mult);
+  return { p, reason: `${age.toFixed(0)}d old / tau ${tau}d / src x${mult}`, age };
+}
+
+/**
+ * harm_if_stale scaled by who actually shows up at this facility.
+ * A 300-visitor overnight respite site is not the same bet as a 20-visitor
+ * hydration cart, and pretending otherwise is how directories get triaged badly.
+ */
+export function harmIfStale(field, facility) {
+  const base = HARM_BASE[field];
+  const vuln = facility.vulnerability_weight ?? 1.0;
+  // log-scaled exposure so a 340-visitor site is ~1.6x a 20-visitor site, not 17x
+  const exposure = 0.6 + 0.4 * (Math.log10(Math.max(10, facility.est_daily_visitors)) / Math.log10(340));
+  // an "unknown" or "standby" activation flag makes open_now far more dangerous
+  let flagBump = 1.0;
+  if (field === 'open_now') {
+    if (facility.seasonal_activation_flag === 'unknown') flagBump = 1.35;
+    else if (facility.seasonal_activation_flag === 'standby') flagBump = 1.2;
+  }
+  return base * vuln * exposure * flagBump;
+}
+
+export function observability(field, lineType) {
+  const prof = LINE_PROFILE[lineType] ?? LINE_PROFILE.main;
+  return OBSERVABILITY[field] * prof.observability;
+}
+
+/** Score every (facility, field) pair. Returns a flat, sortable list. */
+export function scoreDirectory(facilities, lineClassById, nowMs) {
+  const rows = [];
+  for (const f of facilities) {
+    const line = lineClassById(f.id);
+    for (const field of FIELDS) {
+      const published = f.fields[field];
+      const stale = probabilityStale(field, published, nowMs);
+      const harm = harmIfStale(field, f);
+      const obs = observability(field, line);
+      rows.push({
+        facilityId: f.id,
+        field,
+        harm,
+        pStale: stale.p,
+        staleReason: stale.reason,
+        ageDays: stale.age,
+        observability: obs,
+        ehr: harm * stale.p * obs,
+        publishedValue: published?.value ?? null,
+      });
+    }
+  }
+  return rows;
+}

--- a/apps/web/locked-door/js/rng.js
+++ b/apps/web/locked-door/js/rng.js
@@ -1,0 +1,35 @@
+/**
+ * Deterministic randomness. Everything the simulator does must be reproducible
+ * from (seed, facilityId, attempt) so that evaluation numbers are stable and a
+ * reviewer can replay any call.
+ */
+
+export function hashString(str) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+export function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A named, reproducible stream. */
+export function streamFor(...parts) {
+  const rand = mulberry32(hashString(parts.join('|')));
+  return {
+    next: rand,
+    chance: (p) => rand() < p,
+    int: (lo, hi) => lo + Math.floor(rand() * (hi - lo + 1)),
+    pick: (arr) => arr[Math.floor(rand() * arr.length)],
+  };
+}

--- a/apps/web/locked-door/js/transport.js
+++ b/apps/web/locked-door/js/transport.js
@@ -1,0 +1,171 @@
+/**
+ * CALL TRANSPORT — one interface, two implementations.
+ *
+ *   SimulatedFacilityTransport  ACTIVE.   Plays a deterministic recorded-style
+ *                                         conversation from ground truth.
+ *   CalleTelephonyAdapter       DISABLED. Wired, request shape documented and
+ *                                         rendered in the UI, but hard-refuses
+ *                                         to dial. This build has never placed
+ *                                         and cannot place a real phone call.
+ *
+ * The refusal is structural, not a flag someone forgot to flip: `placeCall`
+ * throws before constructing a network request, and there is no fetch() call to
+ * a telephony host anywhere in this codebase.
+ */
+
+import { buildTranscript, materialize, decideOutcome, DISCLOSURE } from './dialogue.js';
+import { hashString } from './rng.js';
+
+/** Non-cryptographic 64-bit-ish digest, for display/idempotency demonstration only. */
+export function displayDigest(str) {
+  const a = hashString(str);
+  const b = hashString(str + '\u0001salt');
+  return (a.toString(16).padStart(8, '0') + b.toString(16).padStart(8, '0')).slice(0, 16);
+}
+
+export function toE164(raw) {
+  if (!raw) return null;
+  const digits = String(raw).replace(/\D/g, '');
+  const core = digits.length > 10 ? digits.slice(-10) : digits;
+  if (core.length !== 10) return null;
+  return `+1${core}`;
+}
+
+/**
+ * The exact body the real adapter would POST. Field order and shape mirror
+ * `packages/calle/src/operation.ts::canonicalCreateCallRequest` in this repo, so
+ * the disabled adapter is wire-compatible with the service that already exists.
+ */
+export function buildCanonicalRequest(plan) {
+  const idempotencyKey = `calle_${plan.runId}_${plan.facilityId}_${displayDigest(
+    plan.facilityId + plan.questions.join(',') + plan.runId,
+  )}`;
+  const body = [
+    ['idempotencyKey', idempotencyKey],
+    ['runId', plan.runId],
+    ['facilityId', plan.facilityId],
+    ['phoneE164', plan.phoneE164],
+    ['disclosure', plan.disclosure],
+    ['questions', plan.questions],
+    ['resultSchemaVersion', plan.resultSchemaVersion],
+    ['maximumAttempts', plan.maximumAttempts],
+    ['approvedPlanDigest', plan.approvedPlanDigest],
+  ];
+  const canonical = JSON.stringify(body);
+  return {
+    method: 'POST',
+    url: 'https://api.heycall-e.com/v1/calls',
+    headers: {
+      'content-type': 'application/json',
+      'idempotency-key': idempotencyKey,
+      authorization: 'Bearer ${CALLE_API_KEY}',
+    },
+    idempotencyKey,
+    canonicalBody: canonical,
+    requestBodyDigest: displayDigest(canonical),
+  };
+}
+
+export class CallTransport {
+  get isReal() {
+    return false;
+  }
+  // eslint-disable-next-line no-unused-vars
+  placeCall(_plan, _hooks) {
+    throw new Error('CallTransport is abstract');
+  }
+}
+
+/** Real telephony. Present, wired, and refusing. */
+export class CalleTelephonyAdapter extends CallTransport {
+  constructor() {
+    super();
+    this.enabled = false; // never set true in this build
+    this.name = 'CALL-E telephony adapter';
+  }
+  get isReal() {
+    return true;
+  }
+  describe(plan) {
+    return buildCanonicalRequest(plan);
+  }
+  /**
+   * Refuses SYNCHRONOUSLY, and deliberately so.
+   *
+   * If this were `async`, the refusal would be delivered as a rejected promise,
+   * and a caller that forgot to `await` would sail straight past it with nothing
+   * but an unhandled-rejection warning somewhere off-screen. On the one boundary
+   * in this codebase that must never be crossed quietly, "you only find out if
+   * you were listening" is not good enough. A plain throw cannot be ignored by
+   * an unawaited call, and still rejects the enclosing promise when it IS
+   * awaited, so both call styles fail loudly.
+   */
+  placeCall(plan) {
+    throw new Error(
+      'REAL_TELEPHONY_DISABLED: this build is not permitted to place phone calls. ' +
+        `Would have sent POST https://api.heycall-e.com/v1/calls with idempotency-key ${
+          this.describe(plan).idempotencyKey
+        }.`,
+    );
+  }
+}
+
+/* ------------------------------------------------------------- retries --- */
+/**
+ * Retry policy. A facility gets at most MAX_ATTEMPTS dials across the whole run,
+ * with exponential backoff, and only for outcomes that could plausibly differ
+ * next time. A disconnected number is terminal — retrying it burns budget.
+ */
+export const MAX_ATTEMPTS = 3;
+export const BACKOFF_REAL_MINUTES = [0, 45, 180];
+export const RETRYABLE = new Set(['no_answer', 'busy', 'voicemail', 'ivr_dead_end']);
+export const TERMINAL = new Set(['disconnected', 'no_number', 'connected', 'connected_via_ivr']);
+
+export class SimulatedFacilityTransport extends CallTransport {
+  constructor(groundTruthById, seed = 'calle-sim-v1') {
+    super();
+    this.gt = groundTruthById;
+    this.seed = seed;
+    this.name = 'Deterministic simulated facility';
+  }
+  get isReal() {
+    return false;
+  }
+
+  /**
+   * Runs the retry loop for one facility and returns every attempt made.
+   * `hooks.onTurn(turn, ctx)` streams turns for the live UI; `hooks.delay(ms)`
+   * controls playback speed.
+   */
+  async placeCall(plan, hooks = {}) {
+    const gt = this.gt.get(plan.facilityId);
+    const attempts = [];
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const outcome = decideOutcome(gt, attempt, this.seed);
+      const turns = buildTranscript(gt, plan.facility, plan.questions, attempt, this.seed, outcome);
+      const mat = materialize(turns);
+
+      if (hooks.onAttemptStart) hooks.onAttemptStart({ attempt, outcome, plan });
+      if (hooks.onTurn) {
+        for (const t of mat.turns) {
+          await hooks.onTurn(t, { attempt, outcome, plan });
+        }
+      }
+
+      attempts.push({
+        attempt,
+        outcome,
+        backoffMinutes: BACKOFF_REAL_MINUTES[attempt],
+        transcript: mat,
+        connected: outcome === 'connected' || outcome === 'connected_via_ivr',
+      });
+
+      if (!RETRYABLE.has(outcome)) break;
+      if (attempt === MAX_ATTEMPTS - 1) break;
+      if (hooks.onBackoff) await hooks.onBackoff({ attempt, nextInMinutes: BACKOFF_REAL_MINUTES[attempt + 1] });
+    }
+    return attempts;
+  }
+}
+
+export { DISCLOSURE };

--- a/apps/web/locked-door/tools/generate-directory.mjs
+++ b/apps/web/locked-door/tools/generate-directory.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Generates the two committed data files:
+ *   app/data/directory.json     - the "published" county directory, with real-world mess
+ *   app/data/ground-truth.json  - what is ACTUALLY true today at each facility, plus the
+ *                                 phone-line behaviour the simulator will play back.
+ *
+ * Deterministic: fixed seed, so regenerating produces byte-identical output.
+ * Run:  node app/tools/generate-directory.mjs
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DATA = resolve(HERE, '..', 'data');
+
+/* ---------------------------------------------------------------- rng ---- */
+function mulberry32(a) {
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rnd = mulberry32(0x0ca11e);
+const pick = (arr) => arr[Math.floor(rnd() * arr.length)];
+const chance = (p) => rnd() < p;
+const int = (lo, hi) => lo + Math.floor(rnd() * (hi - lo + 1));
+
+/* ------------------------------------------------------------- corpus ---- */
+const NOW = new Date('2026-08-26T09:00:00-07:00');
+const iso = (d) => new Date(d).toISOString();
+const daysAgo = (n) => iso(NOW.getTime() - n * 86400000);
+
+const KINDS = [
+  { kind: 'library_cooling_center', vuln: 1.0, label: 'Library Cooling Center' },
+  { kind: 'community_center', vuln: 1.05, label: 'Community Center' },
+  { kind: 'overnight_respite', vuln: 1.3, label: 'Overnight Heat Respite' },
+  { kind: 'hydration_station', vuln: 0.78, label: 'Hydration Station' },
+  { kind: 'faith_based_relief', vuln: 1.12, label: 'Faith-Based Relief Site' },
+  { kind: 'senior_center', vuln: 1.22, label: 'Senior Center' },
+  { kind: 'mobile_unit', vuln: 0.9, label: 'Mobile Relief Unit' },
+  { kind: 'municipal_office', vuln: 0.85, label: 'Municipal Lobby Site' },
+];
+
+const STREETS = [
+  'W Van Buren St', 'E Roosevelt St', 'N Central Ave', 'S 7th Ave', 'W Indian School Rd',
+  'E Thomas Rd', 'N 51st Ave', 'W Camelback Rd', 'S Mill Ave', 'E Broadway Rd',
+  'N Scottsdale Rd', 'W Peoria Ave', 'E Baseline Rd', 'N 35th Ave', 'W Bethany Home Rd',
+  'S Country Club Dr', 'E Guadalupe Rd', 'N 19th Ave', 'W Dunlap Ave', 'E McDowell Rd',
+];
+const CITIES = [
+  ['Phoenix', '850'], ['Mesa', '852'], ['Glendale', '853'], ['Tempe', '852'],
+  ['Chandler', '852'], ['Peoria', '853'], ['Surprise', '853'], ['Avondale', '853'],
+  ['Scottsdale', '852'], ['Gilbert', '852'],
+];
+const NAME_A = [
+  'Sunnyslope', 'Maryvale', 'Encanto', 'Desert Vista', 'Ocotillo', 'Papago', 'South Mountain',
+  'Cave Creek', 'Estrella', 'Palo Verde', 'Camelback East', 'Deer Valley', 'Laveen',
+  'Ahwatukee', 'Verrado', 'Agua Fria', 'Copper Sky', 'Red Mountain', 'Dobson Ranch',
+  'Val Vista', 'Arrowhead', 'Litchfield', 'Roosevelt Row', 'Grant Park', 'Coronado',
+  'Garfield', 'Eastlake', 'Alhambra', 'North Gateway', 'Rio Vista', 'Tolleson',
+  'Sun City', 'Youngtown', 'El Mirage', 'Guadalupe', 'Buckeye', 'Anthem', 'Cactus Park',
+  'Harmon', 'Yucca', 'Ironwood', 'Saguaro', 'Mesquite', 'Chaparral', 'Pinnacle Peak',
+  'Thunderbird', 'Bell Road', 'Greenway', 'Union Hills', 'Shea', 'Lone Butte',
+  'Sossaman', 'Higley', 'Recker', 'Signal Butte', 'Crismon', 'Elliot', 'Warner',
+  'Ray Road', 'Chandler Heights',
+];
+const OPERATORS = [
+  'Maricopa County Human Services', 'City of Phoenix Parks & Rec', 'Salvation Army Valley Corps',
+  'St. Vincent de Paul', 'Phoenix Public Library', 'Mesa Community Services',
+  'Glendale Neighborhood Services', 'Tempe Community Action Agency', 'Lutheran Social Services SW',
+  'Central Arizona Shelter Services', 'Chicanos Por La Causa', 'Society of St. Vincent',
+  'Valley of the Sun United Way', 'Native Health Phoenix', 'Justa Center',
+];
+
+/* ------- messy published hour strings: 8 different formats on purpose ----- */
+const HOUR_FORMATS = [
+  (o, c) => `${o}am-${c}pm`,
+  (o, c) => `${o}:00 AM – ${c}:00 PM`,
+  (o, c) => `M-F ${o}-${c}`,
+  (o, c) => `Mon thru Fri, ${o} a.m. to ${c} p.m.`,
+  (o, c) => `${o}00-${c + 12}00`,
+  (o, c) => `Daily ${o}AM to ${c}PM`,
+  (o, c) => `Open ${o}:00-${c + 12}:00 (closed holidays)`,
+  (o, c) => `${o} am - ${c} pm, weekdays only`,
+];
+const canonicalHours = (o, c) => `${String(o).padStart(2, '0')}:00-${String(c + 12).padStart(2, '0')}:00`;
+
+const PET_VALUES = ['pets_allowed', 'service_animals_only', 'crated_pets_only', 'no_pets'];
+const PET_PUBLISHED_TEXT = {
+  pets_allowed: ['Pets OK', 'pets welcome', 'Pet friendly'],
+  service_animals_only: ['Service animals only', 'ADA service animals only', 'svc animals only'],
+  crated_pets_only: ['Crated pets only', 'pets must be crated'],
+  no_pets: ['No pets', 'no animals permitted'],
+};
+const ACCESS_VALUES = ['fully_accessible', 'ramp_only', 'not_accessible'];
+const INTAKE_VALUES = ['no_id_required', 'id_requested_not_required', 'photo_id_required', 'referral_required'];
+const CAPACITY_VALUES = ['space_available', 'near_capacity', 'at_capacity'];
+
+const PERSONAS = [
+  'knowledgeable_manager',
+  'front_desk_unsure',
+  'new_volunteer',
+  'terse_maintenance',
+  'bilingual_handoff',
+];
+
+/* -------------------------------------------------------------- build ---- */
+const facilities = [];
+const truth = [];
+let dupSourceIdx = -1;
+
+for (let i = 0; i < 60; i++) {
+  const id = `MC-${String(1001 + i)}`;
+  const kindDef = KINDS[i % KINDS.length];
+  const nameA = NAME_A[i % NAME_A.length];
+  const [city, zip3] = CITIES[i % CITIES.length];
+  const name = `${nameA} ${kindDef.label}`;
+  const operator = OPERATORS[i % OPERATORS.length];
+
+  /* ---- phone: several kinds of broken ---- */
+  let phoneRaw = null;
+  let lineType = 'main';
+  const roll = rnd();
+  if (roll < 0.05) {
+    phoneRaw = null; // no number published at all
+    lineType = 'none';
+  } else if (roll < 0.10) {
+    phoneRaw = `(${int(602, 623)}) 555-0${int(100, 199)}`;
+    lineType = 'disconnected';
+  } else if (roll < 0.16) {
+    phoneRaw = `${int(602, 623)}-555-${int(1000, 1999)} ext ${int(2, 9)}${int(10, 99)}`;
+    lineType = 'ivr';
+  } else if (roll < 0.24) {
+    phoneRaw = `+1 ${int(602, 623)} 555 ${int(1000, 1999)}`;
+    lineType = 'mobile';
+  } else if (roll < 0.30) {
+    phoneRaw = `${int(602, 623)}.555.${int(1000, 1999)}`;
+    lineType = 'main';
+  } else {
+    phoneRaw = `(${int(602, 623)}) 555-${int(1000, 1999)}`;
+    lineType = chance(0.18) ? 'ivr' : 'main';
+  }
+
+  /* ---- address: some PO boxes, some incomplete ---- */
+  let address;
+  if (chance(0.08)) {
+    address = `PO Box ${int(1000, 9999)}, ${city}, AZ ${zip3}${int(10, 99)}`;
+  } else if (chance(0.06)) {
+    address = `${city}, AZ`; // street missing entirely
+  } else {
+    address = `${int(100, 9999)} ${STREETS[i % STREETS.length]}, ${city}, AZ ${zip3}${int(10, 99)}`;
+  }
+
+  /* ---- ground truth for today ---- */
+  const tOpenHour = int(7, 10);
+  const tCloseHour = int(4, 9); // pm
+  const t = {
+    open_now: chance(0.78),
+    hours: canonicalHours(tOpenHour, tCloseHour),
+    pet_policy: pick(PET_VALUES),
+    accessibility: pick(ACCESS_VALUES),
+    intake_requirements: pick(INTAKE_VALUES),
+    capacity_status: pick(CAPACITY_VALUES),
+  };
+
+  /* ---- published record: drifted from truth, with gaps ---- */
+  const pubOpenHour = chance(0.72) ? tOpenHour : Math.max(6, tOpenHour + (chance(0.5) ? -1 : 1));
+  const pubCloseHour = chance(0.68) ? tCloseHour : Math.min(11, tCloseHour + (chance(0.5) ? -1 : 2));
+  const fmt = HOUR_FORMATS[i % HOUR_FORMATS.length];
+
+  const mkField = (value, tauDays, opts = {}) => {
+    const age = opts.age ?? int(3, 210);
+    return {
+      value,
+      last_verified: value === null ? null : daysAgo(age),
+      source: opts.source ?? pick(['county_pdf', 'self_reported', 'partner_import', 'phone_2025']),
+    };
+  };
+
+  const petTrue = t.pet_policy;
+  const petPub = chance(0.7) ? petTrue : pick(PET_VALUES);
+  const accPub = chance(0.82) ? t.accessibility : pick(ACCESS_VALUES);
+  const intakePub = chance(0.7) ? t.intake_requirements : pick(INTAKE_VALUES);
+  const capPub = chance(0.4) ? t.capacity_status : pick(CAPACITY_VALUES);
+
+  const fields = {
+    open_now: mkField(chance(0.9) ? true : false, 1.5, { age: int(1, 95) }),
+    hours: chance(0.9)
+      ? mkField(fmt(pubOpenHour, pubCloseHour), 45, { age: int(10, 400) })
+      : mkField(null, 45),
+    pet_policy: chance(0.82)
+      ? mkField(pick(PET_PUBLISHED_TEXT[petPub]), 140, { age: int(30, 500) })
+      : mkField(null, 140),
+    accessibility: chance(0.75) ? mkField(accPub, 300, { age: int(60, 700) }) : mkField(null, 300),
+    intake_requirements: chance(0.66)
+      ? mkField(intakePub, 90, { age: int(20, 420) })
+      : mkField(null, 90),
+    capacity_status: chance(0.45) ? mkField(capPub, 2, { age: int(1, 60) }) : mkField(null, 2),
+  };
+
+  const record = {
+    id,
+    name,
+    operator,
+    kind: kindDef.kind,
+    kind_label: kindDef.label,
+    vulnerability_weight: kindDef.vuln,
+    address,
+    address_is_po_box: address.startsWith('PO Box'),
+    phone: phoneRaw,
+    est_daily_visitors: int(18, 340),
+    seasonal_activation_flag: pick(['activated', 'activated', 'standby', 'unknown', 'activated']),
+    source_document: `Maricopa County Heat Relief Network directory, rev ${pick(['2026-05-30', '2026-06-14', '2026-04-02'])}`,
+    duplicate_of: null,
+    fields,
+  };
+
+  facilities.push(record);
+  // Reachability is a property of the facility, not of luck. Some sites simply
+  // do not pick up the phone on a 112F afternoon, and no retry policy fixes that.
+  const reachRoll = rnd();
+  const reachability = reachRoll < 0.1 ? 'unreachable_today' : reachRoll < 0.26 ? 'hard' : 'normal';
+
+  truth.push({
+    id,
+    line_type: lineType,
+    reachability,
+    persona: pick(PERSONAS),
+    answer_delay_ms: int(220, 900),
+    truth: t,
+    // per-field willingness of THIS facility's staff to answer on the phone
+    knows: {
+      open_now: true,
+      hours: chance(0.95),
+      pet_policy: chance(0.8),
+      accessibility: chance(0.7),
+      intake_requirements: chance(0.78),
+      capacity_status: chance(0.74),
+    },
+  });
+
+  if (dupSourceIdx < 0 && i > 12) dupSourceIdx = i;
+}
+
+/* ---- inject 4 duplicate listings (same phone, slightly different name) ---- */
+const dupTargets = [7, 19, 31, 44];
+dupTargets.forEach((srcIdx, k) => {
+  const src = facilities[srcIdx];
+  const dupId = `MC-9${String(101 + k)}`;
+  const dup = JSON.parse(JSON.stringify(src));
+  dup.id = dupId;
+  dup.name = `${src.name.split(' ').slice(0, 2).join(' ')} Cooling Site (legacy listing)`;
+  dup.operator = '211 Arizona import';
+  dup.duplicate_of = src.id;
+  dup.source_document = '211 Arizona partner feed, rev 2026-03-11';
+  // legacy listings are staler and lose fields
+  dup.fields.capacity_status = { value: null, last_verified: null, source: 'partner_import' };
+  dup.fields.accessibility = { value: null, last_verified: null, source: 'partner_import' };
+  dup.fields.open_now = {
+    value: true,
+    last_verified: daysAgo(int(120, 330)),
+    source: 'partner_import',
+  };
+  facilities.push(dup);
+  const srcTruth = truth[srcIdx];
+  truth.push({
+    id: dupId,
+    line_type: srcTruth.line_type,
+    reachability: srcTruth.reachability,
+    persona: srcTruth.persona,
+    answer_delay_ms: srcTruth.answer_delay_ms,
+    truth: srcTruth.truth,
+    knows: srcTruth.knows,
+    shares_line_with: src.id,
+  });
+});
+
+/* ---- a couple of stale activation flags that are provably wrong today ---- */
+facilities[3].seasonal_activation_flag = 'activated';
+truth[3].truth.open_now = false;
+facilities[3].fields.open_now.value = true;
+facilities[3].fields.open_now.last_verified = daysAgo(88);
+
+facilities[22].seasonal_activation_flag = 'standby';
+truth[22].truth.open_now = true;
+
+mkdirSync(DATA, { recursive: true });
+
+writeFileSync(
+  resolve(DATA, 'directory.json'),
+  JSON.stringify(
+    {
+      dataset: 'Simulated Maricopa County Heat Relief Network directory',
+      note: 'Synthetic. Names, addresses and 555-prefixed numbers are fictional. Modeled on the shape and failure modes of real published county heat-relief directories.',
+      generated_at: iso(NOW),
+      as_of: iso(NOW),
+      field_schema: [
+        'open_now',
+        'hours',
+        'pet_policy',
+        'accessibility',
+        'intake_requirements',
+        'capacity_status',
+      ],
+      facilities,
+    },
+    null,
+    1,
+  ) + '\n',
+);
+
+writeFileSync(
+  resolve(DATA, 'ground-truth.json'),
+  JSON.stringify(
+    {
+      note: 'Ground truth for the DETERMINISTIC SIMULATED FACILITY transport. Used only by the simulator and by the evaluation panel. Never used by the planner or the extractor.',
+      generated_at: iso(NOW),
+      facilities: truth,
+    },
+    null,
+    1,
+  ) + '\n',
+);
+
+const lineCounts = truth.reduce((a, t) => ((a[t.line_type] = (a[t.line_type] || 0) + 1), a), {});
+console.log(`facilities: ${facilities.length}`);
+console.log(`duplicates: ${facilities.filter((f) => f.duplicate_of).length}`);
+console.log(`po boxes:   ${facilities.filter((f) => f.address_is_po_box).length}`);
+console.log(`no phone:   ${facilities.filter((f) => !f.phone).length}`);
+console.log('lines:', lineCounts);
+const missing = {};
+for (const f of facilities)
+  for (const [k, v] of Object.entries(f.fields)) if (v.value === null) missing[k] = (missing[k] || 0) + 1;
+console.log('missing published values:', missing);

--- a/apps/web/locked-door/tools/smoke.mjs
+++ b/apps/web/locked-door/tools/smoke.mjs
@@ -1,0 +1,77 @@
+/**
+ * Headless harness. Runs the exact same engine modules the browser runs, so the
+ * measured numbers reported in the terminal and in the UI come from one codepath.
+ *   node app/tools/smoke.mjs [budget]
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { VerificationEngine } from '../js/engine.js';
+import { countUngroundedPublishes } from '../js/evaluate.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const dir = JSON.parse(readFileSync(resolve(HERE, '../data/directory.json'), 'utf8'));
+const gt = JSON.parse(readFileSync(resolve(HERE, '../data/ground-truth.json'), 'utf8'));
+
+const budget = Number(process.argv[2] ?? 25);
+const NOW = Date.parse(dir.as_of);
+const eng = new VerificationEngine(dir, gt, { now: NOW });
+
+const { plan, baseline } = eng.planCalls(budget);
+console.log(`facilities ingested        ${eng.facilities.length}`);
+console.log(`total available harm       ${eng.totalAvailableHarm.toFixed(2)}`);
+console.log(`plan (risk greedy)         ${plan.calls.length} calls, expected harm reduction ${plan.expectedHarmReduction.toFixed(3)}`);
+console.log(`baseline (oldest first)    ${baseline.calls.length} calls, expected harm reduction ${baseline.expectedHarmReduction.toFixed(3)}`);
+console.log(`planned lift               ${(((plan.expectedHarmReduction / baseline.expectedHarmReduction) - 1) * 100).toFixed(1)}%`);
+
+await eng.runPlan(plan);
+await eng.runBaselineCounterfactual();
+const ev = eng.evaluate();
+
+console.log('\n--- measured, before human review ---');
+console.log(`calls placed               ${ev.callsPlaced} (attempts ${ev.totalAttempts})`);
+console.log(`connected                  ${ev.connected}`);
+console.log(`voicemail                  ${ev.voicemail}`);
+console.log(`no answer / busy           ${ev.noAnswer}`);
+console.log(`dead line / ivr dead end   ${ev.deadLine}`);
+console.log(`attempt-level outcomes     ${JSON.stringify(ev.attemptOutcomes)}`);
+console.log(`attempted field-facts      ${ev.attempted}`);
+console.log(`grounded                   ${ev.grounded}`);
+console.log(`precision                  ${(ev.precision * 100).toFixed(1)}%`);
+console.log(`recall                     ${(ev.recall * 100).toFixed(1)}%`);
+console.log(`unknown rate               ${(ev.unknownRate * 100).toFixed(1)}%`);
+console.log(`auto-published             ${ev.falsePublishAutoOnly.published}, wrong ${ev.falsePublishAutoOnly.wrong} (${(ev.falsePublishAutoOnly.rate * 100).toFixed(2)}%)`);
+console.log(`review queue               ${ev.reviewQueueSize}`);
+console.log(`ungrounded publishes       ${ev.citationGate.ungroundedPublishes}`);
+console.log(`spans resolved             ${ev.citationGate.spanCheck.resolved}/${ev.citationGate.spanCheck.total}`);
+if (ev.citationGate.spanCheck.failures.length) console.log('SPAN FAILURES', ev.citationGate.spanCheck.failures.slice(0, 5));
+
+const approved = eng.approveAll();
+const ev2 = eng.evaluate();
+console.log('\n--- after human approves the review queue ---');
+console.log(`approved from review       ${approved.length}`);
+console.log(`published total            ${ev2.publishedCount}`);
+console.log(`false publish rate         ${(ev2.falsePublish.rate * 100).toFixed(2)}% (${ev2.falsePublish.wrong}/${ev2.falsePublish.published})`);
+console.log(`ungrounded publishes       ${countUngroundedPublishes(eng.store.published)}`);
+console.log(`spans resolved             ${ev2.citationGate.spanCheck.resolved}/${ev2.citationGate.spanCheck.total}`);
+
+console.log('\n--- harm reduction, realized against ground truth ---');
+console.log(`risk-ranked plan           ${ev2.harmRealized.toFixed(3)}`);
+console.log(`naive oldest-first         ${ev2.baseline.harmRealized.toFixed(3)}`);
+console.log(`lift                       ${(((ev2.harmRealized / ev2.baseline.harmRealized) - 1) * 100).toFixed(1)}%`);
+console.log(`baseline connected         ${ev2.baseline.connected}/${ev2.baseline.callsPlaced}`);
+
+console.log('\n--- per field ---');
+for (const [f, v] of Object.entries(ev2.perField)) {
+  console.log(
+    `${f.padEnd(22)} att ${String(v.attempted).padStart(3)}  grounded ${String(v.grounded).padStart(3)}  ` +
+      `P ${v.precision === null ? ' n/a ' : (v.precision * 100).toFixed(0).padStart(3) + '%'}  ` +
+      `R ${v.recall === null ? ' n/a ' : (v.recall * 100).toFixed(0).padStart(3) + '%'}  ` +
+      `unk ${((v.unknownRate ?? 0) * 100).toFixed(0).padStart(3)}%`,
+  );
+}
+if (ev2.falsePublish.examples.length) {
+  console.log('\n--- what got published wrong (all traceable to a quote) ---');
+  for (const e of ev2.falsePublish.examples)
+    console.log(`  ${e.facilityId} ${e.field}: published ${e.published} / truth ${e.truth} / conf ${e.confidence} / hedged ${e.hedged} / "${e.quote}"`);
+}


### PR DESCRIPTION
## What this adds

`apps/web/locked-door/` — a web app that keeps **emergency resource directories** (cooling centers, heat-relief shelters) truthful by verifying, over the phone, the facts that are most dangerous when stale.

The operational fact that matters in a heat emergency — are you open right now, do you take pets, is the accessible entrance still there — very often exists only behind a phone number. This is the policy layer around that call: which facts are worth verifying, what counts as evidence, when to say you do not know, and what may be published without a human.

## Safety: no real calls are placed

The call transport is an interface with two implementations. The real CALL-E adapter is **present but disabled**, documenting the request shape, and `placeCall()` **throws synchronously** so an unawaited call cannot slip past the refusal silently. A deterministic simulated facility with per-facility ground truth backs the demo, including IVR menus, voicemail, hedging and staff who do not know.

A full session makes **zero external network requests** and handles no credentials. This satisfies the CONTRIBUTING requirement for a local dry-run path.

## The rule that makes it trustworthy

Every extracted field must cite a span of the transcript. **If no span supports it, the value is `unknown`** — enforced in code, not by convention, with the citation visible in the UI. Contradicted or low-confidence fields go to a review queue rather than to publication, and output is a time-stamped delta awaiting human approval, never an overwrite.

## Measured, not asserted

Because the simulator carries ground truth, the app scores itself. From a 25-call batch (`node tools/smoke.mjs 25`; browser and headless produce identical numbers):

| Metric | Value |
| --- | --- |
| Precision | 94.4% (67/71) |
| Recall | 44.7% (67/150) |
| Unknown rate | 52.7% |
| **False-publish rate** | **0.00%** (0/37) |
| Wrong values produced / held for review | 4 / 4 |
| Harm reduction vs oldest-first baseline | 49.31 vs 39.35 (**+25.3%**) |
| Citation audit | 71/71 pass, 0 failures |

The citation audit is deliberately independent — it re-slices each stored span out of its retained transcript rather than reusing the engine's own gate.

## Honest limits (also stated in the README and on screen)

- **Recall is 44.7%.** Over half of attempted facts stay `unknown`. That is the designed trade, not a good number in isolation.
- The 0.00% false-publish rate is the rate at which the *system* publishes a wrong value on its own authority. If a human blanket-approves the whole review queue unread it becomes 5.63%; both are shown, because `approveAll()` simulates exactly the rubber-stamping the queue exists to prevent.
- `capacity_status` recall is 24%; `open_now` precision is 84%, weakened by stale voicemail greetings being cited as evidence about today.
- The extractor is rule-based, so unfamiliar phrasing produces `unknown`, never a wrong answer.
- The directory is synthetic — realistic schema, invented facilities.

## Run it

```bash
cd apps/web/locked-door && python3 -m http.server 8810
```

Static files only: no build step, no CDN, no backend. Headless: `node tools/smoke.mjs 25`.

Upstream source: https://github.com/rishabhcli/call-e-your-code-is-calling
Demo video: https://youtu.be/iI-PyPrgk58