### PR TITLE
feat(apps): add TrustRail call resolver

### DIFF
--- a/apps/python/trustrail-call-resolver/README.md
+++ b/apps/python/trustrail-call-resolver/README.md
@@ -1,0 +1,17 @@
+# TrustRail Call Resolver
+
+TrustRail is a consent-gated Python web app for resolving invoice and purchase-order exceptions by phone. It extracts and reconciles fictional demo documents, preserves a human release/hold gate, and uses CALL-E only to collect bounded clarification facts.
+
+Maintained source and runnable demo: https://github.com/northstar-trustrail/trustrail-call-resolver
+
+## Safety and side effects
+
+- Fixture mode places no call and is the default path without credentials.
+- A real call requires a reviewed plan, positive recipient consent, and a separate execution action.
+- Phone numbers are masked in browser responses; transcripts remain provider-side.
+- The workflow refuses bank/routing/card data, tax identifiers, passwords, authentication codes, payment authorization, and automated payment release.
+- Unknown, refusal, voicemail, and low-confidence outcomes route to human review and never become payment approval.
+
+## Setup
+
+See the maintained repository README for Python setup, CALL-E OAuth/API configuration, the six-test safety suite, and reproducible fictional PDF fixtures.


### PR DESCRIPTION
## Summary

Adds TrustRail Call Resolver under the Python app contribution area. TrustRail turns invoice and purchase-order exceptions into a consent-gated CALL-E clarification workflow while preserving a human release/hold decision. The maintained public repository includes a no-call fixture path, six passing safety/reconciliation tests, fictional PDFs, and explicit credential and side-effect boundaries.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior, or are not used.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [ ] `python3 scripts/validate_repository.py` passes (not run in this browser-only fork workflow).

Maintained source: https://github.com/northstar-trustrail/trustrail-call-resolver
