### PR TITLE
feat(call-rehearsal): add offline call-plan rehearsal app and skill

### DIFF
--- a/apps/python/call-rehearsal/README.md
+++ b/apps/python/call-rehearsal/README.md
@@ -1,0 +1,206 @@
+# call-rehearsal
+
+Rehearse a CALL-E call plan against every realistic ending of the call, and find
+out what your automation does on each one, before a phone rings.
+
+A call plan is the three things that together decide whether a phone workflow is
+safe to automate: the `task` the agent speaks, the `result_schema` the call
+returns, and the decision rule the surrounding automation applies to that result.
+Each is usually reviewed on its own. The expensive bugs live in the seam between
+them.
+
+## The bug this catches
+
+A delivery confirmation call. The schema has one field, `confirmed`. The
+automation dispatches unless the customer said no:
+
+```text
+confirmed != false  ->  dispatch the courier
+```
+
+That reads fine. Now the customer's voicemail picks up. Nothing was said, so
+nothing is extracted, so `confirmed` is absent, and `absent != false` is true.
+**The courier is dispatched because nobody answered the phone.**
+
+The same hole swallows a refused consent, a receptionist who would not pass the
+call on, and someone who is not the customer saying "yes, that's fine".
+
+```console
+$ python3 -m callrehearsal examples/delivery-confirmation-unsafe.json
+Rehearsing call plan: delivery-confirmation (before)
+No calls are placed. Nothing is dialled.
+
+What the automation does for each way the call can end:
+
+    Verified human confirmed               ->  dispatch the courier  (side effect)
+    Verified human declined                ->  hold the order  (no side effect)
+ !! Consent refused                        ->  dispatch the courier  (side effect)
+ !! Wrong person answered and agreed       ->  dispatch the courier  (side effect)
+ !! Voicemail answered                     ->  dispatch the courier  (side effect)
+ !! Nobody answered                        ->  dispatch the courier  (side effect)
+    ...
+
+  CRITICAL [voicemail] 'dispatch the courier' runs when voicemail answered
+      An answering machine picked up and no person was reached. No person was
+      reached at all. The result {} (nothing was extracted) still resolves the
+      decision rule to 'dispatch the courier', which changes the real world.
+```
+
+Ten of the twelve endings dispatch the courier. Two of them are a real
+confirmation and a real refusal.
+
+## Where this sits
+
+Two other pieces of this repository check a call before it goes out, and this is
+the third, doing something neither of them does.
+
+| | What it checks |
+| --- | --- |
+| [`calle-script-advisor`](../../../skills/calle-script-advisor/) | The `task` text and schema, read statically for clarity and extraction quality. |
+| [`voice-preflight`](../../../skills/voice-preflight/) | Whether the critical lines survive being spoken aloud. |
+| `call-rehearsal` | Whether the structured result can survive how the call actually ends, and what the automation does when it does not. |
+
+## Install
+
+None. Python 3.9 or newer, standard library only, no dependencies, no
+credentials, no network access.
+
+```bash
+cd apps/python/call-rehearsal
+python3 -m callrehearsal examples/delivery-confirmation-unsafe.json
+```
+
+## Side effects
+
+This app places no calls. It reads one JSON file and writes to stdout. There is
+nothing to cancel and nothing to roll back, because nothing is ever dialled and
+no scheduler job is created. It is safe to run in CI on every commit.
+
+It never reads a CALL-E credential, so there is no credential to handle.
+
+## Usage
+
+```bash
+python3 -m callrehearsal <plan.json>                  # readable report
+python3 -m callrehearsal <plan.json> --json           # machine-readable report
+python3 -m callrehearsal <plan.json> --fail-on critical
+python3 -m callrehearsal <plan.json> --suggest-fields # candidates, applied to nothing
+```
+
+Exit codes follow the convention used elsewhere in this repository:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Nothing at or above the failure threshold. The plan may go out. |
+| `20` | The plan should not go out as written. |
+| `30` | The plan could not be read, so nothing was rehearsed. |
+
+Gate a workflow on it:
+
+```bash
+python3 -m callrehearsal call-plans/delivery.json --fail-on high
+```
+
+## The call plan
+
+```json
+{
+  "name": "delivery-confirmation",
+  "task": "You are calling on behalf of Northwind Logistics ...",
+  "result_schema": {
+    "type": "object",
+    "properties": {
+      "call_status": { "type": "string" },
+      "identity_verified": { "type": "boolean" },
+      "consent_given": { "type": "boolean" },
+      "confirmed": { "type": "boolean" }
+    },
+    "required": ["call_status"]
+  },
+  "fields": {
+    "decision": "confirmed",
+    "reachability": "call_status",
+    "consent": "consent_given",
+    "identity": "identity_verified"
+  },
+  "decision_rule": {
+    "expression": "confirmed == true and identity_verified == true and consent_given == true",
+    "on_true": { "action": "dispatch the courier", "side_effect": true },
+    "on_false": { "action": "hold the order", "side_effect": false }
+  }
+}
+```
+
+`fields` maps result fields onto the roles the rehearsal reasons about:
+`decision`, `reachability`, `consent`, `identity` and `deferral`. Only
+`decision` is required.
+
+**Roles are declared, never inferred.** This repository's design principles say a
+workflow must not guess critical values, and which field carries a decision is
+exactly such a value. Guessing it wrong would rehearse the wrong thing and then
+report a clean run. `--suggest-fields` will offer candidates for a human to pick
+between, and selects none of them.
+
+### Decision expressions
+
+The expression is evaluated, never executed. It is parsed to an AST and rejected
+unless every node is on a small allow-list, so a call plan from a pull request
+cannot run code. There is no attribute access, no indexing and no arbitrary
+call; the only callables are `is_missing(field)` and `is_present(field)`.
+
+A field the call never established evaluates to a `MISSING` sentinel that is
+falsy and equal to nothing, which is precisely how `result.get("confirmed")`
+behaves in real automation code. Modelling that faithfully is what makes the
+silently-skipped confirmation visible.
+
+## What gets rehearsed
+
+Twelve endings, in [`callrehearsal/outcomes.py`](callrehearsal/outcomes.py):
+verified confirmation and refusal, deferral, callback request, ambiguous answer,
+partial answer, refused consent, wrong person, gatekeeper, voicemail, no answer,
+and a failed connection.
+
+Only one of them is a confirmation. An outcome counts as a confirmation when a
+verified callee, who consented to the call, said yes. Every branch marked
+`side_effect: true` that fires on anything else is reported as `CRITICAL`.
+
+| Finding | Severity | Meaning |
+| --- | --- | --- |
+| `unsafe-side-effect` | critical | A branch that changes the real world runs on an ending that is not a confirmation. |
+| `indistinguishable-from-confirmation` | high | A non-confirmation produces byte-identical results to a real one, so no audit can separate them. |
+| `unrecordable-outcome` | high / medium | The schema has no field for reachability, identity, consent or deferral, so that distinction is lost. |
+| `unsatisfiable-required-field` | medium | A `required` field cannot be established on some endings, so the result violates its own schema. |
+| `task-silent-on-outcome` | low | The task text gives the agent no instruction for a path, so behaviour there is improvised. |
+
+## Fixing a plan
+
+[`examples/delivery-confirmation-safe.json`](examples/delivery-confirmation-safe.json)
+is the same call after the two changes the report asks for: record what actually
+happened on the line, and require a confirmation rather than the absence of a
+refusal.
+
+```console
+$ python3 -m callrehearsal examples/delivery-confirmation-safe.json
+No findings. Every ending that is not a verified confirmation stays away from
+the side-effecting branch.
+```
+
+## Tests
+
+```bash
+cd apps/python/call-rehearsal
+python3 -m unittest discover -s tests -t .
+```
+
+29 tests, offline, no calls placed. They cover the expression sandbox
+(including that `__import__`, attribute access and indexing are rejected), plan
+validation, outcome projection, and the exit codes.
+
+## Limits
+
+The outcome library is a model of how calls end, not a transcript of any real
+one. It reasons about the *shape* of the result, not the words spoken, so it
+cannot tell you whether the agent's phrasing is persuasive or whether extraction
+quality is good on a real line. Use `calle-script-advisor` and `voice-preflight`
+for those. A clean rehearsal means the plan survives the endings in the library;
+it is not a guarantee about a live call.

--- a/apps/python/call-rehearsal/callrehearsal/__init__.py
+++ b/apps/python/call-rehearsal/callrehearsal/__init__.py
@@ -1,0 +1,5 @@
+"""Rehearse a CALL-E call plan against realistic call endings, without calling anyone."""
+
+__all__ = ["analysis", "expressions", "outcomes", "plan"]
+
+__version__ = "0.1.0"

--- a/apps/python/call-rehearsal/callrehearsal/__main__.py
+++ b/apps/python/call-rehearsal/callrehearsal/__main__.py
@@ -1,0 +1,150 @@
+"""Command line entry point for call-rehearsal.
+
+Exit codes follow the convention used elsewhere in this repository:
+
+``0``
+    Nothing at or above the failure threshold. The plan may go out.
+``20``
+    The plan should not go out as written.
+``30``
+    The plan could not be read, so nothing was rehearsed.
+
+This tool places no calls, reads no credentials and opens no network
+connection. Rehearsing is always safe to run in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import analysis
+from .plan import PlanError, load_plan, suggest_decision_fields
+
+_SEVERITY_LABEL = {
+    analysis.CRITICAL: "CRITICAL",
+    analysis.HIGH: "HIGH",
+    analysis.MEDIUM: "MEDIUM",
+    analysis.LOW: "LOW",
+}
+
+EXIT_OK = 0
+EXIT_BLOCKED = 20
+EXIT_INPUT_ERROR = 30
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="call-rehearsal",
+        description=(
+            "Rehearse a CALL-E call plan against every realistic ending of the call "
+            "and report what the automation would do. Places no calls."
+        ),
+    )
+    parser.add_argument("plan", type=Path, help="Path to a call plan JSON file.")
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Emit the machine-readable report instead of the readable one.",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=analysis.SEVERITY_ORDER,
+        default=analysis.HIGH,
+        help="Lowest severity that should fail the run. Default: high.",
+    )
+    parser.add_argument(
+        "--suggest-fields",
+        action="store_true",
+        help="Print candidate decision fields for the schema and exit without rehearsing.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.suggest_fields:
+        return _suggest(args.plan)
+
+    try:
+        plan = load_plan(args.plan)
+    except PlanError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    rehearsals = analysis.rehearse(plan)
+    findings = analysis.analyse(plan, rehearsals)
+    report = analysis.to_dict(plan, rehearsals, findings)
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_report(plan.name, rehearsals, findings)
+
+    sys.stdout.flush()
+    threshold = analysis.SEVERITY_ORDER.index(args.fail_on)
+    blocking = [
+        finding
+        for finding in findings
+        if analysis.SEVERITY_ORDER.index(finding.severity) <= threshold
+    ]
+    if blocking:
+        if not args.as_json:
+            print(
+                f"\n{len(blocking)} finding(s) at or above {args.fail_on}. "
+                "This plan should not go out as written.",
+                file=sys.stderr,
+            )
+        return EXIT_BLOCKED
+    return EXIT_OK
+
+
+def _suggest(path: Path) -> int:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read call plan: {exc}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+    schema = raw.get("result_schema") if isinstance(raw, dict) else None
+    candidates = suggest_decision_fields(schema if isinstance(schema, dict) else {})
+    if not candidates:
+        print("No obvious decision-field candidates. Declare fields.decision yourself.")
+        return EXIT_OK
+    print("Candidate decision fields, for a human to choose between:")
+    for name in candidates:
+        print(f"  - {name}")
+    print("\nNothing is selected automatically. Set fields.decision in the plan.")
+    return EXIT_OK
+
+
+def _print_report(name, rehearsals, findings) -> None:
+    print(f"Rehearsing call plan: {name}")
+    print("No calls are placed. Nothing is dialled.\n")
+
+    width = max(len(item.outcome.label) for item in rehearsals)
+    print("What the automation does for each way the call can end:\n")
+    for item in rehearsals:
+        marker = "!!" if item.side_effect and not item.outcome.is_confirmation else "  "
+        effect = "side effect" if item.side_effect else "no side effect"
+        print(f" {marker} {item.outcome.label.ljust(width)}  ->  {item.action}  ({effect})")
+
+    if not findings:
+        print("\nNo findings. Every ending that is not a verified confirmation "
+              "stays away from the side-effecting branch.")
+        return
+
+    print(f"\n{len(findings)} finding(s):\n")
+    for finding in findings:
+        label = _SEVERITY_LABEL[finding.severity]
+        scope = "" if finding.outcome == "-" else f" [{finding.outcome}]"
+        print(f"  {label}{scope} {finding.summary}")
+        print(f"      {finding.detail}")
+        print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/call-rehearsal/callrehearsal/analysis.py
+++ b/apps/python/call-rehearsal/callrehearsal/analysis.py
@@ -1,0 +1,333 @@
+"""Rehearse a call plan against every realistic ending of the call.
+
+The question this answers is not "did the call work". It is: when the call ends
+the way calls actually end, what does the automation on the other side do?
+
+A phone call is a real-world side effect and so is whatever the result triggers.
+The failure that matters is a call that never reached a consenting human still
+resolving to the branch that ships the order.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+
+from . import expressions
+from .outcomes import OUTCOMES, Outcome
+from .plan import CallPlan
+
+CRITICAL = "critical"
+HIGH = "high"
+MEDIUM = "medium"
+LOW = "low"
+
+SEVERITY_ORDER = (CRITICAL, HIGH, MEDIUM, LOW)
+_SEVERITY_RANK = {name: index for index, name in enumerate(SEVERITY_ORDER)}
+
+_ROLE_FOR_RECORD = {
+    "reachability": "reachability",
+    "identity": "identity",
+    "consent": "consent",
+    "deferral": "deferral",
+    "callback": "deferral",
+}
+
+_RECORD_SEVERITY = {
+    "reachability": HIGH,
+    "identity": HIGH,
+    "consent": HIGH,
+    "deferral": MEDIUM,
+}
+
+_TASK_TOPICS = {
+    "reachability": ("voicemail", "answering machine", "voice mail", "no answer", "nobody answers"),
+    "identity": (
+        "identity",
+        "verify",
+        "speaking with",
+        "speaking to",
+        "confirm you are",
+        "right person",
+        "account holder",
+    ),
+    "consent": (
+        "consent",
+        "permission",
+        "good time",
+        "may i",
+        "if they decline",
+        "happy to continue",
+        "willing to continue",
+    ),
+    "deferral": ("call back", "callback", "another time", "decide later", "reschedule"),
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One problem discovered while rehearsing."""
+
+    code: str
+    severity: str
+    outcome: str
+    summary: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class Rehearsal:
+    """What happened when one outcome was rehearsed."""
+
+    outcome: Outcome
+    result: dict
+    branch_taken: bool
+    action: str
+    side_effect: bool
+
+
+def project(plan: CallPlan, outcome: Outcome) -> dict:
+    """Build the structured result CALL-E would plausibly return for an outcome."""
+    result: dict[str, object] = {}
+    decision_field = plan.fields["decision"]
+    if outcome.agreed is not None:
+        result[decision_field] = outcome.agreed
+
+    reachability_field = plan.field_for("reachability")
+    if reachability_field:
+        result[reachability_field] = "answered" if outcome.reached_human else outcome.identifier
+
+    consent_field = plan.field_for("consent")
+    if consent_field and outcome.consent_given is not None:
+        result[consent_field] = outcome.consent_given
+
+    identity_field = plan.field_for("identity")
+    if identity_field and outcome.identity_verified is not None:
+        result[identity_field] = outcome.identity_verified
+
+    deferral_field = plan.field_for("deferral")
+    if deferral_field:
+        result[deferral_field] = "deferral" in outcome.records
+
+    established = outcome.reached_human and (
+        outcome.agreed is not None or outcome.identifier == "partial_answer"
+    )
+    if established:
+        roles = set(plan.fields.values())
+        for name, spec in plan.schema_properties.items():
+            if name in roles or name in result:
+                continue
+            result[name] = _placeholder(spec)
+    return result
+
+
+def _placeholder(spec: object) -> object:
+    kind = spec.get("type") if isinstance(spec, dict) else None
+    if kind == "boolean":
+        return True
+    if kind in ("integer", "number"):
+        return 1
+    if kind == "array":
+        return []
+    if kind == "object":
+        return {}
+    return "stated-on-call"
+
+
+def rehearse(plan: CallPlan) -> list[Rehearsal]:
+    """Run the plan against every outcome in the library."""
+    rehearsals = []
+    for outcome in OUTCOMES:
+        result = project(plan, outcome)
+        taken = expressions.evaluate(plan.expression, result)
+        branch = plan.branch_for(taken)
+        rehearsals.append(
+            Rehearsal(
+                outcome=outcome,
+                result=result,
+                branch_taken=taken,
+                action=branch.action,
+                side_effect=branch.side_effect,
+            )
+        )
+    return rehearsals
+
+
+def analyse(plan: CallPlan, rehearsals: list[Rehearsal]) -> list[Finding]:
+    """Collect every problem the rehearsal exposed."""
+    findings: list[Finding] = []
+    findings.extend(_unsafe_side_effects(rehearsals))
+    findings.extend(_indistinguishable(plan, rehearsals))
+    findings.extend(_unrecordable(plan))
+    findings.extend(_unsatisfiable_required(plan, rehearsals))
+    findings.extend(_silent_task(plan))
+    findings.sort(key=lambda item: (_SEVERITY_RANK[item.severity], item.code, item.outcome))
+    return findings
+
+
+def _unsafe_side_effects(rehearsals: list[Rehearsal]) -> list[Finding]:
+    findings = []
+    for item in rehearsals:
+        if not item.side_effect or item.outcome.is_confirmation:
+            continue
+        reason = _why_not_confirmation(item.outcome)
+        findings.append(
+            Finding(
+                code="unsafe-side-effect",
+                severity=CRITICAL,
+                outcome=item.outcome.identifier,
+                summary=f"'{item.action}' runs when {item.outcome.label.lower()}",
+                detail=(
+                    f"{item.outcome.description} {reason} The result "
+                    f"{_render(item.result)} still resolves the decision rule to "
+                    f"'{item.action}', which changes the real world."
+                ),
+            )
+        )
+    return findings
+
+
+def _why_not_confirmation(outcome: Outcome) -> str:
+    if not outcome.reached_human:
+        return "No person was reached at all."
+    if outcome.identity_verified is not True:
+        return "The intended callee was never confirmed to be on the line."
+    if outcome.consent_given is not True:
+        return "The callee did not consent to continue."
+    return "The callee never said yes."
+
+
+def _indistinguishable(plan: CallPlan, rehearsals: list[Rehearsal]) -> list[Finding]:
+    confirmed = next(
+        (item for item in rehearsals if item.outcome.identifier == "human_confirmed"), None
+    )
+    if confirmed is None:
+        return []
+    findings = []
+    for item in rehearsals:
+        if item.outcome.identifier == "human_confirmed" or item.outcome.is_confirmation:
+            continue
+        if item.result == confirmed.result:
+            findings.append(
+                Finding(
+                    code="indistinguishable-from-confirmation",
+                    severity=HIGH,
+                    outcome=item.outcome.identifier,
+                    summary=f"{item.outcome.label} is indistinguishable from a real confirmation",
+                    detail=(
+                        f"{item.outcome.description} It produces exactly the same result "
+                        f"as a verified human confirmation, {_render(item.result)}, so nothing "
+                        "downstream, and no later audit, can tell the two apart."
+                    ),
+                )
+            )
+    return findings
+
+
+def _unrecordable(plan: CallPlan) -> list[Finding]:
+    findings = []
+    seen: set[str] = set()
+    for outcome in OUTCOMES:
+        for record in outcome.records:
+            role = _ROLE_FOR_RECORD[record]
+            if role in seen or plan.field_for(role):
+                continue
+            seen.add(role)
+            findings.append(
+                Finding(
+                    code="unrecordable-outcome",
+                    severity=_RECORD_SEVERITY[role],
+                    outcome=outcome.identifier,
+                    summary=f"The result schema cannot record {role}",
+                    detail=(
+                        f"Outcomes such as '{outcome.label.lower()}' turn on {role}, but no "
+                        f"field is declared for that role, so the distinction is lost before "
+                        "the result reaches the automation."
+                    ),
+                )
+            )
+    return findings
+
+
+def _unsatisfiable_required(plan: CallPlan, rehearsals: list[Rehearsal]) -> list[Finding]:
+    findings = []
+    for name in plan.required_fields:
+        missing = [item.outcome for item in rehearsals if name not in item.result]
+        if not missing:
+            continue
+        names = ", ".join(outcome.identifier for outcome in missing[:4])
+        findings.append(
+            Finding(
+                code="unsatisfiable-required-field",
+                severity=MEDIUM,
+                outcome=missing[0].identifier,
+                summary=f"Required field '{name}' cannot always be filled",
+                detail=(
+                    f"'{name}' is listed in result_schema.required, but the call cannot "
+                    f"establish it for these outcomes: {names}. The result will either "
+                    "violate its own schema or be filled with a value nobody said."
+                ),
+            )
+        )
+    return findings
+
+
+def _silent_task(plan: CallPlan) -> list[Finding]:
+    lowered = plan.task.lower()
+    findings = []
+    for topic, phrases in _TASK_TOPICS.items():
+        if any(phrase in lowered for phrase in phrases):
+            continue
+        findings.append(
+            Finding(
+                code="task-silent-on-outcome",
+                severity=LOW,
+                outcome="-",
+                summary=f"The task text gives the agent no instruction about {topic}",
+                detail=(
+                    f"Nothing in the task tells the agent what to do about {topic}, so the "
+                    "behaviour on that path is whatever the model improvises."
+                ),
+            )
+        )
+    return findings
+
+
+def worst_severity(findings: list[Finding]) -> str | None:
+    """Return the highest severity present, or None when the plan is clean."""
+    for severity in SEVERITY_ORDER:
+        if any(finding.severity == severity for finding in findings):
+            return severity
+    return None
+
+
+def _render(result: dict) -> str:
+    if not result:
+        return "{} (nothing was extracted)"
+    parts = ", ".join(f"{key}={value!r}" for key, value in sorted(result.items()))
+    return "{" + parts + "}"
+
+
+def to_dict(plan: CallPlan, rehearsals: list[Rehearsal], findings: list[Finding]) -> dict:
+    """Build the machine-readable report."""
+    return {
+        "plan": plan.name,
+        "expression": plan.expression,
+        "outcomes": [
+            {
+                "outcome": item.outcome.identifier,
+                "label": item.outcome.label,
+                "is_confirmation": item.outcome.is_confirmation,
+                "result": {key: _jsonable(value) for key, value in item.result.items()},
+                "branch": "on_true" if item.branch_taken else "on_false",
+                "action": item.action,
+                "side_effect": item.side_effect,
+            }
+            for item in rehearsals
+        ],
+        "findings": [asdict(finding) for finding in findings],
+        "worst_severity": worst_severity(findings),
+    }
+
+
+def _jsonable(value: object) -> object:
+    return value if isinstance(value, (str, int, float, bool, list, dict, type(None))) else str(value)

--- a/apps/python/call-rehearsal/callrehearsal/expressions.py
+++ b/apps/python/call-rehearsal/callrehearsal/expressions.py
@@ -1,0 +1,220 @@
+"""A deliberately small expression language for downstream decision rules.
+
+A call plan declares what the automation *does* with a call result, for example
+``confirmed == true``. Rehearsing the plan means evaluating that rule against
+many possible results, so the rule has to be evaluated, not executed: the file
+is untrusted input and must never be able to run arbitrary Python.
+
+Only the node types listed in ``_ALLOWED_NODES`` survive validation, there is no
+attribute access, indexing, comprehension or arbitrary call, and the only
+callables in scope are the two helpers defined here.
+
+A field the call did not establish evaluates to ``MISSING`` rather than raising.
+``MISSING`` is falsy and compares equal to nothing, which is exactly how
+``result.get("confirmed") == True`` behaves in real automation code. Modelling
+that faithfully is the point: it is what makes a silently-skipped confirmation
+visible.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+class ExpressionError(ValueError):
+    """Raised when a decision expression is not valid or not permitted."""
+
+
+class _Missing:
+    """A field the call never established."""
+
+    _instance = None
+
+    def __new__(cls) -> "_Missing":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Missing)
+
+    def __hash__(self) -> int:
+        return hash("<missing>")
+
+    def __repr__(self) -> str:
+        return "<missing>"
+
+
+MISSING = _Missing()
+
+_LITERALS = {"true": True, "false": False, "null": None, "none": None}
+
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.And,
+    ast.Or,
+    ast.UnaryOp,
+    ast.Not,
+    ast.Compare,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Name,
+    ast.Load,
+    ast.Constant,
+    ast.Call,
+    ast.List,
+    ast.Tuple,
+)
+
+_ALLOWED_CALLS = {"is_missing", "is_present"}
+
+
+def parse(expression: str) -> ast.Expression:
+    """Parse and validate a decision expression."""
+    text = expression.strip()
+    if not text:
+        raise ExpressionError("Decision expression is empty.")
+    try:
+        tree = ast.parse(text, mode="eval")
+    except SyntaxError as exc:
+        raise ExpressionError(f"Could not parse decision expression: {exc.msg}") from exc
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise ExpressionError(
+                f"Decision expressions may not use {type(node).__name__}."
+            )
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name) or node.func.id not in _ALLOWED_CALLS:
+                allowed = ", ".join(sorted(_ALLOWED_CALLS))
+                raise ExpressionError(f"Only these calls are allowed: {allowed}.")
+            if node.keywords:
+                raise ExpressionError("Decision expression calls take no keyword arguments.")
+    return tree
+
+
+def referenced_fields(expression: str) -> set[str]:
+    """Return the result fields a decision expression reads."""
+    tree = parse(expression)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id.lower() not in _LITERALS:
+            if node.id not in _ALLOWED_CALLS:
+                names.add(node.id)
+    return names
+
+
+def evaluate(expression: str, result: dict[str, object]) -> bool:
+    """Evaluate a decision expression against one call result."""
+    tree = parse(expression)
+    return bool(_eval(tree.body, result))
+
+
+def _lookup(name: str, result: dict[str, object]) -> object:
+    lowered = name.lower()
+    if lowered in _LITERALS:
+        return _LITERALS[lowered]
+    if name in result:
+        return result[name]
+    return MISSING
+
+
+def _eval(node: ast.AST, result: dict[str, object]) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return _lookup(node.id, result)
+    if isinstance(node, ast.List):
+        return [_eval(item, result) for item in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_eval(item, result) for item in node.elts)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not _eval(node.operand, result)
+    if isinstance(node, ast.BoolOp):
+        values = [_eval(value, result) for value in node.values]
+        if isinstance(node.op, ast.And):
+            for value in values:
+                if not value:
+                    return False
+            return True
+        for value in values:
+            if value:
+                return True
+        return False
+    if isinstance(node, ast.Compare):
+        return _eval_compare(node, result)
+    if isinstance(node, ast.Call):
+        return _eval_call(node, result)
+    raise ExpressionError(f"Unsupported expression element: {type(node).__name__}.")
+
+
+def _eval_call(node: ast.Call, result: dict[str, object]) -> bool:
+    name = node.func.id if isinstance(node.func, ast.Name) else ""
+    if len(node.args) != 1 or not isinstance(node.args[0], ast.Name):
+        raise ExpressionError(f"{name}() takes exactly one field name.")
+    present = node.args[0].id in result and result[node.args[0].id] is not MISSING
+    return not present if name == "is_missing" else present
+
+
+def _eval_compare(node: ast.Compare, result: dict[str, object]) -> bool:
+    left = _eval(node.left, result)
+    for operator, comparator in zip(node.ops, node.comparators):
+        right = _eval(comparator, result)
+        if not _compare(left, operator, right):
+            return False
+        left = right
+    return True
+
+
+def _compare(left: object, operator: ast.cmpop, right: object) -> bool:
+    if isinstance(operator, ast.Eq):
+        return _equal(left, right)
+    if isinstance(operator, ast.NotEq):
+        return not _equal(left, right)
+    if isinstance(operator, ast.In):
+        return _contains(right, left)
+    if isinstance(operator, ast.NotIn):
+        return not _contains(right, left)
+    if left is MISSING or right is MISSING:
+        return False
+    try:
+        if isinstance(operator, ast.Lt):
+            return left < right          # type: ignore[operator]
+        if isinstance(operator, ast.LtE):
+            return left <= right         # type: ignore[operator]
+        if isinstance(operator, ast.Gt):
+            return left > right          # type: ignore[operator]
+        if isinstance(operator, ast.GtE):
+            return left >= right         # type: ignore[operator]
+    except TypeError:
+        return False
+    raise ExpressionError(f"Unsupported comparison: {type(operator).__name__}.")
+
+
+def _equal(left: object, right: object) -> bool:
+    if left is MISSING or right is MISSING:
+        return isinstance(left, _Missing) and isinstance(right, _Missing)
+    if isinstance(left, bool) or isinstance(right, bool):
+        if isinstance(left, bool) and isinstance(right, bool):
+            return left is right
+        return False
+    return bool(left == right)
+
+
+def _contains(container: object, value: object) -> bool:
+    if container is MISSING or value is MISSING:
+        return False
+    try:
+        return value in container    # type: ignore[operator]
+    except TypeError:
+        return False

--- a/apps/python/call-rehearsal/callrehearsal/outcomes.py
+++ b/apps/python/call-rehearsal/callrehearsal/outcomes.py
@@ -1,0 +1,175 @@
+"""The library of realistic ways a phone call can actually end.
+
+Every entry describes what was true about the *conversation*, not about any
+particular result schema. A call plan is rehearsed by projecting each of these
+onto the plan's own ``result_schema`` and then asking what the downstream
+decision rule does with the projection.
+
+The semantics are deliberately small and explicit:
+
+``reached_human``
+    A person the agent could talk to answered the line. Voicemail, ringing out
+    and a busy signal are all ``False``.
+``identity_verified``
+    The person on the line was confirmed to be the intended callee.
+``consent_given``
+    The person agreed to continue with the purpose of the call.
+``agreed``
+    The answer to the single decision the call exists to establish.
+    ``None`` means the call ended without establishing it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One realistic ending of a phone call."""
+
+    identifier: str
+    label: str
+    description: str
+    reached_human: bool
+    identity_verified: bool | None
+    consent_given: bool | None
+    agreed: bool | None
+    records: tuple[str, ...] = field(default=())
+
+    @property
+    def is_confirmation(self) -> bool:
+        """True only when a verified, consenting human actually said yes.
+
+        This is the single predicate that separates outcomes that may trigger a
+        real-world side effect from every outcome that must not.
+        """
+        return (
+            self.reached_human
+            and self.identity_verified is True
+            and self.consent_given is True
+            and self.agreed is True
+        )
+
+
+OUTCOMES: tuple[Outcome, ...] = (
+    Outcome(
+        identifier="human_confirmed",
+        label="Verified human confirmed",
+        description="The intended callee answered, consented, and said yes.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=True,
+    ),
+    Outcome(
+        identifier="human_declined",
+        label="Verified human declined",
+        description="The intended callee answered, consented, and said no.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=False,
+    ),
+    Outcome(
+        identifier="human_deferred",
+        label="Human deferred the decision",
+        description="The callee asked to decide later, so no answer was established.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=None,
+        records=("deferral",),
+    ),
+    Outcome(
+        identifier="callback_requested",
+        label="Human requested a callback",
+        description="The callee asked to be called back at another time.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=None,
+        records=("deferral", "callback"),
+    ),
+    Outcome(
+        identifier="ambiguous_answer",
+        label="Answer was ambiguous",
+        description="The callee responded, but not in a way that resolves the decision.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=None,
+    ),
+    Outcome(
+        identifier="partial_answer",
+        label="Only part of the ask was answered",
+        description="Some required fields were established and the decision field was not.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=True,
+        agreed=None,
+    ),
+    Outcome(
+        identifier="consent_refused",
+        label="Consent refused",
+        description="The callee declined to continue with the call at all.",
+        reached_human=True,
+        identity_verified=True,
+        consent_given=False,
+        agreed=None,
+        records=("consent",),
+    ),
+    Outcome(
+        identifier="wrong_person",
+        label="Wrong person answered and agreed",
+        description="Somebody who is not the callee answered and said yes anyway.",
+        reached_human=True,
+        identity_verified=False,
+        consent_given=True,
+        agreed=True,
+        records=("identity",),
+    ),
+    Outcome(
+        identifier="gatekeeper_blocked",
+        label="Gatekeeper would not pass the call on",
+        description="A receptionist or family member answered and the callee was never reached.",
+        reached_human=True,
+        identity_verified=False,
+        consent_given=None,
+        agreed=None,
+        records=("identity",),
+    ),
+    Outcome(
+        identifier="voicemail",
+        label="Voicemail answered",
+        description="An answering machine picked up and no person was reached.",
+        reached_human=False,
+        identity_verified=False,
+        consent_given=None,
+        agreed=None,
+        records=("reachability",),
+    ),
+    Outcome(
+        identifier="no_answer",
+        label="Nobody answered",
+        description="The line rang out.",
+        reached_human=False,
+        identity_verified=False,
+        consent_given=None,
+        agreed=None,
+        records=("reachability",),
+    ),
+    Outcome(
+        identifier="line_busy",
+        label="Line was busy or the call failed",
+        description="The call never connected to anything.",
+        reached_human=False,
+        identity_verified=False,
+        consent_given=None,
+        agreed=None,
+        records=("reachability",),
+    ),
+)
+
+
+OUTCOMES_BY_ID = {outcome.identifier: outcome for outcome in OUTCOMES}

--- a/apps/python/call-rehearsal/callrehearsal/plan.py
+++ b/apps/python/call-rehearsal/callrehearsal/plan.py
@@ -1,0 +1,210 @@
+"""Loading and checking a call plan.
+
+A call plan is the three things that decide whether a phone call is safe to
+automate: the ``task`` the agent will speak, the ``result_schema`` the call is
+expected to return, and the ``decision_rule`` the surrounding automation
+applies to that result.
+
+Field roles are declared, never inferred. The repository design principles say
+a workflow must not guess critical values, and which field carries a decision
+is exactly such a value: guessing it wrong would silently rehearse the wrong
+thing and report a clean run. ``suggest_decision_fields`` exists so a human can
+be *offered* candidates, but nothing acts on them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import expressions
+
+FIELD_ROLES = ("decision", "reachability", "consent", "identity", "deferral")
+
+_DECISION_HINTS = (
+    "confirm",
+    "approve",
+    "accept",
+    "agree",
+    "authorized",
+    "consented",
+    "success",
+    "answer",
+    "decision",
+    "outcome",
+)
+
+
+class PlanError(ValueError):
+    """Raised when a call plan cannot be rehearsed as written."""
+
+
+@dataclass(frozen=True)
+class Branch:
+    """What the automation does when the decision rule resolves one way."""
+
+    action: str
+    side_effect: bool
+
+
+@dataclass(frozen=True)
+class CallPlan:
+    """A call plan ready to rehearse."""
+
+    name: str
+    task: str
+    result_schema: dict
+    fields: dict[str, str]
+    expression: str
+    on_true: Branch
+    on_false: Branch
+    source: Path | None = None
+
+    @property
+    def schema_properties(self) -> dict[str, dict]:
+        properties = self.result_schema.get("properties")
+        return properties if isinstance(properties, dict) else {}
+
+    @property
+    def required_fields(self) -> list[str]:
+        required = self.result_schema.get("required")
+        return [item for item in required if isinstance(item, str)] if isinstance(required, list) else []
+
+    def field_for(self, role: str) -> str | None:
+        return self.fields.get(role)
+
+    def branch_for(self, taken: bool) -> Branch:
+        return self.on_true if taken else self.on_false
+
+
+def suggest_decision_fields(result_schema: dict) -> list[str]:
+    """Offer candidate decision fields for a human to choose between."""
+    properties = result_schema.get("properties")
+    if not isinstance(properties, dict):
+        return []
+    candidates = []
+    for name, spec in properties.items():
+        lowered = name.lower()
+        is_boolean = isinstance(spec, dict) and spec.get("type") == "boolean"
+        if is_boolean or any(hint in lowered for hint in _DECISION_HINTS):
+            candidates.append(name)
+    return candidates
+
+
+def load_plan(path: Path) -> CallPlan:
+    """Read a call plan from disk and check that it can be rehearsed."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PlanError(f"Call plan not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PlanError(f"Call plan is not valid JSON ({path}): {exc}") from exc
+    if not isinstance(raw, dict):
+        raise PlanError(f"Call plan must be a JSON object: {path}")
+    return build_plan(raw, source=path)
+
+
+def build_plan(raw: dict, source: Path | None = None) -> CallPlan:
+    """Validate a call plan mapping and return it."""
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise PlanError("Call plan needs a non-empty 'name'.")
+
+    task = raw.get("task")
+    if not isinstance(task, str) or not task.strip():
+        raise PlanError("Call plan needs a non-empty 'task' describing what the agent says.")
+
+    result_schema = raw.get("result_schema")
+    if not isinstance(result_schema, dict):
+        raise PlanError("Call plan needs a 'result_schema' object.")
+    properties = result_schema.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        raise PlanError("'result_schema.properties' must list at least one result field.")
+
+    fields = _read_fields(raw, properties, result_schema)
+    expression, on_true, on_false = _read_decision_rule(raw, properties)
+
+    return CallPlan(
+        name=name.strip(),
+        task=task.strip(),
+        result_schema=result_schema,
+        fields=fields,
+        expression=expression,
+        on_true=on_true,
+        on_false=on_false,
+        source=source,
+    )
+
+
+def _read_fields(raw: dict, properties: dict, result_schema: dict) -> dict[str, str]:
+    fields = raw.get("fields")
+    if not isinstance(fields, dict):
+        raise PlanError(
+            "Call plan needs a 'fields' object declaring at least "
+            "'decision'. Field roles are declared, never inferred."
+        )
+    resolved: dict[str, str] = {}
+    for role in FIELD_ROLES:
+        value = fields.get(role)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise PlanError(f"fields.{role} must be a result field name.")
+        if value not in properties:
+            raise PlanError(
+                f"fields.{role} refers to '{value}', which is not in result_schema.properties."
+            )
+        resolved[role] = value
+
+    unknown = set(fields) - set(FIELD_ROLES)
+    if unknown:
+        known = ", ".join(FIELD_ROLES)
+        raise PlanError(f"Unknown field roles: {', '.join(sorted(unknown))}. Known roles: {known}.")
+
+    if "decision" not in resolved:
+        candidates = suggest_decision_fields(result_schema)
+        hint = f" Candidates in this schema: {', '.join(candidates)}." if candidates else ""
+        raise PlanError(
+            "fields.decision must name the result field that carries the single "
+            "decision this call exists to establish." + hint
+        )
+    return resolved
+
+
+def _read_decision_rule(raw: dict, properties: dict) -> tuple[str, Branch, Branch]:
+    rule = raw.get("decision_rule")
+    if not isinstance(rule, dict):
+        raise PlanError("Call plan needs a 'decision_rule' object.")
+
+    expression = rule.get("expression")
+    if not isinstance(expression, str) or not expression.strip():
+        raise PlanError("decision_rule.expression must be a non-empty expression.")
+    try:
+        referenced = expressions.referenced_fields(expression)
+    except expressions.ExpressionError as exc:
+        raise PlanError(str(exc)) from exc
+
+    unknown = sorted(referenced - set(properties))
+    if unknown:
+        raise PlanError(
+            "decision_rule.expression reads fields that are not in "
+            f"result_schema.properties: {', '.join(unknown)}."
+        )
+    return expression.strip(), _read_branch(rule, "on_true"), _read_branch(rule, "on_false")
+
+
+def _read_branch(rule: dict, key: str) -> Branch:
+    branch = rule.get(key)
+    if not isinstance(branch, dict):
+        raise PlanError(f"decision_rule.{key} must be an object.")
+    action = branch.get("action")
+    if not isinstance(action, str) or not action.strip():
+        raise PlanError(f"decision_rule.{key}.action must describe what the automation does.")
+    side_effect = branch.get("side_effect")
+    if not isinstance(side_effect, bool):
+        raise PlanError(
+            f"decision_rule.{key}.side_effect must be true or false: does this branch "
+            "change the real world?"
+        )
+    return Branch(action=action.strip(), side_effect=side_effect)

--- a/apps/python/call-rehearsal/examples/delivery-confirmation-safe.json
+++ b/apps/python/call-rehearsal/examples/delivery-confirmation-safe.json
@@ -1,0 +1,52 @@
+{
+  "name": "delivery-confirmation (after)",
+  "task": "You are calling on behalf of Northwind Logistics about tomorrow's delivery. First confirm you are speaking with the account holder; if the person who answers is someone else, do not discuss the order and end the call politely. Ask whether now is a good time before continuing, and stop if they decline. Ask whether the customer wants to keep the 09:00 to 12:00 window. If they want to decide later, offer to call back and record when. If voicemail or an answering machine picks up, leave no order details and end the call.",
+  "result_schema": {
+    "type": "object",
+    "properties": {
+      "call_status": {
+        "type": "string",
+        "description": "How the call ended: answered, voicemail, no_answer or line_busy."
+      },
+      "identity_verified": {
+        "type": "boolean",
+        "description": "Whether the account holder was confirmed to be on the line."
+      },
+      "consent_given": {
+        "type": "boolean",
+        "description": "Whether the callee agreed to continue with the call."
+      },
+      "confirmed": {
+        "type": "boolean",
+        "description": "Whether the account holder confirmed the delivery window."
+      },
+      "callback_requested": {
+        "type": "boolean",
+        "description": "Whether the callee asked to be called back instead of deciding now."
+      },
+      "notes": {
+        "type": "string",
+        "description": "Anything else the customer mentioned."
+      }
+    },
+    "required": ["call_status"]
+  },
+  "fields": {
+    "decision": "confirmed",
+    "reachability": "call_status",
+    "consent": "consent_given",
+    "identity": "identity_verified",
+    "deferral": "callback_requested"
+  },
+  "decision_rule": {
+    "expression": "confirmed == true and identity_verified == true and consent_given == true",
+    "on_true": {
+      "action": "dispatch the courier",
+      "side_effect": true
+    },
+    "on_false": {
+      "action": "hold the order and re-contact the customer",
+      "side_effect": false
+    }
+  }
+}

--- a/apps/python/call-rehearsal/examples/delivery-confirmation-unsafe.json
+++ b/apps/python/call-rehearsal/examples/delivery-confirmation-unsafe.json
@@ -1,0 +1,32 @@
+{
+  "name": "delivery-confirmation (before)",
+  "task": "You are calling on behalf of Northwind Logistics about tomorrow's delivery. Ask whether the customer wants to keep the 09:00 to 12:00 window, and thank them before ending the call.",
+  "result_schema": {
+    "type": "object",
+    "properties": {
+      "confirmed": {
+        "type": "boolean",
+        "description": "Whether the customer confirmed the delivery window."
+      },
+      "notes": {
+        "type": "string",
+        "description": "Anything else the customer mentioned."
+      }
+    },
+    "required": ["confirmed"]
+  },
+  "fields": {
+    "decision": "confirmed"
+  },
+  "decision_rule": {
+    "expression": "confirmed != false",
+    "on_true": {
+      "action": "dispatch the courier",
+      "side_effect": true
+    },
+    "on_false": {
+      "action": "hold the order and re-contact the customer",
+      "side_effect": false
+    }
+  }
+}

--- a/apps/python/call-rehearsal/tests/__init__.py
+++ b/apps/python/call-rehearsal/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for call-rehearsal."""

--- a/apps/python/call-rehearsal/tests/test_call_rehearsal.py
+++ b/apps/python/call-rehearsal/tests/test_call_rehearsal.py
@@ -1,0 +1,206 @@
+"""Tests for call-rehearsal.
+
+These run offline and place no calls, which is the whole point of the tool.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import unittest
+from pathlib import Path
+
+from callrehearsal import analysis, expressions
+from callrehearsal.__main__ import EXIT_BLOCKED, EXIT_INPUT_ERROR, EXIT_OK, main
+from callrehearsal.outcomes import OUTCOMES_BY_ID
+from callrehearsal.plan import PlanError, build_plan, load_plan, suggest_decision_fields
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
+UNSAFE = EXAMPLES / "delivery-confirmation-unsafe.json"
+SAFE = EXAMPLES / "delivery-confirmation-safe.json"
+
+
+def minimal_plan(**overrides) -> dict:
+    plan = {
+        "name": "minimal",
+        "task": "Ask whether the appointment still works.",
+        "result_schema": {
+            "type": "object",
+            "properties": {"confirmed": {"type": "boolean"}},
+        },
+        "fields": {"decision": "confirmed"},
+        "decision_rule": {
+            "expression": "confirmed == true",
+            "on_true": {"action": "book it", "side_effect": True},
+            "on_false": {"action": "do nothing", "side_effect": False},
+        },
+    }
+    plan.update(overrides)
+    return plan
+
+
+class ExpressionTests(unittest.TestCase):
+    def test_missing_field_is_falsy_not_an_error(self):
+        self.assertFalse(expressions.evaluate("confirmed == true", {}))
+
+    def test_negation_of_a_missing_field_is_true(self):
+        # This is the silent default that dispatches on voicemail.
+        self.assertTrue(expressions.evaluate("not declined", {}))
+
+    def test_missing_is_not_equal_to_false(self):
+        self.assertTrue(expressions.evaluate("confirmed != false", {}))
+
+    def test_booleans_do_not_compare_equal_to_numbers(self):
+        self.assertFalse(expressions.evaluate("confirmed == 1", {"confirmed": True}))
+
+    def test_is_missing_and_is_present(self):
+        self.assertTrue(expressions.evaluate("is_missing(confirmed)", {}))
+        self.assertTrue(expressions.evaluate("is_present(confirmed)", {"confirmed": False}))
+
+    def test_ordering_against_a_missing_field_is_false(self):
+        self.assertFalse(expressions.evaluate("score > 3", {}))
+
+    def test_referenced_fields_ignores_literals_and_helpers(self):
+        fields = expressions.referenced_fields("confirmed == true and is_missing(notes)")
+        self.assertEqual(fields, {"confirmed", "notes"})
+
+    def test_arbitrary_calls_are_rejected(self):
+        with self.assertRaises(expressions.ExpressionError):
+            expressions.evaluate('__import__("os").system("true")', {})
+
+    def test_attribute_access_is_rejected(self):
+        with self.assertRaises(expressions.ExpressionError):
+            expressions.evaluate("(1).__class__", {})
+
+    def test_subscripting_is_rejected(self):
+        with self.assertRaises(expressions.ExpressionError):
+            expressions.evaluate("result['confirmed']", {})
+
+
+class PlanTests(unittest.TestCase):
+    def test_decision_field_must_be_declared(self):
+        raw = minimal_plan(fields={})
+        with self.assertRaises(PlanError) as caught:
+            build_plan(raw)
+        self.assertIn("fields.decision", str(caught.exception))
+
+    def test_decision_field_must_exist_in_schema(self):
+        raw = minimal_plan(fields={"decision": "nope"})
+        with self.assertRaises(PlanError):
+            build_plan(raw)
+
+    def test_unknown_field_role_is_rejected(self):
+        raw = minimal_plan(fields={"decision": "confirmed", "mood": "confirmed"})
+        with self.assertRaises(PlanError):
+            build_plan(raw)
+
+    def test_expression_cannot_read_unknown_fields(self):
+        raw = minimal_plan()
+        raw["decision_rule"]["expression"] = "mystery == true"
+        with self.assertRaises(PlanError):
+            build_plan(raw)
+
+    def test_side_effect_must_be_declared_explicitly(self):
+        raw = minimal_plan()
+        del raw["decision_rule"]["on_true"]["side_effect"]
+        with self.assertRaises(PlanError):
+            build_plan(raw)
+
+    def test_suggestions_are_offered_but_never_applied(self):
+        schema = {"properties": {"confirmed": {"type": "boolean"}, "notes": {"type": "string"}}}
+        self.assertEqual(suggest_decision_fields(schema), ["confirmed"])
+
+
+class ProjectionTests(unittest.TestCase):
+    def setUp(self):
+        self.plan = load_plan(SAFE)
+
+    def test_unreached_call_leaves_the_decision_absent(self):
+        result = analysis.project(self.plan, OUTCOMES_BY_ID["voicemail"])
+        self.assertNotIn("confirmed", result)
+        self.assertEqual(result["call_status"], "voicemail")
+
+    def test_wrong_person_agrees_but_identity_is_false(self):
+        result = analysis.project(self.plan, OUTCOMES_BY_ID["wrong_person"])
+        self.assertTrue(result["confirmed"])
+        self.assertFalse(result["identity_verified"])
+
+    def test_only_a_verified_consenting_yes_counts_as_confirmation(self):
+        self.assertTrue(OUTCOMES_BY_ID["human_confirmed"].is_confirmation)
+        for identifier in ("wrong_person", "consent_refused", "voicemail", "human_deferred"):
+            self.assertFalse(OUTCOMES_BY_ID[identifier].is_confirmation, identifier)
+
+
+class AnalysisTests(unittest.TestCase):
+    def test_unsafe_plan_dispatches_on_voicemail(self):
+        plan = load_plan(UNSAFE)
+        rehearsals = analysis.rehearse(plan)
+        voicemail = next(r for r in rehearsals if r.outcome.identifier == "voicemail")
+        self.assertTrue(voicemail.side_effect)
+
+        findings = analysis.analyse(plan, rehearsals)
+        critical = [f for f in findings if f.severity == analysis.CRITICAL]
+        self.assertTrue(critical)
+        self.assertIn("voicemail", {f.outcome for f in critical})
+        self.assertEqual(analysis.worst_severity(findings), analysis.CRITICAL)
+
+    def test_safe_plan_has_no_findings(self):
+        plan = load_plan(SAFE)
+        findings = analysis.analyse(plan, analysis.rehearse(plan))
+        self.assertEqual(findings, [])
+
+    def test_safe_plan_never_side_effects_without_a_confirmation(self):
+        plan = load_plan(SAFE)
+        for item in analysis.rehearse(plan):
+            if item.side_effect:
+                self.assertTrue(item.outcome.is_confirmation, item.outcome.identifier)
+
+    def test_every_outcome_is_rehearsed(self):
+        plan = load_plan(SAFE)
+        self.assertEqual(len(analysis.rehearse(plan)), len(OUTCOMES_BY_ID))
+
+    def test_report_is_json_serialisable(self):
+        plan = load_plan(UNSAFE)
+        rehearsals = analysis.rehearse(plan)
+        report = analysis.to_dict(plan, rehearsals, analysis.analyse(plan, rehearsals))
+        json.dumps(report)
+        self.assertEqual(report["worst_severity"], analysis.CRITICAL)
+
+
+class CommandLineTests(unittest.TestCase):
+    def run_cli(self, argv):
+        """Run the CLI, keeping its report out of the test output."""
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = main(argv)
+        return code, out.getvalue()
+
+    def test_unsafe_plan_blocks(self):
+        code, output = self.run_cli([str(UNSAFE)])
+        self.assertEqual(code, EXIT_BLOCKED)
+        self.assertIn("Voicemail answered", output)
+
+    def test_safe_plan_passes(self):
+        code, output = self.run_cli([str(SAFE)])
+        self.assertEqual(code, EXIT_OK)
+        self.assertIn("No findings", output)
+
+    def test_missing_plan_is_an_input_error(self):
+        code, _ = self.run_cli([str(EXAMPLES / "does-not-exist.json")])
+        self.assertEqual(code, EXIT_INPUT_ERROR)
+
+    def test_threshold_can_be_relaxed_but_criticals_still_block(self):
+        code, _ = self.run_cli([str(UNSAFE), "--fail-on", "critical"])
+        self.assertEqual(code, EXIT_BLOCKED)
+
+    def test_json_report_is_emitted(self):
+        code, output = self.run_cli([str(SAFE), "--json"])
+        self.assertEqual(code, EXIT_OK)
+        payload = json.loads(output)
+        self.assertEqual(payload["worst_severity"], None)
+        self.assertEqual(len(payload["outcomes"]), 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/call-rehearsal/SKILL.md
+++ b/skills/call-rehearsal/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: call-rehearsal
+description: Rehearse a phone call plan against every realistic ending of the call before dialling anyone, and refuse a plan whose automation acts on a call that never reached a consenting human.
+license: MIT
+---
+
+# Call Rehearsal
+
+A CALL-E call returns a structured result, and something downstream acts on it.
+The dangerous failure is not a call that fails loudly. It is a call that never
+reached a consenting human whose result still resolves to the branch that ships
+the order.
+
+That happens because an unestablished field is absent, and absent is falsy. A
+rule as ordinary as `confirmed != false` is true when voicemail picked up and
+nothing at all was extracted.
+
+This skill covers finding that before the call, by rehearsing the plan against
+the ways calls actually end.
+
+## When to use it
+
+Use it before the first real call of any workflow whose result triggers a
+real-world side effect: dispatching, shipping, charging, cancelling, granting
+access, or writing a confirmation into a system of record. Use it again whenever
+the `task`, the `result_schema`, or the rule that reads the result changes, since
+this failure is introduced by editing any one of the three without the others.
+
+Skip it for a call whose result nobody acts on automatically. A call that only
+produces a note for a human to read has no branch to get wrong.
+
+## The procedure
+
+1. **Name the single decision.** Write down the one thing the call exists to
+   establish. If there seem to be several, the call is doing too much and the
+   rehearsal will show the decision field carrying weight it cannot hold.
+2. **Write the call plan.** One JSON file with the `task`, the `result_schema`,
+   the `fields` roles, and the `decision_rule` including what each branch does
+   and whether it changes the real world.
+3. **Declare the field roles.** Map result fields onto `decision`,
+   `reachability`, `consent`, `identity` and `deferral`. Only `decision` is
+   required. Do not guess a role: if you cannot say which field carries the
+   decision, ask the person who owns the workflow.
+4. **Rehearse.** Run the plan and read what the automation does for each ending.
+5. **Gate on the exit code.** `0` means no ending above the threshold reaches a
+   side effect, `20` means the plan should not go out as written, `30` means the
+   plan could not be read.
+
+```bash
+cd apps/python/call-rehearsal
+python3 -m callrehearsal <plan.json> --fail-on high
+```
+
+No call is placed, no credential is read, and nothing connects to the network,
+so rehearsing is always safe, including in CI on every commit.
+
+## Reading the result
+
+Every ending that is not a verified, consenting yes must land on a branch with
+`side_effect: false`. A `CRITICAL` finding means one did not.
+
+The two fixes that resolve almost every report:
+
+- **Record what happened on the line.** Add fields for reachability, identity
+  and consent, so voicemail is distinguishable from a refusal and a stranger
+  saying yes is distinguishable from the callee saying yes.
+- **Require a confirmation, not the absence of a refusal.** Replace
+  `confirmed != false` with `confirmed == true`, and conjoin the identity and
+  consent fields.
+
+Read `references/examples.md` for a worked before-and-after, and
+`references/safety.md` for the rules about what may follow a call.
+
+## What this does not do
+
+It reasons about the shape of the result, not the words spoken. It cannot tell
+you whether the phrasing is persuasive or whether extraction is reliable on a
+live line. Use `calle-script-advisor` for the task text and schema, and
+`voice-preflight` for what the critical lines sound like when spoken. A clean
+rehearsal means the plan survives the endings in the library, which is not a
+guarantee about any individual real call.

--- a/skills/call-rehearsal/references/examples.md
+++ b/skills/call-rehearsal/references/examples.md
@@ -1,0 +1,102 @@
+# Worked example
+
+A delivery confirmation call, before and after.
+
+## Before
+
+One boolean, and a rule that dispatches unless the customer said no.
+
+```json
+{
+  "name": "delivery-confirmation",
+  "task": "You are calling on behalf of Northwind Logistics about tomorrow's delivery. Ask whether the customer wants to keep the 09:00 to 12:00 window.",
+  "result_schema": {
+    "type": "object",
+    "properties": {
+      "confirmed": { "type": "boolean" },
+      "notes": { "type": "string" }
+    },
+    "required": ["confirmed"]
+  },
+  "fields": { "decision": "confirmed" },
+  "decision_rule": {
+    "expression": "confirmed != false",
+    "on_true": { "action": "dispatch the courier", "side_effect": true },
+    "on_false": { "action": "hold the order", "side_effect": false }
+  }
+}
+```
+
+Ten of the twelve endings dispatch the courier:
+
+```text
+ !! Consent refused                        ->  dispatch the courier  (side effect)
+ !! Wrong person answered and agreed       ->  dispatch the courier  (side effect)
+ !! Voicemail answered                     ->  dispatch the courier  (side effect)
+ !! Nobody answered                        ->  dispatch the courier  (side effect)
+
+  CRITICAL [voicemail] 'dispatch the courier' runs when voicemail answered
+      The result {} (nothing was extracted) still resolves the decision rule to
+      'dispatch the courier', which changes the real world.
+```
+
+Exit code `20`.
+
+## After
+
+Two changes. Record what happened on the line, and require a confirmation rather
+than the absence of a refusal.
+
+```json
+{
+  "result_schema": {
+    "type": "object",
+    "properties": {
+      "call_status": { "type": "string" },
+      "identity_verified": { "type": "boolean" },
+      "consent_given": { "type": "boolean" },
+      "confirmed": { "type": "boolean" },
+      "callback_requested": { "type": "boolean" }
+    },
+    "required": ["call_status"]
+  },
+  "fields": {
+    "decision": "confirmed",
+    "reachability": "call_status",
+    "consent": "consent_given",
+    "identity": "identity_verified",
+    "deferral": "callback_requested"
+  },
+  "decision_rule": {
+    "expression": "confirmed == true and identity_verified == true and consent_given == true",
+    "on_true": { "action": "dispatch the courier", "side_effect": true },
+    "on_false": { "action": "hold the order", "side_effect": false }
+  }
+}
+```
+
+The task text also gains the instructions the report asked for: confirm the
+account holder is on the line, check that now is a good time, offer a callback
+when the customer wants to decide later, and leave no order details on
+voicemail.
+
+```text
+No findings. Every ending that is not a verified confirmation stays away from
+the side-effecting branch.
+```
+
+Exit code `0`.
+
+## What changed in the report
+
+| Finding | Before | After |
+| --- | --- | --- |
+| `unsafe-side-effect` | 10 critical | none |
+| `indistinguishable-from-confirmation` | wrong person matches a real yes | separated by `identity_verified` |
+| `unrecordable-outcome` | reachability, identity, consent, deferral | none |
+| `unsatisfiable-required-field` | `confirmed` required but not always established | `call_status` is always present |
+
+Both plans are in
+[`apps/python/call-rehearsal/examples`](../../../apps/python/call-rehearsal/examples).
+Phone numbers do not appear in either: a call plan never contains one, because
+the number belongs to the call request, not to the plan being rehearsed.

--- a/skills/call-rehearsal/references/safety.md
+++ b/skills/call-rehearsal/references/safety.md
@@ -1,0 +1,64 @@
+# Safety notes
+
+## A call is a real-world side effect, and so is what follows it
+
+Rehearsing is not. This skill places no call, reads no credential, and opens no
+network connection, so it can run before every call and on every commit.
+
+The thing being made safe is the branch that runs afterwards. Treat any action
+that dispatches, ships, charges, cancels, grants access, or writes a
+confirmation into a system of record as requiring a verified, consenting yes,
+and nothing weaker.
+
+## Absent is not no
+
+The single rule worth carrying away. A field the call never established is
+absent from the result, and absent is falsy in every language anyone writes this
+automation in. So:
+
+- `not declined` is **true** when nobody answered.
+- `confirmed != false` is **true** when voicemail picked up.
+- `status != "refused"` is **true** when the line was busy.
+
+Each of those ships the order because the phone rang out. Write the rule as a
+positive test for the confirmation you need.
+
+## Distinguish the four things that are not a yes
+
+A result schema with one boolean cannot tell these apart, and downstream cannot
+either:
+
+| What happened | Why it is not a confirmation |
+| --- | --- |
+| Voicemail, no answer, busy | No person was reached at all. |
+| A gatekeeper answered | The callee was never reached. |
+| Someone else answered and agreed | The agreement came from the wrong person. |
+| The callee refused to continue | There was no consent to act on. |
+
+Give each of reachability, identity and consent its own field. Without them the
+distinction is lost before the result reaches the automation, and no later audit
+can recover it.
+
+## Do not guess a field role
+
+Which field carries the decision is a critical value, and this repository's
+design principles say a workflow must not guess critical values. If the decision
+field is unclear, ask the workflow owner rather than picking the
+plausible-looking boolean. A wrong guess rehearses the wrong thing and then
+reports a clean run, which is worse than no rehearsal.
+
+`--suggest-fields` offers candidates for a person to choose between and selects
+none of them.
+
+## A required field the call cannot fill
+
+If `result_schema.required` lists the decision field, then every ending that did
+not establish it either violates the schema or gets filled with a value nobody
+said. Require only what the call can always produce, such as how the call ended.
+
+## What a clean rehearsal does not mean
+
+The outcome library is a model of how calls end, not a recording of any real
+one. A clean run means the plan survives those endings. It is not evidence about
+extraction quality, phrasing, or any individual live call, and it does not
+remove the need to listen to the first real calls a workflow makes.


### PR DESCRIPTION
## Summary

A CALL-E call returns a structured result, and something downstream acts on it. The dangerous failure is not a call that fails loudly. It is a call that never reached a consenting human whose result still resolves to the branch that ships the order.

That happens because a field the call never established is absent, and absent is falsy. A rule as ordinary as `confirmed != false` is **true** when voicemail picked up and nothing at all was extracted.

`call-rehearsal` projects a call plan onto twelve realistic endings of a call and reports what the decision rule does on each one:

```console
$ python3 -m callrehearsal examples/delivery-confirmation-unsafe.json
    Verified human confirmed               ->  dispatch the courier  (side effect)
    Verified human declined                ->  hold the order  (no side effect)
 !! Consent refused                        ->  dispatch the courier  (side effect)
 !! Wrong person answered and agreed       ->  dispatch the courier  (side effect)
 !! Voicemail answered                     ->  dispatch the courier  (side effect)
 !! Nobody answered                        ->  dispatch the courier  (side effect)
    ...

  CRITICAL [voicemail] 'dispatch the courier' runs when voicemail answered
      The result {} (nothing was extracted) still resolves the decision rule to
      'dispatch the courier', which changes the real world.
```

Ten of the twelve endings dispatch the courier. The example plan then shows the two changes that fix it: record what happened on the line, and require a confirmation rather than the absence of a refusal. The corrected plan reports no findings and exits `0`.

### Why it belongs here

Two existing pieces check a call before it goes out, and this does something neither does:

| | What it checks |
| --- | --- |
| `calle-script-advisor` | The `task` text and schema, read statically. |
| `voice-preflight` | Whether critical lines survive being spoken aloud. |
| `call-rehearsal` | Whether the structured result can survive how the call actually ends, and what the automation does when it does not. |

It follows the repository design principles directly. Field roles are **declared, never inferred**, because which field carries a decision is a critical value and guessing it wrong would rehearse the wrong thing and then report a clean run; `--suggest-fields` offers candidates and selects none of them. Decision expressions are **evaluated, never executed**: parsed to an AST and rejected unless every node is on a small allow-list, so a call plan arriving in a pull request cannot run code.

### Contents

- `apps/python/call-rehearsal/` - the tool, standard library only, Python 3.9+, no dependencies, plus two example plans and 29 offline tests.
- `skills/call-rehearsal/` - the agent-facing procedure, with `references/safety.md` and `references/examples.md`.

## Type

- [x] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described. This app has none: it places no calls, reads no credential, and opens no network connection, so there is nothing to cancel or roll back.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional. No phone number appears anywhere in this change, because a call plan never contains one.
- [x] Recurring workflows include cancellation behavior. Not applicable: no scheduler job is created.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default. The no-call path is the only path.
- [x] `python3 scripts/validate_repository.py` passes.
