### PR TITLE
feat(urgent-help-escalation-call): add consent-first caregiver escalation

### DIFF
--- a/skills/urgent-help-escalation-call/SKILL.md
+++ b/skills/urgent-help-escalation-call/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: urgent-help-escalation-call
+description: When a vulnerable person asks for help inside an app, ring the human responsible for them and say only what is needed — who asked, and when. Returns whether the message actually landed and whether anyone confirmed they are going. Use for panic and help buttons, lone-worker duress alarms, fall and inactivity alerts, post-discharge escalation, care-home call bells, and any "the notification is not enough, phone someone" workflow.
+license: MIT
+---
+
+# Urgent Help Escalation Call
+
+Use this skill when software has learned that someone needs a human, and a
+notification is not good enough.
+
+An in-app alert is only as good as somebody looking at a screen. The moments
+when that assumption fails are exactly the moments the alert exists for: the
+middle of the night, a shower, a meeting, a commute. A ringing phone is the one
+channel that reliably interrupts.
+
+This skill is the bridge. One trigger, one call, one clear answer about whether
+it landed.
+
+## The two people
+
+Getting this wrong is the failure mode that matters most, so name them
+separately in your own code:
+
+| | Who | Role |
+| --- | --- | --- |
+| **Subject** | the vulnerable person | asked for help; is **never** called by this skill |
+| **Recipient** | the carer, responder, or next of kin | the one whose phone rings |
+
+Dialling the subject instead of the recipient means telling a frightened person
+that a frightened person needs help. Keep the two numbers in separate fields,
+label them unambiguously in any UI, and validate them separately.
+
+## When To Use
+
+- panic buttons and help buttons in apps used by vulnerable people
+- lone-worker duress alarms
+- fall detection, inactivity timeouts, or bed-exit alerts
+- care-home call bells that need to reach staff who are not at a station
+- post-discharge deterioration flags
+- any in-app urgent signal where "they will see the notification" is a bad bet
+
+## When Not To Use
+
+Do not use this skill to:
+
+- replace emergency services — see [Emergencies](#emergencies)
+- call the subject themselves, for any reason
+- deliver clinical detail, triage, or advice by phone
+- send routine or digest notifications; this is for urgent signals only
+- escalate something the subject did not actually ask for, without saying so
+- call a responder who has not agreed to be called
+
+## Required Fields
+
+Ask for anything missing. **Never** infer these:
+
+| Field | Notes |
+| --- | --- |
+| `recipient_phone` | E.164. The responder's number, never the subject's. Validate; never guess a country code. |
+| `subject_name` | What the responder should be told, e.g. "Eleanor". |
+| `triggered_at` | When the request happened, so the call can say *when* rather than "just now". |
+| `recipient_name` | Optional but strongly preferred — being addressed by name at 3am is worth a lot. |
+| `region` | Optional. Chosen, not inferred — it decides which line the call comes from. |
+
+## Core Workflow
+
+1. Confirm the trigger is genuinely urgent and came from the subject or a
+   sensor, not from a routine event.
+2. Check the cooldown for this subject. If a call went out recently, stop —
+   see [`references/repeat-triggers.md`](references/repeat-triggers.md).
+3. Build the message from [`references/call-goal.md`](references/call-goal.md).
+   Short. One fact, one instruction.
+4. Place exactly one call to `recipient_phone`, with an idempotency key derived
+   from the recipient and the trigger minute so a retried request cannot ring
+   twice.
+5. Read the structured result: did it reach the recipient, and did they confirm.
+6. If it did not reach them, follow
+   [`references/escalation-ladder.md`](references/escalation-ladder.md).
+7. Record the outcome where the humans involved can see it.
+
+**Fire the call without blocking the trigger.** The subject is standing there
+having asked for help; the app's response to them must not wait on a phone
+network, and a failure to connect must never surface to them as an error. Raise
+your in-app alert first, place the call alongside it.
+
+## What The Call Says
+
+**Confirm who is listening before you disclose anything.** This ordering is the
+design, not a nicety:
+
+```
+"Hello, this is <product>. Am I speaking with <recipient>?"
+   ├─ no / unsure → "Sorry to have troubled you. Goodbye."  → hang up, say nothing
+   └─ yes         → "<subject> has pressed the help button and is asking for
+                     you. Please go to them when you can."
+                  → "Are you able to get to them?" → thank them → hang up
+```
+
+The obvious design leads with the message to save a second. It is wrong. A
+number will eventually be answered by a neighbour, a partner, a child, or a
+stranger with a recycled number — and leading with the message tells them a
+named vulnerable person has asked for help before you know who is listening.
+Nothing downstream can un-say it, and a "if it's the wrong person, stop" branch
+fires only after the model has already spoken.
+
+After the gate:
+
+- Do not sound alarmed. Panic on the phone gets nobody there faster.
+- Do not speculate about *why*. You do not know, and a guess becomes what the
+  responder believes on the drive over.
+- Say nothing about the subject's health, condition, or history.
+- Never ask a stranger to pass the message on — that is a disclosure with extra
+  steps.
+- Ask whether they can go — **a question, not an instruction**. "Confirm you are
+  going to her" reads as an order barked at someone just woken up. Ask once,
+  accept the answer, do not press. They may be two hours away.
+- Sound like a person passing on a message, not a system issuing one. Models
+  drift officious when handed numbered steps and a schema; say the register you
+  want out loud.
+- **Voicemail names nobody.** It is the one case where the gate cannot run, so
+  the message must be safe for a whole room to overhear: no name, no reason,
+  just "there is an alert waiting in your app".
+- Keep it under a minute.
+
+Full template and the reasoning line by line: [`references/call-goal.md`](references/call-goal.md).
+
+## Structured Result
+
+Two questions, no more:
+
+```json
+{
+  "reached": "caregiver | someone_else | voicemail | no_answer",
+  "acknowledged": "yes | no | unknown"
+}
+```
+
+`reached` is not the same as `acknowledged`. A voicemail is a message left, not
+a person on their way, and the difference decides whether the ladder continues.
+Full schema and the reasoning: [`references/result-schema.md`](references/result-schema.md).
+
+## Consent
+
+Simpler than a call *to* a vulnerable person, but not nothing:
+
+- **The recipient agreed to be called.** They configured the number, or someone
+  authorized to did. Record who and when.
+- **The subject knows this happens.** Pressing a help button should be
+  understood as "this will fetch someone", and any consent flow should say so
+  plainly rather than burying it.
+- **Health information is disclosed to whoever answers.** That is why the
+  message says only that someone asked for you. See
+  [`references/consent-and-boundaries.md`](references/consent-and-boundaries.md).
+
+## Repeat Triggers
+
+Someone frightened, confused, or in pain may press a button many times in a
+minute. The responder needs one call, not eleven — and each one costs money.
+
+Hold a cooldown per subject, not per request. Suppress inside the window and log
+that you did. Never let one subject's cooldown silence another's.
+Details and the trade-offs: [`references/repeat-triggers.md`](references/repeat-triggers.md).
+
+## Emergencies
+
+**This is not an emergency service and must never be presented as one.**
+
+It reaches one nominated person, who may be asleep, driving, or unreachable. It
+cannot assess anything. It does not know whether the subject is hurt.
+
+Say plainly in your product and your setup docs that the subject must have a
+real route to emergency help that does not depend on this call being placed,
+answered, or correctly understood.
+
+## Side Effects, Cancellation, Cost
+
+- **Side effect:** one real outbound phone call to a real person, per trigger
+  that survives the cooldown.
+- **Cancellation:** nothing to cancel once a call connects. This skill creates
+  no provider-side recurrence — it fires on an event, not a schedule.
+- **Cost:** one call from the CALL-E account per escalation. The cooldown is
+  what stands between a distressed subject and a large bill.
+- **No-call path:** this contribution ships a fake CALL-E server
+  (`scripts/fake-calle-api.mjs`) serving the documented shapes, so the trigger,
+  call contract, structured result, and escalation ladder can be exercised
+  without ringing anyone. Use it for tests, CI, and demos.
+
+## Reference design
+
+This pattern was developed for **Yadira**, a companion for people living with
+dementia. In that product, a person presses a help button; the ordinary in-app
+alert is raised immediately, and CALL-E separately rings the configured
+caregiver. The subject's number is never supplied to this workflow.
+
+Two decisions from that implementation are worth copying:
+
+**Do not make the phone call the only alert.** A call can be delayed, silenced,
+or missed. Raise the in-app alert first and treat the phone call as an
+additional interruptive channel.
+
+**The provider's voice is not yours.** If your product depends on a specific,
+familiar voice for the vulnerable person, an outbound provider voice may be the
+wrong channel. This skill deliberately calls the responder instead.

--- a/skills/urgent-help-escalation-call/references/call-goal.md
+++ b/skills/urgent-help-escalation-call/references/call-goal.md
@@ -1,0 +1,93 @@
+# Call Goal Template
+
+The message handed to `POST /v1/calls`. Written as instructions to a person
+making a call, because that is what CALL-E plans against.
+
+**Identity first, message second.** This is the single most important thing on
+this page, and it is the mistake most implementations make — including this one,
+until a real call was tried.
+
+```text
+Call {{recipient_name}}. Before you say anything about why you are calling, confirm you are speaking to the right person.
+
+Follow these steps in order:
+1. Open with exactly this: "Hello, this is {{product_name}}. Am I speaking with {{recipient_name}}?"
+2. If they say no, or they are evasive, or you are not certain it is {{recipient_name}}: say only "Sorry to have troubled you. Goodbye," and end the call. Do NOT say why you are calling. Do NOT name anyone. Do NOT ask them to pass on a message. A wrong number learns only that somebody called.
+3. Once they confirm they are {{recipient_name}}, say: "{{subject_name}} has pressed the help button and is asking for you. Please go to them when you can."
+4. Then ask, gently and once: "Are you able to get to them?" Ask it as a question, not an instruction. Do not press for a commitment, do not repeat it, and do not tell them what to do — they may have been asleep, and they know their own situation better than you do.
+5. Thank them warmly and end the call.
+
+Throughout:
+Sound like a person passing on a message, not a system issuing an order. Warm, unhurried, ordinary.
+Speak clearly and calmly. Do not sound alarmed — panic does not help anyone get there faster.
+Say nothing about their health, their condition, or anything they said. You do not know why they pressed it, and you must not speculate.
+If the call reaches voicemail, do not name {{subject_name}} and do not say why you are calling — a voicemail can be played aloud to a room. Leave only: "This is {{product_name}} calling for {{recipient_name}}. There is an alert waiting in your app. Please check it now."
+Keep the whole call under a minute.
+```
+
+## Why the ordering
+
+The obvious design leads with the message, to save time. It is wrong.
+
+A phone number will eventually be answered by somebody else: a neighbour, a
+partner, a child, a colleague, a stranger with a recycled number, a phone left
+on a kitchen table. Lead with the message and you have already told them that a
+named, vulnerable person has asked for help — before knowing who is listening.
+Nothing downstream can un-say it.
+
+A "if it turns out to be the wrong person, don't say more" branch does not fix
+this. By the time the model reaches that branch, it has spoken.
+
+The gate costs about one second.
+
+## Why each line is there
+
+**"Open with exactly this."** Give the sentence verbatim. Left to improvise, a
+model will pad the opening with context — which is the disclosure you were
+trying to gate.
+
+**"or they are evasive, or you are not certain."** Without it, an ambiguous
+"uh, who's asking?" gets treated as confirmation. Ambiguity must fail closed.
+
+**"Do NOT ask them to pass on a message."** Asking a stranger to relay it is a
+disclosure with extra steps. It feels helpful, which is why it needs forbidding
+explicitly.
+
+**A quoted message, not a summary.** Left to paraphrase, models add detail that
+was never provided — "she sounded distressed", "it may be urgent" — and the
+responder acts on an invention.
+
+**"Do not sound alarmed."** An alarmed voice makes people rush, and rushing to a
+frightened person is not the same as arriving calmly.
+
+**"You must not speculate."** You know a button was pressed. You do not know why.
+A guess becomes what the responder believes for the whole drive over.
+
+**"Are you able to get to them?" — a question, not an instruction.** This fills
+`acknowledged` in the result: without it you know a phone was answered, not that
+anyone is coming. But how you ask matters. An earlier version said "confirm you
+have heard and are going", and on a real call that landed as an order barked at
+someone who had just been woken up. It is their family member. They know their
+own situation, and they may be two hours away. Ask once, accept the answer, and
+do not press.
+
+**"Sound like a person passing on a message, not a system issuing an order."**
+Models drift officious when given a list of numbered steps and a schema to
+fill. Say the register you want out loud, or the call feels like being
+processed at the worst moment of someone's week.
+
+**The voicemail line names nobody.** Voicemail is the case where the identity
+gate cannot run — there is no one to answer the question. So the message must be
+safe for anyone to hear, which means it carries no name and no reason. Point
+them at the app, which is behind their login.
+
+**"Under a minute."** This call has one job. Length adds only the risk of saying
+something it should not.
+
+## Adapting it
+
+Swap "pressed their help button" for what actually happened — "triggered their
+duress alarm", "has not moved since six this morning". Keep it factual and
+observable, and never editorialise a trigger into a diagnosis.
+
+Keep the gate exactly as it is. Everything else here is adjustable; that is not.

--- a/skills/urgent-help-escalation-call/references/consent-and-boundaries.md
+++ b/skills/urgent-help-escalation-call/references/consent-and-boundaries.md
@@ -1,0 +1,63 @@
+# Consent and Boundaries
+
+This call is placed **to a responder**, about a **subject**. Consent runs
+differently for each, and the boundary that matters is what the call is allowed
+to say.
+
+## The recipient
+
+The person whose phone rings is a consenting adult who signed up for exactly
+this. Record who configured the number and when, and let them remove it as
+easily as they added it.
+
+Two things to get right:
+
+- **They know what the calls are.** "We will phone this number when Eleanor asks
+  for help" — not buried in terms.
+- **Automated-call rules still apply.** Prior express consent is commonly
+  required for automated or AI-voice calls, and several jurisdictions now require
+  disclosing that the caller is an AI. The call identifies itself as the product
+  in its first sentence, which covers this cleanly; do not remove that.
+
+## The subject
+
+The person who pressed the button is not on the call, but the call is *about*
+them, and it is their information travelling down the line.
+
+- Pressing a help button should be plainly understood as "this fetches someone".
+  Say so where they or their family will read it, at setup.
+- Where the subject cannot meaningfully consent, the person legally responsible
+  for them agrees on their behalf — the same authorization that covers the rest
+  of your product's care features.
+
+## What the call may say
+
+Only: **who asked for you, and when.**
+
+That is not minimalism for its own sake. You cannot know who answered the phone
+— a neighbour, a child, a colleague, a stranger with a recycled number. Every
+additional sentence is disclosed to whoever that turns out to be.
+
+Specifically, never:
+
+- name a condition, symptom, medication, or diagnosis
+- describe what the subject said, did, or sounded like
+- speculate about why the trigger fired
+- read out an address unless the responder asks and identifies themselves
+
+If the responder wants detail, the app has it, behind their login. The phone
+call's job is to get them to look, not to be the record.
+
+## Recording
+
+If you retain transcripts, treat them as recordings: some jurisdictions require
+every party's consent. And a transcript of this call contains a vulnerable
+person's name attached to a help request — handle it with whatever your
+health-information obligations are, not as ordinary telemetry.
+
+## Not an emergency service
+
+Say it plainly in the product, in the setup flow, and in your documentation.
+This reaches one nominated person who may be asleep, driving, or unreachable. It
+assesses nothing. The subject must have a real route to emergency help that does
+not depend on this call being placed, answered, or correctly understood.

--- a/skills/urgent-help-escalation-call/references/escalation-ladder.md
+++ b/skills/urgent-help-escalation-call/references/escalation-ladder.md
@@ -1,0 +1,71 @@
+# Escalation Ladder
+
+What to do when the call does not land. An escalation that stops at the first
+unanswered phone has done nothing except create the feeling that somebody was
+told.
+
+## The rungs
+
+1. **Primary recipient.** One call. If `reached: caregiver` and
+   `acknowledged: yes`, stop — somebody is going.
+2. **Voicemail or no answer → the backup contact**, if one is configured. Same
+   message, same rules. Do not wait long between rungs; the reason you are on
+   this ladder is that the first rung failed.
+3. **Nobody reachable → say so loudly in the product.** The in-app alert should
+   change state to something like "we could not reach anyone by phone", not sit
+   there looking identical to a delivered escalation. This is the state most
+   likely to be silently wrong, and the one a family most needs to know about.
+4. **Stop.** Do not loop the ladder indefinitely. Each pass costs money and none
+   of them are reaching anybody.
+
+## Never
+
+**Never call the subject back.** They are already frightened, already waiting.
+A ringing phone from the system that was supposed to fetch help is not reassurance.
+
+**Never re-ring a recipient who acknowledged.** They said they are going. Calling
+again while they are driving there is actively unhelpful.
+
+**Never suppress an escalation because a similar one happened yesterday.**
+Repetition across days is information — surface the pattern, but escalate each
+one. Suppression belongs inside the [cooldown window](repeat-triggers.md), not
+across incidents.
+
+**Never send the raw provider payload, credentials, or the full phone number**
+into whatever channel carries the escalation onward.
+
+## Timing, honestly
+
+Placing a call is not instantaneous. **Measured on CALL-E: about two minutes**
+from the API call to the phone actually ringing — button pressed at 04:04, phone
+rang at 04:06.
+
+Write your product copy accordingly. "You will be called" is true. "You will be
+called instantly" is not, and the gap between them is where trust is lost.
+
+If the trigger is genuinely time-critical — a fall, a cardiac event — this skill
+is an addition to an emergency route, never a substitute for one. Two minutes is
+a long time when someone is on the floor.
+
+## The call arrives from a number they do not know
+
+The single most practical problem, and it is easy to miss until a real call
+lands: the escalation arrives from an unfamiliar number, at exactly the hour
+people decline unfamiliar numbers. Modern phones silence unknown callers by
+default, and Do Not Disturb rules commonly allow contacts only.
+
+Whatever your provider gives you, do two things:
+
+- **Show the number in the product** once you know it, and tell the recipient
+  plainly to save it as a contact. This is setup work, not an afterthought — an
+  escalation declined as spam has failed at the only job it had.
+- **Never rely on the call alone.** The in-app alert is what the recipient will
+  see if the call is silenced, so it must carry the same information and must
+  not be downgraded to a summary of "we called you".
+
+## Recording it
+
+For every rung, keep: who was called (masked), when, what came back, and what
+you did next. When a family asks "did anyone actually try to reach me", that
+record is the answer, and reconstructing it afterwards from provider logs is
+both slow and incomplete.

--- a/skills/urgent-help-escalation-call/references/examples.md
+++ b/skills/urgent-help-escalation-call/references/examples.md
@@ -1,0 +1,83 @@
+# Examples
+
+These examples are intentionally small and use fictional names. Use the fake CALL-E server for testing; do not ring a real person while validating the workflow.
+
+## Correct recipient acknowledges
+
+Trigger: Eleanor presses the help button. Thomas is the configured responder.
+
+Expected call flow:
+
+1. "Hello, this is Yadira. Am I speaking with Thomas?"
+2. Thomas confirms.
+3. "Eleanor has pressed the help button and is asking for you. Please go to them when you can."
+4. "Are you able to get to them?"
+5. Thomas says yes.
+
+Expected structured result:
+
+```json
+{
+  "reached": "caregiver",
+  "acknowledged": "yes"
+}
+```
+
+Stop the escalation ladder.
+
+## Wrong person answers
+
+Expected call flow:
+
+1. "Hello, this is Yadira. Am I speaking with Thomas?"
+2. The person says no.
+3. "Sorry to have troubled you. Goodbye."
+4. End the call without naming Eleanor or explaining the alert.
+
+Expected structured result:
+
+```json
+{
+  "reached": "someone_else",
+  "acknowledged": "unknown"
+}
+```
+
+Treat this as not delivered.
+
+## Voicemail
+
+Do not run the identity gate against voicemail and do not name the subject.
+
+Safe message:
+
+> This is Yadira calling for Thomas. There is an alert waiting in your app. Please check it now.
+
+Expected structured result:
+
+```json
+{
+  "reached": "voicemail",
+  "acknowledged": "unknown"
+}
+```
+
+A voicemail is not an acknowledgement. Continue to a configured backup contact or surface that nobody has yet confirmed.
+
+## Repeated help-button presses
+
+If the subject presses again inside the cooldown window, answer them in the app again but do not place another phone call. Record that the call was suppressed by the cooldown. The second press should never produce silence for the subject.
+
+## No-call testing
+
+Run one of the fake scenarios:
+
+```bash
+node scripts/fake-calle-api.mjs acknowledged
+node scripts/fake-calle-api.mjs heardNotGoing
+node scripts/fake-calle-api.mjs voicemail
+node scripts/fake-calle-api.mjs noAnswer
+node scripts/fake-calle-api.mjs stranger
+```
+
+Point the host application at `http://127.0.0.1:9099` with a test API key. The fake server returns CALL-E-compatible shapes without placing a call.

--- a/skills/urgent-help-escalation-call/references/repeat-triggers.md
+++ b/skills/urgent-help-escalation-call/references/repeat-triggers.md
@@ -1,0 +1,74 @@
+# Repeat Triggers
+
+Someone frightened, confused, or in pain presses a button more than once. That
+is not a bug in their behaviour — it is what a person does when they are not
+sure the first press worked.
+
+The responder needs one call, not eleven. Each one costs real money, and a phone
+ringing repeatedly reads as a malfunction rather than an emergency.
+
+## The pattern
+
+Hold a cooldown **per subject**, not per request:
+
+```
+on trigger:
+  if withinCooldown(subject) -> log the suppression, do not call
+  else                       -> markCalled(subject), place the call
+```
+
+Two properties that matter:
+
+**Mark before you call, not after.** Two triggers a second apart will both pass a
+check that only records success. Claim the window first.
+
+**One subject's cooldown must never silence another's.** Key it on the subject
+or the care circle, never globally. A shared counter means a busy household
+suppresses a quiet one's genuine emergency.
+
+## Choosing the window
+
+Ten minutes is a reasonable default. The question to ask is: *if the same person
+presses again this soon, does the responder learn anything new?* Usually not —
+they are already being called, or already on their way.
+
+Make it configurable. A care home with one responder per floor wants something
+very different from a family of one.
+
+## What suppression must not mean
+
+**It is not silence — least of all towards the person who pressed.** Someone
+frightened presses a button repeatedly precisely because they are not sure it
+worked, and that is the moment they most need an answer. Suppressing the *call*
+is right; suppressing the *response to them* is the opposite of what the button
+is for.
+
+Answer every press, and say something different the second time: not "alert
+already raised", but "they already know, and they're on their way". The
+suppression is an implementation detail they should never encounter.
+
+**The in-app alert still fires on every press.** Only the *call* is suppressed,
+because the call has already been made.
+
+**It is not invisible.** Log every suppression with the subject and the time. A
+run of suppressed triggers is a person pressing a button over and over, which is
+itself worth a human knowing about.
+
+**It does not survive forever.** If your cooldown lives in process memory, a
+restart clears it and a redeploy mid-incident can allow one extra call. That is
+usually an acceptable trade — an extra call is a smaller harm than a missed one
+— but know which way your implementation fails, and prefer shared storage once
+you run more than one instance.
+
+## Idempotency as the second layer
+
+The cooldown protects against a distressed human. An idempotency key protects
+against your own retries:
+
+```
+idempotency_key = `${product}-help-${recipient_phone}-${floor(triggered_at / 60000)}`
+```
+
+Same recipient, same minute, same key — so a retried request after a timeout
+cannot place a second call. The two layers guard different failures and you
+want both.

--- a/skills/urgent-help-escalation-call/references/result-schema.md
+++ b/skills/urgent-help-escalation-call/references/result-schema.md
@@ -1,0 +1,57 @@
+# Structured Result
+
+Declare this as `recipient_result_schema` on the call, so CALL-E returns it
+validated instead of you inferring an outcome from a transcript.
+
+```json
+{
+  "type": "object",
+  "required": ["reached"],
+  "properties": {
+    "reached": {
+      "type": "string",
+      "enum": ["caregiver", "someone_else", "voicemail", "no_answer"],
+      "description": "Who the message actually reached."
+    },
+    "acknowledged": {
+      "type": "string",
+      "enum": ["yes", "no", "unknown"],
+      "description": "Did they confirm they heard and are going to the subject?"
+    }
+  }
+}
+```
+
+Two fields. An escalation call has exactly two questions, and adding a third
+invites the model to editorialise about a situation it cannot see.
+
+## `reached` is not `acknowledged`
+
+The distinction is the whole point of the schema, and it is what drives the
+[escalation ladder](escalation-ladder.md):
+
+| `reached` | `acknowledged` | What actually happened |
+| --- | --- | --- |
+| `caregiver` | `yes` | Someone is going. Stop. |
+| `caregiver` | `no` / `unknown` | A person heard it. Nobody promised anything. |
+| `voicemail` | — | A message exists. Nobody has heard it. **Keep going.** |
+| `someone_else` | — | A stranger has your message. Treat as not delivered. |
+| `no_answer` | — | Nothing landed. **Keep going.** |
+
+Treating voicemail as success is the most tempting mistake here, and the one
+that leaves somebody waiting.
+
+## Rules
+
+**Never put the subject's condition in the result.** The readout is about the
+*call*, not the person. Anything clinical that appears in it will end up in logs
+and notifications that were never scoped for it.
+
+**Mask the number** in the result, the logs, and any error message —
+`+1555***4567`, not the whole thing.
+
+**Record the outcome where a human will see it.** An escalation whose result is
+only in a server log has told nobody anything.
+
+**Keep the call id.** It is how you check status later, and how you tell a
+support conversation what actually happened at 03:14.

--- a/skills/urgent-help-escalation-call/references/safety.md
+++ b/skills/urgent-help-escalation-call/references/safety.md
@@ -1,0 +1,25 @@
+# Safety
+
+This workflow places a real outbound phone call to a consenting responder after an explicit urgent-help trigger. It is an additional escalation channel, not an emergency service.
+
+## Required safeguards
+
+- Require explicit user intent or an explicitly configured urgent-help trigger before placing a call.
+- Call only the configured responder. Never call the vulnerable subject as part of this skill.
+- Require an E.164 responder phone number; never infer or repair a country code silently.
+- Confirm the responder's identity before naming the subject or explaining why the call was placed.
+- If identity is wrong, uncertain, or evasive, disclose nothing and end the call.
+- Voicemail must not name the subject or reveal the reason for the call. Direct the recipient to the authenticated app instead.
+- Do not include diagnoses, symptoms, medications, health history, or speculation about why the trigger occurred.
+- Do not expose credentials, raw provider payloads, or full phone numbers in logs or summaries.
+- Use a per-subject cooldown plus an idempotency key so retries or repeated button presses do not create duplicate calls.
+- Treat voicemail and no-answer as unacknowledged outcomes; do not report them as successful human handoff.
+- Keep an independent route to emergency help. CALL-E may be delayed, silenced, unanswered, or unavailable.
+
+## Side effect and cancellation
+
+A live execution creates one real outbound call for each trigger that survives the cooldown. There is no recurring provider job to cancel. Once a call connects, it cannot be recalled; cancellation therefore happens before call creation by suppressing or rejecting the trigger.
+
+## No-call verification
+
+Use `../scripts/fake-calle-api.mjs` to exercise acknowledged, declined, voicemail, no-answer, and wrong-recipient outcomes without ringing a real phone.

--- a/skills/urgent-help-escalation-call/scripts/fake-calle-api.mjs
+++ b/skills/urgent-help-escalation-call/scripts/fake-calle-api.mjs
@@ -25,22 +25,28 @@ const SCENARIOS = {
   acknowledged: {
     structured: { reached: 'caregiver', acknowledged: 'yes' },
     turns: [
-      { speaker: 'bot', text: 'Thomas, this is Yadira. Eleanor pressed the help button at 3:14 and is asking for you.' },
-      { speaker: 'user', text: 'Understood, I am going now.' },
+      { speaker: 'bot', text: 'Hello, this is Yadira. Am I speaking with Thomas?' },
+      { speaker: 'user', text: 'Yes, this is Thomas.' },
+      { speaker: 'bot', text: 'Eleanor pressed the help button at 3:14 and is asking for you. Are you able to get to them?' },
+      { speaker: 'user', text: 'Yes, I am going now.' },
     ],
   },
   heardNotGoing: {
     structured: { reached: 'caregiver', acknowledged: 'no' },
     turns: [
-      { speaker: 'bot', text: 'Thomas, this is Yadira. Eleanor pressed the help button at 3:14.' },
+      { speaker: 'bot', text: 'Hello, this is Yadira. Am I speaking with Thomas?' },
+      { speaker: 'user', text: 'Yes, this is Thomas.' },
+      { speaker: 'bot', text: 'Eleanor pressed the help button at 3:14 and is asking for you. Are you able to get to them?' },
       { speaker: 'user', text: 'I am two hours away, I cannot get there.' },
     ],
   },
   // The tempting failure: a message exists, but nobody has heard it. The ladder
-  // must continue.
+  // must continue. The voicemail text intentionally names nobody.
   voicemail: {
     structured: { reached: 'voicemail', acknowledged: 'unknown' },
-    turns: [{ speaker: 'bot', text: 'Leaving a message.' }],
+    turns: [
+      { speaker: 'bot', text: 'This is Yadira calling. There is an alert waiting in your app. Please check it now.' },
+    ],
   },
   noAnswer: {
     structured: { reached: 'no_answer', acknowledged: 'unknown' },
@@ -49,8 +55,9 @@ const SCENARIOS = {
   stranger: {
     structured: { reached: 'someone_else', acknowledged: 'unknown' },
     turns: [
-      { speaker: 'bot', text: 'Is this Thomas?' },
+      { speaker: 'bot', text: 'Hello, this is Yadira. Am I speaking with Thomas?' },
       { speaker: 'user', text: 'No, wrong number.' },
+      { speaker: 'bot', text: 'Sorry to have troubled you. Goodbye.' },
     ],
   },
 };

--- a/skills/urgent-help-escalation-call/scripts/fake-calle-api.mjs
+++ b/skills/urgent-help-escalation-call/scripts/fake-calle-api.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// A stand-in CALL-E Developer API, so an escalation can be exercised end to end
+// without ringing anybody.
+//
+//   node scripts/fake-calle-api.mjs            # recipient answers and confirms
+//   node scripts/fake-calle-api.mjs voicemail  # a message exists; nobody heard it
+//   node scripts/fake-calle-api.mjs noAnswer   # nothing landed
+//   node scripts/fake-calle-api.mjs stranger   # someone else picked up
+//   node scripts/fake-calle-api.mjs heardNotGoing
+//
+// Point your app at it:
+//   CALLE_API_KEY=test CALLE_API_BASE_URL=http://127.0.0.1:9099 npm start
+//
+// The contribution guidelines rule out apps that depend on a private service
+// with no fake-server path. The reasoning applies to whoever maintains this
+// first: nobody should have to place a real emergency call to find out whether
+// the ladder works.
+
+import http from 'http';
+
+const PORT = Number(process.env.FAKE_CALLE_PORT || 9099);
+const scenario = process.argv[2] || 'acknowledged';
+
+const SCENARIOS = {
+  acknowledged: {
+    structured: { reached: 'caregiver', acknowledged: 'yes' },
+    turns: [
+      { speaker: 'bot', text: 'Thomas, this is Yadira. Eleanor pressed the help button at 3:14 and is asking for you.' },
+      { speaker: 'user', text: 'Understood, I am going now.' },
+    ],
+  },
+  heardNotGoing: {
+    structured: { reached: 'caregiver', acknowledged: 'no' },
+    turns: [
+      { speaker: 'bot', text: 'Thomas, this is Yadira. Eleanor pressed the help button at 3:14.' },
+      { speaker: 'user', text: 'I am two hours away, I cannot get there.' },
+    ],
+  },
+  // The tempting failure: a message exists, but nobody has heard it. The ladder
+  // must continue.
+  voicemail: {
+    structured: { reached: 'voicemail', acknowledged: 'unknown' },
+    turns: [{ speaker: 'bot', text: 'Leaving a message.' }],
+  },
+  noAnswer: {
+    structured: { reached: 'no_answer', acknowledged: 'unknown' },
+    turns: [],
+  },
+  stranger: {
+    structured: { reached: 'someone_else', acknowledged: 'unknown' },
+    turns: [
+      { speaker: 'bot', text: 'Is this Thomas?' },
+      { speaker: 'user', text: 'No, wrong number.' },
+    ],
+  },
+};
+
+const chosen = SCENARIOS[scenario] || SCENARIOS.acknowledged;
+
+http
+  .createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      if (req.method === 'POST' && req.url === '/v1/calls') {
+        const body = JSON.parse(Buffer.concat(chunks).toString() || '{}');
+        const recipient = body.recipients?.[0] || {};
+        console.log('[fake CALL-E] POST /v1/calls');
+        console.log('  authorization:  ', req.headers.authorization ? 'Bearer <present>' : '(none)');
+        console.log('  idempotency-key:', req.headers['idempotency-key'] || '(none)');
+        console.log('  recipient:      ', JSON.stringify(recipient));
+        console.log('  result schema:  ', Object.keys(body.recipient_result_schema?.properties || {}).join(', ') || '(none)');
+        console.log('  message:        ', String(body.task || '').split('\n')[1] || String(body.task || '').slice(0, 90));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ call_id: 'call_fake_1', status: 'queued' }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url.startsWith('/v1/calls/')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            status: 'completed',
+            task_completed: chosen.structured.reached === 'caregiver',
+            completion_confidence: { score: 0.9, label: 'high' },
+            evidence: [`fake scenario: ${scenario}`],
+            recipients: [
+              {
+                structured_result: chosen.structured,
+                attempts: [
+                  {
+                    transcript_turns: chosen.turns.map((t, i) => ({ offset_seconds: i * 4, ...t })),
+                  },
+                ],
+              },
+            ],
+          })
+        );
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: 'not found' } }));
+    });
+  })
+  .listen(PORT, '127.0.0.1', () =>
+    console.log(`[fake CALL-E] listening on ${PORT}, scenario=${scenario} — no call will be placed`)
+  );


### PR DESCRIPTION
## Summary

Adds urgent-help-escalation-call, a reusable CALL-E Agent Skill for turning an explicit urgent-help signal into a privacy-preserving phone escalation. It confirms the intended responder before disclosing why it called, treats voicemail separately from acknowledgement, suppresses duplicate calls, documents emergency/consent boundaries, and includes a fake CALL-E server for no-call testing. The pattern was developed for Yadira’s caregiver help button.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [ ] Repository-facing content is written in English.
- [ ] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [ ] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [ ] Real-world side effects are clearly described.
- [ ] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior.
- [ ] Runnable code has a dry-run, fake-server, or no-call path by default.
- [ ] `python3 scripts/validate_repository.py` passes.
