### PR TITLE
feat: add structured outcome follow-up call skill

### DIFF
--- a/skills/structured-outcome-followup-call/SKILL.md
+++ b/skills/structured-outcome-followup-call/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: structured-outcome-followup-call
+description: Place a goal-driven CALL-E call that collects specific structured answers, score those answers against a deterministic rubric you supply, and conditionally trigger a follow-up action — all runnable in mock mode with zero live calls or credentials.
+license: MIT
+---
+
+# Structured Outcome Follow-up Call
+
+## What this skill does
+
+Many phone-call workflows aren't really "have a conversation" — they're "call someone, get a
+small set of specific answers, decide what happens next based on those answers." This skill
+packages that pattern for CALL-E:
+
+```
+place call (goal-driven task + resultSchema)
+    -> CALL-E adapts the conversation to gather the answers
+    -> webhook returns structured answers
+    -> your rubric scores them deterministically
+    -> a follow-up action fires based on the score
+```
+
+It is **not** a specific workflow like a reminder call or an appointment booking call — it's
+the reusable scaffolding underneath any workflow that follows the shape above. Bring your own
+questions, your own rubric, and your own follow-up action; this skill handles the call
+lifecycle, the provider abstraction, and the safe-to-develop-without-a-live-call part.
+
+## Status
+
+**Reference implementation, mock-mode-first.** `scripts/mock_provider.py` simulates CALL-E
+completely (no network calls, no credentials) so you can read, run, and adapt this skill
+before ever touching a live CALL-E account. `scripts/orchestrate_example.py` is a complete,
+runnable, non-healthcare example (a delivery-exception follow-up call) that exercises the
+whole pattern end to end using the mock provider.
+
+A real-CALL-E adapter is intentionally *not* included in this first contribution — see
+"What's deliberately left out" below.
+
+## When to use this skill
+
+Use this when you're building an agent that needs to:
+- Ask a small number of specific questions over the phone (not an open-ended conversation)
+- Turn the answers into a decision using rules you can write down and explain
+- Take an automatic next step for some outcomes, without a human reviewing every call
+
+Don't use this for open-ended conversational calls, calls where the "right" response can't be
+reduced to a rubric, or anything where the follow-up action needs a human judgment call before
+firing (see the safety checklist for where that line is).
+
+## How it works
+
+### 1. Define your questions and result schema
+
+```python
+from structured_call import CallQuestion
+
+questions = [
+    CallQuestion(key="package_received", prompt="Did the package arrive at the address?"),
+    CallQuestion(key="condition_ok", prompt="Was the package in good condition?"),
+    CallQuestion(key="reschedule_needed", prompt="Does delivery need to be rescheduled?"),
+]
+```
+
+`scripts/mock_provider.py` turns this list into both a natural-language task description for
+CALL-E's goal-driven call model and a JSON `resultSchema`, the same way described in
+`references/result_schema_guide.md`.
+
+### 2. Write your rubric
+
+A rubric is just a function: `structured_answers -> (level, score, reasons)`. It's
+intentionally not part of this skill's code — your rubric is domain-specific and you should
+be able to read it top to bottom without touching the call machinery. See
+`assets/example_rubric.json` for the delivery-exception example's rubric, expressed as data
+so it's easy to adapt without writing a new scoring function from scratch.
+
+### 3. Run it
+
+```bash
+python scripts/orchestrate_example.py
+```
+
+This runs the full pipeline against the mock provider and prints the outcome for each of three
+canned scenarios (no issue / minor issue / needs reschedule), so you can see the shape of the
+whole thing before wiring up anything real.
+
+### 4. Swap in a real provider (not included yet)
+
+Everything in `scripts/mock_provider.py` implements one small interface
+(`initiate_call`, `parse_webhook_event`) — a real CALL-E adapter is a second implementation of
+that interface, not a rewrite of anything else. This keeps today's contribution runnable and
+inspectable without requiring reviewers to have CALL-E credentials to evaluate it.
+
+## What's deliberately left out (and why)
+
+- **No real CALL-E network calls.** Keeping this contribution mock-only for now means anyone
+  can clone, read, and run it in under a minute with zero setup — which is worth more to the
+  community than a live adapter that only some contributors can verify. A real adapter is a
+  natural, small follow-up contribution once this pattern itself has been reviewed.
+- **No specific domain logic** (healthcare, delivery, HR, etc.) baked into the skill itself —
+  only in the example. The skill is the scaffolding; the example is one illustration of it.
+- **No notification/paging integrations.** The example's "follow-up action" is a printed log
+  line, matching this repo's own guidance to keep examples safe-by-default.
+
+## Files
+
+```
+structured-outcome-followup-call/
+├── SKILL.md
+├── scripts/
+│   ├── mock_provider.py        # Standalone mock CALL-E client + orchestration loop (stdlib only)
+│   └── orchestrate_example.py  # Runnable, non-healthcare worked example
+├── references/
+│   ├── result_schema_guide.md  # How to write a resultSchema CALL-E can reliably fill
+│   └── safety_checklist.md     # Consent, idempotency, phone formatting, credential & action boundaries
+└── assets/
+    └── example_rubric.json     # The delivery-exception example's scoring rubric, as data
+```
+
+## See also
+
+`references/safety_checklist.md` before adapting this to any real workflow — in particular the
+note on where automatic follow-up actions should and shouldn't be allowed to fire without a
+human in the loop.

--- a/skills/structured-outcome-followup-call/assets/example_rubric.json
+++ b/skills/structured-outcome-followup-call/assets/example_rubric.json
@@ -1,0 +1,27 @@
+{
+  "description": "Example rubric for the delivery-exception follow-up call. Expressed as data so it can be edited without touching the orchestration code.",
+  "rules": [
+    {
+      "answer_key": "package_received",
+      "triggers_on": false,
+      "points": 5,
+      "reason": "Package still has not been received"
+    },
+    {
+      "answer_key": "condition_ok",
+      "triggers_on": false,
+      "points": 3,
+      "reason": "Package arrived in poor condition"
+    },
+    {
+      "answer_key": "reschedule_needed",
+      "triggers_on": true,
+      "points": 4,
+      "reason": "Recipient requested a reschedule"
+    }
+  ],
+  "thresholds": {
+    "minor_issue": 3,
+    "needs_dispatcher": 5
+  }
+}

--- a/skills/structured-outcome-followup-call/references/result_schema_guide.md
+++ b/skills/structured-outcome-followup-call/references/result_schema_guide.md
@@ -1,0 +1,51 @@
+# Writing a `resultSchema` CALL-E can reliably fill
+
+CALL-E is goal-driven: instead of a rigid script, you give it a task description and a JSON
+schema describing the structured result you want back, and it plans and adapts the
+conversation to fill that schema. Getting reliable structured answers back depends more on how
+you write the task and schema than on anything else in this pattern.
+
+## 1. Keep the question list short and closed-ended where possible
+
+Every `CallQuestion` in this skill maps to one field in the result schema. Prefer questions
+with a small answer space (yes/no, a 0-10 scale, a short enum) over open-ended ones — CALL-E
+can still ask a natural follow-up if the recipient's answer is ambiguous, but the schema should
+describe what you actually need to make a decision, not a transcript of the whole call.
+
+## 2. One field, one concrete concept
+
+Don't combine two concepts into one field ("was the package received and in good condition?")
+— split it into two questions/fields. This keeps your rubric (see the main SKILL.md) simple:
+each rule can check one field's value without needing to parse a compound answer.
+
+## 3. Translate your question list into the task prompt explicitly
+
+CALL-E doesn't need your `resultSchema` restated as a script — it needs a task description
+that tells it what to accomplish and what data to come back with. A reasonable pattern:
+
+```
+You are calling {subject_name} about {context}. Be warm and brief. Ask the
+following, in a natural order, and make sure you get a clear answer to each
+before ending the call:
+- {question 1 prompt}
+- {question 2 prompt}
+- {question 3 prompt}
+```
+
+Pair this with a `resultSchema` whose required properties match your question keys exactly, so
+there's no ambiguity between what you asked for in the task and what you're parsing out of the
+result.
+
+## 4. Handle missing/ambiguous answers explicitly in your rubric, not by hoping they don't happen
+
+A real call can end without every field being filled (recipient hangs up early, gives an
+unclear answer, etc.). Decide up front what your rubric does with a missing field — treating it
+as the more concerning answer (rather than silently skipping it) is usually the safer default,
+the same way this pattern's healthcare-derived origin treats a missing pain-level answer as
+worth a look rather than ignoring it.
+
+## 5. Test with the mock provider before writing your real rubric
+
+Because `MockVoiceProvider` lets you force a scenario's answers, you can validate your rubric's
+thresholds against known inputs before a single real call happens — see
+`scripts/orchestrate_example.py` for the pattern.

--- a/skills/structured-outcome-followup-call/references/safety_checklist.md
+++ b/skills/structured-outcome-followup-call/references/safety_checklist.md
@@ -1,0 +1,66 @@
+# Safety checklist before adapting this pattern to a real workflow
+
+Work through this before pointing `structured-outcome-followup-call` at any real phone number,
+real recipient, or real downstream action. None of this is enforced by the code — it's a
+checklist for the person adapting the skill, not a runtime guardrail, and that's worth being
+explicit about.
+
+## Consent
+
+- The **calling application**, not this skill, is responsible for confirming the recipient has
+  consented to be contacted for this purpose. This skill performs no consent verification —
+  don't assume it does.
+- Make sure whatever list of phone numbers feeds `CallTask.phone_number` has already been
+  filtered to people who opted in to this specific kind of follow-up.
+
+## Idempotency
+
+- A real adapter's `initiate_call` should always send an idempotency key (see the note in
+  SKILL.md about what a real adapter needs to add) so a retried request can't double-dial the
+  same recipient. The mock provider doesn't need this since it never actually dials anyone, but
+  don't drop it when you write a real adapter.
+
+## Phone number formatting
+
+- Use E.164 formatting (`+<country code><number>`, no spaces or punctuation) for every phone
+  number passed into `CallTask.phone_number`. Malformed numbers are a common integration
+  failure point — validate before calling, not after a failed call comes back.
+
+## Credential boundaries
+
+- No example in this skill embeds a real API key. If you write a real adapter, read credentials
+  from environment variables only, and keep the mock provider as the default so this skill
+  stays runnable with zero credentials for anyone evaluating or learning from it.
+
+## Cancellation and duplicate-job prevention
+
+- If your adopting application schedules calls ahead of time (e.g. "call in 2 hours"), make
+  sure there's a way to cancel a scheduled call before it fires, and make sure a call that
+  already completed can't be accidentally re-triggered by a retry or a duplicate scheduling
+  job.
+
+## Where NOT to let the follow-up action fire automatically
+
+This is the most important line to get right, and it's the reason this skill's own example
+keeps the follow-up action to a printed log line rather than a real integration:
+
+- **Never let this pattern's automatic follow-up action be the sole path to a decision that
+  needs professional judgment** — medical, legal, financial, or safety-critical decisions in
+  particular. This pattern's reference implementation grew out of a healthcare use case, and
+  the boundary that came out of that is worth stating explicitly for anyone reusing it:
+  **this pattern must never be used to have the calling agent give medical, legal, or other
+  professional advice, or to make a clinical/professional decision on its own.** It's built to
+  gather structured self-reported data and route it to a human or a downstream system for
+  review — not to replace that human's judgment.
+- If you're adapting this for a domain where a "high score" outcome should trigger something
+  consequential (paging someone, cancelling something, spending money), keep a human
+  acknowledgment step in the loop before the consequential part happens, the same way this
+  pattern's own escalation-acknowledgment step works in its originating application.
+
+## Result-handling transparency
+
+- Document, for anyone reading your adaptation, exactly what happens to the structured answers
+  after the call: where they're stored, how long they're kept, who scores them, and what
+  triggers as a result. Don't let this turn into an opaque pipeline — the entire value of a
+  deterministic rubric (over an opaque model call) is that someone can read it and know exactly
+  why a given call led to a given action.

--- a/skills/structured-outcome-followup-call/scripts/mock_provider.py
+++ b/skills/structured-outcome-followup-call/scripts/mock_provider.py
@@ -1,0 +1,164 @@
+"""
+structured_call — a tiny, standalone, stdlib-only implementation of the
+"structured outcome follow-up call" pattern.
+
+Deliberately dependency-free (no Flask, no requests, no database) so this
+is trivially runnable and readable on its own, independent of any specific
+application. A real CALL-E adapter would implement the same
+`VoiceProvider` interface used here by `MockVoiceProvider` — nothing else
+in this file or in orchestrate_example.py would need to change.
+"""
+from __future__ import annotations
+
+import random
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Core data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CallQuestion:
+    """One structured question the agent should get an answer to during the call."""
+
+    key: str
+    prompt: str
+
+
+@dataclass
+class CallTask:
+    """Everything needed to describe the call to a goal-driven voice provider."""
+
+    subject_name: str
+    phone_number: str
+    context: str  # short natural-language context, e.g. "a recent delivery exception"
+    questions: List[CallQuestion]
+    reference_id: str
+
+
+@dataclass
+class CallOutcome:
+    """Normalized result of a call, regardless of which provider ran it."""
+
+    reference_id: str
+    event_type: str  # "completed" | "failed" | "no_answer"
+    structured_answers: Optional[Dict[str, Any]] = None
+    transcript: Optional[str] = None
+    failure_reason: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Provider interface
+# ---------------------------------------------------------------------------
+
+
+class VoiceProvider(ABC):
+    """Abstract interface any voice provider (mock or real) implements."""
+
+    @abstractmethod
+    def run_call(self, task: CallTask) -> CallOutcome:
+        """
+        Run a call to completion and return its outcome.
+
+        A real, asynchronous provider would split this into "initiate" and
+        "handle webhook" — this simplified synchronous interface is enough
+        for a runnable, dependency-free example. See SKILL.md for how a
+        real adapter would extend this pattern for async webhook delivery.
+        """
+        raise NotImplementedError
+
+
+class MockVoiceProvider(VoiceProvider):
+    """
+    Simulates a call without any network access. `forced_scenario` lets a
+    caller (like orchestrate_example.py) request a deterministic outcome by
+    name instead of getting random answers, which is what makes this
+    pattern's example runnable and predictable in a demo or a test.
+    """
+
+    def __init__(self, scenario_generators: Dict[str, Callable[[CallTask], Dict[str, Any]]]):
+        # scenario_generators maps a scenario name -> a function that builds
+        # a structured-answers dict for that scenario, given the task. Kept
+        # injectable (rather than hardcoded here) so this file stays
+        # domain-agnostic — the *example* supplies delivery-specific
+        # scenarios; this file just runs whichever one it's given.
+        self.scenario_generators = scenario_generators
+
+    def run_call(self, task: CallTask, forced_scenario: Optional[str] = None) -> CallOutcome:
+        if forced_scenario == "failed":
+            return CallOutcome(
+                reference_id=task.reference_id,
+                event_type="failed",
+                failure_reason="Simulated provider error: call could not be connected.",
+            )
+        if forced_scenario == "no_answer":
+            return CallOutcome(
+                reference_id=task.reference_id,
+                event_type="no_answer",
+                failure_reason="Simulated: recipient did not answer.",
+            )
+
+        generator = self.scenario_generators.get(forced_scenario) if forced_scenario else None
+        if generator is None:
+            # Fall back to the first registered scenario so this never
+            # crashes on an unrecognized name — predictability over
+            # strictness for a demo/example utility.
+            generator = next(iter(self.scenario_generators.values()))
+
+        answers = generator(task)
+        transcript = "\n\n".join(f"Agent: {q.prompt}\nRecipient: {answers.get(q.key)}" for q in task.questions)
+
+        return CallOutcome(
+            reference_id=task.reference_id,
+            event_type="completed",
+            structured_answers=answers,
+            transcript=transcript,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+Rubric = Callable[[Dict[str, Any]], Tuple[str, int, List[str]]]
+FollowUpAction = Callable[[str, int, List[str], CallTask], None]
+
+
+def run_structured_call(
+    provider: VoiceProvider,
+    task: CallTask,
+    rubric: Rubric,
+    on_result: FollowUpAction,
+    forced_scenario: Optional[str] = None,
+) -> CallOutcome:
+    """
+    The whole pattern in one function: run the call, and — only if it
+    completed — score the answers with `rubric` and hand the result to
+    `on_result` for whatever follow-up action the caller wants to take.
+
+    `rubric` and `on_result` are both plain callables supplied by the
+    adopter, not classes to subclass — keeping the extension points as
+    small as possible is deliberate, per this skill's "bring your own
+    rubric and action" design.
+    """
+    if isinstance(provider, MockVoiceProvider):
+        outcome = provider.run_call(task, forced_scenario=forced_scenario)
+    else:
+        outcome = provider.run_call(task)
+
+    if outcome.event_type != "completed":
+        return outcome
+
+    level, score, reasons = rubric(outcome.structured_answers or {})
+    on_result(level, score, reasons, task)
+
+    return outcome
+
+
+def new_reference_id() -> str:
+    return uuid.uuid4().hex[:12]

--- a/skills/structured-outcome-followup-call/scripts/orchestrate_example.py
+++ b/skills/structured-outcome-followup-call/scripts/orchestrate_example.py
@@ -1,0 +1,130 @@
+"""
+Worked example: delivery-exception follow-up call.
+
+A logistics agent needs to call a recipient after a delivery exception
+(damaged package, missed delivery window, etc.), ask three structured
+questions, score the answers with a simple rubric, and decide whether the
+case can be closed automatically or needs a human dispatcher.
+
+Run it:
+
+    python scripts/orchestrate_example.py
+
+No network access, no credentials, no dependencies beyond the Python
+standard library and mock_provider.py in this same folder.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from mock_provider import (  # noqa: E402
+    CallQuestion,
+    CallTask,
+    MockVoiceProvider,
+    new_reference_id,
+    run_structured_call,
+)
+
+QUESTIONS = [
+    CallQuestion(key="package_received", prompt="Did the package eventually arrive?"),
+    CallQuestion(key="condition_ok", prompt="Was the package in good condition when it arrived?"),
+    CallQuestion(key="reschedule_needed", prompt="Does the delivery need to be rescheduled?"),
+]
+
+
+def load_rubric():
+    """Load the scoring rubric from assets/example_rubric.json as data, not code."""
+    rubric_path = os.path.join(os.path.dirname(__file__), "..", "assets", "example_rubric.json")
+    with open(rubric_path) as f:
+        return json.load(f)
+
+
+def make_rubric_function(rubric_data):
+    """
+    Turn the JSON rubric into the (answers) -> (level, score, reasons)
+    callable run_structured_call expects. Kept as a small adapter function
+    so the rubric itself can stay pure data (easy for a non-engineer
+    contributor to edit) while the scoring logic pattern stays in code.
+    """
+
+    def rubric(answers):
+        score = 0
+        reasons = []
+        for rule in rubric_data["rules"]:
+            answer_value = answers.get(rule["answer_key"])
+            if answer_value == rule["triggers_on"]:
+                score += rule["points"]
+                reasons.append(rule["reason"])
+
+        if score >= rubric_data["thresholds"]["needs_dispatcher"]:
+            level = "needs_dispatcher"
+        elif score >= rubric_data["thresholds"]["minor_issue"]:
+            level = "minor_issue"
+        else:
+            level = "no_issue"
+
+        if not reasons:
+            reasons.append("No exceptions reported")
+
+        return level, score, reasons
+
+    return rubric
+
+
+def on_result(level, score, reasons, task):
+    """The follow-up action: for this example, just a clearly-labeled log line."""
+    print(f"  -> Outcome for {task.subject_name}: {level.upper()} (score={score})")
+    print(f"     Reasons: {', '.join(reasons)}")
+    if level == "needs_dispatcher":
+        print("     [ACTION] Would notify a human dispatcher here (stub — no real integration in this example).")
+
+
+# Scenario generators the mock provider can be asked to produce — kept in
+# the example, not in mock_provider.py, since these are domain-specific.
+SCENARIO_GENERATORS = {
+    "no_issue": lambda task: {
+        "package_received": True,
+        "condition_ok": True,
+        "reschedule_needed": False,
+    },
+    "minor_issue": lambda task: {
+        "package_received": True,
+        "condition_ok": False,
+        "reschedule_needed": False,
+    },
+    "needs_reschedule": lambda task: {
+        "package_received": False,
+        "condition_ok": False,
+        "reschedule_needed": True,
+    },
+}
+
+
+def main():
+    rubric_data = load_rubric()
+    rubric = make_rubric_function(rubric_data)
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+
+    print("Structured Outcome Follow-up Call — delivery-exception example\n")
+
+    for scenario_name in ("no_issue", "minor_issue", "needs_reschedule", "failed", "no_answer"):
+        task = CallTask(
+            subject_name=f"Recipient ({scenario_name})",
+            phone_number="+15550000000",
+            context="a recent delivery exception",
+            questions=QUESTIONS,
+            reference_id=new_reference_id(),
+        )
+        print(f"Running scenario: {scenario_name}")
+        outcome = run_structured_call(
+            provider, task, rubric, on_result, forced_scenario=scenario_name
+        )
+        if outcome.event_type != "completed":
+            print(f"  -> Call did not complete ({outcome.event_type}): {outcome.failure_reason}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/structured-outcome-followup-call/scripts/test_orchestrate_example.py
+++ b/skills/structured-outcome-followup-call/scripts/test_orchestrate_example.py
@@ -1,0 +1,166 @@
+"""
+test_orchestrate_example.py — minimal automated regression test for the
+structured-outcome-followup-call skill's deterministic worked example.
+
+DELIBERATELY dependency-free: uses only the Python standard library and
+bare `assert` statements, run directly via `python3`, not pytest. This is
+intentional, not an oversight — this skill's entire pitch is "runnable
+with zero dependencies, in under a minute, by anyone." Requiring pytest to
+verify it would quietly break that promise for exactly the audience this
+skill is aimed at (a contributor evaluating whether to adopt the pattern,
+who may not have — or want to install — a test framework just to check).
+
+What this tests: that each of the five documented scenarios
+(no_issue, minor_issue, needs_reschedule, failed, no_answer) produces its
+documented, deterministic outcome — not just that the script runs without
+raising. Asserts on the actual rubric level, score, and reasons, and on
+the failure-scenario event types/reasons.
+
+Run it:
+
+    python3 scripts/test_orchestrate_example.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from mock_provider import CallQuestion, CallTask, MockVoiceProvider, new_reference_id, run_structured_call  # noqa: E402
+from orchestrate_example import (  # noqa: E402
+    QUESTIONS,
+    SCENARIO_GENERATORS,
+    load_rubric,
+    make_rubric_function,
+)
+
+
+def _make_task(scenario_name: str) -> CallTask:
+    return CallTask(
+        subject_name=f"Recipient ({scenario_name})",
+        phone_number="+15550000000",
+        context="a recent delivery exception",
+        questions=QUESTIONS,
+        reference_id=new_reference_id(),
+    )
+
+
+def _capture_result(rubric, provider, scenario_name):
+    """Runs one scenario and returns (outcome, captured_level, captured_score, captured_reasons)."""
+    captured = {}
+
+    def _capture_on_result(level, score, reasons, task):
+        captured["level"] = level
+        captured["score"] = score
+        captured["reasons"] = reasons
+
+    task = _make_task(scenario_name)
+    outcome = run_structured_call(provider, task, rubric, _capture_on_result, forced_scenario=scenario_name)
+    return outcome, captured
+
+
+def test_no_issue_scenario_is_deterministic():
+    rubric = make_rubric_function(load_rubric())
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+    outcome, captured = _capture_result(rubric, provider, "no_issue")
+
+    assert outcome.event_type == "completed"
+    assert captured["level"] == "no_issue"
+    assert captured["score"] == 0
+    assert captured["reasons"] == ["No exceptions reported"]
+
+
+def test_minor_issue_scenario_is_deterministic():
+    rubric = make_rubric_function(load_rubric())
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+    outcome, captured = _capture_result(rubric, provider, "minor_issue")
+
+    assert outcome.event_type == "completed"
+    assert captured["level"] == "minor_issue"
+    assert captured["score"] == 3
+    assert captured["reasons"] == ["Package arrived in poor condition"]
+
+
+def test_needs_reschedule_scenario_is_deterministic():
+    """
+    All three rubric rules fire simultaneously for this scenario — the
+    scenario most likely to break silently if the rubric or scenario data
+    ever drifts, since it depends on every rule firing together correctly.
+    """
+    rubric = make_rubric_function(load_rubric())
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+    outcome, captured = _capture_result(rubric, provider, "needs_reschedule")
+
+    assert outcome.event_type == "completed"
+    assert captured["level"] == "needs_dispatcher"
+    assert captured["score"] == 12  # 5 + 3 + 4, every rule firing
+    assert captured["reasons"] == [
+        "Package still has not been received",
+        "Package arrived in poor condition",
+        "Recipient requested a reschedule",
+    ]
+
+
+def test_failed_scenario_never_reaches_the_rubric():
+    """
+    A failed call must not produce a rubric result at all — run_result
+    should never be invoked, and the outcome must clearly report failure.
+    """
+    rubric = make_rubric_function(load_rubric())
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+    outcome, captured = _capture_result(rubric, provider, "failed")
+
+    assert outcome.event_type == "failed"
+    assert outcome.structured_answers is None
+    assert outcome.failure_reason is not None
+    assert captured == {}, "on_result must not fire for a failed call"
+
+
+def test_no_answer_scenario_never_reaches_the_rubric():
+    rubric = make_rubric_function(load_rubric())
+    provider = MockVoiceProvider(scenario_generators=SCENARIO_GENERATORS)
+    outcome, captured = _capture_result(rubric, provider, "no_answer")
+
+    assert outcome.event_type == "no_answer"
+    assert outcome.structured_answers is None
+    assert outcome.failure_reason is not None
+    assert captured == {}, "on_result must not fire for a no-answer call"
+
+
+def test_rubric_data_loads_from_the_actual_asset_file():
+    """Guards against the rubric json and the code silently drifting apart."""
+    rubric_data = load_rubric()
+    assert rubric_data["thresholds"]["minor_issue"] == 3
+    assert rubric_data["thresholds"]["needs_dispatcher"] == 5
+    assert {rule["answer_key"] for rule in rubric_data["rules"]} == {
+        "package_received", "condition_ok", "reschedule_needed",
+    }
+
+
+ALL_TESTS = [
+    test_no_issue_scenario_is_deterministic,
+    test_minor_issue_scenario_is_deterministic,
+    test_needs_reschedule_scenario_is_deterministic,
+    test_failed_scenario_never_reaches_the_rubric,
+    test_no_answer_scenario_never_reaches_the_rubric,
+    test_rubric_data_loads_from_the_actual_asset_file,
+]
+
+
+def main():
+    passed, failed = 0, []
+    for test_fn in ALL_TESTS:
+        try:
+            test_fn()
+            passed += 1
+            print(f"PASS: {test_fn.__name__}")
+        except AssertionError as e:
+            failed.append((test_fn.__name__, str(e)))
+            print(f"FAIL: {test_fn.__name__} -> {e}")
+
+    print(f"\n{passed}/{len(ALL_TESTS)} passed")
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a reusable **Structured Outcome Follow-Up Call** skill for CALL-E phone agents.

The skill demonstrates a safe pattern for:

- collecting structured recipient outcomes from a phone call;
- separating call completion state from structured answers;
- distinguishing completed calls from `failed` and `no_answer` outcomes;
- applying a deterministic rubric only after a valid completed outcome;
- preserving explicit uncertainty instead of silently treating missing information as reassuring.

## Included

- `SKILL.md` — skill instructions and usage guidance
- `assets/example_rubric.json` — deterministic example scoring rubric
- `references/result_schema_guide.md` — structured-result guidance
- `references/safety_checklist.md` — implementation safety checklist
- `scripts/mock_provider.py` — deterministic mock CALL-E provider
- `scripts/orchestrate_example.py` — runnable orchestration example
- `scripts/test_orchestrate_example.py` — zero-dependency regression tests

## Testing

Run from the skill directory:

    python3 scripts/test_orchestrate_example.py

Verified result:

    PASS: test_no_issue_scenario_is_deterministic
    PASS: test_minor_issue_scenario_is_deterministic
    PASS: test_needs_reschedule_scenario_is_deterministic
    PASS: test_failed_scenario_never_reaches_the_rubric
    PASS: test_no_answer_scenario_never_reaches_the_rubric
    PASS: test_rubric_data_loads_from_the_actual_asset_file

    6/6 passed

The test script uses only the Python standard library.

## Safety behavior

The example deliberately keeps transport/call outcome state separate from structured recipient answers.

In particular:

- `failed` calls do not enter the rubric;
- `no_answer` calls do not enter the rubric;
- incomplete call outcomes are not converted into reassuring answers;
- deterministic scoring occurs only after an appropriate completed result;
- the included safety checklist documents additional considerations for real-world deployments.

## Compatibility

The contribution is self-contained under:

`skills/structured-outcome-followup-call/`

It does not modify existing repository skills or application code.

## Cancellation / rollback

This example demonstrates a **one-shot follow-up call workflow**, rather than a recurring or scheduled autonomous workflow.

There is therefore no recurring job requiring cancellation or rollback. Failed and unanswered calls terminate without invoking downstream rubric processing.
