### PR TITLE
feat(apps): add appointment confirmation agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 ### Skills
 
 - [`accesscall`](skills/accesscall/) - Phone-based accessibility intake for VPAT 2.4/Section 508 audits. Run `npm install` in `skills/accesscall/` before using `scripts/format-to-vpat.js`, or it fails with `Cannot find module 'jszip'`.
+- [`appointment-confirm`](skills/appointment-confirm/) - Confirms one existing appointment by phone, captures yes/no plus time as structured JSON, and leaves calendar writes to a human.
 - [`candidate-availability-call`](skills/candidate-availability-call/) - Recruiting coordination skill that confirms candidate interview availability by phone, returns evidence-backed time windows, and leaves scheduling commitments to a human.
 - [`call-reminder`](skills/call-reminder/) - Scheduler wrapper skill for recurring CALL-E phone-call reminders.
 - [`callparity-claimkill`](skills/callparity-claimkill/) - ClaimKill (CallParity) compiles the next CALL-E call as a leak-scored refute of a quoted claim; pytest runs on fixtures with zero live calls.
@@ -175,6 +176,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/call-on-behalf`](apps/typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
 | [`apps/typescript/lost-line-coordinator`](apps/typescript/lost-line-coordinator/) | TypeScript | Consent-first lost-property route coordinator with inspectable calls, locally validated feature evidence, adaptive early stopping, and privacy-minimized results. |
 | [`apps/typescript/surplus-signal`](apps/typescript/surplus-signal/) | TypeScript | Consent-first surplus-food pickup confirmations with strict structured results and a redacted candidate manifest that still requires human dispatch approval. |
+| [`apps/python/appointment-confirm`](apps/python/appointment-confirm/) | Python | Consent-first appointment confirmation with a no-call preview, fixture mock, and one-shot CALL-E execute path that returns yes/no + time as fail-closed JSON. |
 | [`apps/python/leash`](apps/python/leash/) | Python | Revokes an unattended agent's Google credential unless one call clears twelve conditions; silence, a machine answering, or a result that disagrees with its own transcript all end the lease. |
 | [`apps/typescript/recallready`](apps/typescript/recallready/) | TypeScript | Consent-gated product-recall qualification calls grounded in official CPSC records, with masked destinations, single-use previews, structured remedies, and a no-call default. |
 | [`apps/typescript/readyline`](apps/typescript/readyline/) | TypeScript | Event load-in coordinator that turns authorized CALL-E vendor results into deterministic access, dock, power, and deadline checks, with a no-call demo and human-approved follow-up. |

--- a/apps/python/appointment-confirm/README.md
+++ b/apps/python/appointment-confirm/README.md
@@ -1,0 +1,101 @@
+# Appointment Confirm
+
+Consent-first **appointment confirmation** runner for CALL-E. It places (or mocks) one disclosed phone call, captures **yes/no + time**, and returns fail-closed structured JSON. A human still owns calendar changes.
+
+This is a runnable demo app, not a CALL-E SDK.
+
+## Setup
+
+Python 3.11+. No packages required for preview or mock.
+
+```bash
+cd apps/python/appointment-confirm
+python3 client.py --request fixtures/sample_appointment.json
+```
+
+Optional live SDK (only needed for a real call):
+
+```bash
+pip install 'calle-ai>=0.7.0'
+```
+
+## Preview without a call
+
+Default. No credentials, no network.
+
+```bash
+python3 client.py --request fixtures/sample_appointment.json
+```
+
+Prints a masked plan, the CALL-E task text, result schemas, and the idempotency key.
+
+## Mock / dev path (still no call)
+
+Replays a conversation fixture through the same schema and fail-closed classifier:
+
+```bash
+python3 client.py --request fixtures/sample_appointment.json --mock
+python3 client.py --request fixtures/sample_appointment.json \
+  --mock --fixture fixtures/conversation_reschedule.json
+```
+
+Fixtures:
+
+| File | Outcome |
+| --- | --- |
+| `conversation_confirm_yes.json` | `can_attend=yes`, confirmed 10:00 |
+| `conversation_reschedule.json` | `no` + requested 14:00, needs a human to rebook |
+| `conversation_decline.json` | `no` / declined |
+| `conversation_voicemail.json` | `unknown` / voicemail |
+| `conversation_ambiguous.json` | low confidence → `needs_human` |
+
+## One live CALL-E call
+
+```bash
+export CALLE_API_KEY="<your key from dashboard.heycall-e.com/account/api-keys>"
+export CALLE_BASE_URL="https://api.heycall-e.com"
+# Replace the fixture phone with an E.164 number you are authorized to call.
+python3 client.py --request your-authorized-appointment.json \
+  --execute --confirm-consent --output ../../tickets/live.json
+```
+
+`--execute` without `--confirm-consent` or without `CALLE_API_KEY` is refused. New CALL-E accounts include 20 free calls after signup at [heycall-e.com](https://www.heycall-e.com/).
+
+
+## Sample phone number
+
+Fixtures use the UK drama number `+447700900123` (Ofcom reserved). Do not replace it with a real number unless you are authorized to call that number.
+
+## Output
+
+```json
+{
+  "mode": "mock",
+  "creates_phone_call": false,
+  "can_attend": "yes",
+  "confirmed_time": "2026-09-03T10:00:00+01:00",
+  "requested_time": "",
+  "disposition": "confirmed",
+  "needs_human": false,
+  "phone_masked": "+44******0123"
+}
+```
+
+`can_attend` is `yes` / `no` / `unknown`. Time is ISO-8601 or empty. `reschedule_requested` always sets `needs_human: true`.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+All tests are offline. They never need `CALLE_API_KEY`.
+
+
+## Cancellation
+
+This is a one-shot call, not a recurring job. If you have not run `--execute`, do not execute. If a live call already ran, reuse the same `idempotency_key` (`appointment_confirm:{request_id}:{starts_at}`) so CALL-E does not create a second task. Do not retry an ambiguous result by dialing again; route it to a human. There is no cancel-task API in the current Developer API release.
+
+## Side effects
+
+See [docs/safety.md](docs/safety.md). Live mode places exactly one outbound call. Preview and mock place none. This app does not create recurring jobs and does not write calendars.

--- a/apps/python/appointment-confirm/appointment_confirm/__init__.py
+++ b/apps/python/appointment-confirm/appointment_confirm/__init__.py
@@ -1,0 +1,6 @@
+"""Appointment confirmation phone-call agent for CALL-E."""
+
+__version__ = "0.1.0"
+
+TRUSTED_BASE_URL = "https://api.heycall-e.com"
+WORKFLOW_TYPE = "appointment_confirm"

--- a/apps/python/appointment-confirm/appointment_confirm/dispositions.py
+++ b/apps/python/appointment-confirm/appointment_confirm/dispositions.py
@@ -1,0 +1,114 @@
+"""Fail-closed classification of a CALL-E (or mock) terminal payload."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .phone import mask_phone
+from .schema import CAN_ATTEND, DISPOSITIONS
+from .task import idempotency_key
+
+LOW_CONFIDENCE = 0.6
+
+
+def _confidence_score(payload: dict[str, Any]) -> float | None:
+    raw = payload.get("completion_confidence")
+    if isinstance(raw, dict) and isinstance(raw.get("score"), (int, float)):
+        return float(raw["score"])
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def classify(intake: dict[str, Any], payload: dict[str, Any], *, mode: str) -> dict[str, Any]:
+    """Turn a CALL-E-shaped result into the app's public JSON.
+
+    Ambiguity, schema drift, and low confidence become needs_human. A yes is
+    never inferred from a missing field.
+    """
+    phone_masked = mask_phone(intake["phone"])
+    base = {
+        "mode": mode,
+        "creates_phone_call": mode == "live",
+        "request_id": intake["request_id"],
+        "idempotency_key": idempotency_key(intake),
+        "phone_masked": phone_masked,
+        "appointment_starts_at": intake["appointment"]["starts_at"],
+        "call_id": payload.get("id") or payload.get("call_id"),
+        "status": payload.get("status"),
+        "task_completed": payload.get("task_completed"),
+        "completion_confidence": payload.get("completion_confidence"),
+        "can_attend": "unknown",
+        "confirmed_time": "",
+        "requested_time": "",
+        "disposition": "needs_human",
+        "evidence": [],
+        "needs_human": True,
+        "notes": "",
+    }
+
+    if payload.get("status") != "completed" or payload.get("task_completed") is not True:
+        base["notes"] = "Call did not complete successfully; routed to a human."
+        return base
+
+    recipients = payload.get("recipients") or []
+    if not isinstance(recipients, list) or len(recipients) != 1:
+        base["notes"] = "Expected exactly one recipient result."
+        return base
+
+    structured = recipients[0].get("structured_result") if isinstance(recipients[0], dict) else None
+    if not isinstance(structured, dict):
+        structured = payload.get("structured_result")
+    if not isinstance(structured, dict):
+        base["notes"] = "Missing structured_result."
+        return base
+
+    can_attend = structured.get("can_attend")
+    disposition = structured.get("disposition")
+    confirmed_time = structured.get("confirmed_time") or ""
+    requested_time = structured.get("requested_time") or ""
+    if can_attend not in CAN_ATTEND or disposition not in DISPOSITIONS:
+        base["notes"] = "structured_result used an unbound enum value."
+        return base
+    if not isinstance(confirmed_time, str) or not isinstance(requested_time, str):
+        base["notes"] = "Time fields must be strings."
+        return base
+
+    score = _confidence_score(payload)
+    if score is not None and score < LOW_CONFIDENCE:
+        base["notes"] = "Completion confidence below fail-closed threshold."
+        base["can_attend"] = can_attend
+        base["confirmed_time"] = confirmed_time
+        base["requested_time"] = requested_time
+        base["disposition"] = "needs_human"
+        base["evidence"] = list(payload.get("evidence") or [])
+        return base
+
+    if disposition == "confirmed" and can_attend != "yes":
+        base["notes"] = "confirmed disposition requires can_attend=yes."
+        return base
+    if disposition == "confirmed" and not confirmed_time:
+        base["notes"] = "confirmed disposition requires confirmed_time."
+        return base
+
+    needs_human = disposition in {"needs_human", "voicemail", "no_answer", "wrong_number"}
+    if can_attend == "unknown" and disposition not in {"voicemail", "no_answer", "wrong_number"}:
+        needs_human = True
+        disposition = "needs_human"
+
+    evidence = list(payload.get("evidence") or [])
+    base.update(
+        {
+            "can_attend": can_attend,
+            "confirmed_time": confirmed_time,
+            "requested_time": requested_time,
+            "disposition": disposition,
+            "evidence": evidence,
+            "needs_human": needs_human or disposition == "reschedule_requested",
+            "notes": "",
+        }
+    )
+    if disposition == "reschedule_requested":
+        base["notes"] = "Recipient asked to move the slot. A human must rebook."
+        base["needs_human"] = True
+    return base

--- a/apps/python/appointment-confirm/appointment_confirm/engine.py
+++ b/apps/python/appointment-confirm/appointment_confirm/engine.py
@@ -1,0 +1,70 @@
+"""Preview, mock, and live execution for one appointment-confirmation call."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+
+from . import WORKFLOW_TYPE
+from .dispositions import classify
+from .mock_client import MockCalleClient, load_fixture
+from .phone import mask_phone
+from .preview import preview
+from .schema import recipient_result_schema, task_result_schema
+from .task import build_task, idempotency_key
+
+
+class CallClient(Protocol):
+    def create_and_wait(self, **kwargs: Any) -> dict[str, Any]: ...
+
+
+def default_fixture_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "fixtures" / "conversation_confirm_yes.json"
+
+
+def execute_with_client(
+    intake: dict[str, Any],
+    client: CallClient,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    payload = client.create_and_wait(
+        task=build_task(intake),
+        recipients=[
+            {
+                "phones": [intake["phone"]],
+                "region": intake["region"],
+                "locale": intake["locale"],
+            }
+        ],
+        result_schema=task_result_schema(),
+        recipient_result_schema=recipient_result_schema(),
+        metadata={
+            "workflow_run_id": intake["request_id"],
+            "workflow_type": WORKFLOW_TYPE,
+            "business": intake["business_display_name"],
+        },
+        idempotency_key=idempotency_key(intake),
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("CALL-E client returned a non-object result")
+    ticket = classify(intake, payload, mode=mode)
+    transcript = []
+    recipients = payload.get("recipients") or []
+    if recipients and isinstance(recipients[0], dict):
+        attempts = recipients[0].get("attempts") or []
+        if attempts and isinstance(attempts[0], dict):
+            transcript = attempts[0].get("transcript_turns") or []
+    ticket["transcript_turns"] = transcript
+    ticket["phone_masked"] = mask_phone(intake["phone"])
+    return ticket
+
+
+def execute_mock(intake: dict[str, Any], fixture_path: Path | None = None) -> dict[str, Any]:
+    path = fixture_path or default_fixture_path()
+    fixture = load_fixture(path)
+    client = MockCalleClient(fixture, intake)
+    ticket = execute_with_client(intake, client, mode="mock")
+    ticket["fixture"] = str(path)
+    ticket["creates_phone_call"] = False
+    return ticket

--- a/apps/python/appointment-confirm/appointment_confirm/extract.py
+++ b/apps/python/appointment-confirm/appointment_confirm/extract.py
@@ -1,0 +1,160 @@
+"""Deterministic transcript extractor used by the mock/dev path.
+
+Live CALL-E fills the same schema itself. This extractor exists so a fixture
+conversation can produce structured JSON without credentials.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+YES_RE = re.compile(
+    r"\b(yes|yeah|yep|confirm(?:ed)?|i(?:'ll| will) be there|that works|see you then)\b",
+    re.I,
+)
+NO_RE = re.compile(
+    r"\b(no|cannot|can'?t|won'?t make it|cancel(?:ling|ed)?)\b",
+    re.I,
+)
+RESCHEDULE_RE = re.compile(
+    r"\b(reschedule|another time|different time|move (?:it|the appointment)|instead)\b",
+    re.I,
+)
+VOICEMAIL_RE = re.compile(
+    r"\b(voicemail|leave (?:a |your )?message|after the (?:tone|beep)|not available)\b",
+    re.I,
+)
+WRONG_RE = re.compile(r"\b(wrong number|you have the wrong|no one (?:here )?by that name)\b", re.I)
+CLOCK_RE = re.compile(r"\b(\d{1,2}):(\d{2})\s*(am|pm)?\b|\b(\d{1,2})\s*(am|pm)\b", re.I)
+
+
+def _user_text(turns: list[dict[str, Any]]) -> str:
+    return " ".join(
+        str(turn.get("text") or "")
+        for turn in turns
+        if str(turn.get("speaker") or "").lower() in {"user", "human", "recipient"}
+    )
+
+
+def _time_needles(iso_value: str) -> set[str]:
+    parsed = datetime.fromisoformat(iso_value.replace("Z", "+00:00"))
+    hour12 = parsed.strftime("%I").lstrip("0") or "12"
+    minute = parsed.strftime("%M")
+    ampm = parsed.strftime("%p").lower()
+    needles = {
+        parsed.strftime("%H:%M"),
+        f"{hour12}{ampm}",
+        f"{hour12} {ampm}",
+        f"{hour12}:{minute} {ampm}",
+        f"{hour12}:{minute}{ampm}",
+        f"{hour12}:{minute}",
+    }
+    if minute == "00":
+        needles.update({f"{hour12} {ampm}", f"{hour12}{ampm}", f"{int(hour12)} o'clock"})
+    return {item.lower() for item in needles}
+
+
+def parse_mentioned_time(text: str, intake: dict[str, Any]) -> str:
+    """Map a spoken time onto a booked slot or an allowed reschedule window."""
+    windows = [intake["appointment"]["starts_at"], *intake["reschedule_windows"]]
+    lowered = text.lower().replace(".", "")
+
+    for window in windows:
+        if any(needle and needle in lowered for needle in _time_needles(window)):
+            return window
+
+    match = CLOCK_RE.search(text)
+    if not match:
+        return ""
+    if match.group(1) is not None:
+        hour = int(match.group(1))
+        minute = int(match.group(2) or 0)
+        ampm = (match.group(3) or "").lower()
+    else:
+        hour = int(match.group(4))
+        minute = 0
+        ampm = (match.group(5) or "").lower()
+    if ampm == "pm" and hour < 12:
+        hour += 12
+    if ampm == "am" and hour == 12:
+        hour = 0
+    if hour > 23 or minute > 59:
+        return ""
+    for window in windows:
+        parsed = datetime.fromisoformat(window.replace("Z", "+00:00"))
+        if parsed.hour == hour and parsed.minute == minute:
+            return window
+    booked = datetime.fromisoformat(intake["appointment"]["starts_at"].replace("Z", "+00:00"))
+    return booked.replace(hour=hour, minute=minute, second=0, microsecond=0).isoformat()
+
+
+def extract_from_turns(turns: list[dict[str, Any]], intake: dict[str, Any]) -> dict[str, str]:
+    user = _user_text(turns)
+    booked = intake["appointment"]["starts_at"]
+    mentioned = parse_mentioned_time(user, intake)
+
+    if not user.strip():
+        return {
+            "can_attend": "unknown",
+            "confirmed_time": "",
+            "requested_time": "",
+            "disposition": "no_answer",
+        }
+    if VOICEMAIL_RE.search(user):
+        return {
+            "can_attend": "unknown",
+            "confirmed_time": "",
+            "requested_time": "",
+            "disposition": "voicemail",
+        }
+    if WRONG_RE.search(user):
+        return {
+            "can_attend": "unknown",
+            "confirmed_time": "",
+            "requested_time": "",
+            "disposition": "wrong_number",
+        }
+
+    wants_move = bool(RESCHEDULE_RE.search(user))
+    said_yes = bool(YES_RE.search(user))
+    said_no = bool(NO_RE.search(user))
+
+    if wants_move or (said_no and mentioned and mentioned != booked):
+        return {
+            "can_attend": "no",
+            "confirmed_time": "",
+            "requested_time": mentioned if mentioned != booked else "",
+            "disposition": "reschedule_requested",
+        }
+    if said_yes and not said_no:
+        return {
+            "can_attend": "yes",
+            "confirmed_time": booked,
+            "requested_time": "",
+            "disposition": "confirmed",
+        }
+    if said_no:
+        return {
+            "can_attend": "no",
+            "confirmed_time": "",
+            "requested_time": "",
+            "disposition": "declined",
+        }
+    return {
+        "can_attend": "unknown",
+        "confirmed_time": "",
+        "requested_time": "",
+        "disposition": "needs_human",
+    }
+
+
+def evidence_from_turns(turns: list[dict[str, Any]]) -> list[str]:
+    quotes = []
+    for turn in turns:
+        speaker = str(turn.get("speaker") or "").lower()
+        text = str(turn.get("text") or "").strip()
+        if speaker in {"user", "human", "recipient"} and text:
+            quotes.append(text)
+    return quotes[:4]

--- a/apps/python/appointment-confirm/appointment_confirm/live_client.py
+++ b/apps/python/appointment-confirm/appointment_confirm/live_client.py
@@ -1,0 +1,39 @@
+"""Live CALL-E client. Imports calle-ai at execute time only."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import TRUSTED_BASE_URL
+
+
+def validate_trusted_base_url(base_url: str) -> str:
+    value = (base_url or "").strip().rstrip("/")
+    if value != TRUSTED_BASE_URL:
+        raise ValueError(
+            f"base URL must be {TRUSTED_BASE_URL} (got {base_url!r}). "
+            "Refusing to send CALLE_API_KEY to any other origin."
+        )
+    return value
+
+
+class LiveCalleClient:
+    """Thin wrapper so tests can swap in a fake with the same create_and_wait."""
+
+    def __init__(self, api_key: str, base_url: str = TRUSTED_BASE_URL):
+        if not api_key or not api_key.strip():
+            raise ValueError("CALLE_API_KEY is required for live calls")
+        if api_key.strip().startswith("calle_test") and "example" in api_key:
+            raise ValueError("refusing a placeholder API key")
+        self.base_url = validate_trusted_base_url(base_url)
+        try:
+            from calle import CalleClient
+        except ImportError as exc:
+            raise RuntimeError(
+                "Live mode needs the official Python SDK: pip install 'calle-ai>=0.7.0'. "
+                "The import name is `calle`. Without a key, use --mock instead."
+            ) from exc
+        self._client = CalleClient(api_key=api_key.strip(), base_url=self.base_url)
+
+    def create_and_wait(self, **kwargs: Any) -> dict[str, Any]:
+        return self._client.calls.create_and_wait(**kwargs)

--- a/apps/python/appointment-confirm/appointment_confirm/mock_client.py
+++ b/apps/python/appointment-confirm/appointment_confirm/mock_client.py
@@ -1,0 +1,59 @@
+"""In-process CALL-E stand-in driven by a conversation fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .extract import evidence_from_turns, extract_from_turns
+
+
+class MockCalleClient:
+    """Implements create_and_wait using a local transcript fixture."""
+
+    def __init__(self, fixture: dict[str, Any], intake: dict[str, Any]):
+        self.fixture = fixture
+        self.intake = intake
+
+    def create_and_wait(self, **kwargs: Any) -> dict[str, Any]:
+        turns = self.fixture.get("transcript_turns") or []
+        if not isinstance(turns, list):
+            raise ValueError("fixture transcript_turns must be a list")
+        structured = extract_from_turns(turns, self.intake)
+        expected = self.fixture.get("expected_structured_result")
+        if isinstance(expected, dict):
+            # Fixture author can pin the schema fields; extractor still runs in tests.
+            for key in ("can_attend", "confirmed_time", "requested_time", "disposition"):
+                if key in expected:
+                    structured[key] = expected[key]
+        evidence = self.fixture.get("evidence") or evidence_from_turns(turns)
+        confidence = self.fixture.get(
+            "completion_confidence", {"score": 0.93, "label": "high"}
+        )
+        call_id = self.fixture.get("call_id", "call_mock_appointment_confirm")
+        return {
+            "id": call_id,
+            "status": self.fixture.get("status", "completed"),
+            "task_completed": self.fixture.get("task_completed", True),
+            "completion_confidence": confidence,
+            "evidence": evidence,
+            "structured_result": {"completed_count": 1},
+            "recipients": [
+                {
+                    "phones": [self.intake["phone"]],
+                    "region": self.intake["region"],
+                    "locale": self.intake["locale"],
+                    "structured_result": structured,
+                    "attempts": [{"transcript_turns": turns}],
+                }
+            ],
+            "metadata": kwargs.get("metadata") or {},
+        }
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("fixture must be a JSON object")
+    return data

--- a/apps/python/appointment-confirm/appointment_confirm/phone.py
+++ b/apps/python/appointment-confirm/appointment_confirm/phone.py
@@ -1,0 +1,29 @@
+"""E.164 validation and masking. Never log a full phone number."""
+
+from __future__ import annotations
+
+import re
+
+# E.164: + then 1-9, then 7-14 more digits (8-15 digits total after +).
+# Rejects +0 prefixes used in some test fakes that are not dialable.
+E164_RE = re.compile(r"^\+[1-9]\d{7,14}$")
+
+
+def validate_e164(phone: str) -> str:
+    if not isinstance(phone, str) or not phone.strip():
+        raise ValueError("phone is required and must be an E.164 string")
+    value = phone.strip()
+    if not E164_RE.fullmatch(value):
+        raise ValueError(
+            "phone must be E.164 (+ then 8-15 digits, no leading 0 after +), "
+            "for example +447700900123"
+        )
+    return value
+
+
+def mask_phone(phone: str) -> str:
+    """Keep country-ish prefix and last 4 digits. Safe for stdout and fixtures."""
+    value = phone.strip()
+    if len(value) < 8:
+        return "****"
+    return value[:3] + ("*" * (len(value) - 7)) + value[-4:]

--- a/apps/python/appointment-confirm/appointment_confirm/preview.py
+++ b/apps/python/appointment-confirm/appointment_confirm/preview.py
@@ -1,0 +1,37 @@
+"""No-call preview. Never contacts CALL-E."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .phone import mask_phone
+from .schema import recipient_result_schema, task_result_schema
+from .task import build_task, idempotency_key
+
+
+def preview(intake: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "mode": "preview",
+        "creates_phone_call": False,
+        "request_id": intake["request_id"],
+        "phone_masked": mask_phone(intake["phone"]),
+        "region": intake["region"],
+        "locale": intake["locale"],
+        "timezone": intake["timezone"],
+        "business_display_name": intake["business_display_name"],
+        "appointment": intake["appointment"],
+        "reschedule_windows": intake["reschedule_windows"],
+        "idempotency_key": idempotency_key(intake),
+        "task": build_task(intake),
+        "result_schema": task_result_schema(),
+        "recipient_result_schema": recipient_result_schema(),
+        "side_effects": [
+            "Preview does not dial, authenticate, or send network requests.",
+            "A later --mock run uses a local fixture and still places no call.",
+            "A later --execute --confirm-consent run places exactly one real CALL-E call.",
+        ],
+        "cancellation": (
+            "This workflow is one-shot. Do not re-run --execute with the same "
+            "request_id and starts_at. CALL-E will reuse the idempotency key."
+        ),
+    }

--- a/apps/python/appointment-confirm/appointment_confirm/schema.py
+++ b/apps/python/appointment-confirm/appointment_confirm/schema.py
@@ -1,0 +1,146 @@
+"""Intake validation and CALL-E result schemas."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .phone import validate_e164
+
+REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{3,80}$")
+CAN_ATTEND = ("yes", "no", "unknown")
+DISPOSITIONS = (
+    "confirmed",
+    "declined",
+    "reschedule_requested",
+    "voicemail",
+    "no_answer",
+    "wrong_number",
+    "needs_human",
+)
+
+
+def recipient_result_schema() -> dict[str, Any]:
+    """Per-recipient schema CALL-E fills after the call. Strict object."""
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["can_attend", "confirmed_time", "requested_time", "disposition"],
+        "properties": {
+            "can_attend": {
+                "type": "string",
+                "enum": list(CAN_ATTEND),
+                "description": "Did the recipient confirm they will attend the booked slot?",
+            },
+            "confirmed_time": {
+                "type": "string",
+                "description": "ISO-8601 start time they confirmed, or empty string if none.",
+            },
+            "requested_time": {
+                "type": "string",
+                "description": "ISO-8601 start time they asked to move to, or empty string if none.",
+            },
+            "disposition": {
+                "type": "string",
+                "enum": list(DISPOSITIONS),
+            },
+        },
+    }
+
+
+def task_result_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["completed_count"],
+        "properties": {
+            "completed_count": {"type": "integer"},
+        },
+    }
+
+
+def _require_str(data: dict[str, Any], key: str, *, max_len: int = 200) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    value = value.strip()
+    if len(value) > max_len:
+        raise ValueError(f"{key} is too long (max {max_len})")
+    return value
+
+
+def _parse_iso(value: str, field: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be ISO-8601, got {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone offset")
+    return parsed.isoformat()
+
+
+def load_intake(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"intake is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("intake must be a JSON object")
+    return validate_intake(data)
+
+
+def validate_intake(data: dict[str, Any]) -> dict[str, Any]:
+    request_id = _require_str(data, "request_id", max_len=80)
+    if not REQUEST_ID_RE.fullmatch(request_id):
+        raise ValueError("request_id must be 3-80 chars of letters, numbers, . _ : -")
+
+    if data.get("consent") is not True:
+        raise ValueError("consent must be boolean true (recipient asked to be called)")
+    if data.get("do_not_call") is True:
+        raise ValueError("do_not_call is true; refusing to plan or place a call")
+
+    appointment = data.get("appointment")
+    if not isinstance(appointment, dict):
+        raise ValueError("appointment object is required")
+    starts_at = _parse_iso(_require_str(appointment, "starts_at", max_len=40), "appointment.starts_at")
+    duration = appointment.get("duration_minutes", 30)
+    if not isinstance(duration, int) or duration < 5 or duration > 480:
+        raise ValueError("appointment.duration_minutes must be an integer 5-480")
+
+    windows_in = data.get("reschedule_windows") or []
+    if not isinstance(windows_in, list) or len(windows_in) > 6:
+        raise ValueError("reschedule_windows must be a list of at most 6 ISO-8601 times")
+    windows = [_parse_iso(str(item), "reschedule_windows[]") for item in windows_in]
+
+    phone = validate_e164(_require_str(data, "phone", max_len=20))
+
+    forbidden = ("password", "api_key", "secret", "token", "ssn", "card")
+    blob = json.dumps(data).lower()
+    for word in forbidden:
+        if word in blob:
+            raise ValueError(f"intake must not contain {word}")
+
+    return {
+        "request_id": request_id,
+        "business_display_name": _require_str(data, "business_display_name", max_len=80),
+        "caller_role": _require_str(data, "caller_role", max_len=80),
+        "recipient_first_name": _require_str(data, "recipient_first_name", max_len=40),
+        "phone": phone,
+        "region": _require_str(data, "region", max_len=8).upper(),
+        "locale": _require_str(data, "locale", max_len=16),
+        "timezone": _require_str(data, "timezone", max_len=64),
+        "appointment": {
+            "service": _require_str(appointment, "service", max_len=80),
+            "starts_at": starts_at,
+            "duration_minutes": duration,
+            "location": _require_str(appointment, "location", max_len=120),
+        },
+        "consent": True,
+        "authorized_reason": _require_str(data, "authorized_reason", max_len=240),
+        "reschedule_windows": windows,
+        "do_not_call": False,
+    }

--- a/apps/python/appointment-confirm/appointment_confirm/task.py
+++ b/apps/python/appointment-confirm/appointment_confirm/task.py
@@ -1,0 +1,70 @@
+"""Build the CALL-E task text and a stable idempotency key."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from . import WORKFLOW_TYPE
+
+
+def _friendly_when(iso_value: str, timezone_name: str) -> str:
+    parsed = datetime.fromisoformat(iso_value.replace("Z", "+00:00"))
+    return f"{parsed.strftime('%A %d %B %Y at %H:%M')} ({timezone_name})"
+
+
+def build_task(intake: dict[str, Any]) -> str:
+    apt = intake["appointment"]
+    when = _friendly_when(apt["starts_at"], intake["timezone"])
+    windows = intake["reschedule_windows"]
+    if windows:
+        window_lines = "\n".join(f"- {_friendly_when(item, intake['timezone'])}" for item in windows)
+        window_block = (
+            "If they cannot attend the booked slot, offer ONLY these alternative times "
+            "and capture the one they choose:\n"
+            f"{window_lines}\n"
+            "Do not invent other times. Do not book, move, or cancel anything in a calendar."
+        )
+    else:
+        window_block = (
+            "If they cannot attend, capture any time they request as requested_time text, "
+            "but do not promise a new booking. Leave rescheduling to a human."
+        )
+
+    return f"""You are an AI phone assistant calling on behalf of {intake['business_display_name']}.
+Disclose immediately that you are AI, that this is one appointment-confirmation call, and that
+{intake['caller_role']} authorized it because: {intake['authorized_reason']}
+
+Speak with {intake['recipient_first_name']}. If you have the wrong person, apologise, end the call,
+and set disposition to wrong_number.
+
+Purpose: confirm one existing appointment. Do not sell, collect payment, give medical/legal/financial
+advice, or discuss anything outside this booking.
+
+Appointment:
+- Service: {apt['service']}
+- When: {when}
+- Duration: {apt['duration_minutes']} minutes
+- Location: {apt['location']}
+
+Ask:
+1. Is this {intake['recipient_first_name']}?
+2. Can they attend this appointment? Capture can_attend as yes, no, or unknown.
+3. If yes, read the time back and capture confirmed_time as the booked start time.
+4. If no, ask whether they want to cancel or move.
+{window_block}
+
+If voicemail answers, leave a short message asking them to call the studio back. Do not include
+any other personal details. Set disposition to voicemail and can_attend to unknown.
+If they decline, set can_attend to no and disposition to declined.
+If they ask to move to one of the allowed windows, set can_attend to no, disposition to
+reschedule_requested, and requested_time to that window.
+Do not infer yes from silence. Ambiguity must be unknown / needs_human.
+
+Return the structured result. Do not update any calendar yourself.
+"""
+
+
+def idempotency_key(intake: dict[str, Any]) -> str:
+    starts = intake["appointment"]["starts_at"]
+    return f"{WORKFLOW_TYPE}:{intake['request_id']}:{starts}"

--- a/apps/python/appointment-confirm/client.py
+++ b/apps/python/appointment-confirm/client.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Appointment confirmation CLI.
+
+Default is a no-call preview. --mock runs a fixture conversation locally.
+--execute --confirm-consent places exactly one real CALL-E call.
+
+Examples:
+  python3 client.py --request fixtures/sample_appointment.json
+  python3 client.py --request fixtures/sample_appointment.json --mock
+  CALLE_API_KEY=... python3 client.py --request fixtures/sample_appointment.json \
+      --execute --confirm-consent
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent
+if str(APP_DIR) not in sys.path:
+    sys.path.insert(0, str(APP_DIR))
+
+from appointment_confirm import TRUSTED_BASE_URL
+from appointment_confirm.engine import execute_mock, execute_with_client, preview
+from appointment_confirm.live_client import LiveCalleClient, validate_trusted_base_url
+from appointment_confirm.schema import load_intake
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preview, mock, or place one appointment-confirmation phone call via CALL-E."
+    )
+    parser.add_argument("--request", required=True, type=Path, help="Appointment intake JSON.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write JSON here. Existing files are never overwritten (mode 0600).",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--preview", action="store_true", help="No-call plan (default).")
+    mode.add_argument(
+        "--mock",
+        action="store_true",
+        help="Run a local conversation fixture. Places no phone call. Needs no API key.",
+    )
+    mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Place exactly one real CALL-E call. Requires CALLE_API_KEY and --confirm-consent.",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Conversation fixture for --mock. Defaults to fixtures/conversation_confirm_yes.json.",
+    )
+    parser.add_argument(
+        "--confirm-consent",
+        action="store_true",
+        help="Required with --execute. Confirms the recipient consented to this call.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("CALLE_BASE_URL", TRUSTED_BASE_URL),
+        help=f"Must be {TRUSTED_BASE_URL}.",
+    )
+    return parser.parse_args(argv)
+
+
+def write_output(path: Path | None, payload: dict) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if path is None:
+        sys.stdout.write(rendered)
+        return
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("x", encoding="utf-8") as handle:
+        handle.write(rendered)
+    destination.chmod(0o600)
+    sys.stdout.write(f"Wrote {destination}\n")
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        intake = load_intake(args.request)
+        if args.execute:
+            if not args.confirm_consent:
+                raise ValueError("--execute requires --confirm-consent")
+            validate_trusted_base_url(args.base_url)
+            api_key = os.environ.get("CALLE_API_KEY", "").strip()
+            if not api_key:
+                raise ValueError(
+                    "CALLE_API_KEY is missing. For a real call, create a CALL-E account "
+                    "(20 free calls) at https://www.heycall-e.com/ then copy a key from "
+                    "https://dashboard.heycall-e.com/account/api-keys . "
+                    "Until then, run --mock (no key, no dial)."
+                )
+            client = LiveCalleClient(api_key=api_key, base_url=args.base_url)
+            ticket = execute_with_client(intake, client, mode="live")
+            write_output(args.output, ticket)
+            return 0
+        if args.mock:
+            ticket = execute_mock(intake, args.fixture)
+            write_output(args.output, ticket)
+            return 0
+        write_output(args.output, preview(intake))
+        return 0
+    except (FileExistsError, OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/appointment-confirm/docs/safety.md
+++ b/apps/python/appointment-confirm/docs/safety.md
@@ -1,0 +1,37 @@
+# Safety notes — appointment confirmation
+
+This workflow places **one outbound phone call** when `--execute --confirm-consent` is used with a live `CALLE_API_KEY`. Preview and mock place no calls.
+
+## Required before a live call
+
+- The intake records `consent: true` because the recipient asked to be called about this booking.
+- The operator passes `--confirm-consent` as a second, explicit confirmation.
+- `phone` is E.164 and belongs to a number you are authorized to call.
+- `do_not_call` is false.
+- You are confirming an existing appointment, not selling, collecting payment, or giving advice.
+
+## Disclosure
+
+The CALL-E task text tells the agent to disclose immediately that it is AI, who authorized the call, and why. Wrong-person and opt-out end the call.
+
+## Fail-closed
+
+Silence, voicemail, low confidence (`< 0.6`), missing schema fields, unbound enums, and incomplete CALL-E statuses become `needs_human`. A reschedule request is captured as structured JSON but **never written to a calendar**.
+
+## Credentials
+
+- Keep `CALLE_API_KEY` in the environment or a secret manager. Never put it in intake JSON, fixtures, git, or the 3-minute video.
+- The live client will only send the key to `https://api.heycall-e.com`.
+- Keys are server credentials. Do not ship them in a browser app.
+
+## Out of scope
+
+Not for medical, legal, financial, emergency, collections, political, or unsolicited marketing calls. Not a scheduler. Not a retry loop. Not a hidden recurring job.
+
+## Cancellation
+
+One-shot. If you have not executed, do not execute. If you already executed, reuse the same `idempotency_key` (`appointment_confirm:{request_id}:{starts_at}`) so CALL-E does not create a second task. There is no cancel-task API in the current Developer API release; do not "retry" an ambiguous result by dialing again.
+
+## Phone numbers in samples
+
+Fixtures use the UK drama number `+447700900123` (Ofcom reserved). Masked output looks like `+44******0123`.

--- a/apps/python/appointment-confirm/fixtures/conversation_ambiguous.json
+++ b/apps/python/appointment-confirm/fixtures/conversation_ambiguous.json
@@ -1,0 +1,31 @@
+{
+  "call_id": "call_mock_ambiguous",
+  "status": "completed",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.41,
+    "label": "low"
+  },
+  "description": "Unclear answer plus low confidence must fail closed to needs_human.",
+  "transcript_turns": [
+    {
+      "offset_seconds": 0,
+      "speaker": "bot",
+      "text": "Can you attend Thursday at 10:00?"
+    },
+    {
+      "offset_seconds": 4,
+      "speaker": "user",
+      "text": "Maybe, I will have to see."
+    }
+  ],
+  "expected_structured_result": {
+    "can_attend": "unknown",
+    "confirmed_time": "",
+    "requested_time": "",
+    "disposition": "needs_human"
+  },
+  "evidence": [
+    "Maybe, I will have to see."
+  ]
+}

--- a/apps/python/appointment-confirm/fixtures/conversation_confirm_yes.json
+++ b/apps/python/appointment-confirm/fixtures/conversation_confirm_yes.json
@@ -1,0 +1,52 @@
+{
+  "call_id": "call_mock_confirm_yes",
+  "status": "completed",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.94,
+    "label": "high"
+  },
+  "description": "Recipient confirms the booked Thursday 10:00 slot.",
+  "transcript_turns": [
+    {
+      "offset_seconds": 0,
+      "speaker": "bot",
+      "text": "Hi Amelia, this is an AI assistant calling from KAY2 Studios. I am calling to confirm your brand strategy session on Thursday 3 September at 10:00. Is this Amelia?"
+    },
+    {
+      "offset_seconds": 6,
+      "speaker": "user",
+      "text": "Yes, that's me."
+    },
+    {
+      "offset_seconds": 9,
+      "speaker": "bot",
+      "text": "Great. Can you confirm you can attend the 10:00 session on Thursday 3 September at KAY2 Studios, London?"
+    },
+    {
+      "offset_seconds": 14,
+      "speaker": "user",
+      "text": "Yes, I'll be there at 10."
+    },
+    {
+      "offset_seconds": 18,
+      "speaker": "bot",
+      "text": "Thank you. You are confirmed for 10:00 on Thursday. A human at the studio will keep the booking. Goodbye."
+    },
+    {
+      "offset_seconds": 24,
+      "speaker": "user",
+      "text": "See you then."
+    }
+  ],
+  "expected_structured_result": {
+    "can_attend": "yes",
+    "confirmed_time": "2026-09-03T10:00:00+01:00",
+    "requested_time": "",
+    "disposition": "confirmed"
+  },
+  "evidence": [
+    "Yes, that's me.",
+    "Yes, I'll be there at 10."
+  ]
+}

--- a/apps/python/appointment-confirm/fixtures/conversation_decline.json
+++ b/apps/python/appointment-confirm/fixtures/conversation_decline.json
@@ -1,0 +1,36 @@
+{
+  "call_id": "call_mock_decline",
+  "status": "completed",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.9,
+    "label": "high"
+  },
+  "description": "Recipient cancels. No alternative time.",
+  "transcript_turns": [
+    {
+      "offset_seconds": 0,
+      "speaker": "bot",
+      "text": "Hi Amelia, calling from KAY2 Studios to confirm Thursday 10:00. Can you attend?"
+    },
+    {
+      "offset_seconds": 5,
+      "speaker": "user",
+      "text": "No, I need to cancel."
+    },
+    {
+      "offset_seconds": 8,
+      "speaker": "bot",
+      "text": "Understood. I will mark this as declined so a human can cancel the booking. Thank you."
+    }
+  ],
+  "expected_structured_result": {
+    "can_attend": "no",
+    "confirmed_time": "",
+    "requested_time": "",
+    "disposition": "declined"
+  },
+  "evidence": [
+    "No, I need to cancel."
+  ]
+}

--- a/apps/python/appointment-confirm/fixtures/conversation_reschedule.json
+++ b/apps/python/appointment-confirm/fixtures/conversation_reschedule.json
@@ -1,0 +1,42 @@
+{
+  "call_id": "call_mock_reschedule",
+  "status": "completed",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.91,
+    "label": "high"
+  },
+  "description": "Recipient cannot make 10:00 and asks for the 14:00 window.",
+  "transcript_turns": [
+    {
+      "offset_seconds": 0,
+      "speaker": "bot",
+      "text": "Hi Amelia, this is an AI assistant calling from KAY2 Studios about your 10:00 brand strategy session on Thursday 3 September. Can you still attend?"
+    },
+    {
+      "offset_seconds": 7,
+      "speaker": "user",
+      "text": "I can't make 10. Can we move it to 2pm instead?"
+    },
+    {
+      "offset_seconds": 12,
+      "speaker": "bot",
+      "text": "I can note 14:00 on Thursday 3 September as a request. A human will rebook if that slot is still free. I will not change the calendar myself."
+    },
+    {
+      "offset_seconds": 18,
+      "speaker": "user",
+      "text": "2pm works, thanks."
+    }
+  ],
+  "expected_structured_result": {
+    "can_attend": "no",
+    "confirmed_time": "",
+    "requested_time": "2026-09-03T14:00:00+01:00",
+    "disposition": "reschedule_requested"
+  },
+  "evidence": [
+    "I can't make 10. Can we move it to 2pm instead?",
+    "2pm works, thanks."
+  ]
+}

--- a/apps/python/appointment-confirm/fixtures/conversation_voicemail.json
+++ b/apps/python/appointment-confirm/fixtures/conversation_voicemail.json
@@ -1,0 +1,31 @@
+{
+  "call_id": "call_mock_voicemail",
+  "status": "completed",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.88,
+    "label": "high"
+  },
+  "description": "Machine answers. Agent leaves a short message and does not treat silence as yes.",
+  "transcript_turns": [
+    {
+      "offset_seconds": 0,
+      "speaker": "user",
+      "text": "Hi, you've reached Amelia. I am not available, please leave a message after the beep."
+    },
+    {
+      "offset_seconds": 6,
+      "speaker": "bot",
+      "text": "This is an AI assistant calling from KAY2 Studios about a booked session on Thursday. Please call the studio back to confirm. Goodbye."
+    }
+  ],
+  "expected_structured_result": {
+    "can_attend": "unknown",
+    "confirmed_time": "",
+    "requested_time": "",
+    "disposition": "voicemail"
+  },
+  "evidence": [
+    "Hi, you've reached Amelia. I am not available, please leave a message after the beep."
+  ]
+}

--- a/apps/python/appointment-confirm/fixtures/sample_appointment.json
+++ b/apps/python/appointment-confirm/fixtures/sample_appointment.json
@@ -1,0 +1,23 @@
+{
+  "request_id": "apt-2026-09-03-amelia",
+  "business_display_name": "KAY2 Studios",
+  "caller_role": "studio coordinator",
+  "recipient_first_name": "Amelia",
+  "phone": "+447700900123",
+  "region": "GB",
+  "locale": "en-GB",
+  "timezone": "Europe/London",
+  "appointment": {
+    "service": "brand strategy session",
+    "starts_at": "2026-09-03T10:00:00+01:00",
+    "duration_minutes": 45,
+    "location": "KAY2 Studios, London"
+  },
+  "consent": true,
+  "authorized_reason": "Recipient booked this session online and asked the studio to call to confirm.",
+  "reschedule_windows": [
+    "2026-09-03T14:00:00+01:00",
+    "2026-09-04T10:00:00+01:00"
+  ],
+  "do_not_call": false
+}

--- a/apps/python/appointment-confirm/tests/test_extract.py
+++ b/apps/python/appointment-confirm/tests/test_extract.py
@@ -1,0 +1,42 @@
+import json
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from appointment_confirm.extract import extract_from_turns
+from appointment_confirm.schema import load_intake
+
+APP = Path(__file__).resolve().parents[1]
+FIXTURES = APP / "fixtures"
+
+
+class ExtractorTests(unittest.TestCase):
+    def setUp(self):
+        self.intake = load_intake(FIXTURES / "sample_appointment.json")
+
+    def _run(self, name: str):
+        fixture = json.loads((FIXTURES / name).read_text())
+        got = extract_from_turns(fixture["transcript_turns"], self.intake)
+        self.assertEqual(got, fixture["expected_structured_result"], name)
+        return got
+
+    def test_confirm_yes(self):
+        self._run("conversation_confirm_yes.json")
+
+    def test_reschedule(self):
+        self._run("conversation_reschedule.json")
+
+    def test_decline(self):
+        self._run("conversation_decline.json")
+
+    def test_voicemail(self):
+        self._run("conversation_voicemail.json")
+
+    def test_ambiguous(self):
+        self._run("conversation_ambiguous.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/appointment-confirm/tests/test_flow.py
+++ b/apps/python/appointment-confirm/tests/test_flow.py
@@ -1,0 +1,173 @@
+import json
+import os
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from appointment_confirm.engine import execute_mock, execute_with_client, preview
+from appointment_confirm.live_client import validate_trusted_base_url
+from appointment_confirm.schema import load_intake
+from appointment_confirm.task import idempotency_key
+import client as cli
+
+APP = Path(__file__).resolve().parents[1]
+FIXTURES = APP / "fixtures"
+
+
+class FakeCalle:
+    def __init__(self, payload):
+        self.payload = payload
+        self.kwargs = None
+
+    def create_and_wait(self, **kwargs):
+        self.kwargs = kwargs
+        return self.payload
+
+
+class FlowTests(unittest.TestCase):
+    def setUp(self):
+        self.intake = load_intake(FIXTURES / "sample_appointment.json")
+
+    def test_preview_does_not_call(self):
+        plan = preview(self.intake)
+        self.assertFalse(plan["creates_phone_call"])
+        self.assertEqual(plan["mode"], "preview")
+        self.assertIn("+44", plan["phone_masked"])
+        self.assertNotIn("7700900123", json.dumps(plan))
+        self.assertIn("recipient_result_schema", plan)
+        self.assertEqual(plan["idempotency_key"], idempotency_key(self.intake))
+
+    def test_mock_confirm_yes_json(self):
+        ticket = execute_mock(self.intake, FIXTURES / "conversation_confirm_yes.json")
+        self.assertEqual(ticket["mode"], "mock")
+        self.assertFalse(ticket["creates_phone_call"])
+        self.assertEqual(ticket["can_attend"], "yes")
+        self.assertEqual(ticket["confirmed_time"], "2026-09-03T10:00:00+01:00")
+        self.assertEqual(ticket["disposition"], "confirmed")
+        self.assertFalse(ticket["needs_human"])
+
+    def test_mock_reschedule_needs_human(self):
+        ticket = execute_mock(self.intake, FIXTURES / "conversation_reschedule.json")
+        self.assertEqual(ticket["can_attend"], "no")
+        self.assertEqual(ticket["requested_time"], "2026-09-03T14:00:00+01:00")
+        self.assertEqual(ticket["disposition"], "reschedule_requested")
+        self.assertTrue(ticket["needs_human"])
+
+    def test_mock_voicemail_unknown(self):
+        ticket = execute_mock(self.intake, FIXTURES / "conversation_voicemail.json")
+        self.assertEqual(ticket["can_attend"], "unknown")
+        self.assertEqual(ticket["disposition"], "voicemail")
+        self.assertTrue(ticket["needs_human"])
+
+    def test_low_confidence_fail_closed(self):
+        ticket = execute_mock(self.intake, FIXTURES / "conversation_ambiguous.json")
+        self.assertEqual(ticket["disposition"], "needs_human")
+        self.assertTrue(ticket["needs_human"])
+
+    def test_incomplete_call_fail_closed(self):
+        fake = FakeCalle({"status": "failed", "task_completed": False, "recipients": [{}]})
+        ticket = execute_with_client(self.intake, fake, mode="live")
+        self.assertEqual(ticket["disposition"], "needs_human")
+        self.assertTrue(ticket["creates_phone_call"])
+
+    def test_live_client_receives_schema_and_idempotency(self):
+        payload = {
+            "id": "call_test",
+            "status": "completed",
+            "task_completed": True,
+            "completion_confidence": {"score": 0.95, "label": "high"},
+            "evidence": ["Yes"],
+            "recipients": [
+                {
+                    "structured_result": {
+                        "can_attend": "yes",
+                        "confirmed_time": "2026-09-03T10:00:00+01:00",
+                        "requested_time": "",
+                        "disposition": "confirmed",
+                    },
+                    "attempts": [{"transcript_turns": []}],
+                }
+            ],
+        }
+        fake = FakeCalle(payload)
+        ticket = execute_with_client(self.intake, fake, mode="live")
+        self.assertEqual(ticket["can_attend"], "yes")
+        self.assertIn("recipient_result_schema", fake.kwargs)
+        self.assertEqual(fake.kwargs["recipients"][0]["phones"], [self.intake["phone"]])
+        self.assertTrue(fake.kwargs["idempotency_key"].startswith("appointment_confirm:"))
+
+    def test_base_url_locked(self):
+        with self.assertRaises(ValueError):
+            validate_trusted_base_url("https://evil.example")
+
+    def test_cli_preview_and_mock(self):
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            rc = cli.main(["--request", str(FIXTURES / "sample_appointment.json"), "--preview"])
+        self.assertEqual(rc, 0)
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            rc = cli.main(
+                [
+                    "--request",
+                    str(FIXTURES / "sample_appointment.json"),
+                    "--mock",
+                    "--fixture",
+                    str(FIXTURES / "conversation_decline.json"),
+                ]
+            )
+        self.assertEqual(rc, 0)
+
+    def test_cli_execute_without_consent(self):
+        with patch("sys.stderr", StringIO()):
+            rc = cli.main(["--request", str(FIXTURES / "sample_appointment.json"), "--execute"])
+        self.assertEqual(rc, 2)
+
+    def test_cli_execute_without_key(self):
+        env = {k: v for k, v in os.environ.items() if k != "CALLE_API_KEY"}
+        with patch.dict(os.environ, env, clear=True), patch("sys.stderr", StringIO()):
+            rc = cli.main(
+                [
+                    "--request",
+                    str(FIXTURES / "sample_appointment.json"),
+                    "--execute",
+                    "--confirm-consent",
+                ]
+            )
+        self.assertEqual(rc, 2)
+
+    def test_output_file_mode_and_no_overwrite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "ticket.json"
+            with patch("sys.stdout", StringIO()):
+                rc = cli.main(
+                    [
+                        "--request",
+                        str(FIXTURES / "sample_appointment.json"),
+                        "--mock",
+                        "--output",
+                        str(dest),
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            self.assertEqual(oct(dest.stat().st_mode)[-3:], "600")
+            with patch("sys.stderr", StringIO()):
+                rc = cli.main(
+                    [
+                        "--request",
+                        str(FIXTURES / "sample_appointment.json"),
+                        "--mock",
+                        "--output",
+                        str(dest),
+                    ]
+                )
+            self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/appointment-confirm/tests/test_phone.py
+++ b/apps/python/appointment-confirm/tests/test_phone.py
@@ -1,0 +1,30 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from appointment_confirm.phone import mask_phone, validate_e164
+
+
+class PhoneTests(unittest.TestCase):
+    def test_accepts_gb_drama_number(self):
+        self.assertEqual(validate_e164("+447700900123"), "+447700900123")
+
+    def test_rejects_missing_plus(self):
+        with self.assertRaises(ValueError):
+            validate_e164("447700900123")
+
+    def test_rejects_plus_zero(self):
+        with self.assertRaises(ValueError):
+            validate_e164("+0447700900123")
+
+    def test_mask_keeps_last_four(self):
+        masked = mask_phone("+447700900123")
+        self.assertTrue(masked.endswith("0123"))
+        self.assertNotIn("7700900", masked)
+        self.assertIn("*", masked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/appointment-confirm/tests/test_schema.py
+++ b/apps/python/appointment-confirm/tests/test_schema.py
@@ -1,0 +1,44 @@
+import json
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from appointment_confirm.schema import load_intake, validate_intake
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+class SchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.intake = json.loads((FIXTURES / "sample_appointment.json").read_text())
+
+    def test_sample_loads(self):
+        loaded = load_intake(FIXTURES / "sample_appointment.json")
+        self.assertEqual(loaded["request_id"], "apt-2026-09-03-amelia")
+        self.assertTrue(loaded["consent"])
+
+    def test_rejects_false_consent(self):
+        self.intake["consent"] = False
+        with self.assertRaises(ValueError):
+            validate_intake(self.intake)
+
+    def test_rejects_do_not_call(self):
+        self.intake["do_not_call"] = True
+        with self.assertRaises(ValueError):
+            validate_intake(self.intake)
+
+    def test_rejects_secret_like_fields(self):
+        self.intake["authorized_reason"] = "here is an api_key leak"
+        with self.assertRaises(ValueError):
+            validate_intake(self.intake)
+
+    def test_rejects_naive_datetime(self):
+        self.intake["appointment"]["starts_at"] = "2026-09-03T10:00:00"
+        with self.assertRaises(ValueError):
+            validate_intake(self.intake)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/appointment-confirm/SKILL.md
+++ b/skills/appointment-confirm/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: appointment-confirm
+description: Confirm one existing appointment by phone with CALL-E, capture yes/no and time as structured JSON, and leave calendar changes to a human. Dry-run and fixture modes by default.
+license: MIT
+---
+
+# Appointment Confirm
+
+Use this skill when a studio, clinic, or coordinator has explicit authority to place **one** disclosed phone call to confirm an existing booking. The call asks whether the recipient can attend the booked slot, captures a yes/no plus a confirmed or requested time, and returns fail-closed structured JSON.
+
+This skill does not book, move, or cancel calendar events. A human reviews the result before any diary change.
+
+## When To Use
+
+- Confirm a booked appointment the recipient already knows about
+- Capture a decline or a requested move to a pre-approved window
+- Leave a short voicemail that asks them to call the business back
+- Produce an evidence-backed disposition for a coordinator
+
+## When Not To Use
+
+- First-contact sales, lead qualification, or unsolicited marketing
+- Medical, legal, financial, emergency, collections, or political calls
+- Calling a number the user did not provide and authorize
+- Hidden retries, recurring reminders, or automatic calendar writes
+- Collecting payment, ID numbers, or health details
+
+## Required Inputs
+
+- `request_id`: stable local identifier
+- `business_display_name`: name disclosed on the call
+- `recipient_first_name`
+- `to_phone_e164`: E.164, authorized
+- `appointment.service`, `appointment.starts_at` (ISO-8601 with offset), `appointment.location`
+- `timezone`: IANA
+- `consent`: must be true
+- `authorized_reason`: why this specific call is allowed
+
+Optional: `reschedule_windows` (max 6 ISO-8601 times the coordinator can actually honor).
+
+## Preflight
+
+1. Confirm the user authorized this one confirmation call.
+2. Confirm the phone is E.164 and came from the booking workflow.
+3. Refuse if `do_not_call` is true or `consent` is not true.
+4. Run a local preview before any CALL-E plan.
+
+## Dry-Run Preview
+
+From the repository root (no CALL-E credentials, no network):
+
+```bash
+python3 apps/python/appointment-confirm/client.py --request skills/appointment-confirm/assets/sample-appointment.json
+python3 apps/python/appointment-confirm/client.py --request skills/appointment-confirm/assets/sample-appointment.json --mock
+```
+
+From the app directory:
+
+```bash
+cd apps/python/appointment-confirm
+python3 client.py --request fixtures/sample_appointment.json
+```
+
+Preview prints a masked phone, the CALL-E task, and the result schema. It does not dial.
+
+## CALL-E Goal Template
+
+```text
+You are an AI phone assistant calling on behalf of {business_display_name}.
+Disclose immediately that you are AI and that this is one appointment-confirmation call.
+
+Speak with {recipient_first_name}. If you have the wrong person, apologise and end the call.
+
+Purpose: confirm the existing {service} on {starts_at_friendly} at {location}.
+Do not sell, collect payment, or give medical, legal, or financial advice.
+
+Ask whether they can attend. Capture can_attend as yes, no, or unknown.
+If yes, read the time back and capture confirmed_time.
+If no, offer only these windows: {reschedule_windows}. Capture requested_time.
+Do not infer yes from silence. Do not update any calendar.
+```
+
+## Structured Result
+
+```json
+{
+  "can_attend": "yes | no | unknown",
+  "confirmed_time": "ISO-8601 or empty",
+  "requested_time": "ISO-8601 or empty",
+  "disposition": "confirmed | declined | reschedule_requested | voicemail | no_answer | wrong_number | needs_human"
+}
+```
+
+A `confirmed` result is not a calendar write. `reschedule_requested`, voicemail, and unknown all need a human.
+
+## Live Planning
+
+Only after explicit user authorization and CALL-E authentication:
+
+```bash
+export CALLE_API_KEY="<server key>"
+python3 apps/python/appointment-confirm/client.py --request <authorized-intake.json> --execute --confirm-consent
+```
+
+Planning via the CALL-E CLI is also valid and is not execution:
+
+```bash
+calle call plan --to-phone <E164_PHONE> --goal "<reviewed goal text>" --timezone Europe/London --language English --region GB
+```
+
+Do not run `calle call start` or this app's `--execute` unless the user separately confirms.
+
+## Cancellation And Idempotency
+
+Idempotency key: `appointment_confirm:{request_id}:{starts_at}`. If the user cancels before dial, do not execute. If a result is ambiguous, route to a human rather than calling again.
+
+## Safety Notes
+
+Read `references/safety.md` and `references/examples.md` before live planning.

--- a/skills/appointment-confirm/assets/sample-appointment.json
+++ b/skills/appointment-confirm/assets/sample-appointment.json
@@ -1,0 +1,23 @@
+{
+  "request_id": "apt-2026-09-03-amelia",
+  "business_display_name": "KAY2 Studios",
+  "caller_role": "studio coordinator",
+  "recipient_first_name": "Amelia",
+  "phone": "+447700900123",
+  "region": "GB",
+  "locale": "en-GB",
+  "timezone": "Europe/London",
+  "appointment": {
+    "service": "brand strategy session",
+    "starts_at": "2026-09-03T10:00:00+01:00",
+    "duration_minutes": 45,
+    "location": "KAY2 Studios, London"
+  },
+  "consent": true,
+  "authorized_reason": "Recipient booked this session online and asked the studio to call to confirm.",
+  "reschedule_windows": [
+    "2026-09-03T14:00:00+01:00",
+    "2026-09-04T10:00:00+01:00"
+  ],
+  "do_not_call": false
+}

--- a/skills/appointment-confirm/references/examples.md
+++ b/skills/appointment-confirm/references/examples.md
@@ -1,0 +1,15 @@
+# Examples
+
+## Safe
+
+- A studio coordinator confirms Thursday 10:00 with someone who booked online and asked to be called.
+- Mocking `fixtures/conversation_reschedule.json` to show a 14:00 request without dialing.
+- Previewing a masked plan in a demo video.
+
+## Unsafe
+
+- Calling a scraped lead list.
+- Treating voicemail as a yes.
+- Writing a Google Calendar event from `requested_time` without a human.
+- Putting an API key in the intake JSON or on screen during a recording.
+- Retrying automatically when CALL-E returns `unknown`.

--- a/skills/appointment-confirm/references/safety.md
+++ b/skills/appointment-confirm/references/safety.md
@@ -1,0 +1,10 @@
+# Safety
+
+- Explicit consent on the intake **and** `--confirm-consent` on the CLI.
+- E.164 only. Mask phones in logs and video.
+- Never commit `CALLE_API_KEY`. Live calls only go to `https://api.heycall-e.com`.
+- One-shot. No hidden retries or recurring schedules.
+- Fail closed: silence, voicemail, low confidence, and schema drift become `needs_human`.
+- The agent discloses it is AI. Wrong-person ends the call.
+- Out of scope: medical, legal, financial, emergency, collections, political, unsolicited marketing.
+- Calendar writes stay with a human, including every reschedule request.

--- a/skills/appointment-confirm/scripts/preview.py
+++ b/skills/appointment-confirm/scripts/preview.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Skill-local preview wrapper. Places no calls."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+APP = ROOT / "apps/python/appointment-confirm"
+ASSET = Path(__file__).resolve().parents[1] / "assets" / "sample-appointment.json"
+sys.path.insert(0, str(APP))
+
+from client import main
+
+if __name__ == "__main__":
+    argv = sys.argv[1:] or ["--request", str(ASSET), "--preview"]
+    raise SystemExit(main(argv))


### PR DESCRIPTION
KAY2Studios CALL-E hackathon entry (Devpost kay2).

Adds:
- skills/appointment-confirm
- apps/python/appointment-confirm

Consent-first appointment confirmation over the phone. Preview and fixture mock by default. Live CALL-E path is gated behind --execute and CALLE_API_KEY. 26 offline tests, no live calls in CI. Fictional UK drama number +447700900123 in samples.

`python3 scripts/validate_repository.py` passed.