### PR TITLE
feat(partline-part-sourcing): add sourcing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`call-summarizer`](skills/call-summarizer/) - Post-call analysis skill that turns a completed CALL-E transcript into a masked, actionable brief with a one-line outcome, extracted action items with owners and due dates, caller sentiment, and a one-way caller fingerprint for de-duplicating repeat callers.
 - [`ringer-consumer-tasks`](skills/ringer-consumer-tasks/) - Compose and safely place the dreaded consumer phone calls (bill negotiation, cancellation, refund, booking, quote comparison, inquiry) as CALL-E tasks with strict result schemas, dry-run-by-default previews, and human-in-the-loop decision authority.
 - [`incident-escalation-call`](skills/incident-escalation-call/) - Walks an on-call escalation ladder one phone call at a time and records an acknowledgement only when an owner and an ETA are both quoted by words the recipient spoke, then re-reads the call over a second transport before the incident is reported as owned.
+- [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
 
 ### Apps
 

--- a/skills/partline-part-sourcing/SKILL.md
+++ b/skills/partline-part-sourcing/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: partline-part-sourcing
+description: Safely source an exact industrial replacement part by calling approved suppliers with CALL-E and returning an evidence-backed comparison for human purchase approval.
+---
+
+# PartLine
+
+Use this skill when a maintenance or procurement user needs current supplier facts that are best confirmed by phone: exact part identity, on-hand quantity, shipping cutoff, lead time and explicitly confirmed alternatives.
+
+## Required inputs
+
+Collect all of the following before creating a preview:
+
+- requester and facility
+- sourcing request ID
+- exact manufacturer and part number
+- quantity and need-by timestamp
+- non-negotiable physical or electrical specifications
+- whether alternatives may be discussed
+- one to five supplier phone numbers in E.164 format
+- region, locale and a purpose-bound authorization reference for every contact
+- the suppliers' local timezone and weekday calling window
+
+Do not infer missing specifications. Do not search for personal phone numbers. Use business contacts provided or approved by the user.
+
+## Workflow
+
+1. Write the request to a JSON file matching `assets/example-request.json`.
+2. Run `partline preview REQUEST.json`.
+3. Show the masked recipients, call count, exact task, purchase boundary and approval token.
+4. Pause for explicit user approval. A request to preview is not approval to call.
+5. Only after explicit approval, run the exact command printed by preview.
+6. Poll the returned call ID. Never create a second task because polling timed out.
+7. Rank exact matches before compatible matches. Mark unknown, contradictory or unsupported results for human follow-up.
+8. Present evidence and caveats. Never purchase, reserve, negotiate or accept supplier terms.
+
+## Safety rules
+
+- Preview by default.
+- Never pass `--live` without explicit approval in the current conversation.
+- Never call outside the configured weekday call window.
+- Never include another supplier's name, quote or inventory in a call.
+- Never claim compatibility unless the supplier confirms every required specification.
+- Treat a proposed alternate as requiring engineering approval.
+- Do not persist raw transcripts unless the user provides a retention purpose and location.
+- A CALL-E result supplies research evidence, not purchasing authority.
+
+## Useful commands
+
+The reference implementation lives in [`apps/python/partline`](../../apps/python/partline/).
+
+```bash
+cd apps/python/partline
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+
+partline preview fixtures/example-request.json
+partline summarize fixtures/completed-call.json --request fixtures/example-request.json
+```
+
+`preview` never places a call. It prints masked recipients, the call count and an
+approval token that is bound to that exact request. A live run additionally
+requires `--live`, the matching token and an open weekday call window.
+

--- a/skills/partline-part-sourcing/assets/example-request.json
+++ b/skills/partline-part-sourcing/assets/example-request.json
@@ -1,0 +1,49 @@
+{
+  "request_id": "PL-1042",
+  "requester": "Maya Chen",
+  "facility": "Northstar Packaging, Line 4",
+  "part_number": "6205-2RS-C3",
+  "manufacturer": "Fictional Bearing Co.",
+  "description": "Deep-groove ball bearing for the Line 4 drive assembly",
+  "quantity": 6,
+  "acceptable_alternatives": true,
+  "required_specs": [
+    "25 mm bore",
+    "52 mm outside diameter",
+    "15 mm width",
+    "double rubber seal",
+    "C3 internal clearance"
+  ],
+  "need_by": "2026-08-31T15:00:00-05:00",
+  "call_window": {
+    "timezone": "America/Chicago",
+    "start": "09:00",
+    "end": "16:30"
+  },
+  "suppliers": [
+    {
+      "name": "Acme Industrial Supply",
+      "phone": "+1555010101",
+      "region": "US",
+      "locale": "en-US",
+      "authorized_contact": true,
+      "authorization_reference": "supplier allowlist 2026-08"
+    },
+    {
+      "name": "Central Motion Components",
+      "phone": "+1555010102",
+      "region": "US",
+      "locale": "en-US",
+      "authorized_contact": true,
+      "authorization_reference": "supplier allowlist 2026-08"
+    },
+    {
+      "name": "Lakeside Bearings",
+      "phone": "+1555010103",
+      "region": "US",
+      "locale": "en-US",
+      "authorized_contact": true,
+      "authorization_reference": "supplier allowlist 2026-08"
+    }
+  ]
+}

--- a/skills/partline-part-sourcing/references/examples.md
+++ b/skills/partline-part-sourcing/references/examples.md
@@ -1,0 +1,89 @@
+# Examples
+
+All phone numbers, suppliers and manufacturers in these examples are fictional.
+
+## Preview, the default
+
+A preview never places a call. It masks every number, states the exact side
+effect and prints an approval token bound to that request.
+
+Input: [`assets/example-request.json`](../assets/example-request.json)
+
+```bash
+partline preview fixtures/example-request.json
+```
+
+Output:
+
+```text
+PARTLINE  /  CALL PREVIEW
+========================================================================
+Request     PL-1042
+Purpose     Source 6 x Fictional Bearing Co. 6205-2RS-C3
+Window      Weekdays 09:00-16:30 America/Chicago
+Side effect Places 3 outbound phone call(s).
+Authority   Purchase authority: none
+
+APPROVED CONTACTS
+Supplier                       Masked number      Authorization
+------------------------------------------------------------------------
+Acme Industrial Supply         +15******01        supplier allowlist 20...
+Central Motion Components      +15******02        supplier allowlist 20...
+Lakeside Bearings              +15******03        supplier allowlist 20...
+
+APPROVAL CHECKPOINT
+No call was placed. Review this exact request before approving it.
+Token        PARTLINE-D908AF7C0BA4
+Live command partline run fixtures/example-request.json --live --confirm PARTLINE-D908AF7C0BA4
+```
+
+## Refused live run
+
+A token from a different request, or an edited request, invalidates approval.
+The command exits non-zero and places no call.
+
+```bash
+partline run fixtures/example-request.json --live --confirm WRONG-TOKEN
+```
+
+```text
+PartLine refused: Approval token does not match this exact sourcing request.
+```
+
+The call window is enforced independently of the token. Outside the request's
+local weekday window, a correct token is still refused:
+
+```text
+PartLine refused: The configured supplier calling window is closed. Run preview now and execute during the window.
+```
+
+## Comparison of completed results
+
+Ranking is derived locally from schema-constrained CALL-E results. Quoted
+evidence and derived ranking stay separate, and ambiguity stays unresolved.
+
+```bash
+partline summarize fixtures/completed-call.json --request fixtures/example-request.json
+```
+
+```text
+CANDIDATE COMPARISON
+Supplier                   Match       Qty   Lead    Ship date    Decision
+--------------------------------------------------------------------------------------
+Acme Industrial Supply     EXACT       8     1d      2026-08-28   Candidate
+Central Motion Components  COMPATIBLE  12    1d      2026-08-28   Review
+Lakeside Bearings          UNKNOWN     -     -       -            Review
+
+EVIDENCE
+- Acme Industrial Supply: I have eight of 6205-2RS-C3 on the shelf and can ship six tomorrow.
+- Central Motion Components: It is dimensionally the same with two rubber seals and C3 clearance.
+  Caveat: Supplier states dimensions, seals and C3 clearance match. Engineering approval required.
+- Lakeside Bearings: Please email the request to our applications desk.
+
+HUMAN DECISION REQUIRED
+PartLine does not purchase, reserve stock, approve alternates or accept supplier terms.
+```
+
+An alternate that a supplier calls equivalent is never promoted to a
+recommendation. It is marked for engineering approval. A supplier who deflects
+to email is recorded as `unknown` rather than as a negative result.

--- a/skills/partline-part-sourcing/references/safety.md
+++ b/skills/partline-part-sourcing/references/safety.md
@@ -1,0 +1,79 @@
+# Safety Reference
+
+A sourcing call is a real-world side effect on a real business line. Preview is
+the default. Stop whenever recipient authorization, part scope or supplier
+identity is ambiguous.
+
+## Authorization And Consent
+
+Every recipient needs a purpose-bound authorization reference tied to this
+sourcing request, such as an existing supplier account or an approved vendor
+allowlist entry. Possession of a phone number is not authorization.
+
+Do not source numbers from a public website, a search result or caller ID. Do
+not call a personal number. Use business contacts the user provided or
+approved. A request limits the batch to five recipients.
+
+## Phone Numbers
+
+Require E.164 format. Documentation and fixtures use reserved fictional
+numbers.
+
+Numbers are masked in previews, summaries and the local evidence console. The
+full number appears only in the private provider payload. The browser console
+receives neither a full number nor an API key.
+
+## Disclosure
+
+The call opens by disclosing that an AI assistant is calling, naming the
+requester and facility on whose behalf it calls.
+
+## Information Boundaries
+
+A call may discuss only this request: manufacturer, part number, quantity,
+required specifications, need-by date, availability, ship date, cutoff and lead
+time. Price is recorded only when the supplier volunteers it.
+
+The call must never:
+
+- place an order, reserve stock or hold inventory
+- negotiate, accept or acknowledge commercial terms
+- approve an alternate part or a specification deviation
+- disclose another supplier's name, quote, stock or pricing
+- provide engineering, legal, financial or emergency advice
+
+If a supplier raises a commercial decision, record it for human follow-up and
+return to the approved factual questions.
+
+## Execution Gate
+
+A live run is accepted only when all three hold:
+
+1. `--live` is present.
+2. `--confirm` exactly matches the token printed by the current preview. The
+   token is derived from the request, so any edit invalidates it.
+3. The current time falls inside the request's local weekday call window.
+
+A failed gate exits non-zero and places no call.
+
+## Duplicate Calls
+
+The idempotency key is derived from the approved request, not from a retry
+attempt. If a response is uncertain, resubmit the same unchanged request rather
+than editing it, then reconcile by call ID. Never create a second task because
+polling timed out.
+
+## Result Handling
+
+A supplier answer is sourcing evidence, never purchase authority or engineering
+approval. Rank exact matches before compatible ones. Treat unknown,
+contradictory or low-evidence outcomes as human follow-up rather than as
+negative results. Treat any proposed alternate as requiring engineering
+approval.
+
+Do not persist raw transcripts or phone numbers unless the user supplies a
+retention purpose and location.
+
+## Out Of Scope
+
+Not for emergencies, and not for medical, legal or financial decisions.


### PR DESCRIPTION
Follow-up to #246, which added `apps/python/partline` but not the Agent Skill that packages the workflow.

## What this adds

- `skills/partline-part-sourcing/SKILL.md` - required inputs, the preview-then-approve workflow and the safety rules, pointing at the merged app as its reference implementation.
- `references/examples.md` - real preview, refusal and comparison output.
- `references/safety.md` - authorization, disclosure, information boundaries, the three-condition execution gate, idempotency and result handling.
- `assets/example-request.json` - the fixture request, fictional 555 numbers only.
- One README entry under Skills.

## Notes

- No new call-placing code. The skill wraps the app that already merged.
- Preview remains the default. A live run needs `--live`, a request-bound approval token and an open weekday call window.
- `python3 scripts/validate_repository.py` passes.
- All phone numbers are reserved fictional 555 numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)