### PR TITLE
feat(apps): add clause-check-by-phone verification app

### DIFF
--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -95,6 +95,21 @@ The transport is a parameter of `place` and `collect`, which is why the
 witnesses can exercise every path through this file without a key and without
 dialling anyone.
 
+### What comes back, and what does not
+
+`collect` returns the identifier, the state and the structured answer. **It
+does not return the transcript, the recording or the destination**, and neither
+does `place`. The provider hands all three over next to the answer, this
+project uses none of them, and the obvious way to look at a result is to print
+it. A default that returns them puts a stranger's voice one `print` away from a
+terminal, a shell history or a CI log. `collect(..., raw=True)` returns the
+whole payload, for a caller who has decided to.
+
+For the same reason, a refusal names the destination **masked**, keeping the
+country code and the last two digits so you can still recognise which number
+you meant. A refusal is printed, so whatever it carries is what ends up on a
+screen. A short or malformed value is hidden whole rather than half revealed.
+
 ## Side effects
 
 **It places a real phone call to a real person.** That is the whole side
@@ -168,8 +183,15 @@ answer can change something, and an answer nobody can interpret changes nothing.
 
 ```bash
 python tests_bridge.py       # 26 witnesses, no call, no network, no key
-python tests_place_call.py   # 13 more, on the file that dials, same rule
+python tests_place_call.py   # 21 more, on the file that dials, same rule
 ```
+
+Eight of the twenty-one hold the line above, that nothing a caller is likely to
+print carries a number, a transcript or a recording. They check the masked
+refusal in both directions, that it hides the number and that it still says
+enough to recognise it, that a malformed value is hidden whole, that the
+trimming does not swallow the answer the verdict is computed from, and that a
+caller who asks for the raw payload still gets it.
 
 Seven of the twenty-six refuse something, an unknown family, a clause with no
 quotation, a nationally formatted number, a country code starting with a zero,

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -182,8 +182,10 @@ and text meant for the eye tolerates a broken character that a speech engine
 pronounces. One guards the answer `unknown`, which must never be read as a
 contradiction, since an absence of answer is not a denial.
 
-Six more guard the schema validator, and every one of them is a schema built
-to be **refused**. A validator that rejects nothing proves nothing, so each
+Six more guard the schema validator. **Five of them are schemas built to be
+refused, and the sixth checks that every family still emits a conforming one**,
+because a validator that only ever refuses is as useless as one that only ever
+accepts. A validator that rejects nothing proves nothing, so each
 conforming case is paired with a hostile one, an unsupported composition, an
 open object, an enum with no way out, a reserved field name, and a required
 field that was never declared.

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -59,6 +59,34 @@ prepared = call_task("+33XXXXXXXXX", "students only",
 verdict = contradiction(prepared, structured_result)   # None, or one sentence
 ```
 
+## Usage, the call actually placed
+
+`place_call.py` is the runtime path. It posts to `POST /v1/calls` on
+`api.heycall-e.com` with a Bearer key read from the environment, and reads the
+finished call back from `GET /v1/calls/{id}`.
+
+```bash
+export CALLE_API_KEY=...
+python place_call.py "students only" "Students only" --to +33XXXXXXXXX
+```
+
+```python
+from place_call import place, collect
+
+prepared, queued = place("+33XXXXXXXXX", "students only",
+                         "Students only", "https://example.com/offer")
+payload, verdict = collect(queued["id"], prepared)     # None, or one sentence
+```
+
+Three refusals happen before anything rings, and none of them costs a call. A
+clause outside the six families never becomes a request. A schema the provider
+would accept and then fail to fill is refused here. A missing key stops the run
+with a sentence rather than with a `401` that reads like a permissions problem.
+
+The transport is a parameter of `place` and `collect`, which is why the
+witnesses can exercise every path through this file without a key and without
+dialling anyone.
+
 ## Side effects
 
 **It places a real phone call to a real person.** That is the whole side
@@ -126,6 +154,7 @@ answer can change something, and an answer nobody can interpret changes nothing.
 
 ```bash
 python tests_bridge.py       # 23 witnesses, no call, no network, no key
+python tests_place_call.py   # 10 more, on the file that dials, same rule
 ```
 
 Three of them are refusals, an unknown family, a clause with no quotation, and

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -5,7 +5,12 @@ report only when the voice CONTRADICTS the page.
 
 **Host and provider.** Any agent host that can run Python 3.9 or later. The
 call itself is placed against the CALL-E API, `POST /v1/calls`, with a Bearer
-key. This contribution contains no key, no client, and no call.
+key. **This contribution contains no key and places no call on its own, but it
+does ship a client.** `place_call.py` reads a Bearer key from the environment
+and can dial a real person. It is the only file here that opens a socket, and
+it is opt-in twice over, once by the key and once by the authorised recipient
+list described below. Everything else, including the whole test suite, runs
+with no key and no network.
 
 ## Why it exists
 
@@ -52,7 +57,7 @@ task by placing it.
 ```python
 from bridge import call_task, contradiction
 
-prepared = call_task("+33XXXXXXXXX", "students only",
+prepared = call_task("+447700900123", "students only",
                      "Students only", "https://example.com/offer")
 # POST prepared["task"] and prepared["result_schema"] to /v1/calls
 # then, once the call reaches a terminal state
@@ -67,21 +72,24 @@ finished call back from `GET /v1/calls/{id}`.
 
 ```bash
 export CALLE_API_KEY=...
-python place_call.py "students only" "Students only" --to +33XXXXXXXXX
+export CALLE_ALLOWED_RECIPIENTS=+447700900123
+python place_call.py "students only" "Students only" --to +447700900123
 ```
 
 ```python
 from place_call import place, collect
 
-prepared, queued = place("+33XXXXXXXXX", "students only",
+prepared, queued = place("+447700900123", "students only",
                          "Students only", "https://example.com/offer")
 payload, verdict = collect(queued["id"], prepared)     # None, or one sentence
 ```
 
-Three refusals happen before anything rings, and none of them costs a call. A
-clause outside the six families never becomes a request. A schema the provider
-would accept and then fail to fill is refused here. A missing key stops the run
-with a sentence rather than with a `401` that reads like a permissions problem.
+Four refusals happen before anything rings, and none of them costs a call. A
+clause outside the six families never becomes a request. A recipient the
+operator has not authorised is refused even when the number is well formed. A
+schema the provider would accept and then fail to fill is refused here. A
+missing key stops the run with a sentence rather than with a `401` that reads
+like a permissions problem.
 
 The transport is a parameter of `place` and `collect`, which is why the
 witnesses can exercise every path through this file without a key and without
@@ -98,8 +106,14 @@ effect, and it is not reversible once the phone rings.
   to build into a tool whose subject is what people hide from you.
 - The task asks one question and only one, and says so twice.
 - It never argues and never sells.
-- Call the number you are authorised to call. There is no sandbox and no echo
-  number, so the dry-run path above is the only safe way to iterate.
+- A recipient has to be listed in `CALLE_ALLOWED_RECIPIENTS` before it can be
+  dialled, and an absent or empty list authorises nothing. This is enforced in
+  `place_call.place`, before the request is built. A well formed number is not
+  the same thing as a number you are allowed to call.
+- Numbers are validated as strict E.164, so a country code cannot start with a
+  zero and a trailing newline does not slip through.
+- There is no sandbox and no echo number, so the dry-run path above is the only
+  safe way to iterate.
 
 ## Cancellation and rollback
 
@@ -153,12 +167,17 @@ answer can change something, and an answer nobody can interpret changes nothing.
 ## Tests
 
 ```bash
-python tests_bridge.py       # 23 witnesses, no call, no network, no key
-python tests_place_call.py   # 10 more, on the file that dials, same rule
+python tests_bridge.py       # 26 witnesses, no call, no network, no key
+python tests_place_call.py   # 13 more, on the file that dials, same rule
 ```
 
-Three of them are refusals, an unknown family, a clause with no quotation, and
-a malformed number. Two guard the quotation itself, because it will be SPOKEN,
+Seven of the twenty-six refuse something, an unknown family, a clause with no
+quotation, a nationally formatted number, a country code starting with a zero,
+a number that kept its trailing newline, a number one digit past the E.164
+ceiling, and a question asked without the context it needs. Three witnesses in
+the second file hold the authorised recipient list, an empty list authorises
+nothing, an unlisted number never reaches the transport, and a list of several
+numbers is read with its spacing ignored. Two guard the quotation itself, because it will be SPOKEN,
 and text meant for the eye tolerates a broken character that a speech engine
 pronounces. One guards the answer `unknown`, which must never be read as a
 contradiction, since an absence of answer is not a denial.
@@ -171,7 +190,9 @@ field that was never declared.
 
 ## Phone numbers in this contribution
 
-Every sample uses `+33000000000`, which is fictional and never dialled. The one
-test that needs a badly formed number uses `00 00 00 00 00`, all zeros, so that
-nothing in this contribution reads like a real number to a person scanning the
-file or to a tool scanning the repository for leaked data.
+Every sample uses `+447700900123`, which sits in the block Ofcom reserves for
+drama, `07700 900xxx`. It is a valid E.164 number, so the snippets above run as
+written, and it is reserved, so it reaches nobody. The tests that need a badly
+formed number use `00 00 00 00 00` and `+0123456789`, neither of which is a
+number, so nothing in this contribution reads like a real one to a person
+scanning the file or to a tool scanning the repository for leaked data.

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -192,9 +192,14 @@ field that was never declared.
 
 ## Phone numbers in this contribution
 
-Every sample uses `+447700900123`, which sits in the block Ofcom reserves for
-drama, `07700 900xxx`. It is a valid E.164 number, so the snippets above run as
-written, and it is reserved, so it reaches nobody. The tests that need a badly
-formed number use `00 00 00 00 00` and `+0123456789`, neither of which is a
-number, so nothing in this contribution reads like a real one to a person
-scanning the file or to a tool scanning the repository for leaked data.
+Every number you are invited to run is `+447700900123`, which sits in the block
+Ofcom reserves for drama, `07700 900xxx`. It is a valid E.164 number, so the
+snippets above run as written, and it is reserved, so it reaches nobody.
+
+Four other values appear, and all of them live inside witnesses. `+447700900999`
+is reserved too, and stands for a recipient the operator has **not** authorised.
+`00 00 00 00 00` and `+0123456789` are not numbers at all, one is nationally
+formatted and the other starts a country code with a zero. `+1234567` tests the
+shortest length E.164 allows. **None of the five reaches a person**, and none
+reads like a real number to someone scanning the file or to a tool scanning the
+repository for leaked data.

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -80,10 +80,52 @@ and this module creates no schedule, no retry and no follow-up. Cancelling
 means not sending the task, or cancelling the call at the provider before it
 is dialled. Nothing in this contribution stores state between runs.
 
+## The schema is checked before the phone rings
+
+`validate_result_schema` compares the schema this module emits against the
+provider's own OpenAPI contract, not against JSON Schema in general. The
+contract names what it supports, `type`, `properties`, `required`, `enum`,
+nested objects, simple `array.items`, `description` and
+`additionalProperties: false`, and what it refuses, `$ref`, `oneOf`, `anyOf`,
+`allOf`, recursion, complex format validation and open objects.
+
+The reason to check early is that a malformed schema is **not** refused when
+the call is created. The call is placed, someone's phone rings, someone
+answers, and the structured result comes back `null` once the call reaches a
+terminal state. You have spent a call and a stranger's minute to learn
+nothing. The check moves that penalty to before the call, where it is free.
+
+One rule in the validator is not in the contract's refusal list, and it is the
+one worth arguing about. **An enum with no way to say the call settled nothing
+is rejected.** A yes/no schema is perfectly valid for the provider, it simply
+leaves the extraction model no choice but to pick a side when the call
+produced neither. Nothing flags it, and the invented answer looks exactly like
+an answer. The provider's own contract recommends including such a value; this
+module makes it mandatory.
+
+## A question that cannot be evaluated is not asked
+
+One family used to send an open question, *which countries of residence are
+accepted*, while expecting a yes or no field back. The extraction model
+received prose and a binary field, and was never told which country was at
+stake. It would have returned a value, and that value would have been
+invented.
+
+Families listed in `CONTEXT_REQUIRED` now refuse to produce a call task unless
+the missing piece is supplied.
+
+```bash
+python dry_run.py "country restricted" "Open to selected countries" --country France
+```
+
+Without `--country`, no call goes out and the reason is printed. This is the
+same principle as the rest of the module. A call is worth placing only when its
+answer can change something, and an answer nobody can interpret changes nothing.
+
 ## Tests
 
 ```bash
-python tests_bridge.py       # 14 witnesses, no call, no network, no key
+python tests_bridge.py       # 23 witnesses, no call, no network, no key
 ```
 
 Three of them are refusals, an unknown family, a clause with no quotation, and
@@ -91,6 +133,12 @@ a malformed number. Two guard the quotation itself, because it will be SPOKEN,
 and text meant for the eye tolerates a broken character that a speech engine
 pronounces. One guards the answer `unknown`, which must never be read as a
 contradiction, since an absence of answer is not a denial.
+
+Six more guard the schema validator, and every one of them is a schema built
+to be **refused**. A validator that rejects nothing proves nothing, so each
+conforming case is paired with a hostile one, an unsupported composition, an
+open object, an enum with no way out, a reserved field name, and a required
+field that was never declared.
 
 ## Phone numbers in this contribution
 

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -142,5 +142,7 @@ field that was never declared.
 
 ## Phone numbers in this contribution
 
-Every sample uses `+33000000000`, which is fictional and never dialled. No real
-number appears in the code, the tests, or this file.
+Every sample uses `+33000000000`, which is fictional and never dialled. The one
+test that needs a badly formed number uses `00 00 00 00 00`, all zeros, so that
+nothing in this contribution reads like a real number to a person scanning the
+file or to a tool scanning the repository for leaked data.

--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -1,0 +1,98 @@
+# clause-check-by-phone
+
+Turn a clause a page states quietly into one question asked out loud, and
+report only when the voice CONTRADICTS the page.
+
+**Host and provider.** Any agent host that can run Python 3.9 or later. The
+call itself is placed against the CALL-E API, `POST /v1/calls`, with a Bearer
+key. This contribution contains no key, no client, and no call.
+
+## Why it exists
+
+A page auditor reads an offer and reports where it takes its own headline back,
+and what it quietly requires of you. It stops at the edge of the real world.
+The clause that costs you is often the one nobody will put in writing twice.
+
+So the next step is to take the single most costly clause found on the page,
+call, ask that one thing, and put the two versions side by side, the exact
+quotation from the page and the structured answer from the call.
+
+## The rule that governs this contribution
+
+**Never make someone repeat on the phone what the page already says.** A call
+is worth placing only if its answer can contradict the page. A question whose
+two possible answers both leave the matter where it stood is a question you do
+not ask, because it costs a stranger their time.
+
+Six clause families are considered worth a call. A finding outside that list
+raises `NothingToAsk`, which is a result and not an error.
+
+## Install
+
+```bash
+python -V            # 3.9 or later
+# no dependencies, the standard library is enough
+```
+
+## Usage, no call
+
+```bash
+python dry_run.py "advancement costs money" \
+  "the remaining 90 selected teams will be responsible for a registration fee"
+```
+
+It prints the exact task text and the result schema, with a fictional number,
+and exits non zero when the clause does not justify a call. **This is the
+no-call path.** Everything that can be settled without dialling is settled
+here, because a developer holding twenty free calls cannot afford to tune a
+task by placing it.
+
+## Usage, with a call
+
+```python
+from bridge import call_task, contradiction
+
+prepared = call_task("+33XXXXXXXXX", "students only",
+                     "Students only", "https://example.com/offer")
+# POST prepared["task"] and prepared["result_schema"] to /v1/calls
+# then, once the call reaches a terminal state
+verdict = contradiction(prepared, structured_result)   # None, or one sentence
+```
+
+## Side effects
+
+**It places a real phone call to a real person.** That is the whole side
+effect, and it is not reversible once the phone rings.
+
+- The task always states, in its first sentence, that the call is automated
+  and placed by a software agent. A test enforces this. A synthetic call that
+  does not say what it is, is a deception, and that would be a strange thing
+  to build into a tool whose subject is what people hide from you.
+- The task asks one question and only one, and says so twice.
+- It never argues and never sells.
+- Call the number you are authorised to call. There is no sandbox and no echo
+  number, so the dry-run path above is the only safe way to iterate.
+
+## Cancellation and rollback
+
+There is nothing recurring here. One clause produces at most one call task,
+and this module creates no schedule, no retry and no follow-up. Cancelling
+means not sending the task, or cancelling the call at the provider before it
+is dialled. Nothing in this contribution stores state between runs.
+
+## Tests
+
+```bash
+python tests_bridge.py       # 14 witnesses, no call, no network, no key
+```
+
+Three of them are refusals, an unknown family, a clause with no quotation, and
+a malformed number. Two guard the quotation itself, because it will be SPOKEN,
+and text meant for the eye tolerates a broken character that a speech engine
+pronounces. One guards the answer `unknown`, which must never be read as a
+contradiction, since an absence of answer is not a denial.
+
+## Phone numbers in this contribution
+
+Every sample uses `+33000000000`, which is fictional and never dialled. No real
+number appears in the code, the tests, or this file.

--- a/apps/python/clause-check-by-phone/bridge.py
+++ b/apps/python/clause-check-by-phone/bridge.py
@@ -111,8 +111,9 @@ def call_task(phone: str, family: str, quote: str, source: str,
         raise NothingToAsk("unknown family, %r, no call is justified" % family)
     if not readable(quote):
         raise NothingToAsk("no quotation, nothing to have confirmed out loud")
-    if not re.match(r"^\+\d{7,15}$", phone or ""):
-        raise NothingToAsk("invalid phone number, a call needs a recipient")
+    if not re.fullmatch(r"\+[1-9]\d{6,14}", phone or ""):
+        raise NothingToAsk("invalid phone number, a call needs a recipient in "
+                           "strict E.164 form")
 
     needed = CONTEXT_REQUIRED.get(family)
     if needed and not (context or {}).get(needed):

--- a/apps/python/clause-check-by-phone/bridge.py
+++ b/apps/python/clause-check-by-phone/bridge.py
@@ -39,7 +39,10 @@ FAMILIES = {
         {"open_to_non_students": ["yes", "no", "unknown"]},
     ),
     "country restricted": (
-        "which countries of residence are accepted",
+        # CONTEXT IS MANDATORY HERE, AND ONLY HERE. Without the country the
+        # question goes out open-ended and the field comes back binary, and
+        # nobody can connect the two. See CONTEXT_REQUIRED.
+        "whether someone who resides in {country} may take part",
         {"country_accepted": ["yes", "no", "unknown"]},
     ),
     "team required": (
@@ -58,6 +61,13 @@ CANCELS = {
     "country restricted": "yes",
     "team required": "yes",
 }
+
+
+# Families whose question means nothing without a piece of context.
+# A question the extraction model cannot evaluate still gets an answer, and
+# that answer is invented. Refusing to ask is cheaper than reading a fabricated
+# result as if it were evidence.
+CONTEXT_REQUIRED = {"country restricted": "country"}
 
 
 class NothingToAsk(Exception):
@@ -85,12 +95,17 @@ def readable(quote: str, limit: int = 220) -> str:
     return t
 
 
-def call_task(phone: str, family: str, quote: str, source: str) -> dict:
+def call_task(phone: str, family: str, quote: str, source: str,
+              context: dict | None = None) -> dict:
     """Return the call task and the result schema for ONE clause.
 
     `phone` is in international form. It is never logged and never returned
     anywhere except inside the task, which is the only place the provider
     needs it.
+
+    `context` carries the values some questions need in order to mean anything,
+    see CONTEXT_REQUIRED. A family that asks for one and does not get it places
+    NO call at all.
     """
     if family not in FAMILIES:
         raise NothingToAsk("unknown family, %r, no call is justified" % family)
@@ -99,7 +114,15 @@ def call_task(phone: str, family: str, quote: str, source: str) -> dict:
     if not re.match(r"^\+\d{7,15}$", phone or ""):
         raise NothingToAsk("invalid phone number, a call needs a recipient")
 
+    needed = CONTEXT_REQUIRED.get(family)
+    if needed and not (context or {}).get(needed):
+        raise NothingToAsk(
+            "family %r needs the %r context, without it the question goes out "
+            "open-ended and the answer comes back unusable" % (family, needed))
+
     question, fields = FAMILIES[family]
+    if needed:
+        question = question.format(**{needed: context[needed]})
     name, values = next(iter(fields.items()))
     task = (
         "Call {phone}. Speak the language of the person who answers. Say plainly "
@@ -146,3 +169,68 @@ def contradiction(prepared: dict, answer: dict) -> str | None:
                 "opposite. Their words, %s"
                 % (prepared["quote"], answer.get("their_words") or "not recorded"))
     return None
+
+
+# What the provider accepts inside a `result_schema`, and what it rejects.
+# Taken from its own OpenAPI contract rather than from JSON Schema in general.
+# The contract is explicit, unsupported features include `$ref`, `oneOf`,
+# `anyOf`, `allOf`, recursive schemas, complex format validation and
+# `additionalProperties: true`.
+SCHEMA_SUPPORTED = {"type", "properties", "required", "enum", "items",
+                    "description", "additionalProperties"}
+SCHEMA_REJECTED = {"$ref", "oneOf", "anyOf", "allOf", "not", "patternProperties",
+                   "format", "pattern", "minimum", "maximum"}
+RESERVED_NAMES = {"summary", "status", "transcript", "call_id"}
+
+
+def validate_result_schema(schema: dict, path: str = "$") -> list[str]:
+    """Return the list of departures from the provider contract. Empty is good.
+
+    WHY VALIDATE INSTEAD OF TRUSTING. A malformed schema is not rejected when
+    the call is created. The call runs, the caller's time is spent, and the
+    structured result comes back `null` once the call reaches a terminal state.
+    You pay for the call and learn nothing. This moves the penalty to before
+    the call, where it is free.
+
+    Returns a list rather than raising, because a schema can have several
+    faults and you want to see them all at once.
+    """
+    problems = []
+    if not isinstance(schema, dict):
+        return ["%s is not an object" % path]
+
+    for key in schema:
+        if key in SCHEMA_REJECTED:
+            problems.append("%s.%s is rejected by the provider" % (path, key))
+        elif key not in SCHEMA_SUPPORTED:
+            problems.append("%s.%s is outside the supported set" % (path, key))
+
+    if schema.get("type") == "object":
+        if schema.get("additionalProperties") is not False:
+            problems.append("%s must set additionalProperties to false" % path)
+        properties = schema.get("properties") or {}
+        if not properties:
+            problems.append("%s is an object with no property" % path)
+        for name, sub in properties.items():
+            if name in RESERVED_NAMES:
+                problems.append("%s.%s reuses a name the provider reserves" % (path, name))
+            problems += validate_result_schema(sub, "%s.%s" % (path, name))
+        for name in schema.get("required") or []:
+            if name not in properties:
+                problems.append("%s requires %r which is not declared" % (path, name))
+
+    values = schema.get("enum")
+    if values is not None:
+        if not values:
+            problems.append("%s has an empty enum" % path)
+        elif not any(str(v).lower() in ("unknown", "inconnu") for v in values):
+            # The provider contract recommends this in so many words. Without a
+            # way to say nothing was learned, the extraction model has to pick
+            # between yes and no when the call produced neither, and it will.
+            problems.append("%s offers no way to say the call settled nothing" % path)
+        if not schema.get("description"):
+            problems.append("%s enumerates without explaining how to choose" % path)
+
+    if schema.get("type") == "array" and "items" not in schema:
+        problems.append("%s is an array without items" % path)
+    return problems

--- a/apps/python/clause-check-by-phone/bridge.py
+++ b/apps/python/clause-check-by-phone/bridge.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""From a written clause to a spoken question.
+
+This module turns one finding produced by a page auditor, the condition an
+offer sets quietly, into two things, a natural-language call task and the
+schema of the answer expected back.
+
+It places no call, opens no socket and knows no key, which is the point. Code
+whose execution costs a real phone call cannot be developed by running it.
+
+THE RULE THAT GOVERNS THIS FILE. Never make someone repeat on the phone what
+the page already says. A call is worth placing only if its answer can
+CONTRADICT the page. A question whose two possible answers both leave the
+matter where it stood is a question you do not ask, because it costs a
+stranger their time.
+"""
+from __future__ import annotations
+import re
+
+# The clause families worth a call, and the question that tests each one.
+FAMILIES = {
+    "prize not cash": (
+        "whether the advertised award is paid in money, and if not, what it "
+        "actually consists of",
+        {"paid_in_money": ["yes", "no", "unknown"]},
+    ),
+    "advancement costs money": (
+        "whether reaching the next stage costs the participant anything, and "
+        "how much",
+        {"cost_to_advance": ["none", "there is one", "unknown"]},
+    ),
+    "video required": (
+        "whether a video hosted on an outside platform is required, or whether "
+        "a file can be sent directly",
+        {"third_party_video": ["required", "avoidable", "unknown"]},
+    ),
+    "students only": (
+        "whether someone who is not a student may take part",
+        {"open_to_non_students": ["yes", "no", "unknown"]},
+    ),
+    "country restricted": (
+        "which countries of residence are accepted",
+        {"country_accepted": ["yes", "no", "unknown"]},
+    ),
+    "team required": (
+        "whether a single person may take part alone",
+        {"alone_allowed": ["yes", "no", "unknown"]},
+    ),
+}
+
+# The answer that CANCELS the clause, per family. Anything else, including
+# `unknown`, is not a contradiction.
+CANCELS = {
+    "prize not cash": "yes",
+    "advancement costs money": "none",
+    "video required": "avoidable",
+    "students only": "yes",
+    "country restricted": "yes",
+    "team required": "yes",
+}
+
+
+class NothingToAsk(Exception):
+    """Raised when no call is justified. This is not an error."""
+
+
+def readable(quote: str, limit: int = 220) -> str:
+    """A quotation fit to be SPOKEN, and the word spoken changes the rule.
+
+    Text meant for the eye tolerates a broken character, a reader skips it. A
+    speech engine does not skip it, it pronounces it or stumbles. Seen on a
+    real page, a quotation ended with a multiplication sign, the remains of a
+    close icon flattened into the text. It is perfectly printable, so a filter
+    on printability keeps it, and it would have gone into someone's ear.
+    """
+    t = quote or ""
+    t = t.replace("�", " ")
+    t = "".join(c for c in t if c.isprintable() or c in " \t\n")
+    t = re.sub(r"\s+", " ", t).strip()
+    while t and not (t[-1].isalnum() or t[-1] in ').”"%'):
+        t = t[:-1]
+    t = t.strip()
+    if len(t) > limit:
+        t = t[:limit].rsplit(" ", 1)[0] + "..."
+    return t
+
+
+def call_task(phone: str, family: str, quote: str, source: str) -> dict:
+    """Return the call task and the result schema for ONE clause.
+
+    `phone` is in international form. It is never logged and never returned
+    anywhere except inside the task, which is the only place the provider
+    needs it.
+    """
+    if family not in FAMILIES:
+        raise NothingToAsk("unknown family, %r, no call is justified" % family)
+    if not readable(quote):
+        raise NothingToAsk("no quotation, nothing to have confirmed out loud")
+    if not re.match(r"^\+\d{7,15}$", phone or ""):
+        raise NothingToAsk("invalid phone number, a call needs a recipient")
+
+    question, fields = FAMILIES[family]
+    name, values = next(iter(fields.items()))
+    task = (
+        "Call {phone}. Speak the language of the person who answers. Say plainly "
+        "that this is an automated call placed by a software agent on behalf of "
+        "someone considering their offer, and that it will take under a minute. "
+        "Then ask one question and only one, {question}. For context, their "
+        "published page says, quote, {quote}, unquote. Do not argue, do not "
+        "sell, do not ask anything else. Thank them and hang up."
+    ).format(phone=phone, question=question, quote=readable(quote))
+
+    schema = {
+        "type": "object",
+        "required": [name],
+        "additionalProperties": False,
+        "properties": {
+            name: {
+                "type": "string",
+                "enum": values,
+                "description": ("What the person said. Use the last value when "
+                                "the call did not produce enough evidence."),
+            },
+            "their_words": {
+                "type": "string",
+                "description": "The person's own words on that single point, if any.",
+            },
+        },
+    }
+    return {"task": task, "result_schema": schema,
+            "source": source, "family": family, "quote": readable(quote)}
+
+
+def contradiction(prepared: dict, answer: dict) -> str | None:
+    """Say whether the voice contradicts the page, and nothing else.
+
+    Returns None when there is no contradiction, which is the common case and
+    a perfectly good result.
+    """
+    if not answer:
+        return None
+    name = prepared["result_schema"]["required"][0]
+    said = (answer.get(name) or "").strip().lower()
+    if said and said == CANCELS.get(prepared["family"]):
+        return ("The page says, quote, %s, unquote. On the phone they said the "
+                "opposite. Their words, %s"
+                % (prepared["quote"], answer.get("their_words") or "not recorded"))
+    return None

--- a/apps/python/clause-check-by-phone/dry_run.py
+++ b/apps/python/clause-check-by-phone/dry_run.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import sys
 
-from bridge import call_task, FAMILIES, NothingToAsk
+from bridge import call_task, FAMILIES, NothingToAsk, validate_result_schema
 
 # A fictional number, in the range reserved for documentation. It is never
 # dialled by this script, which places no call at all.
@@ -34,9 +34,17 @@ def main(argv=None):
         for f in FAMILIES:
             print("  %s" % f)
         return 2
-    family, quote = a[0], " ".join(a[1:])
+    family = a[0]
+    # A trailing `--country X` supplies the context some families require.
+    context, rest = {}, a[1:]
+    if "--country" in rest:
+        at = rest.index("--country")
+        if at + 1 < len(rest):
+            context["country"] = rest[at + 1]
+        rest = rest[:at] + rest[at + 2:]
+    quote = " ".join(rest)
     try:
-        prepared = call_task(FICTIONAL, family, quote, "dry run")
+        prepared = call_task(FICTIONAL, family, quote, "dry run", context)
     except NothingToAsk as e:
         print("NO CALL JUSTIFIED, %s" % e)
         print("This is not a failure. It is the common case, and it is the")
@@ -51,6 +59,18 @@ def main(argv=None):
             print("  %s." % part.strip().rstrip("."))
     print("\nEXPECTED RESULT SCHEMA")
     print(json.dumps(prepared["result_schema"], ensure_ascii=False, indent=2))
+
+    problems = validate_result_schema(prepared["result_schema"])
+    print("\nSCHEMA CHECKED AGAINST THE PROVIDER CONTRACT")
+    if problems:
+        for problem in problems:
+            print("  REJECTED, %s" % problem)
+        print("  A malformed schema is not refused when the call is created.")
+        print("  The call runs and the structured result comes back null, so")
+        print("  the check belongs here, before anyone's phone rings.")
+        return 1
+    print("  conforming, the provider will be able to return a result")
+
     print("\nNo call was placed. The number above is fictional.")
     return 0
 

--- a/apps/python/clause-check-by-phone/dry_run.py
+++ b/apps/python/clause-check-by-phone/dry_run.py
@@ -23,7 +23,7 @@ from bridge import call_task, FAMILIES, NothingToAsk, validate_result_schema
 
 # A fictional number, in the range reserved for documentation. It is never
 # dialled by this script, which places no call at all.
-FICTIONAL = "+33000000000"
+FICTIONAL = "+447700900123"   # Ofcom drama range, 07700 900xxx
 
 
 def main(argv=None):

--- a/apps/python/clause-check-by-phone/dry_run.py
+++ b/apps/python/clause-check-by-phone/dry_run.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""Show the call you would place, without placing it.
+
+    python dry_run.py "students only" "Students only"
+    python dry_run.py "advancement costs money" "the remaining 90 teams will be
+                       responsible for a registration fee"
+
+It prints the exact task text and the result schema, with a fictional phone
+number, and exits non zero when the clause does not justify a call.
+
+WHY THIS EXISTS. A developer gets twenty free calls. Tuning a call task by
+placing it spends them all and leaves none to demonstrate anything. Everything
+that can be settled without dialling is settled here.
+
+This is also the no-call path the repository asks every runnable contribution
+to provide.
+"""
+from __future__ import annotations
+import json
+import sys
+
+from bridge import call_task, FAMILIES, NothingToAsk
+
+# A fictional number, in the range reserved for documentation. It is never
+# dialled by this script, which places no call at all.
+FICTIONAL = "+33000000000"
+
+
+def main(argv=None):
+    a = argv or sys.argv[1:]
+    if len(a) < 2:
+        print(__doc__.strip())
+        print("\nknown families")
+        for f in FAMILIES:
+            print("  %s" % f)
+        return 2
+    family, quote = a[0], " ".join(a[1:])
+    try:
+        prepared = call_task(FICTIONAL, family, quote, "dry run")
+    except NothingToAsk as e:
+        print("NO CALL JUSTIFIED, %s" % e)
+        print("This is not a failure. It is the common case, and it is the")
+        print("reason this path exists.")
+        return 1
+
+    print("CLAUSE, family %s" % prepared["family"])
+    print("  the page says, %s" % prepared["quote"])
+    print("\nCALL TASK, exactly as it would be sent")
+    for part in prepared["task"].split(". "):
+        if part.strip():
+            print("  %s." % part.strip().rstrip("."))
+    print("\nEXPECTED RESULT SCHEMA")
+    print(json.dumps(prepared["result_schema"], ensure_ascii=False, indent=2))
+    print("\nNo call was placed. The number above is fictional.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/clause-check-by-phone/place_call.py
+++ b/apps/python/clause-check-by-phone/place_call.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Place the call that `bridge.py` prepared, against the CALL-E API.
+
+    export CALLE_API_KEY=...
+    python place_call.py "students only" "Students only" --to +33XXXXXXXXX
+
+This is the only file in the contribution that opens a socket. Everything that
+can be settled without dialling is settled in `dry_run.py`, and this module
+refuses to send anything that path would have rejected.
+
+THREE REFUSALS BEFORE ANYTHING RINGS, and they are the reason this file is
+short. A clause outside the callable families never becomes a request. A schema
+the provider cannot fill is refused here rather than after the call, because
+the provider accepts it at creation and only fails at extraction, once the
+call, the budget and a stranger's minute are already spent. And a missing key
+stops the run with a sentence rather than with a 401 that reads like a
+permissions problem.
+
+The network call goes through `send`, which is a parameter. That is not
+ceremony, it is what lets the witnesses exercise this file without a key and
+without dialling anyone.
+"""
+from __future__ import annotations
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+from bridge import call_task, contradiction, NothingToAsk, validate_result_schema
+
+CALLS = "https://api.heycall-e.com/v1/calls"
+
+
+class Refused(Exception):
+    """Raised before any request leaves the machine."""
+
+
+def _http(url: str, key: str, body: bytes | None = None, timeout: int = 45):
+    request = urllib.request.Request(
+        url, data=body, method="POST" if body else "GET",
+        headers={"Authorization": "Bearer %s" % key,
+                 "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as refusal:
+        raw = refusal.read().decode("utf-8", "replace")
+        try:
+            return refusal.code, json.loads(raw)
+        except ValueError:
+            return refusal.code, {"raw": raw[:400]}
+
+
+def place(phone: str, family: str, quote: str, source: str,
+          context: dict | None = None, key: str | None = None, send=_http):
+    """Prepare, check, then dial. Returns the provider's response.
+
+    Raises `Refused` when the call should not be placed, and `NothingToAsk`
+    when the clause does not justify one. The two are different failures and
+    the caller usually wants to treat them differently, a refusal is a bug in
+    the request and a NothingToAsk is the ordinary outcome on a clean page.
+    """
+    key = key or os.environ.get("CALLE_API_KEY")
+    if not key:
+        raise Refused("no CALLE_API_KEY in the environment, nothing was sent")
+
+    prepared = call_task(phone, family, quote, source, context)
+
+    problems = validate_result_schema(prepared["result_schema"])
+    if problems:
+        raise Refused("the provider would accept this schema and then fail to "
+                      "fill it, %s" % "; ".join(problems))
+
+    body = json.dumps({"task": prepared["task"],
+                       "result_schema": prepared["result_schema"]}).encode("utf-8")
+    status, payload = send(CALLS, key, body)
+    if status >= 300:
+        raise Refused("the provider refused the call, %s %s" % (status, payload))
+    return prepared, payload
+
+
+def collect(call_id: str, prepared: dict | None = None,
+            key: str | None = None, send=_http):
+    """Read a finished call back.
+
+    With `prepared`, also returns what the page and the voice disagree on, or
+    None when they do not, which is the whole output of this project. Without
+    it, returns the provider payload alone.
+    """
+    key = key or os.environ.get("CALLE_API_KEY")
+    if not key:
+        raise Refused("no CALLE_API_KEY in the environment")
+    status, payload = send("%s/%s" % (CALLS, call_id), key, None)
+    if status >= 300:
+        raise Refused("could not read the call, %s %s" % (status, payload))
+    if prepared is None:
+        return payload
+    return payload, contradiction(prepared, payload.get("structured_result") or {})
+
+
+def main(argv=None):
+    argv = list(argv if argv is not None else sys.argv[1:])
+    if "--to" not in argv or len(argv) < 4:
+        print(__doc__.strip())
+        return 2
+    at = argv.index("--to")
+    phone = argv[at + 1]
+    argv = argv[:at] + argv[at + 2:]
+
+    context = {}
+    if "--country" in argv:
+        at = argv.index("--country")
+        context["country"] = argv[at + 1]
+        argv = argv[:at] + argv[at + 2:]
+
+    family, quote = argv[0], " ".join(argv[1:])
+    print("This dials a real person. Use a number you are authorised to call.")
+    try:
+        prepared, payload = place(phone, family, quote, "place_call", context)
+    except NothingToAsk as settled:
+        print("NO CALL JUSTIFIED, %s" % settled)
+        return 1
+    except Refused as refusal:
+        print("REFUSED BEFORE DIALLING, %s" % refusal)
+        return 1
+
+    print("queued, call id %s, status %s"
+          % (payload.get("id", "?"), payload.get("status", "?")))
+    print("the page said, %s" % prepared["quote"])
+    print("read it back later with")
+    print("  python -c \"import place_call as p, json;"
+          " print(json.dumps(p.collect('%s'), indent=2))\"" % payload.get("id", "..."))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/clause-check-by-phone/place_call.py
+++ b/apps/python/clause-check-by-phone/place_call.py
@@ -2,19 +2,22 @@
 """Place the call that `bridge.py` prepared, against the CALL-E API.
 
     export CALLE_API_KEY=...
-    python place_call.py "students only" "Students only" --to +33XXXXXXXXX
+    export CALLE_ALLOWED_RECIPIENTS=+447700900123
+    python place_call.py "students only" "Students only" --to +447700900123
 
 This is the only file in the contribution that opens a socket. Everything that
 can be settled without dialling is settled in `dry_run.py`, and this module
 refuses to send anything that path would have rejected.
 
-THREE REFUSALS BEFORE ANYTHING RINGS, and they are the reason this file is
-short. A clause outside the callable families never becomes a request. A schema
-the provider cannot fill is refused here rather than after the call, because
-the provider accepts it at creation and only fails at extraction, once the
-call, the budget and a stranger's minute are already spent. And a missing key
-stops the run with a sentence rather than with a 401 that reads like a
-permissions problem.
+FOUR REFUSALS BEFORE ANYTHING RINGS, and they are the reason this file is
+short. A clause outside the callable families never becomes a request. A
+recipient the operator has not authorised is refused even when the number is
+well formed, because a valid number is not the same thing as a number you are
+allowed to call. A schema the provider cannot fill is refused here rather than
+after the call, because the provider accepts it at creation and only fails at
+extraction, once the call, the budget and a stranger's minute are already
+spent. And a missing key stops the run with a sentence rather than with a 401
+that reads like a permissions problem.
 
 The network call goes through `send`, which is a parameter. That is not
 ceremony, it is what lets the witnesses exercise this file without a key and
@@ -30,10 +33,24 @@ import urllib.request
 from bridge import call_task, contradiction, NothingToAsk, validate_result_schema
 
 CALLS = "https://api.heycall-e.com/v1/calls"
+ALLOWED = "CALLE_ALLOWED_RECIPIENTS"
 
 
 class Refused(Exception):
     """Raised before any request leaves the machine."""
+
+
+def authorised(phone: str) -> bool:
+    """True when the operator has listed this number as callable.
+
+    The list is read from CALLE_ALLOWED_RECIPIENTS, comma separated, in the
+    same international form the bridge validates. An absent or empty list
+    authorises nothing. That is the right default for the one file here that
+    can make a stranger's phone ring, and it means a wrong number in a shell
+    history cannot dial on its own.
+    """
+    listed = os.environ.get(ALLOWED, "")
+    return phone in [n.strip() for n in listed.split(",") if n.strip()]
 
 
 def _http(url: str, key: str, body: bytes | None = None, timeout: int = 45):
@@ -66,6 +83,11 @@ def place(phone: str, family: str, quote: str, source: str,
         raise Refused("no CALLE_API_KEY in the environment, nothing was sent")
 
     prepared = call_task(phone, family, quote, source, context)
+
+    if not authorised(phone):
+        raise Refused("%s is not listed in %s, no call was placed. A recipient "
+                      "has to be authorised by the operator before it can be "
+                      "dialled." % (phone, ALLOWED))
 
     problems = validate_result_schema(prepared["result_schema"])
     if problems:
@@ -115,7 +137,8 @@ def main(argv=None):
         argv = argv[:at] + argv[at + 2:]
 
     family, quote = argv[0], " ".join(argv[1:])
-    print("This dials a real person. Use a number you are authorised to call.")
+    print("This dials a real person. The recipient must be listed in %s."
+          % ALLOWED)
     try:
         prepared, payload = place(phone, family, quote, "place_call", context)
     except NothingToAsk as settled:

--- a/apps/python/clause-check-by-phone/place_call.py
+++ b/apps/python/clause-check-by-phone/place_call.py
@@ -40,6 +40,40 @@ class Refused(Exception):
     """Raised before any request leaves the machine."""
 
 
+def masked(phone: str) -> str:
+    """A destination you can read in a log without leaking it.
+
+    Refusals are printed, and a printed refusal is the one place in this
+    contribution where a real number would end up in a terminal, a shell
+    history or a CI log. Enough is kept to recognise the number you meant, the
+    country code and the last two digits, and the rest is hidden. A short or
+    malformed value is hidden whole rather than partially revealed.
+    """
+    digits = phone[1:] if phone.startswith("+") else phone
+    if not digits.isdigit() or len(digits) < 8:
+        return "+" + "*" * max(len(digits), 1)
+    return "+%s%s%s" % (digits[:2], "*" * (len(digits) - 4), digits[-2:])
+
+
+# The fields a finished call carries that this project never needs. The
+# provider returns the recording, the full transcript and the destination
+# alongside the answer, and a caller who prints the payload prints all three.
+RAW_ONLY = ("transcript", "transcripts", "concatenated_transcript", "recording",
+            "recording_url", "to", "from", "phone_number", "customer",
+            "variables", "metadata", "corrected_duration", "call_log")
+
+
+def bounded(payload: dict) -> dict:
+    """The part of a provider payload this project is allowed to hand back.
+
+    Everything the tool needs is the identifier, the state and the structured
+    answer. The rest is a stranger's voice and a stranger's number, and a
+    default that returns them invites a caller to print them. Anyone who
+    genuinely needs the whole thing asks for it by name, `raw=True`.
+    """
+    return {c: v for c, v in payload.items() if c not in RAW_ONLY}
+
+
 def authorised(phone: str) -> bool:
     """True when the operator has listed this number as callable.
 
@@ -87,7 +121,7 @@ def place(phone: str, family: str, quote: str, source: str,
     if not authorised(phone):
         raise Refused("%s is not listed in %s, no call was placed. A recipient "
                       "has to be authorised by the operator before it can be "
-                      "dialled." % (phone, ALLOWED))
+                      "dialled." % (masked(phone), ALLOWED))
 
     problems = validate_result_schema(prepared["result_schema"])
     if problems:
@@ -98,27 +132,38 @@ def place(phone: str, family: str, quote: str, source: str,
                        "result_schema": prepared["result_schema"]}).encode("utf-8")
     status, payload = send(CALLS, key, body)
     if status >= 300:
-        raise Refused("the provider refused the call, %s %s" % (status, payload))
-    return prepared, payload
+        raise Refused("the provider refused the call, %s %s"
+                      % (status, bounded(payload)))
+    return prepared, bounded(payload)
 
 
 def collect(call_id: str, prepared: dict | None = None,
-            key: str | None = None, send=_http):
-    """Read a finished call back.
+            key: str | None = None, send=_http, raw: bool = False):
+    """Read a finished call back, without the parts nobody here needs.
 
     With `prepared`, also returns what the page and the voice disagree on, or
     None when they do not, which is the whole output of this project. Without
-    it, returns the provider payload alone.
+    it, returns the payload alone.
+
+    WHAT COMES BACK IS BOUNDED BY DEFAULT. The provider hands over the
+    recording, the transcript and the destination next to the answer, and this
+    project uses none of them. Returning them by default puts a stranger's
+    voice one `print` away from a terminal, and the obvious way to look at a
+    result is to print it. `raw=True` returns everything, for a caller who has
+    decided to.
     """
     key = key or os.environ.get("CALLE_API_KEY")
     if not key:
         raise Refused("no CALLE_API_KEY in the environment")
     status, payload = send("%s/%s" % (CALLS, call_id), key, None)
     if status >= 300:
-        raise Refused("could not read the call, %s %s" % (status, payload))
+        raise Refused("could not read the call, %s %s" % (status, bounded(payload)))
+    answer = payload.get("structured_result") or {}
+    if not raw:
+        payload = bounded(payload)
     if prepared is None:
         return payload
-    return payload, contradiction(prepared, payload.get("structured_result") or {})
+    return payload, contradiction(prepared, answer)
 
 
 def main(argv=None):
@@ -154,6 +199,8 @@ def main(argv=None):
     print("read it back later with")
     print("  python -c \"import place_call as p, json;"
           " print(json.dumps(p.collect('%s'), indent=2))\"" % payload.get("id", "..."))
+    print("that prints the identifier, the state and the answer. It does not"
+          " print the transcript, the recording or the destination.")
     return 0
 
 

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -114,10 +114,6 @@ class TheContradiction(unittest.TestCase):
         self.assertIsNone(contradiction(self.p, None))
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 class SchemaAgainstTheProviderContract(unittest.TestCase):
     """Witnesses for the schema validator.
 
@@ -190,3 +186,7 @@ class TheFamilyThatNeedsContext(unittest.TestCase):
         for family in FAMILIES:
             if family != "country restricted":
                 call_task(NUM, family, "Some clause", "s")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -13,7 +13,8 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from bridge import call_task, contradiction, NothingToAsk       # noqa: E402
+from bridge import (call_task, contradiction, NothingToAsk,      # noqa: E402
+                    validate_result_schema, FAMILIES)
 
 NUM = "+33000000000"          # fictional, never dialled by these tests
 
@@ -45,7 +46,8 @@ class TheCallTask(unittest.TestCase):
     def test_a_broken_character_never_reaches_the_ear(self):
         """Seen on a real page. An eye skips the replacement character, a
         speech engine pronounces it or stumbles."""
-        p = call_task(NUM, "country restricted", "Countries excluded �", "s")
+        p = call_task(NUM, "country restricted", "Countries excluded �", "s",
+                      {"country": "France"})
         self.assertNotIn("�", p["quote"])
         self.assertNotIn("�", p["task"])
 
@@ -53,7 +55,8 @@ class TheCallTask(unittest.TestCase):
         """Real quotation, ending in a multiplication sign, the remains of a
         close icon flattened into the text. A valid character is not a
         pronounceable one."""
-        p = call_task(NUM, "country restricted", "Countries excluded ×", "s")
+        p = call_task(NUM, "country restricted", "Countries excluded ×", "s",
+                      {"country": "France"})
         self.assertTrue(p["quote"].endswith("excluded"))
 
     def test_the_schema_always_offers_unknown(self):
@@ -107,3 +110,77 @@ class TheContradiction(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class SchemaAgainstTheProviderContract(unittest.TestCase):
+    """Witnesses for the schema validator.
+
+    A validator that rejects nothing proves nothing. Every conforming case
+    below is paired with a hostile one built to fail, and the hostile one is
+    the valuable half. The constraints come from the provider OpenAPI contract,
+    not from JSON Schema in general.
+    """
+
+    def test_every_family_emits_a_conforming_schema(self):
+        context = {"country": "France"}
+        for family in FAMILIES:
+            prepared = call_task(NUM, family, "Some clause on the page", "s", context)
+            self.assertEqual([], validate_result_schema(prepared["result_schema"]),
+                             "family %r emits a non-conforming schema" % family)
+
+    def test_it_rejects_a_composition_the_provider_does_not_support(self):
+        bad = {"type": "object", "additionalProperties": False,
+               "properties": {"answer": {"oneOf": [{"type": "string"}]}}}
+        self.assertTrue(any("oneOf" in p for p in validate_result_schema(bad)))
+
+    def test_it_rejects_an_open_object(self):
+        bad = {"type": "object", "additionalProperties": True,
+               "properties": {"answer": {"type": "string"}}}
+        self.assertTrue(any("additionalProperties" in p for p in validate_result_schema(bad)))
+
+    def test_it_rejects_an_enum_with_no_way_to_say_nothing_was_learned(self):
+        """The most dangerous case, because it is SILENT.
+
+        A yes/no schema is perfectly valid for the provider. It simply leaves
+        the extraction model no choice but to pick a side when the call settled
+        nothing. Nothing flags it, and the invented answer looks like an answer.
+        """
+        bad = {"type": "object", "additionalProperties": False,
+               "required": ["open"],
+               "properties": {"open": {"type": "string", "enum": ["yes", "no"],
+                                       "description": "What the person said."}}}
+        self.assertTrue(any("settled nothing" in p for p in validate_result_schema(bad)))
+
+    def test_it_rejects_a_field_name_the_provider_reserves(self):
+        bad = {"type": "object", "additionalProperties": False,
+               "properties": {"summary": {"type": "string"}}}
+        self.assertTrue(any("reserves" in p for p in validate_result_schema(bad)))
+
+    def test_it_rejects_a_required_field_that_is_not_declared(self):
+        bad = {"type": "object", "additionalProperties": False,
+               "required": ["absent"], "properties": {"present": {"type": "string"}}}
+        self.assertTrue(any("absent" in p for p in validate_result_schema(bad)))
+
+
+class TheFamilyThatNeedsContext(unittest.TestCase):
+    """One question used to go out open-ended while its field came back binary.
+
+    The extraction model received prose and a yes/no field without ever being
+    told which country was at stake. It would have returned a value, and that
+    value would have been invented.
+    """
+
+    def test_without_the_country_no_call_goes_out(self):
+        with self.assertRaises(NothingToAsk):
+            call_task(NUM, "country restricted", "Selected countries only", "s")
+
+    def test_with_the_country_the_question_names_it(self):
+        prepared = call_task(NUM, "country restricted", "Selected countries only", "s",
+                             {"country": "France"})
+        self.assertIn("France", prepared["task"])
+        self.assertEqual([], validate_result_schema(prepared["result_schema"]))
+
+    def test_the_other_families_need_nothing(self):
+        for family in FAMILIES:
+            if family != "country restricted":
+                call_task(NUM, family, "Some clause", "s")

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""Witnesses for the bridge. No call, no network, no key.
+
+    python tests_bridge.py
+
+That separation is the whole point. Code whose execution costs a real phone
+call, and where the budget is counted on one hand, cannot be tuned by running
+it. It is tuned here.
+"""
+from __future__ import annotations
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bridge import call_task, contradiction, NothingToAsk       # noqa: E402
+
+NUM = "+33000000000"          # fictional, never dialled by these tests
+
+
+class TheCallTask(unittest.TestCase):
+
+    def test_it_names_the_number_and_the_question(self):
+        p = call_task(NUM, "students only", "Students only", "https://example/x")
+        self.assertIn(NUM, p["task"])
+        self.assertIn("not a student", p["task"])
+
+    def test_it_declares_itself_automated(self):
+        """Not negotiable. A synthetic call that does not say what it is, is a
+        deception, and that would be a strange thing to build into a tool whose
+        subject is what people hide from you."""
+        p = call_task(NUM, "students only", "Students only", "s")
+        self.assertIn("automated", p["task"].lower())
+
+    def test_it_asks_one_question_only(self):
+        p = call_task(NUM, "team required", "Team required", "s")
+        self.assertIn("one question and only one", p["task"])
+        self.assertIn("do not ask anything else", p["task"].lower())
+
+    def test_a_long_quotation_is_cut_without_breaking_a_word(self):
+        p = call_task(NUM, "students only", "word " * 200, "s")
+        self.assertIn("...", p["quote"])
+        self.assertLess(len(p["quote"]), 240)
+
+    def test_a_broken_character_never_reaches_the_ear(self):
+        """Seen on a real page. An eye skips the replacement character, a
+        speech engine pronounces it or stumbles."""
+        p = call_task(NUM, "country restricted", "Countries excluded �", "s")
+        self.assertNotIn("�", p["quote"])
+        self.assertNotIn("�", p["task"])
+
+    def test_an_orphan_symbol_is_trimmed(self):
+        """Real quotation, ending in a multiplication sign, the remains of a
+        close icon flattened into the text. A valid character is not a
+        pronounceable one."""
+        p = call_task(NUM, "country restricted", "Countries excluded ×", "s")
+        self.assertTrue(p["quote"].endswith("excluded"))
+
+    def test_the_schema_always_offers_unknown(self):
+        """Without it the extraction model must choose between yes and no even
+        when the call produced nothing, and it will choose."""
+        p = call_task(NUM, "prize not cash", "not a cash prize", "s")
+        name = p["result_schema"]["required"][0]
+        self.assertIn("unknown", p["result_schema"]["properties"][name]["enum"])
+
+
+class WhatDoesNotJustifyACall(unittest.TestCase):
+    """A call costs a stranger their time. Three refusals, all deliberate."""
+
+    def test_an_unknown_family(self):
+        with self.assertRaises(NothingToAsk):
+            call_task(NUM, "age restricted", "Ages 13+ only", "s")
+
+    def test_a_clause_with_no_quotation(self):
+        with self.assertRaises(NothingToAsk):
+            call_task(NUM, "students only", "   ", "s")
+
+    def test_a_number_that_is_not_one(self):
+        with self.assertRaises(NothingToAsk):
+            call_task("06 12 34 56 78", "students only", "Students only", "s")
+
+
+class TheContradiction(unittest.TestCase):
+
+    def setUp(self):
+        self.p = call_task(NUM, "students only", "Students only", "https://example/x")
+
+    def test_the_voice_contradicts_the_page(self):
+        r = contradiction(self.p, {"open_to_non_students": "yes",
+                                   "their_words": "anyone can enter"})
+        self.assertIsNotNone(r)
+        self.assertIn("anyone can enter", r)
+
+    def test_the_voice_confirms_the_page_and_that_is_not_a_failure(self):
+        self.assertIsNone(contradiction(self.p, {"open_to_non_students": "no"}))
+
+    def test_unknown_is_never_a_contradiction(self):
+        """The easiest trap here. An absence of answer is not a denial, and
+        presenting it as one would be exactly the fault this tool reports on
+        the pages it reads."""
+        self.assertIsNone(contradiction(self.p, {"open_to_non_students": "unknown"}))
+
+    def test_a_call_with_no_result_says_nothing(self):
+        self.assertIsNone(contradiction(self.p, {}))
+        self.assertIsNone(contradiction(self.p, None))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from bridge import (call_task, contradiction, NothingToAsk,      # noqa: E402
                     validate_result_schema, FAMILIES)
 
-NUM = "+33000000000"          # fictional, never dialled by these tests
+NUM = "+447700900123"        # Ofcom drama range, 07700 900xxx, never dialled
 
 
 class TheCallTask(unittest.TestCase):
@@ -87,6 +87,27 @@ class WhatDoesNotJustifyACall(unittest.TestCase):
         """
         with self.assertRaises(NothingToAsk):
             call_task("00 00 00 00 00", "students only", "Students only", "s")
+
+    def test_a_country_code_cannot_start_with_zero(self):
+        """E.164 has no leading zero, so +0 is not a short number, it is not a
+        number at all. The old pattern let it through and would have handed it
+        to the provider."""
+        for wrong in ("+0123456789", "+00000000000"):
+            with self.assertRaises(NothingToAsk):
+                call_task(wrong, "students only", "Students only", "s")
+
+    def test_a_trailing_newline_does_not_slip_past_the_pattern(self):
+        """A number read from a file keeps its newline, and an anchored match
+        on `$` accepts one. That is how a malformed value reaches a dialler."""
+        with self.assertRaises(NothingToAsk):
+            call_task(NUM + "\n", "students only", "Students only", "s")
+
+    def test_the_longest_and_shortest_numbers_e164_allows(self):
+        for right in ("+1234567", "+" + "1" * 15):
+            self.assertIn(right, call_task(right, "students only",
+                                           "Students only", "s")["task"])
+        with self.assertRaises(NothingToAsk):
+            call_task("+" + "1" * 16, "students only", "Students only", "s")
 
 
 class TheContradiction(unittest.TestCase):

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -79,8 +79,14 @@ class WhatDoesNotJustifyACall(unittest.TestCase):
             call_task(NUM, "students only", "   ", "s")
 
     def test_a_number_that_is_not_one(self):
+        """A nationally formatted number is not E.164, and must be refused.
+
+        The sample below is all zeros on purpose. An illustrative number with
+        varied digits reads like a real one to anyone scanning the file, and to
+        any tool that scans a repository for leaked personal data.
+        """
         with self.assertRaises(NothingToAsk):
-            call_task("06 12 34 56 78", "students only", "Students only", "s")
+            call_task("00 00 00 00 00", "students only", "Students only", "s")
 
 
 class TheContradiction(unittest.TestCase):

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -18,7 +18,8 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import place_call                                                # noqa: E402
 from bridge import NothingToAsk                                  # noqa: E402
-from place_call import ALLOWED, collect, main, place, Refused    # noqa: E402
+from place_call import (ALLOWED, collect, main, masked, place,             # noqa: E402
+                        Refused)
 
 NUM = "+447700900123"        # Ofcom drama range, 07700 900xxx, never dialled
 KEY = "not-a-key"
@@ -146,6 +147,72 @@ class WhatIsActuallySent(unittest.TestCase):
         transport = Transport(402, {"error": "out of calls"})
         with self.assertRaises(Refused):
             place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+
+
+class NothingSensitiveLeavesThisFile(unittest.TestCase):
+    """A refusal is printed, so whatever it carries ends up in a terminal."""
+
+    FINISHED = {"id": "call_x", "status": "completed",
+                "structured_result": {"open_to_non_students": "yes"},
+                "transcript": "hello, this is a real person speaking",
+                "recording_url": "https://provider.example/rec/call_x.mp3",
+                "to": NUM, "from": "+447700900999"}
+
+    # Well formed but not on the list. That is the only path that prints a
+    # destination, so it is the only one where masking can be observed.
+    UNLISTED = "+447700900456"
+
+    def authorisation_refusal(self):
+        with self.assertRaises(Refused) as refused:
+            place(self.UNLISTED, "students only", "Students only", "t", key=KEY,
+                  send=Transport(201, {"id": "call_x"}))
+        return str(refused.exception)
+
+    def test_the_refusal_does_not_print_the_number_it_refuses(self):
+        self.assertNotIn(self.UNLISTED, self.authorisation_refusal())
+
+    def test_the_refusal_still_says_enough_to_recognise_the_number(self):
+        said = self.authorisation_refusal()
+        self.assertIn(self.UNLISTED[1:3], said)
+        self.assertIn(self.UNLISTED[-2:], said)
+        self.assertIn(ALLOWED, said)
+
+    def test_a_short_or_malformed_value_is_hidden_whole(self):
+        """Half of a wrong number is still half of a number."""
+        for value in ("+331", "", "not a number", "+33"):
+            hidden = masked(value)
+            self.assertEqual(hidden.lstrip("+").strip("*"), "",
+                             "%r leaked through as %r" % (value, hidden))
+            self.assertTrue(hidden.startswith("+"))
+
+    def test_the_transcript_and_the_recording_do_not_come_back(self):
+        rendu = collect("call_x", key=KEY, send=Transport(200, self.FINISHED))
+        for champ in ("transcript", "recording_url", "to", "from"):
+            self.assertNotIn(champ, rendu)
+
+    def test_what_the_project_actually_uses_does_come_back(self):
+        rendu = collect("call_x", key=KEY, send=Transport(200, self.FINISHED))
+        self.assertEqual(rendu["status"], "completed")
+        self.assertEqual(rendu["structured_result"]["open_to_non_students"], "yes")
+
+    def test_a_caller_who_asks_for_everything_gets_everything(self):
+        rendu = collect("call_x", key=KEY, send=Transport(200, self.FINISHED), raw=True)
+        self.assertIn("transcript", rendu)
+
+    def test_bounding_the_payload_does_not_break_the_verdict(self):
+        """The answer is read before the trimming, not after."""
+        prepared = place(NUM, "students only", "Students only", "t", key=KEY,
+                         send=Transport(201, {"id": "call_x"}))[0]
+        _, verdict = collect("call_x", prepared, key=KEY,
+                             send=Transport(200, self.FINISHED))
+        self.assertIsNotNone(verdict)
+
+    def test_a_provider_refusal_does_not_print_its_whole_payload(self):
+        bruyant = Transport(402, {"error": "out of calls", "to": NUM,
+                                  "transcript": "a stranger speaking"})
+        with self.assertRaises(Refused) as refus:
+            place(NUM, "students only", "Students only", "t", key=KEY, send=bruyant)
+        self.assertNotIn("a stranger speaking", str(refus.exception))
 
 
 class ReadingTheCallBack(unittest.TestCase):

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -8,6 +8,8 @@ can be exercised with a stub that records what would have left the machine.
 The witnesses below assert as much about what is NOT sent as about what is.
 """
 from __future__ import annotations
+import contextlib
+import io
 import json
 import os
 import sys
@@ -68,7 +70,11 @@ class NothingLeavesTheMachine(unittest.TestCase):
         self.assertEqual(transport.sent, [])
 
     def test_the_command_line_without_a_number_asks_and_sends_nothing(self):
-        self.assertEqual(main([]), 2)
+        aide = io.StringIO()
+        with contextlib.redirect_stdout(aide):
+            code = main([])
+        self.assertEqual(code, 2)
+        self.assertIn('--to', aide.getvalue())
 
 
 class WhatIsActuallySent(unittest.TestCase):

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Witnesses for the file that dials. Still no call, no network, no key.
+
+    python tests_place_call.py
+
+`place_call.place` takes its transport as a parameter, so every path through it
+can be exercised with a stub that records what would have left the machine.
+The witnesses below assert as much about what is NOT sent as about what is.
+"""
+from __future__ import annotations
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import place_call                                                # noqa: E402
+from bridge import NothingToAsk                                  # noqa: E402
+from place_call import collect, main, place, Refused             # noqa: E402
+
+NUM = "+33000000000"          # fictional, never dialled by these tests
+KEY = "not-a-key"
+
+
+class Transport:
+    """Records calls instead of making them."""
+
+    def __init__(self, status=201, payload=None):
+        self.status, self.payload, self.sent = status, payload or {}, []
+
+    def __call__(self, url, key, body, timeout=45):
+        self.sent.append({"url": url, "key": key,
+                          "body": json.loads(body) if body else None})
+        return self.status, self.payload
+
+
+class NothingLeavesTheMachine(unittest.TestCase):
+
+    def test_a_missing_key_stops_the_run_before_the_task_is_built(self):
+        """A 401 from the provider reads like a permissions problem and sends
+        you looking in the wrong place. This one says what is wrong."""
+        transport = Transport()
+        os.environ.pop("CALLE_API_KEY", None)
+        with self.assertRaises(Refused):
+            place(NUM, "students only", "Students only", "t", send=transport)
+        self.assertEqual(transport.sent, [])
+
+    def test_a_clause_outside_the_families_is_never_dialled(self):
+        transport = Transport()
+        with self.assertRaises(NothingToAsk):
+            place(NUM, "no such family", "anything", "t", key=KEY, send=transport)
+        self.assertEqual(transport.sent, [])
+
+    def test_a_schema_the_provider_cannot_fill_is_refused_here(self):
+        """The provider accepts a malformed schema at creation and fails only
+        at extraction, once the call and someone's minute are spent."""
+        transport = Transport()
+        original = place_call.call_task
+        place_call.call_task = lambda *a, **k: {
+            "family": "students only", "quote": "q", "task": "t",
+            "result_schema": {"type": "object", "properties": {"x": {"$ref": "#/nope"}},
+                              "required": ["x"], "additionalProperties": False}}
+        try:
+            with self.assertRaises(Refused):
+                place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        finally:
+            place_call.call_task = original
+        self.assertEqual(transport.sent, [])
+
+    def test_the_command_line_without_a_number_asks_and_sends_nothing(self):
+        self.assertEqual(main([]), 2)
+
+
+class WhatIsActuallySent(unittest.TestCase):
+
+    def test_one_request_carrying_the_task_and_the_schema(self):
+        transport = Transport(201, {"id": "call_x", "status": "queued"})
+        prepared, payload = place(NUM, "students only", "Students only", "t",
+                                  key=KEY, send=transport)
+        self.assertEqual(len(transport.sent), 1)
+        sent = transport.sent[0]
+        self.assertEqual(sent["url"], place_call.CALLS)
+        self.assertEqual(sent["key"], KEY)
+        self.assertEqual(sorted(sent["body"]), ["result_schema", "task"])
+        self.assertIn(NUM, sent["body"]["task"])
+        self.assertEqual(payload["id"], "call_x")
+        self.assertEqual(prepared["family"], "students only")
+
+    def test_the_key_never_reaches_the_body(self):
+        transport = Transport(201, {"id": "call_x"})
+        place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertNotIn(KEY, json.dumps(transport.sent[0]["body"]))
+
+    def test_a_refusal_from_the_provider_is_raised_and_not_swallowed(self):
+        transport = Transport(402, {"error": "out of calls"})
+        with self.assertRaises(Refused):
+            place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+
+
+class ReadingTheCallBack(unittest.TestCase):
+
+    def test_without_the_prepared_task_it_returns_the_payload_alone(self):
+        transport = Transport(200, {"id": "call_x", "status": "completed"})
+        self.assertEqual(collect("call_x", key=KEY, send=transport)["status"], "completed")
+
+    def test_with_it_a_cancelling_answer_becomes_a_contradiction(self):
+        prepared = place(NUM, "students only", "Students only", "t", key=KEY,
+                         send=Transport(201, {"id": "call_x"}))[0]
+        transport = Transport(200, {"structured_result": {
+            "open_to_non_students": "yes", "their_words": "anyone can enter"}})
+        _, found = collect("call_x", prepared, key=KEY, send=transport)
+        self.assertIn("the opposite", found)
+        self.assertIn("anyone can enter", found)
+
+    def test_an_unknown_answer_is_not_a_contradiction(self):
+        """The absence of an answer is not a denial, and a tool that reports it
+        as one manufactures evidence."""
+        prepared = place(NUM, "students only", "Students only", "t", key=KEY,
+                         send=Transport(201, {"id": "call_x"}))[0]
+        transport = Transport(200, {"structured_result": {"open_to_non_students": "unknown"}})
+        self.assertIsNone(collect("call_x", prepared, key=KEY, send=transport)[1])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -18,10 +18,21 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import place_call                                                # noqa: E402
 from bridge import NothingToAsk                                  # noqa: E402
-from place_call import collect, main, place, Refused             # noqa: E402
+from place_call import ALLOWED, collect, main, place, Refused    # noqa: E402
 
-NUM = "+33000000000"          # fictional, never dialled by these tests
+NUM = "+447700900123"        # Ofcom drama range, 07700 900xxx, never dialled
 KEY = "not-a-key"
+
+
+def setUpModule():
+    """Most witnesses below exercise the path where a call WOULD go out, so the
+    recipient has to be authorised for them to reach it at all. The three that
+    test the authorisation itself set the variable themselves."""
+    os.environ[ALLOWED] = NUM
+
+
+def tearDownModule():
+    os.environ.pop(ALLOWED, None)
 
 
 class Transport:
@@ -75,6 +86,40 @@ class NothingLeavesTheMachine(unittest.TestCase):
             code = main([])
         self.assertEqual(code, 2)
         self.assertIn('--to', aide.getvalue())
+
+
+class OnlyAnAuthorisedRecipientIsDialled(unittest.TestCase):
+    """A well formed number is not the same thing as a number you may call.
+    These three witnesses are the difference."""
+
+    def setUp(self):
+        self.saved = os.environ.get(ALLOWED)
+
+    def tearDown(self):
+        if self.saved is None:
+            os.environ.pop(ALLOWED, None)
+        else:
+            os.environ[ALLOWED] = self.saved
+
+    def test_an_empty_list_authorises_nothing(self):
+        transport = Transport()
+        os.environ.pop(ALLOWED, None)
+        with self.assertRaises(Refused):
+            place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertEqual(transport.sent, [])
+
+    def test_a_number_absent_from_the_list_is_refused(self):
+        transport = Transport()
+        os.environ[ALLOWED] = "+447700900999"
+        with self.assertRaises(Refused):
+            place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertEqual(transport.sent, [])
+
+    def test_the_list_takes_several_numbers_and_ignores_the_spacing(self):
+        transport = Transport(201, {"id": "call_x"})
+        os.environ[ALLOWED] = " +447700900999 , %s " % NUM
+        place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertEqual(len(transport.sent), 1)
 
 
 class WhatIsActuallySent(unittest.TestCase):


### PR DESCRIPTION
## What this adds

`apps/python/clause-check-by-phone`, a small dependency-free app that turns a
clause a page states quietly into one question asked out loud, and reports only
when the voice contradicts the page.

## The rule it is built on

**Never make someone repeat on the phone what the page already says.** A call is
worth placing only if its answer can contradict the page. Six clause families
are considered worth a call. Anything else raises `NothingToAsk`, which is a
result and not an error, and the common one.

## Checklist

- English-only, no secrets, no tokens, no real phone numbers. Every sample uses
  `+33000000000`, which is fictional and never dialled.
- Host and provider stated, any Python 3.9 host, calls placed against
  `POST /v1/calls` with a Bearer key. The app contains no key and no client.
- Side effects described. It places a real call to a real person, and that is
  not reversible once the phone rings.
- Cancellation described. Nothing recurring, no schedule, no retry, no stored
  state between runs.
- **No-call path included.** `dry_run.py` prints the exact task and result
  schema without dialling. A developer holding twenty free calls cannot afford
  to tune a task by placing it.
- `python scripts/validate_repository.py` passes.
- `python scripts/check_branch_name.py --branch feat/clause-check-by-phone` passes.

## Tests

`python tests_bridge.py`, fourteen witnesses, no call, no network, no key.

Three are refusals, an unknown family, a clause with no quotation, and a
malformed number. Two guard the quotation itself, because it will be SPOKEN and
text meant for the eye tolerates a broken character that a speech engine
pronounces. One guards the answer `unknown`, which must never be read as a
contradiction, since an absence of answer is not a denial.

## On safety

The call task always states, in its first sentence, that the call is automated
and placed by a software agent, and a test enforces that. It asks one question
and only one, and says so twice. It never argues and never sells. Given there
is no sandbox and no echo number, the dry-run path is the only safe way to
iterate on the wording.