### PR TITLE
Add bounty-hotline skill: real CALL-E call when a real GitHub bounty appears

### DIFF
--- a/skills/bounty-hotline/SKILL.md
+++ b/skills/bounty-hotline/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: bounty-hotline
+description: Watch a live feed of GitHub bounty-labeled issues, filter farm spam by dollar amount, repo credibility and freshness, and place a real CALL-E phone call to the developer when a worth-answering bounty appears. Includes an audit log and dedupe so the phone rings once per bounty.
+license: MIT
+---
+
+# Bounty Hotline
+
+Use this skill when the user wants to be **phoned** when a real, fresh, paid GitHub bounty appears — instead of refreshing issue trackers or drowning in notification spam.
+
+`bounty-hotline` is a feed-watch + filter + one-off-call skill. It wraps the existing one-off CALL-E call workflow in a watch loop owned by the client (cron, launchd, or any scheduler). Every filtering decision and every call is written to an audit log.
+
+## When To Use
+
+Use this skill for:
+
+- "call me when a real bounty shows up on GitHub"
+- alerting freelancers to fresh paid issues while filtering duplicate "$9k" farm spam
+- any watch-feed → filter → real outbound call pipeline that must stay silent unless a threshold passes
+
+## When Not To Use
+
+Do not use this skill to:
+
+- call third parties who did not consent to receive calls
+- guess phone numbers, country codes, timezones, languages, or regions
+- place a call without a valid region-bound `HOTLINE_PHONE` and explicit per-run confirmation
+- spam the recipient: one call per bounty key, ever (dedupe is mandatory)
+- run without an audit log — if it isn't logged, it didn't happen
+
+## Filters (silence is a feature)
+
+A bounty triggers a call only when ALL pass:
+
+1. parsed amount ≥ threshold (default `$150`, env `HOTLINE_MIN_USD`)
+2. repo credibility grade A or B (stars, age, activity via GitHub API, 6h cache)
+3. issue age is known and younger than `HOTLINE_MAX_AGE_H` (default 48h)
+4. issue key never called before (dedupe state file)
+
+## Core Workflow
+
+1. Confirm the user explicitly wants bounty calls and collect:
+   - E.164 destination phone number (`HOTLINE_PHONE`), bound to the operator's own region (`HOTLINE_REGION`)
+   - optional thresholds (`HOTLINE_MIN_USD`, `HOTLINE_MAX_AGE_H`)
+2. Resolve the CALL-E CLI using the bootstrap documented in the `call-reminder` skill, or install once via `npm install -g @call-e/cli`.
+3. Run the watch loop:
+   - `python3 hotline.py --dry-run` to preview filter decisions without dialing
+   - `python3 hotline.py --yes --once` for cron, or `--yes --loop` for a daemon (`--yes` = per-run live-dialing consent)
+4. On a passing bounty the skill follows the documented plan-confirmation flow:
+   - builds a concise reading-order narration (repo, issue number, title, amount)
+   - calls `calle call plan` with `--to-phone`, goal text, language and explicit region; proceeds only when the plan is `ready_to_run` and returns both `plan_id` and `confirm_token`
+   - calls `calle call run --plan-id … --confirm-token …`; treats a non-zero exit or refused run as a failure, and `call_started: "unknown"` as an unrecoverable-by-retry outcome to finish through `calle call recover`
+   - marks a bounty as called only after the run returns a `run_id`
+   - appends eval/plan/run decisions to `hotline_log.jsonl`
+5. Report outcomes honestly: if the IVR maze ate the call, say so.
+
+## Safety
+
+- The recipient number lives in the user's environment (`HOTLINE_PHONE`), never in code or repos; it is validated as strict E.164 and must match `HOTLINE_REGION`'s country code (fail-closed for unmapped regions).
+- Live dialing requires per-run confirmation (`--yes`); one-time configuration alone never dials.
+- One call per bounty, ever, and only after CALL-E confirms the call started; failed runs stay eligible, uncertain runs must not be retried with a new plan.
+- Never call businesses or third parties as part of the bounty flow; the hotline calls the consenting owner only.
+- All calls, evals, and errors are append-only logged for audit.
+- Keep raw call artifacts out of repositories: run IDs, recordings, diarized transcripts, and raw status payloads about any call — including calls to businesses — must not be committed. A public repo is not the right place for call records about a third party. Summarize outcomes in prose instead; identifiers and raw payloads stay in the operator's local, private storage.
+
+## Reference implementation
+
+A complete runnable implementation (feed module, filter daemon, CALL-E integration) lives at [github.com/shamanov39-dev/bounty-hotline](https://github.com/shamanov39-dev/bounty-hotline) (MIT), built for the CALL-E: Your Code Is Calling hackathon.

--- a/skills/bounty-hotline/references/examples.md
+++ b/skills/bounty-hotline/references/examples.md
@@ -1,0 +1,18 @@
+# Examples
+
+## Safe
+
+- A freelancer sets `HOTLINE_PHONE` and `HOTLINE_REGION` to their own number and region, runs the watcher from cron with `--yes`, and gets a single evening call when a fresh $300 bounty on a credible repo appears; the call reads repo, issue number, title, and amount, then ends, and the bounty is deduped only after CALL-E returns a `run_id`.
+- An operator starts the daemon without `--yes` after a reboot: the feed is evaluated and logged, nothing dials, and the log records `live_refused` until a human passes `--yes` again.
+- A mismatched number is caught before any call: `HOTLINE_PHONE="+447700900123"` with `HOTLINE_REGION="US"` fails the region-bound E.164 gate and exits without dialing.
+- The feed lists ten bounty-labeled issues; nine fail the filters (stale, duplicate, sub-threshold farm spam, or unknown age), so the log records ten eval decisions and the phone stays silent.
+- The skill is demonstrated end-to-end in a dry-run mode that plans and previews the narration for a fictional bounty (`acme-widgets`, issue #12, $200, `example.com`-style repo) without placing a call.
+
+## Unsafe
+
+- Calling a maintainer's personal number scraped from a bounty issue to "negotiate" the payout.
+- Pointing `HOTLINE_PHONE` at a business switchboard, a looked-up number, or any number the operator does not own.
+- Treating a planned call as a placed one: marking the bounty called when `calle call run` was refused, errored, or returned no `run_id` — this silently swallows real bounties forever.
+- Retrying an uncertain run (`call_started: "unknown"`) by planning a fresh call instead of finishing it through `calle call recover`; this can ring the recipient twice for one issue.
+- Leaving the daemon looping on a one-time configuration with no per-run confirmation, so it keeps dialing long after the operator stopped watching.
+- Committing a real run's transcript, status JSON, or run ID to a repository or pasting them into a public issue.

--- a/skills/bounty-hotline/references/safety.md
+++ b/skills/bounty-hotline/references/safety.md
@@ -1,0 +1,10 @@
+# Safety
+
+- The destination number is operator-owned config (`HOTLINE_PHONE`, E.164), never hardcoded; it is validated against `HOTLINE_REGION`'s country code and refuses unmapped region mappings unless explicitly overridden.
+- Live dialing requires per-run operator confirmation (`--yes`); a one-time configuration never places calls on its own. `--dry-run` previews filter decisions without dialing.
+- Consent is explicit: the skill calls the person who configured it, nobody else. Never call businesses, third parties, or numbers found in feed content.
+- One call per bounty key, ever — and only after CALL-E confirms the call actually started (`run_id` returned). Refused or schema-drifted runs are logged as failures and retried later; `call_started: "unknown"` must not be retried with a new plan, it is finished through the documented `calle call recover` flow.
+- Silence is the default: amount threshold, credibility grade (strict A/B), and known freshness must all pass, and every accept/reject decision is appended to the audit log (`hotline_log.jsonl`).
+- Every run follows the documented plan → confirm-token → run flow through the official `calle` CLI; a non-zero CLI exit or refused run is a failure, never recorded as a placed call. Plan and confirmation tokens are never logged or committed.
+- Report outcomes honestly: an unanswered or mis-routed call is a failure, not a success. Never fabricate transcript content or completion status.
+- Keep call records out of version control: no run IDs, phone numbers, recordings, transcripts, or raw status payloads in commits, issues, or pull requests.


### PR DESCRIPTION
## Contribution Area
Agent Skills (`skills/`)

## What is this
**bounty-hotline** — a feed-watch + filter + one-off-call skill: it watches a live feed of GitHub bounty-labeled issues, filters farm spam (amount ≥ threshold, repo credibility A/B, freshness < 48h, per-bounty dedupe), and places a **real CALL-E phone call** to the consenting developer when a worth-answering bounty appears — reading repo, issue and dollar amount aloud.

## Why it belongs here
- Wraps the standard one-off CALL-E call workflow in a client-owned watch loop (scheduler-agnostic, cron-friendly)
- Safety-first: recipient number is env config, never code; one call per bounty ever; full append-only audit log; explicit consent required
- Ships with the required `references/safety.md` and `references/examples.md`, and documents a keep-raw-call-artifacts-out-of-repositories policy

## Reference implementation
Complete runnable implementation (MIT): https://github.com/shamanov39-dev/bounty-hotline
Built for the CALL-E: Your Code Is Calling hackathon.