### PR TITLE
feat(apps): add table-rescue cascade coordinator and capacity-backfill skill

### DIFF
--- a/apps/python/table-rescue/.gitignore
+++ b/apps/python/table-rescue/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/apps/python/table-rescue/.gitignore
+++ b/apps/python/table-rescue/.gitignore
@@ -5,3 +5,8 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+
+# Working data and run state may contain real phone numbers - never commit
+state/
+data/reservations.jsonl
+data/waitlist.jsonl

--- a/apps/python/table-rescue/.gitignore
+++ b/apps/python/table-rescue/.gitignore
@@ -10,3 +10,4 @@ build/
 state/
 data/reservations.jsonl
 data/waitlist.jsonl
+data/authorized_destinations.jsonl

--- a/apps/python/table-rescue/.gitignore
+++ b/apps/python/table-rescue/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.hypothesis/
 *.egg-info/
 dist/
 build/

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -1,4 +1,103 @@
 # table-rescue
 
 Cascade coordinator that recovers cancelled restaurant tables with CALL-E phone calls.
-Documentation for setup, side effects, and cancellation is added before the pull request.
+It confirms reservations before service, and when a guest cancels, it offers the freed
+table to waitlist guests in priority order until someone accepts.
+
+Dry-run is the default. Live calls require an explicit `--live` flag and always run
+inside a call budget.
+
+## How it works
+
+1. Confirm phase: call each `PENDING_CONFIRM` reservation; the agent ends every call by
+   stating an `OUTCOME:` token (CONFIRMED, CANCELLED, RESCHEDULED, NO_ANSWER).
+2. Cascade phase: for each cancelled slot, call matching waitlist entries (consent,
+   WAITING status, party size within tolerance, slot inside their window) in priority
+   order until one ACCEPTED. The slot is marked RECOVERED.
+3. Writeback: reservations and waitlist files are rewritten atomically, every decision
+   is appended to the run audit log, and a masked staff report is written.
+
+## Safety model
+
+- Dry-run by default: outcomes come from `data/fixtures/dry_run_outcomes.jsonl`; no
+  network access.
+- Live calls need `--live` plus a `--max-calls` budget (default 10). The engine stops
+  before dialing once the budget is exhausted.
+- Consent: records with `consent: false` are never dialled (audited as
+  SKIPPED_NO_CONSENT).
+- Idempotency: reruns with the same `--run-id` skip already-dialled targets
+  (SKIPPED_DUPLICATE).
+- Cancel: `table-rescue cancel --run-id <id>` marks the run cancelled; later
+  invocations with the same run id refuse to dial.
+- Call window: live calls are refused outside `--call-window-start/end`
+  (default 09:00-21:00 local).
+- All sample phone numbers are fictional reserved numbers; reports mask numbers to the
+  last two digits.
+
+## Setup
+
+Requires Python 3.10+. The CALL-E CLI is only needed for live calls.
+
+```bash
+cd apps/python/table-rescue
+python -m venv .venv
+source .venv/Scripts/activate   # Windows Git Bash; use .venv/bin/activate on POSIX
+pip install -e ".[dev]"
+```
+
+For live calls, install and log in to the CALL-E CLI (npm package `@call-e/cli`):
+
+```bash
+npm install -g @call-e/cli
+calle auth login --base-url https://seleven-mcp-sg.airudder.com --channel openagent_oauth
+```
+
+## Usage
+
+Dry-run (no calls):
+
+```bash
+cp data/reservations.sample.jsonl data/reservations.jsonl
+cp data/waitlist.sample.jsonl data/waitlist.jsonl
+table-rescue run --run-id smoke-1
+```
+
+Live (real calls through CALL-E MCP Streamable HTTP using the CALL-E CLI token cache):
+
+```bash
+table-rescue run --run-id live-1 --live --max-calls 6
+```
+
+Cancel a run:
+
+```bash
+table-rescue cancel --run-id live-1
+```
+
+## Side effects
+
+- Live mode places real outbound phone calls through CALL-E and consumes call credit.
+- Live mode reads the CALL-E CLI token cache (`~/.calle-mcp/cli`); the app never stores
+  credentials.
+- The app rewrites `data/reservations.jsonl` and `data/waitlist.jsonl` in place and
+  writes `state/runs/<run-id>/audit.jsonl` plus `state/runs/<run-id>/report.md`.
+
+## Credential handling
+
+Access tokens are read from the CALL-E CLI token cache at call time, held in memory
+only, and never written to app state or logs.
+
+## Tests
+
+```bash
+python -m pytest
+```
+
+The default suite is a dry-run/fake path: no CALL-E credentials, no network, no real
+calls. Live verification is opt-in: run one small `--live --max-calls 1` run against a
+phone you control.
+
+## Limitations
+
+- Cascade runs only for reservations cancelled during the same run.
+- One retry per no-answer target (`--no-answer-retries`).

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -15,7 +15,8 @@ inside a call budget.
    WAITING status, party size within tolerance, slot inside their window) in priority
    order until one ACCEPTED. The slot is marked RECOVERED.
 3. Writeback: reservations and waitlist files are rewritten atomically, every decision
-   is appended to the run audit log, and a masked staff report is written.
+   is appended to the run audit log, and a masked staff report is written, optionally
+   with a protected-revenue estimate (`--avg-check-per-guest`).
 
 ## Safety model
 
@@ -25,6 +26,8 @@ inside a call budget.
   before dialing once the budget is exhausted.
 - Consent: records with `consent: false` are never dialled (audited as
   SKIPPED_NO_CONSENT).
+- Disclosure by design: every call goal instructs the agent to identify itself as an
+  automated assistant before proceeding.
 - Idempotency: reruns with the same `--run-id` skip already-dialled targets
   (SKIPPED_DUPLICATE).
 - Cancel: `table-rescue cancel --run-id <id>` marks the run cancelled; later
@@ -59,7 +62,7 @@ Dry-run (no calls):
 ```bash
 cp data/reservations.sample.jsonl data/reservations.jsonl
 cp data/waitlist.sample.jsonl data/waitlist.jsonl
-table-rescue run --run-id smoke-1
+table-rescue run --run-id smoke-1 --avg-check-per-guest 25
 ```
 
 Live (real calls through CALL-E MCP Streamable HTTP using the CALL-E CLI token cache):
@@ -102,13 +105,15 @@ phone you control.
 - **The problem is measurable revenue loss.** Restaurant seats are perishable inventory:
   an empty table at 8pm is inventory gone forever. Cornell's restaurant revenue
   management research treats no-shows and overbooking as core levers of restaurant
-  revenue ([Kimes et al., Cornell Center for Hospitality Research](https://ecommons.cornell.edu/bitstreams/56f1b36d-beb8-42fb-aeea-9fdb59be6c29/download)).
-- **Proactive reminder calls work.** Systematic reviews consistently find reminder calls
-  and messages reduce no-shows and improve attendance
-  ([McLean et al. 2016](https://pmc.ncbi.nlm.nih.gov/articles/PMC4831598/);
-  [Al-Turbag et al. 2026 meta-analysis](https://jhmhp.amegroups.org/article/view/10215/html)),
-  and live conversational calls outperform one-way automated reminders in some settings
-  ([Parikh et al. 2010, American Journal of Medicine](https://www.amjmed.com/article/S0002-9343(10)00108-7/fulltext)).
+  revenue ([Kimes 2004, Cornell Center for Hospitality Research](https://ecommons.cornell.edu/entities/publication/779ca191-03a2-4abe-8e4b-2de7fdd4f7ff)).
+- **Proactive reminder calls work.** Systematic reviews consistently find reminders
+  improve attendance across modalities
+  ([Gurol-Urganci et al. 2013, Cochrane review](https://pubmed.ncbi.nlm.nih.gov/24310741/);
+  [McLean et al. 2016](https://pmc.ncbi.nlm.nih.gov/articles/PMC4831598/)). Simple
+  one-way reminders are the floor, not the ceiling: McLean et al. find "reminder plus"
+  designs that enable a response outperform bare reminders, and in one outpatient study
+  live conversational reminders beat automated ones
+  ([Parikh et al. 2010, American Journal of Medicine](https://pubmed.ncbi.nlm.nih.gov/20569761/)).
   A conversational agent that can actually accept "move it to 8pm" as an answer is the
   natural next step of that evidence.
 - **Consent-first is a legal requirement, not a nicety.** The FCC's 2024 declaratory
@@ -119,7 +124,7 @@ phone you control.
 - **Structured results need a protocol plus a fallback.** Structured-output techniques
   improve machine-readability of LLM responses but do not guarantee semantic validity;
   empirical studies document failure modes such as well-formed but wrong or missing
-  fields ([arXiv empirical study](https://arxiv.org/html/2606.09395v1)). The OUTCOME
+  fields ([Song et al. 2026, arXiv:2606.09395](https://arxiv.org/abs/2606.09395)). The OUTCOME
   token protocol, keyword fallback, and ERROR escalation are a pragmatic
   trust-but-verify design for the same problem on voice summaries.
 - **Idempotency keys and budgets are proven reliability patterns.** Duplicate-call
@@ -127,10 +132,36 @@ phone you control.
   call budget is a circuit-breaker against runaway automation.
 - **Escalate ambiguity to humans.** No-answer and error targets get exactly one retry,
   then a staff escalation in the report - human-in-the-loop practice for consequential
-  automated actions, in the spirit of disclosure-by-design popularized by early
-  phone-calling agents ([Google Duplex disclosure debate, 2018](https://www.theverge.com/2018/5/10/17342414/google-duplex-ai-assistant-voice-calling-identify-itself-update)).
+  automated actions, in the spirit of disclosure-by-design that the first
+  consumer phone-calling agent adopted after public debate ([Google Duplex, 2018](https://research.google/blog/google-duplex-an-ai-system-for-accomplishing-real-world-tasks-over-the-phone/)).
 
 ## Limitations
 
 - Cascade runs only for reservations cancelled during the same run.
 - One retry per no-answer target (`--no-answer-retries`).
+
+## References
+
+1. Kimes, S. E. (2004). _Restaurant Revenue Management_. Cornell Center for Hospitality
+   Research Reports 4(2).
+   https://ecommons.cornell.edu/entities/publication/779ca191-03a2-4abe-8e4b-2de7fdd4f7ff
+2. Gurol-Urganci, I., de Jongh, T., Vodopivec-Jamsek, V., Atun, R., & Car, J. (2013).
+   _Mobile phone messaging reminders for attendance at healthcare appointments._
+   Cochrane Database of Systematic Reviews, CD007458.
+   https://pubmed.ncbi.nlm.nih.gov/24310741/
+3. McLean, S., Booth, A., Gee, M., Salway, S., Cobb, M., Bhanbhro, S., & Nancarrow, S.
+   (2016). _Appointment reminder systems are effective but not optimal._ Patient
+   Preference and Adherence. https://pmc.ncbi.nlm.nih.gov/articles/PMC4831598/
+4. Parikh, A., Gupta, K., Wilson, A. C., Fields, K., Cosgrove, N. M., & Kostis, J. B.
+   (2010). _The effectiveness of outpatient appointment reminder systems in reducing
+   no-show rates._ American Journal of Medicine 123(6), 542-548.
+   https://pubmed.ncbi.nlm.nih.gov/20569761/
+5. Federal Communications Commission (2024). _Declaratory Ruling FCC 24-17: AI-generated
+   voices in robocalls are "artificial" under the TCPA._
+   https://docs.fcc.gov/public/attachments/FCC-24-17A1.pdf
+6. Song, Y., Rajput, P., Sun, T., Ezzini, S., Bissyande, T. F., & Klein, J. (2026).
+   _Empirical Study for Structured Output Control in LLMs for Software Engineering._
+   arXiv:2606.09395. https://arxiv.org/abs/2606.09395
+7. Google Research (2018). _Google Duplex: An AI System for Accomplishing Real-World
+   Tasks Over the Phone._
+   https://research.google/blog/google-duplex-an-ai-system-for-accomplishing-real-world-tasks-over-the-phone/

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -85,6 +85,16 @@ table-rescue cancel --run-id live-1
 - The app rewrites `data/reservations.jsonl` and `data/waitlist.jsonl` in place and
   writes `state/runs/<run-id>/audit.jsonl` plus `state/runs/<run-id>/report.md`.
 
+## Where the data comes from
+
+The JSONL files are the integration boundary, not a product UI: restaurants keep their
+waitlist and reservations wherever they live today - a booking platform (OpenTable,
+Resy), the POS, or a shared sheet - and any export or API poll that maps those records
+into the documented schema (see the skill's `io-schemas.md`) feeds the cascade. The
+consent flag is captured by staff when a guest joins the waitlist; guests without
+consent are skipped and audited. Native connectors (booking-platform writebacks,
+n8n/Dify plugins) are the natural next step.
+
 ## Credential handling
 
 Access tokens are read from the CALL-E CLI token cache at call time, held in memory

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -97,6 +97,39 @@ The default suite is a dry-run/fake path: no CALL-E credentials, no network, no 
 calls. Live verification is opt-in: run one small `--live --max-calls 1` run against a
 phone you control.
 
+## Design rationale and evidence
+
+- **The problem is measurable revenue loss.** Restaurant seats are perishable inventory:
+  an empty table at 8pm is inventory gone forever. Cornell's restaurant revenue
+  management research treats no-shows and overbooking as core levers of restaurant
+  revenue ([Kimes et al., Cornell Center for Hospitality Research](https://ecommons.cornell.edu/bitstreams/56f1b36d-beb8-42fb-aeea-9fdb59be6c29/download)).
+- **Proactive reminder calls work.** Systematic reviews consistently find reminder calls
+  and messages reduce no-shows and improve attendance
+  ([McLean et al. 2016](https://pmc.ncbi.nlm.nih.gov/articles/PMC4831598/);
+  [Al-Turbag et al. 2026 meta-analysis](https://jhmhp.amegroups.org/article/view/10215/html)),
+  and live conversational calls outperform one-way automated reminders in some settings
+  ([Parikh et al. 2010, American Journal of Medicine](https://www.amjmed.com/article/S0002-9343(10)00108-7/fulltext)).
+  A conversational agent that can actually accept "move it to 8pm" as an answer is the
+  natural next step of that evidence.
+- **Consent-first is a legal requirement, not a nicety.** The FCC's 2024 declaratory
+  ruling holds that AI-generated voices in outbound calls fall under the TCPA's
+  "artificial voice" provisions, which require prior express consent
+  ([FCC 24-17](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)).
+  The consent flag, masked reports, and call-window guard implement this position.
+- **Structured results need a protocol plus a fallback.** Structured-output techniques
+  improve machine-readability of LLM responses but do not guarantee semantic validity;
+  empirical studies document failure modes such as well-formed but wrong or missing
+  fields ([arXiv empirical study](https://arxiv.org/html/2606.09395v1)). The OUTCOME
+  token protocol, keyword fallback, and ERROR escalation are a pragmatic
+  trust-but-verify design for the same problem on voice summaries.
+- **Idempotency keys and budgets are proven reliability patterns.** Duplicate-call
+  prevention mirrors idempotency-key practice in payment APIs, and the stop-before-dial
+  call budget is a circuit-breaker against runaway automation.
+- **Escalate ambiguity to humans.** No-answer and error targets get exactly one retry,
+  then a staff escalation in the report - human-in-the-loop practice for consequential
+  automated actions, in the spirit of disclosure-by-design popularized by early
+  phone-calling agents ([Google Duplex disclosure debate, 2018](https://www.theverge.com/2018/5/10/17342414/google-duplex-ai-assistant-voice-calling-identify-itself-update)).
+
 ## Limitations
 
 - Cascade runs only for reservations cancelled during the same run.

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -1,0 +1,4 @@
+# table-rescue
+
+Cascade coordinator that recovers cancelled restaurant tables with CALL-E phone calls.
+Documentation for setup, side effects, and cancellation is added before the pull request.

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -74,6 +74,11 @@ npm install -g @call-e/cli
 calle auth login --base-url https://seleven-mcp-sg.airudder.com --channel openagent_oauth
 ```
 
+Live runs also need a region and an operator-curated allowlist: put every real
+destination phone (exact E.164 string) in `data/authorized_destinations.jsonl`
+(copy `data/authorized_destinations.sample.jsonl` for the format), then run
+`table-rescue preflight` to validate everything before dialing.
+
 ## Usage
 
 Dry-run (no calls):
@@ -84,10 +89,12 @@ cp data/waitlist.sample.jsonl data/waitlist.jsonl
 table-rescue run --run-id smoke-1 --avg-check-per-guest 25
 ```
 
-Live (real calls through CALL-E MCP Streamable HTTP using the CALL-E CLI token cache):
+Live (real calls through CALL-E MCP Streamable HTTP using the CALL-E CLI token
+cache; requires `--region` and every destination present in
+`data/authorized_destinations.jsonl` - see Setup and the Safety model):
 
 ```bash
-table-rescue run --run-id live-1 --live --max-calls 6
+table-rescue run --run-id live-1 --live --region VN --max-calls 6
 ```
 
 Validate every live prerequisite without placing any call:

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -20,22 +20,41 @@ inside a call budget.
 
 ## Safety model
 
-- Dry-run by default: outcomes come from `data/fixtures/dry_run_outcomes.jsonl`; no
-  network access.
-- Live calls need `--live` plus a `--max-calls` budget (default 10). The engine stops
-  before dialing once the budget is exhausted.
-- Consent: records with `consent: false` are never dialled (audited as
-  SKIPPED_NO_CONSENT).
-- Disclosure by design: every call goal instructs the agent to identify itself as an
-  automated assistant before proceeding.
-- Idempotency: reruns with the same `--run-id` skip already-dialled targets
-  (SKIPPED_DUPLICATE).
-- Cancel: `table-rescue cancel --run-id <id>` marks the run cancelled; later
-  invocations with the same run id refuse to dial.
-- Call window: live calls are refused outside `--call-window-start/end`
-  (default 09:00-21:00 local).
-- All sample phone numbers are fictional reserved numbers; reports mask numbers to the
-  last two digits.
+Every guard lives in `table_rescue/safety.py` and is enforced by code, not
+configuration.
+
+| Threat | Control | Reviewer item |
+| --- | --- | --- |
+| Misdirected live dials | Region-aware E.164 validation at load time; per-region calling code and national length checks; reserved fictional NANP numbers (555 block) can never be dialed live | 1 |
+| Unauthorized destinations | Operator-curated `data/authorized_destinations.jsonl` allowlist keyed on the exact E.164 string; a printed manifest requires typed confirmation before the first call; every dial re-checks authorization | 1 |
+| Credential exfiltration | The MCP origin is pinned to `https://seleven-mcp-sg.airudder.com`; `--base-url` values outside the allowlist (including any `http://` origin) are rejected before any network call, including `calle auth` | 2 |
+| Double-booking after an uncertain call | Outcomes are classified from the explicit `OUTCOME:` token only, per leg family; prose keywords are informational hints; NO_ANSWER/UNCERTAIN/ERROR mark the target NEEDS_REVIEW and stop the run (exit code 2) before anyone else is called | 3 |
+| Run continuation | `table-rescue resume --run-id <id>` retries only NEEDS_REVIEW/pending targets after human review; settled targets are never re-dialed; operator-cancelled runs refuse resume | 3 |
+
+Exit codes: `0` success, `2` reconciliation required, `3` budget exhausted,
+`1` other errors. `table-rescue preflight` validates every live prerequisite
+without placing calls (`--json` for CI).
+
+### Verification matrix
+
+| Reviewer concern | Proof |
+| --- | --- |
+| "models accept arbitrary strings" | `tests/test_models.py::test_reservation_from_line_rejects_non_e164_phone` |
+| "bundled non-reserved sample numbers can reach the live path" | `tests/test_safety.py::TestFictionalBlock`, `tests/test_cli.py::test_run_live_fictional_number_never_reaches_dial` |
+| "region-aware E.164 validation" | `tests/test_safety.py::TestRegionRules` |
+| "exact operator authorization" | `tests/test_safety.py::TestRunSafety`, `tests/test_cli.py::test_run_live_aborts_on_missing_authorization` |
+| "no credential to arbitrary/insecure origin" | `tests/test_calle_client.py::test_mcp_client_rejects_foreign_origin`, `tests/test_safety.py::TestOrigin` |
+| "no-answer and ambiguous outcomes must stop" | `tests/test_engine.py::test_waitlist_no_answer_never_advances_to_next_recipient`, `e2e/test_full_run.py::test_uncertain_outcome_stops_run_and_never_conflicts` |
+| "no conflicting offer after an uncertain call" | `tests/test_calle_client.py::test_map_terminal_status_token_only_decisions`, `tests/test_calle_client.py::test_prose_without_token_is_never_decisive` |
+
+Dry-run by default: outcomes come from `data/fixtures/dry_run_outcomes.jsonl`; no
+network access. Other standing guards: live calls need `--live` plus a `--max-calls`
+budget (default 10) and stay inside `--call-window-start/end` (default 09:00-21:00
+local); records with `consent: false` are never dialled (SKIPPED_NO_CONSENT); every
+call goal instructs the agent to identify itself as an automated assistant; reruns
+with the same `--run-id` skip already-dialled targets (SKIPPED_DUPLICATE);
+`table-rescue cancel --run-id <id>` marks a run cancelled and later invocations
+refuse to dial; reports mask numbers to the last two digits.
 
 ## Setup
 
@@ -71,6 +90,24 @@ Live (real calls through CALL-E MCP Streamable HTTP using the CALL-E CLI token c
 table-rescue run --run-id live-1 --live --max-calls 6
 ```
 
+Validate every live prerequisite without placing any call:
+
+```bash
+table-rescue preflight --data-dir data --region VN
+```
+
+Machine-readable (CI):
+
+```bash
+table-rescue preflight --data-dir data --region VN --json
+```
+
+After a run stops with NEEDS REVIEW (exit code 2), review the report, then:
+
+```bash
+table-rescue resume --run-id run-20260910-190000 --data-dir data
+```
+
 Cancel a run:
 
 ```bash
@@ -98,7 +135,9 @@ n8n/Dify plugins) are the natural next step.
 ## Credential handling
 
 Access tokens are read from the CALL-E CLI token cache at call time, held in memory
-only, and never written to app state or logs.
+only, and never written to app state or logs. Tokens are sent only to the pinned
+official MCP origin (`https://seleven-mcp-sg.airudder.com`); any other `--base-url`
+is rejected before any network call.
 
 ## Tests
 
@@ -131,24 +170,29 @@ phone you control.
   "artificial voice" provisions, which require prior express consent
   ([FCC 24-17](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)).
   The consent flag, masked reports, and call-window guard implement this position.
-- **Structured results need a protocol plus a fallback.** Structured-output techniques
+- **Structured results need a protocol, not prose.** Structured-output techniques
   improve machine-readability of LLM responses but do not guarantee semantic validity;
   empirical studies document failure modes such as well-formed but wrong or missing
-  fields ([Song et al. 2026, arXiv:2606.09395](https://arxiv.org/abs/2606.09395)). The OUTCOME
-  token protocol, keyword fallback, and ERROR escalation are a pragmatic
-  trust-but-verify design for the same problem on voice summaries.
+  fields ([Song et al. 2026, arXiv:2606.09395](https://arxiv.org/abs/2606.09395)). Outcomes are
+  classified from the explicit `OUTCOME:` token only: a prose-only summary stops the
+  run for review (UNCERTAIN), and keyword hints from the transcript appear in the
+  report for the human reviewer. This is a pragmatic trust-but-verify design for the
+  same problem on voice summaries.
 - **Idempotency keys and budgets are proven reliability patterns.** Duplicate-call
   prevention mirrors idempotency-key practice in payment APIs, and the stop-before-dial
   call budget is a circuit-breaker against runaway automation.
 - **Escalate ambiguity to humans.** No-answer and error targets get exactly one retry,
-  then a staff escalation in the report - human-in-the-loop practice for consequential
+  then the run stops (exit code 2) with the target marked NEEDS_REVIEW for a staff
+  escalation in the report - human-in-the-loop practice for consequential
   automated actions, in the spirit of disclosure-by-design that the first
   consumer phone-calling agent adopted after public debate ([Google Duplex, 2018](https://research.google/blog/google-duplex-an-ai-system-for-accomplishing-real-world-tasks-over-the-phone/)).
 
 ## Limitations
 
 - Cascade runs only for reservations cancelled during the same run.
-- One retry per no-answer target (`--no-answer-retries`).
+- One retry per no-answer target (`--no-answer-retries`); afterwards the target is
+  marked NEEDS_REVIEW and the run stops with exit code 2 and a Needs review report
+  section - uncertain outcomes never advance the cascade on their own.
 
 ## References
 

--- a/apps/python/table-rescue/README.md
+++ b/apps/python/table-rescue/README.md
@@ -54,7 +54,9 @@ local); records with `consent: false` are never dialled (SKIPPED_NO_CONSENT); ev
 call goal instructs the agent to identify itself as an automated assistant; reruns
 with the same `--run-id` skip already-dialled targets (SKIPPED_DUPLICATE);
 `table-rescue cancel --run-id <id>` marks a run cancelled and later invocations
-refuse to dial; reports mask numbers to the last two digits.
+refuse to dial; reports, live manifests, and error messages mask phone numbers to
+the last two digits, and provider summaries/errors are sanitized before any
+print or persistence.
 
 ## Setup
 
@@ -188,18 +190,20 @@ phone you control.
 - **Idempotency keys and budgets are proven reliability patterns.** Duplicate-call
   prevention mirrors idempotency-key practice in payment APIs, and the stop-before-dial
   call budget is a circuit-breaker against runaway automation.
-- **Escalate ambiguity to humans.** No-answer and error targets get exactly one retry,
-  then the run stops (exit code 2) with the target marked NEEDS_REVIEW for a staff
-  escalation in the report - human-in-the-loop practice for consequential
-  automated actions, in the spirit of disclosure-by-design that the first
+- **Escalate ambiguity to humans.** The first no-answer or error target stops the
+  run (exit code 2) with the target marked NEEDS_REVIEW for a staff escalation in
+  the report; the same recipient is never redialed automatically - human-in-the-loop
+  practice for consequential automated actions, in the spirit of
+  disclosure-by-design that the first
   consumer phone-calling agent adopted after public debate ([Google Duplex, 2018](https://research.google/blog/google-duplex-an-ai-system-for-accomplishing-real-world-tasks-over-the-phone/)).
 
 ## Limitations
 
 - Cascade runs only for reservations cancelled during the same run.
-- One retry per no-answer target (`--no-answer-retries`); afterwards the target is
-  marked NEEDS_REVIEW and the run stops with exit code 2 and a Needs review report
-  section - uncertain outcomes never advance the cascade on their own.
+- The first no-answer marks the target NEEDS_REVIEW and stops the run with exit
+  code 2 and a Needs review report section - uncertain outcomes never advance the
+  cascade and the same recipient is never auto-redialed; continue only via
+  `table-rescue resume` after review.
 
 ## References
 

--- a/apps/python/table-rescue/data/authorized_destinations.sample.jsonl
+++ b/apps/python/table-rescue/data/authorized_destinations.sample.jsonl
@@ -1,0 +1,6 @@
+{"phone": "+15550101", "name": "Fictional Guest One", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}
+{"phone": "+15550102", "name": "Fictional Guest Two", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}
+{"phone": "+15550103", "name": "Fictional Guest Three", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}
+{"phone": "+15550111", "name": "Fictional Waitlist One", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}
+{"phone": "+15550112", "name": "Fictional Waitlist Two", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}
+{"phone": "+15550113", "name": "Fictional Waitlist Three", "authorized_by": "sample-operator", "authorized_at": "2026-09-07T00:00:00+07:00"}

--- a/apps/python/table-rescue/data/fixtures/dry_run_outcomes.jsonl
+++ b/apps/python/table-rescue/data/fixtures/dry_run_outcomes.jsonl
@@ -1,0 +1,5 @@
+{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, "notes": "guest cannot make it tonight"}
+{"target_id": "R-002", "status": "CONFIRMED", "new_slot": null, "notes": "see you then"}
+{"target_id": "W-001", "status": "DECLINED", "new_slot": null, "notes": "already booked elsewhere"}
+{"target_id": "W-003", "status": "ACCEPTED", "new_slot": null, "notes": "we will take the table"}
+{"target_id": "DEFAULT", "status": "NO_ANSWER", "new_slot": null, "notes": "nobody picked up"}

--- a/apps/python/table-rescue/data/reservations.sample.jsonl
+++ b/apps/python/table-rescue/data/reservations.sample.jsonl
@@ -1,0 +1,3 @@
+{"booking_id": "R-001", "name": "Fictional Guest One", "phone": "+15550101", "party_size": 4, "slot": "2026-09-10T19:00:00+07:00", "consent": true, "status": "PENDING_CONFIRM"}
+{"booking_id": "R-002", "name": "Fictional Guest Two", "phone": "+15550102", "party_size": 2, "slot": "2026-09-10T18:30:00+07:00", "consent": true, "status": "PENDING_CONFIRM"}
+{"booking_id": "R-003", "name": "Fictional Guest Three", "phone": "+15550103", "party_size": 6, "slot": "2026-09-10T20:00:00+07:00", "consent": false, "status": "PENDING_CONFIRM"}

--- a/apps/python/table-rescue/data/waitlist.sample.jsonl
+++ b/apps/python/table-rescue/data/waitlist.sample.jsonl
@@ -1,0 +1,3 @@
+{"entry_id": "W-001", "name": "Fictional Waitlist One", "phone": "+15550111", "party_size": 4, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 1, "consent": true, "status": "WAITING"}
+{"entry_id": "W-002", "name": "Fictional Waitlist Two", "phone": "+15550112", "party_size": 2, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 2, "consent": true, "status": "WAITING"}
+{"entry_id": "W-003", "name": "Fictional Waitlist Three", "phone": "+15550113", "party_size": 4, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 3, "consent": true, "status": "WAITING"}

--- a/apps/python/table-rescue/e2e/test_full_run.py
+++ b/apps/python/table-rescue/e2e/test_full_run.py
@@ -57,3 +57,7 @@ def test_full_dry_run_recovers_cancelled_table(tmp_path):
     assert skipped[0]["target_id"] == "R-003"
     report = (state_dir / "runs" / "e2e-1" / "report.md").read_text(encoding="utf-8")
     assert "Slots recovered: 1" in report
+    assert "Calls placed: 4" in report
+    # The staff report must show the declined waitlist offer, not just the
+    # accepted one (regression: fill_slot used to swallow non-accepted outcomes).
+    assert "| W-001 |" in report and "DECLINED" in report

--- a/apps/python/table-rescue/e2e/test_full_run.py
+++ b/apps/python/table-rescue/e2e/test_full_run.py
@@ -41,11 +41,19 @@ def test_full_dry_run_recovers_cancelled_table(tmp_path):
         for row in read_jsonl(data_dir / "waitlist.jsonl")
     }
     assert waitlist_statuses["W-001"] == "DECLINED"
+    assert waitlist_statuses["W-002"] == "WAITING"
     assert waitlist_statuses["W-003"] == "ACCEPTED"
     audit = read_jsonl(state_dir / "runs" / "e2e-1" / "audit.jsonl")
     dialed = [row for row in audit if row["status"] in DIALLED]
     assert len(dialed) == 4
+    assert [(row["target_id"], row["status"]) for row in dialed] == [
+        ("R-001", "CANCELLED"),
+        ("W-001", "DECLINED"),
+        ("W-003", "ACCEPTED"),
+        ("R-002", "CONFIRMED"),
+    ]
     skipped = [row for row in audit if row["status"] == "SKIPPED_NO_CONSENT"]
     assert len(skipped) == 1
+    assert skipped[0]["target_id"] == "R-003"
     report = (state_dir / "runs" / "e2e-1" / "report.md").read_text(encoding="utf-8")
     assert "Slots recovered: 1" in report

--- a/apps/python/table-rescue/e2e/test_full_run.py
+++ b/apps/python/table-rescue/e2e/test_full_run.py
@@ -1,0 +1,51 @@
+import shutil
+from pathlib import Path
+
+from table_rescue.cli import main
+from table_rescue.stores import read_jsonl
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+DIALLED = {"CONFIRMED", "CANCELLED", "RESCHEDULED", "NO_ANSWER", "ACCEPTED", "DECLINED"}
+
+
+def test_full_dry_run_recovers_cancelled_table(tmp_path):
+    data_dir = tmp_path / "data"
+    (data_dir / "fixtures").mkdir(parents=True)
+    shutil.copy(APP_ROOT / "data" / "reservations.sample.jsonl", data_dir / "reservations.jsonl")
+    shutil.copy(APP_ROOT / "data" / "waitlist.sample.jsonl", data_dir / "waitlist.jsonl")
+    shutil.copy(
+        APP_ROOT / "data" / "fixtures" / "dry_run_outcomes.jsonl",
+        data_dir / "fixtures" / "dry_run_outcomes.jsonl",
+    )
+    state_dir = tmp_path / "state"
+    exit_code = main(
+        [
+            "run",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(state_dir),
+            "--run-id", "e2e-1",
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
+        ]
+    )
+    assert exit_code == 0
+    statuses = {
+        row["booking_id"]: row["status"]
+        for row in read_jsonl(data_dir / "reservations.jsonl")
+    }
+    assert statuses["R-001"] == "RECOVERED"
+    assert statuses["R-002"] == "CONFIRMED"
+    assert statuses["R-003"] == "PENDING_CONFIRM"
+    waitlist_statuses = {
+        row["entry_id"]: row["status"]
+        for row in read_jsonl(data_dir / "waitlist.jsonl")
+    }
+    assert waitlist_statuses["W-001"] == "DECLINED"
+    assert waitlist_statuses["W-003"] == "ACCEPTED"
+    audit = read_jsonl(state_dir / "runs" / "e2e-1" / "audit.jsonl")
+    dialed = [row for row in audit if row["status"] in DIALLED]
+    assert len(dialed) == 4
+    skipped = [row for row in audit if row["status"] == "SKIPPED_NO_CONSENT"]
+    assert len(skipped) == 1
+    report = (state_dir / "runs" / "e2e-1" / "report.md").read_text(encoding="utf-8")
+    assert "Slots recovered: 1" in report

--- a/apps/python/table-rescue/e2e/test_full_run.py
+++ b/apps/python/table-rescue/e2e/test_full_run.py
@@ -61,3 +61,41 @@ def test_full_dry_run_recovers_cancelled_table(tmp_path):
     # The staff report must show the declined waitlist offer, not just the
     # accepted one (regression: fill_slot used to swallow non-accepted outcomes).
     assert "| W-001 |" in report and "DECLINED" in report
+
+
+def test_uncertain_outcome_stops_run_and_never_conflicts(tmp_path):
+    data_dir = tmp_path / "data"
+    (data_dir / "fixtures").mkdir(parents=True)
+    shutil.copy(APP_ROOT / "data" / "reservations.sample.jsonl", data_dir / "reservations.jsonl")
+    shutil.copy(APP_ROOT / "data" / "waitlist.sample.jsonl", data_dir / "waitlist.jsonl")
+    (data_dir / "fixtures" / "dry_run_outcomes.jsonl").write_text(
+        '{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, "notes": "cannot make it"}\n'
+        '{"target_id": "W-001", "status": "UNCERTAIN", "new_slot": null, '
+        '"notes": "line went quiet", "uncertainty_reason": "PROVIDER_FAILED"}\n',
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    exit_code = main(
+        [
+            "run",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(state_dir),
+            "--run-id", "e2e-stop",
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
+        ]
+    )
+    assert exit_code == 2
+    audit = read_jsonl(state_dir / "runs" / "e2e-stop" / "audit.jsonl")
+    dialed = [row["target_id"] for row in audit]
+    # W-002 and W-003 must never be offered the slot after W-001's uncertain call.
+    assert dialed == ["R-001", "W-001"]
+    waitlist_statuses = {
+        row["entry_id"]: row["status"]
+        for row in read_jsonl(data_dir / "waitlist.jsonl")
+    }
+    assert waitlist_statuses["W-001"] == "NEEDS_REVIEW"
+    assert waitlist_statuses["W-002"] == "WAITING"
+    report = (state_dir / "runs" / "e2e-stop" / "report.md").read_text(encoding="utf-8")
+    assert "Needs review" in report
+    assert "PROVIDER_FAILED" in report

--- a/apps/python/table-rescue/pyproject.toml
+++ b/apps/python/table-rescue/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "table-rescue"
+version = "0.1.0"
+description = "Cascade coordinator that recovers cancelled restaurant tables via CALL-E waitlist calls"
+requires-python = ">=3.10"
+dependencies = ["fastmcp"]
+
+[project.optional-dependencies]
+dev = ["pytest", "hypothesis"]
+
+[project.scripts]
+table-rescue = "table_rescue.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["table_rescue*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "e2e"]

--- a/apps/python/table-rescue/table_rescue/__init__.py
+++ b/apps/python/table-rescue/table_rescue/__init__.py
@@ -1,0 +1,1 @@
+"""Table Rescue: cascade coordinator that recovers cancelled tables via CALL-E."""

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -29,6 +29,12 @@ TERMINAL_STATUSES = {
 }
 OUTCOME_RE = re.compile(r"\bOUTCOME:\s*([A-Z_]+)\b", re.IGNORECASE)
 
+# plan_call can report ready_to_run=false transiently when the callee was just
+# called (observed live: back-to-back calls to the same number). Retry with a
+# pause before giving up.
+PLAN_RETRY_ATTEMPTS = 3
+PLAN_RETRY_DELAY_SECONDS = 10.0
+
 # Last-resort keyword hints when the agent omits the OUTCOME token. Order matters:
 # negative/definitive verbs are checked before the affirmative "confirm".
 KEYWORD_FALLBACKS: tuple[tuple[str, CallStatus], ...] = (
@@ -161,6 +167,8 @@ class McpCallClient:
         language: str | None = None,
         poll_interval_seconds: float = 10.0,
         poll_timeout_seconds: float = 900.0,
+        plan_retry_attempts: int = PLAN_RETRY_ATTEMPTS,
+        plan_retry_delay_seconds: float = PLAN_RETRY_DELAY_SECONDS,
         client_factory: Callable[[], Any] | None = None,
     ):
         self.base_url = base_url.rstrip("/")
@@ -172,6 +180,8 @@ class McpCallClient:
         self.language = language
         self.poll_interval_seconds = poll_interval_seconds
         self.poll_timeout_seconds = poll_timeout_seconds
+        self.plan_retry_attempts = plan_retry_attempts
+        self.plan_retry_delay_seconds = plan_retry_delay_seconds
         self._client_factory = client_factory
 
     def _run_calle_json(self, args: list[str]) -> dict[str, Any]:
@@ -234,11 +244,9 @@ class McpCallClient:
         if self.language:
             arguments["language"] = self.language
         async with factory() as client:
-            plan = await self._call_tool(client, "plan_call", arguments)
-            plan_id = plan.get("plan_id")
-            confirm_token = plan.get("confirm_token")
-            if not plan.get("ready_to_run") or not plan_id or not confirm_token:
-                raise RuntimeError(f"plan_call not ready for target {request.target_id}")
+            plan = await self._plan_with_retry(client, arguments, request.target_id)
+            plan_id = plan["plan_id"]
+            confirm_token = plan["confirm_token"]
             run = await self._call_tool(
                 client, "run_call", {"plan_id": plan_id, "confirm_token": confirm_token}
             )
@@ -248,6 +256,31 @@ class McpCallClient:
                     f"run_call returned no run_id for target {request.target_id}"
                 )
             return await self._poll(client, request, call_run_id)
+
+    async def _plan_with_retry(
+        self,
+        client: Any,
+        arguments: dict[str, Any],
+        target_id: str,
+    ) -> dict[str, Any]:
+        attempts = self.plan_retry_attempts
+        delay_seconds = self.plan_retry_delay_seconds
+        plan: dict[str, Any] = {}
+        for attempt in range(attempts):
+            plan = await self._call_tool(client, "plan_call", arguments)
+            if (
+                plan.get("ready_to_run")
+                and plan.get("plan_id")
+                and plan.get("confirm_token")
+            ):
+                return plan
+            if attempt < attempts - 1:
+                await asyncio.sleep(delay_seconds)
+        detail = json.dumps(plan, default=str)[:300]
+        raise RuntimeError(
+            f"plan_call not ready for target {target_id} "
+            f"after {attempts} attempts: {detail}"
+        )
 
     def _default_factory(self, token: str) -> Callable[[], Any]:
         def build():

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -3,6 +3,7 @@ import asyncio
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -111,6 +112,22 @@ def compact_summary(summary: Any) -> str | None:
     return " ".join(str(summary).split())[:200]
 
 
+def extract_post_summary(payload: dict[str, Any]) -> str | None:
+    """Read the post-call summary from a get_call_run payload.
+
+    CALL-E nests the summary under "result" (post_summary mirrors summary);
+    tolerate a flat payload as well.
+    """
+    result_block = payload.get("result")
+    if not isinstance(result_block, dict):
+        result_block = {}
+    return (
+        payload.get("post_summary")
+        or result_block.get("post_summary")
+        or result_block.get("summary")
+    )
+
+
 class DryRunClient:
     """Returns fixture outcomes keyed by target_id; never touches the network."""
 
@@ -171,6 +188,11 @@ class McpCallClient:
             str(Path(self.cache_root).expanduser()),
             "--json",
         ]
+        # npm installs the CLI as a .cmd shim on Windows; resolve the real
+        # executable so subprocess can launch it without shell=True.
+        resolved = shutil.which(command[0])
+        if resolved:
+            command[0] = resolved
         completed = subprocess.run(command, capture_output=True, text=True, check=False)
         if completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()
@@ -261,7 +283,7 @@ class McpCallClient:
             payload = await self._call_tool(client, "get_call_run", {"run_id": call_run_id})
             status = str(payload.get("status") or "").upper()
             if status in TERMINAL_STATUSES:
-                summary = payload.get("post_summary")
+                summary = extract_post_summary(payload)
                 return CallOutcome(
                     run_id=request.run_id,
                     target_id=request.target_id,

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -106,3 +106,154 @@ class DryRunClient:
                 f"no dry-run fixture for target {request.target_id} and no DEFAULT row"
             )
         return CallOutcome.from_payload(request.run_id, request.target_id, payload)
+
+
+class McpCallClient:
+    """Places real calls through CALL-E MCP Streamable HTTP.
+
+    The calle CLI owns login and the token cache (same pattern as
+    apps/python/batch-runner): plan_call -> run_call -> get_call_run polling.
+    """
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        channel: str = DEFAULT_CHANNEL,
+        cache_root: str = DEFAULT_CACHE_ROOT,
+        calle_command: str = "calle",
+        region: str | None = None,
+        language: str | None = None,
+        poll_interval_seconds: float = 10.0,
+        poll_timeout_seconds: float = 900.0,
+        client_factory: Callable[[], Any] | None = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.channel = channel
+        self.server_url = f"{self.base_url}/mcp/{channel.strip().lower() or DEFAULT_CHANNEL}"
+        self.cache_root = cache_root
+        self.calle_command = calle_command
+        self.region = region
+        self.language = language
+        self.poll_interval_seconds = poll_interval_seconds
+        self.poll_timeout_seconds = poll_timeout_seconds
+        self._client_factory = client_factory
+
+    def _run_calle_json(self, args: list[str]) -> dict[str, Any]:
+        command = [
+            *self.calle_command.split(),
+            *args,
+            "--base-url",
+            self.base_url,
+            "--channel",
+            self.channel,
+            "--server-url",
+            self.server_url,
+            "--cache-root",
+            str(Path(self.cache_root).expanduser()),
+            "--json",
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(f"calle command failed: {' '.join(command)}\n{detail}")
+        parsed = json.loads(completed.stdout)
+        if not isinstance(parsed, dict):
+            raise RuntimeError("calle command did not return a JSON object")
+        return parsed
+
+    def ensure_access_token(self) -> str:
+        status = self._run_calle_json(["auth", "status"])
+        if not status.get("usable"):
+            raise RuntimeError(
+                "CALL-E CLI is not logged in. Run: "
+                f"{self.calle_command} auth login --base-url {self.base_url} "
+                f"--channel {self.channel} --server-url {self.server_url} "
+                f"--cache-root {self.cache_root}"
+            )
+        cache_path = status.get("cache_path") or self._fallback_cache_path()
+        document = json.loads(Path(cache_path).expanduser().read_text(encoding="utf-8"))
+        access_token = (document.get("token") or {}).get("access_token")
+        if not access_token:
+            raise RuntimeError(f"token cache at {cache_path} has no access token")
+        return access_token
+
+    def _fallback_cache_path(self) -> str:
+        digest = hashlib.md5(self.server_url.encode("utf-8")).hexdigest()
+        return str(Path(self.cache_root).expanduser() / digest / "token.json")
+
+    def place_call(self, request: CallRequest) -> CallOutcome:
+        return asyncio.run(self._execute(request))
+
+    async def _execute(self, request: CallRequest) -> CallOutcome:
+        token = self.ensure_access_token()
+        factory = self._client_factory or self._default_factory(token)
+        arguments: dict[str, Any] = {"to_phones": [request.phone], "goal": request.goal}
+        if self.region:
+            arguments["region"] = self.region
+        if self.language:
+            arguments["language"] = self.language
+        async with factory() as client:
+            plan = await self._call_tool(client, "plan_call", arguments)
+            plan_id = plan.get("plan_id")
+            confirm_token = plan.get("confirm_token")
+            if not plan.get("ready_to_run") or not plan_id or not confirm_token:
+                raise RuntimeError(f"plan_call not ready for target {request.target_id}")
+            run = await self._call_tool(
+                client, "run_call", {"plan_id": plan_id, "confirm_token": confirm_token}
+            )
+            call_run_id = run.get("run_id")
+            if not call_run_id:
+                raise RuntimeError(
+                    f"run_call returned no run_id for target {request.target_id}"
+                )
+            return await self._poll(client, request, call_run_id)
+
+    def _default_factory(self, token: str) -> Callable[[], Any]:
+        def build():
+            from fastmcp import Client
+            from fastmcp.client.transports import StreamableHttpTransport
+
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "X-Call-E-Integration": INTEGRATION_HEADER,
+            }
+            return Client(StreamableHttpTransport(self.server_url, headers=headers))
+
+        return build
+
+    async def _call_tool(
+        self, client: Any, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = await client.call_tool(name=name, arguments=arguments)
+        structured = getattr(result, "structured_content", None)
+        if isinstance(structured, dict):
+            return structured
+        structured = getattr(result, "structuredContent", None)
+        if isinstance(structured, dict):
+            return structured
+        raise RuntimeError(f"{name} returned no structured content")
+
+    async def _poll(
+        self, client: Any, request: CallRequest, call_run_id: str
+    ) -> CallOutcome:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.poll_timeout_seconds
+        while True:
+            payload = await self._call_tool(client, "get_call_run", {"run_id": call_run_id})
+            status = str(payload.get("status") or "").upper()
+            if status in TERMINAL_STATUSES:
+                summary = payload.get("post_summary")
+                return CallOutcome(
+                    run_id=request.run_id,
+                    target_id=request.target_id,
+                    status=map_terminal_status(status, summary),
+                    new_slot=None,
+                    notes=compact_summary(summary),
+                    transcript_ref=call_run_id,
+                    call_cost_id=call_run_id,
+                )
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"call {call_run_id} for target {request.target_id} did not finish in time"
+                )
+            await asyncio.sleep(self.poll_interval_seconds)

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -1,0 +1,108 @@
+"""CALL-E clients: fixture dry-run client and live MCP Streamable HTTP client."""
+import asyncio
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from .models import CallOutcome, CallStatus
+from .stores import read_jsonl
+
+DEFAULT_BASE_URL = "https://seleven-mcp-sg.airudder.com"
+DEFAULT_CHANNEL = "openagent_oauth"
+DEFAULT_CACHE_ROOT = "~/.calle-mcp/cli"
+INTEGRATION_HEADER = "apps/python/table-rescue/0.0.0"
+TERMINAL_STATUSES = {
+    "BUSY",
+    "CANCELED",
+    "CANCELLED",
+    "COMPLETED",
+    "DECLINED",
+    "EXPIRED",
+    "FAILED",
+    "NO_ANSWER",
+    "VOICEMAIL",
+}
+OUTCOME_RE = re.compile(r"OUTCOME:\s*([A-Z_]+)")
+
+CONFIRM_GOAL = (
+    "You are calling {name} about their restaurant reservation for a party of "
+    "{party_size} at {slot}. Ask whether they will keep the booking, cancel it, or move "
+    "it to another time; if they want another time, agree on a new slot. End the call by "
+    "stating exactly one of: OUTCOME: CONFIRMED, OUTCOME: CANCELLED, OUTCOME: RESCHEDULED, "
+    "or OUTCOME: NO_ANSWER."
+)
+
+OFFER_GOAL = (
+    "You are calling {name} from a restaurant waitlist. A table for a party of "
+    "{party_size} just became available at {slot}. Ask whether they accept the table. "
+    "End the call by stating exactly one of: OUTCOME: ACCEPTED, OUTCOME: DECLINED, or "
+    "OUTCOME: NO_ANSWER."
+)
+
+
+@dataclass(frozen=True)
+class CallRequest:
+    run_id: str
+    target_id: str
+    phone: str
+    goal: str
+
+
+class CallClient(Protocol):
+    def place_call(self, request: CallRequest) -> CallOutcome: ...
+
+
+def build_confirm_goal(name: str, party_size: int, slot: str) -> str:
+    return CONFIRM_GOAL.format(name=name, party_size=party_size, slot=slot)
+
+
+def build_offer_goal(name: str, party_size: int, slot: str) -> str:
+    return OFFER_GOAL.format(name=name, party_size=party_size, slot=slot)
+
+
+def parse_outcome(summary: str | None) -> CallStatus | None:
+    if not summary:
+        return None
+    match = OUTCOME_RE.search(summary)
+    if not match:
+        return None
+    try:
+        return CallStatus(match.group(1))
+    except ValueError:
+        return None
+
+
+def map_terminal_status(status: str, summary: str | None) -> CallStatus:
+    if status == "COMPLETED":
+        return parse_outcome(summary) or CallStatus.ERROR
+    if status in {"NO_ANSWER", "BUSY", "VOICEMAIL"}:
+        return CallStatus.NO_ANSWER
+    if status == "DECLINED":
+        return CallStatus.DECLINED
+    return CallStatus.ERROR
+
+
+def compact_summary(summary: Any) -> str | None:
+    if not summary:
+        return None
+    return " ".join(str(summary).split())[:200]
+
+
+class DryRunClient:
+    """Returns fixture outcomes keyed by target_id; never touches the network."""
+
+    def __init__(self, fixture_path: str | Path):
+        self._outcomes = {row["target_id"]: row for row in read_jsonl(fixture_path)}
+        self._default = self._outcomes.get("DEFAULT")
+
+    def place_call(self, request: CallRequest) -> CallOutcome:
+        payload = self._outcomes.get(request.target_id, self._default)
+        if payload is None:
+            raise KeyError(
+                f"no dry-run fixture for target {request.target_id} and no DEFAULT row"
+            )
+        return CallOutcome.from_payload(request.run_id, request.target_id, payload)

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -39,18 +39,22 @@ KEYWORD_FALLBACKS: tuple[tuple[str, CallStatus], ...] = (
 )
 
 CONFIRM_GOAL = (
-    "You are calling {name} about their restaurant reservation for a party of "
-    "{party_size} at {slot}. Ask whether they will keep the booking, cancel it, or move "
-    "it to another time; if they want another time, agree on a new slot. End the call by "
-    "stating exactly one of: OUTCOME: CONFIRMED, OUTCOME: CANCELLED, OUTCOME: RESCHEDULED, "
-    "or OUTCOME: NO_ANSWER."
+    "You are an automated calling assistant working for a restaurant. Begin the call "
+    "by identifying yourself as an automated assistant and asking whether it is a good "
+    "time to talk. You are calling {name} about their restaurant reservation for a "
+    "party of {party_size} at {slot}. Ask whether they will keep the booking, cancel "
+    "it, or move it to another time; if they want another time, agree on a new slot. "
+    "End the call by stating exactly one of: OUTCOME: CONFIRMED, OUTCOME: CANCELLED, "
+    "OUTCOME: RESCHEDULED, or OUTCOME: NO_ANSWER."
 )
 
 OFFER_GOAL = (
-    "You are calling {name} from a restaurant waitlist. A table for a party of "
-    "{party_size} just became available at {slot}. Ask whether they accept the table. "
-    "End the call by stating exactly one of: OUTCOME: ACCEPTED, OUTCOME: DECLINED, or "
-    "OUTCOME: NO_ANSWER."
+    "You are an automated calling assistant working for a restaurant. Begin the call "
+    "by identifying yourself as an automated assistant and asking whether it is a good "
+    "time to talk. You are calling {name} from the restaurant waitlist. A table for a "
+    "party of {party_size} just became available at {slot}. Ask whether they accept "
+    "the table. End the call by stating exactly one of: OUTCOME: ACCEPTED, OUTCOME: "
+    "DECLINED, or OUTCOME: NO_ANSWER."
 )
 
 

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -26,7 +26,17 @@ TERMINAL_STATUSES = {
     "NO_ANSWER",
     "VOICEMAIL",
 }
-OUTCOME_RE = re.compile(r"OUTCOME:\s*([A-Z_]+)")
+OUTCOME_RE = re.compile(r"\bOUTCOME:\s*([A-Z_]+)\b", re.IGNORECASE)
+
+# Last-resort keyword hints when the agent omits the OUTCOME token. Order matters:
+# negative/definitive verbs are checked before the affirmative "confirm".
+KEYWORD_FALLBACKS: tuple[tuple[str, CallStatus], ...] = (
+    ("cancel", CallStatus.CANCELLED),
+    ("reschedul", CallStatus.RESCHEDULED),
+    ("accept", CallStatus.ACCEPTED),
+    ("declin", CallStatus.DECLINED),
+    ("confirm", CallStatus.CONFIRMED),
+)
 
 CONFIRM_GOAL = (
     "You are calling {name} about their restaurant reservation for a party of "
@@ -65,15 +75,20 @@ def build_offer_goal(name: str, party_size: int, slot: str) -> str:
 
 
 def parse_outcome(summary: str | None) -> CallStatus | None:
+    """Parse the OUTCOME token; fall back to keyword hints before giving up."""
     if not summary:
         return None
     match = OUTCOME_RE.search(summary)
-    if not match:
-        return None
-    try:
-        return CallStatus(match.group(1))
-    except ValueError:
-        return None
+    if match:
+        try:
+            return CallStatus(match.group(1).upper())
+        except ValueError:
+            pass
+    lowered = summary.lower()
+    for keyword, status in KEYWORD_FALLBACKS:
+        if keyword in lowered:
+            return status
+    return None
 
 
 def map_terminal_status(status: str, summary: str | None) -> CallStatus:

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 
 from .models import CallOutcome, CallStatus
-from .safety import validate_origin
+from .safety import sanitize_text, validate_origin
 from .stores import read_jsonl
 
 DEFAULT_BASE_URL = "https://seleven-mcp-sg.airudder.com"
@@ -237,7 +237,8 @@ class McpCallClient:
             command[0] = resolved
         completed = subprocess.run(command, capture_output=True, text=True, check=False)
         if completed.returncode != 0:
-            detail = completed.stderr.strip() or completed.stdout.strip()
+            # Provider stderr can quote dialed numbers; sanitize before raise.
+            detail = sanitize_text(completed.stderr.strip() or completed.stdout.strip())
             raise RuntimeError(f"calle command failed: {' '.join(command)}\n{detail}")
         parsed = json.loads(completed.stdout)
         if not isinstance(parsed, dict):
@@ -308,7 +309,7 @@ class McpCallClient:
                 return plan
             if attempt < attempts - 1:
                 await asyncio.sleep(delay_seconds)
-        detail = json.dumps(plan, default=str)[:300]
+        detail = sanitize_text(json.dumps(plan, default=str))[:300]
         raise RuntimeError(
             f"plan_call not ready for target {target_id} "
             f"after {attempts} attempts: {detail}"

--- a/apps/python/table-rescue/table_rescue/calle_client.py
+++ b/apps/python/table-rescue/table_rescue/calle_client.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 
 from .models import CallOutcome, CallStatus
+from .safety import validate_origin
 from .stores import read_jsonl
 
 DEFAULT_BASE_URL = "https://seleven-mcp-sg.airudder.com"
@@ -29,21 +30,24 @@ TERMINAL_STATUSES = {
 }
 OUTCOME_RE = re.compile(r"\bOUTCOME:\s*([A-Z_]+)\b", re.IGNORECASE)
 
+LEG_CONFIRM = "confirm"
+LEG_OFFER = "offer"
+
+# A status only counts as decisive on the leg whose goal template asked for
+# it; anything else is UNCERTAIN and stops the run for reconciliation.
+CONFIRM_FAMILY = frozenset(
+    {CallStatus.CONFIRMED, CallStatus.CANCELLED, CallStatus.RESCHEDULED}
+)
+OFFER_FAMILY = frozenset({CallStatus.ACCEPTED, CallStatus.DECLINED})
+
+# Prose hints are recorded for the human reviewer; they never classify.
+HINT_KEYWORDS: tuple[str, ...] = ("cancel", "reschedul", "accept", "declin", "confirm")
+
 # plan_call can report ready_to_run=false transiently when the callee was just
 # called (observed live: back-to-back calls to the same number). Retry with a
 # pause before giving up.
 PLAN_RETRY_ATTEMPTS = 3
 PLAN_RETRY_DELAY_SECONDS = 10.0
-
-# Last-resort keyword hints when the agent omits the OUTCOME token. Order matters:
-# negative/definitive verbs are checked before the affirmative "confirm".
-KEYWORD_FALLBACKS: tuple[tuple[str, CallStatus], ...] = (
-    ("cancel", CallStatus.CANCELLED),
-    ("reschedul", CallStatus.RESCHEDULED),
-    ("accept", CallStatus.ACCEPTED),
-    ("declin", CallStatus.DECLINED),
-    ("confirm", CallStatus.CONFIRMED),
-)
 
 CONFIRM_GOAL = (
     "You are an automated calling assistant working for a restaurant. Begin the call "
@@ -71,6 +75,7 @@ class CallRequest:
     target_id: str
     phone: str
     goal: str
+    leg: str = LEG_CONFIRM
 
 
 class CallClient(Protocol):
@@ -85,31 +90,57 @@ def build_offer_goal(name: str, party_size: int, slot: str) -> str:
     return OFFER_GOAL.format(name=name, party_size=party_size, slot=slot)
 
 
-def parse_outcome(summary: str | None) -> CallStatus | None:
-    """Parse the OUTCOME token; fall back to keyword hints before giving up."""
+def parse_outcome_token(summary: str | None) -> CallStatus | None:
+    """Read the explicit OUTCOME token; no keyword fallback, ever."""
     if not summary:
         return None
     match = OUTCOME_RE.search(summary)
-    if match:
-        try:
-            return CallStatus(match.group(1).upper())
-        except ValueError:
-            pass
+    if not match:
+        return None
+    try:
+        return CallStatus(match.group(1).upper())
+    except ValueError:
+        return None
+
+
+def keyword_hint(summary: str | None) -> str | None:
+    """Informational prose hint for the staff report; never a decision."""
+    if not summary:
+        return None
     lowered = summary.lower()
-    for keyword, status in KEYWORD_FALLBACKS:
+    for keyword in HINT_KEYWORDS:
         if keyword in lowered:
-            return status
+            return keyword
     return None
 
 
-def map_terminal_status(status: str, summary: str | None) -> CallStatus:
-    if status == "COMPLETED":
-        return parse_outcome(summary) or CallStatus.ERROR
+def map_terminal_status(status: str, summary: str | None, leg: str) -> CallStatus:
     if status in {"NO_ANSWER", "BUSY", "VOICEMAIL"}:
         return CallStatus.NO_ANSWER
     if status == "DECLINED":
         return CallStatus.DECLINED
-    return CallStatus.ERROR
+    if status == "COMPLETED":
+        token = parse_outcome_token(summary)
+        family = CONFIRM_FAMILY if leg == LEG_CONFIRM else OFFER_FAMILY
+        if token is not None and (
+            token in family or token is CallStatus.NO_ANSWER
+        ):
+            return token
+        return CallStatus.UNCERTAIN
+    return CallStatus.UNCERTAIN
+
+
+def uncertainty_reason_for(status: str, summary: str | None, leg: str) -> str | None:
+    """Explain why an outcome is uncertain, for the Needs Review report."""
+    if status == "COMPLETED":
+        token = parse_outcome_token(summary)
+        family = CONFIRM_FAMILY if leg == LEG_CONFIRM else OFFER_FAMILY
+        if token is None:
+            return "UNPARSEABLE_SUMMARY"
+        if not (token in family or token is CallStatus.NO_ANSWER):
+            return "WRONG_FAMILY_TOKEN"
+        return None
+    return "PROVIDER_FAILED"
 
 
 def compact_summary(summary: Any) -> str | None:
@@ -171,6 +202,7 @@ class McpCallClient:
         plan_retry_delay_seconds: float = PLAN_RETRY_DELAY_SECONDS,
         client_factory: Callable[[], Any] | None = None,
     ):
+        validate_origin(base_url)
         self.base_url = base_url.rstrip("/")
         self.channel = channel
         self.server_url = f"{self.base_url}/mcp/{channel.strip().lower() or DEFAULT_CHANNEL}"
@@ -317,14 +349,25 @@ class McpCallClient:
             status = str(payload.get("status") or "").upper()
             if status in TERMINAL_STATUSES:
                 summary = extract_post_summary(payload)
+                mapped = map_terminal_status(status, summary, request.leg)
+                notes = compact_summary(summary)
+                if mapped is CallStatus.UNCERTAIN:
+                    hint = keyword_hint(summary)
+                    if hint:
+                        notes = f"{notes} [hint: {hint}]" if notes else f"[hint: {hint}]"
                 return CallOutcome(
                     run_id=request.run_id,
                     target_id=request.target_id,
-                    status=map_terminal_status(status, summary),
+                    status=mapped,
                     new_slot=None,
-                    notes=compact_summary(summary),
+                    notes=notes,
                     transcript_ref=call_run_id,
                     call_cost_id=call_run_id,
+                    uncertainty_reason=(
+                        uncertainty_reason_for(status, summary, request.leg)
+                        if mapped is CallStatus.UNCERTAIN
+                        else None
+                    ),
                 )
             if loop.time() >= deadline:
                 raise TimeoutError(

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -120,9 +120,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             outcome = engine.confirm_reservation(run_id, reservation, now)
             outcomes.append(outcome)
             if outcome.status == CallStatus.CANCELLED:
-                fill = engine.fill_slot(run_id, reservation, waitlist, now)
-                if fill is not None:
-                    outcomes.append(fill)
+                outcomes.extend(engine.fill_slot(run_id, reservation, waitlist, now))
     except BudgetExceededError as error:
         print(f"WARNING: {error}; writing back state collected so far", file=sys.stderr)
         exit_code = 2

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -38,6 +38,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=0,
         help="How much smaller than the slot a waitlist party may be",
     )
+    run.add_argument(
+        "--avg-check-per-guest",
+        type=float,
+        default=None,
+        help="Optional average check per guest used to estimate protected revenue",
+    )
     run.add_argument("--no-answer-retries", type=int, default=1)
     run.add_argument("--call-window-start", default="09:00")
     run.add_argument("--call-window-end", default="21:00")
@@ -125,7 +131,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         data_dir / "reservations.jsonl", [r.to_line() for r in reservations]
     )
     write_jsonl_atomic(data_dir / "waitlist.jsonl", [w.to_line() for w in waitlist])
-    report = render_report(run_id, outcomes, reservations, waitlist)
+    report = render_report(
+        run_id, outcomes, reservations, waitlist,
+        avg_check_per_guest=args.avg_check_per_guest,
+    )
     report_path = audit.run_dir / "report.md"
     report_path.write_text(report, encoding="utf-8")
     print(report)

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -1,0 +1,138 @@
+"""Command line entrypoint."""
+import argparse
+import sys
+from datetime import datetime, time as dt_time
+from pathlib import Path
+
+from .calle_client import DEFAULT_BASE_URL, DEFAULT_CACHE_ROOT, DEFAULT_CHANNEL, DryRunClient, McpCallClient
+from .engine import BudgetExceededError, CascadeEngine, EngineConfig
+from .models import CallOutcome, CallStatus, ReservationStatus
+from .report import render_report
+from .stores import AuditLog, load_reservations, load_waitlist, write_jsonl_atomic
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="table-rescue",
+        description=(
+            "Confirm restaurant reservations and backfill cancelled tables from the "
+            "waitlist via CALL-E. Dry-run by default; --live places real calls."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run", help="Run confirm + cascade phases")
+    run.add_argument("--data-dir", default="data")
+    run.add_argument("--state-dir", default="state")
+    run.add_argument(
+        "--fixture",
+        default=None,
+        help="Dry-run fixture JSONL (default: <data-dir>/fixtures/dry_run_outcomes.jsonl)",
+    )
+    run.add_argument("--run-id", default=None, help="Stable run id; defaults to timestamped")
+    run.add_argument("--live", action="store_true", help="Place real calls (default: dry-run)")
+    run.add_argument("--max-calls", type=int, default=10, help="Live call budget per run")
+    run.add_argument(
+        "--party-size-tolerance",
+        type=int,
+        default=0,
+        help="How much smaller than the slot a waitlist party may be",
+    )
+    run.add_argument("--no-answer-retries", type=int, default=1)
+    run.add_argument("--call-window-start", default="09:00")
+    run.add_argument("--call-window-end", default="21:00")
+    run.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    run.add_argument("--channel", default=DEFAULT_CHANNEL)
+    run.add_argument("--cache-root", default=DEFAULT_CACHE_ROOT)
+    run.add_argument("--calle-command", default="calle")
+    run.add_argument("--region", default=None)
+    run.add_argument("--language", default=None)
+    run.set_defaults(func=cmd_run)
+
+    cancel = subparsers.add_parser("cancel", help="Mark a run as operator-cancelled")
+    cancel.add_argument("--run-id", required=True)
+    cancel.add_argument("--state-dir", default="state")
+    cancel.set_defaults(func=cmd_cancel)
+    return parser
+
+
+def parse_window(value: str) -> dt_time:
+    hour, minute = value.split(":")
+    return dt_time(int(hour), int(minute))
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    data_dir = Path(args.data_dir)
+    state_dir = Path(args.state_dir)
+    run_id = args.run_id or f"run-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    fixture = args.fixture or str(data_dir / "fixtures" / "dry_run_outcomes.jsonl")
+
+    config = EngineConfig(
+        max_calls=args.max_calls,
+        party_size_tolerance=args.party_size_tolerance,
+        no_answer_retries=args.no_answer_retries,
+        call_window_start=parse_window(args.call_window_start),
+        call_window_end=parse_window(args.call_window_end),
+    )
+    reservations = load_reservations(data_dir / "reservations.jsonl")
+    waitlist = load_waitlist(data_dir / "waitlist.jsonl")
+
+    if args.live:
+        client = McpCallClient(
+            base_url=args.base_url,
+            channel=args.channel,
+            cache_root=args.cache_root,
+            calle_command=args.calle_command,
+            region=args.region,
+            language=args.language,
+        )
+    else:
+        client = DryRunClient(fixture)
+
+    audit = AuditLog(state_dir / "runs" / run_id)
+    engine = CascadeEngine(client, audit, config)
+    now = datetime.now().astimezone()
+    outcomes: list[CallOutcome] = []
+    exit_code = 0
+    pending = [r for r in reservations if r.status == ReservationStatus.PENDING_CONFIRM]
+    try:
+        for reservation in pending:
+            outcome = engine.confirm_reservation(run_id, reservation, now)
+            outcomes.append(outcome)
+            if outcome.status == CallStatus.CANCELLED:
+                fill = engine.fill_slot(run_id, reservation, waitlist, now)
+                if fill is not None:
+                    outcomes.append(fill)
+    except BudgetExceededError as error:
+        print(f"WARNING: {error}; writing back state collected so far", file=sys.stderr)
+        exit_code = 2
+
+    write_jsonl_atomic(
+        data_dir / "reservations.jsonl", [r.to_line() for r in reservations]
+    )
+    write_jsonl_atomic(data_dir / "waitlist.jsonl", [w.to_line() for w in waitlist])
+    report = render_report(run_id, outcomes, reservations, waitlist)
+    report_path = audit.run_dir / "report.md"
+    report_path.write_text(report, encoding="utf-8")
+    print(report)
+    print(f"Report: {report_path}")
+    return exit_code
+
+
+def cmd_cancel(args: argparse.Namespace) -> int:
+    audit = AuditLog(Path(args.state_dir) / "runs" / args.run_id)
+    audit.append(
+        CallOutcome(
+            run_id=args.run_id, target_id="-", status=CallStatus.CANCELLED_BY_OPERATOR
+        )
+    )
+    print(
+        f"Run {args.run_id} marked CANCELLED_BY_OPERATOR. "
+        "Later invocations with the same run id refuse to dial."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -74,8 +74,19 @@ def cmd_run(args: argparse.Namespace) -> int:
         call_window_start=parse_window(args.call_window_start),
         call_window_end=parse_window(args.call_window_end),
     )
-    reservations = load_reservations(data_dir / "reservations.jsonl")
-    waitlist = load_waitlist(data_dir / "waitlist.jsonl")
+    reservations_path = data_dir / "reservations.jsonl"
+    waitlist_path = data_dir / "waitlist.jsonl"
+    for missing in (reservations_path, waitlist_path):
+        if not missing.exists():
+            print(
+                f"ERROR: {missing} not found. Copy the samples first, e.g. "
+                "cp data/reservations.sample.jsonl data/reservations.jsonl "
+                "(see README Setup).",
+                file=sys.stderr,
+            )
+            return 1
+    reservations = load_reservations(reservations_path)
+    waitlist = load_waitlist(waitlist_path)
 
     if args.live:
         client = McpCallClient(
@@ -87,6 +98,9 @@ def cmd_run(args: argparse.Namespace) -> int:
             language=args.language,
         )
     else:
+        if not Path(fixture).exists():
+            print(f"ERROR: dry-run fixture {fixture} not found.", file=sys.stderr)
+            return 1
         client = DryRunClient(fixture)
 
     audit = AuditLog(state_dir / "runs" / run_id)
@@ -136,3 +150,7 @@ def cmd_cancel(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -5,9 +5,20 @@ from datetime import datetime, time as dt_time
 from pathlib import Path
 
 from .calle_client import DEFAULT_BASE_URL, DEFAULT_CACHE_ROOT, DEFAULT_CHANNEL, DryRunClient, McpCallClient
-from .engine import BudgetExceededError, CascadeEngine, EngineConfig
+from .engine import (
+    BudgetExceededError,
+    CascadeEngine,
+    EngineConfig,
+    ReconciliationRequiredError,
+)
 from .models import CallOutcome, CallStatus, ReservationStatus
 from .report import render_report
+from .safety import (
+    RunSafety,
+    SafetyViolation,
+    load_authorizations,
+    missing_authorizations,
+)
 from .stores import AuditLog, load_reservations, load_waitlist, write_jsonl_atomic
 
 
@@ -31,6 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--run-id", default=None, help="Stable run id; defaults to timestamped")
     run.add_argument("--live", action="store_true", help="Place real calls (default: dry-run)")
+    run.add_argument("--yes", action="store_true", help="Skip the live manifest confirmation prompt")
     run.add_argument("--max-calls", type=int, default=10, help="Live call budget per run")
     run.add_argument(
         "--party-size-tolerance",
@@ -72,14 +84,6 @@ def cmd_run(args: argparse.Namespace) -> int:
     state_dir = Path(args.state_dir)
     run_id = args.run_id or f"run-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
     fixture = args.fixture or str(data_dir / "fixtures" / "dry_run_outcomes.jsonl")
-
-    config = EngineConfig(
-        max_calls=args.max_calls,
-        party_size_tolerance=args.party_size_tolerance,
-        no_answer_retries=args.no_answer_retries,
-        call_window_start=parse_window(args.call_window_start),
-        call_window_end=parse_window(args.call_window_end),
-    )
     reservations_path = data_dir / "reservations.jsonl"
     waitlist_path = data_dir / "waitlist.jsonl"
     for missing in (reservations_path, waitlist_path):
@@ -93,24 +97,123 @@ def cmd_run(args: argparse.Namespace) -> int:
             return 1
     reservations = load_reservations(reservations_path)
     waitlist = load_waitlist(waitlist_path)
+    return _run_pipeline(
+        args, run_id, reservations, waitlist, state_dir, data_dir, fixture,
+        resumed_from=None, refill_cancelled=False,
+    )
 
-    if args.live:
-        client = McpCallClient(
-            base_url=args.base_url,
-            channel=args.channel,
-            cache_root=args.cache_root,
-            calle_command=args.calle_command,
-            region=args.region,
-            language=args.language,
+
+def _build_config(args: argparse.Namespace) -> EngineConfig:
+    return EngineConfig(
+        max_calls=args.max_calls,
+        party_size_tolerance=args.party_size_tolerance,
+        no_answer_retries=args.no_answer_retries,
+        call_window_start=parse_window(args.call_window_start),
+        call_window_end=parse_window(args.call_window_end),
+    )
+
+
+def _render_manifest(run_id, reservations, waitlist, region, authorizations, max_calls):
+    lines = [
+        f"Live call manifest for run {run_id}",
+        "",
+        f"Region: {region} | Budget: {max_calls} calls | Origin: pinned official MCP endpoint",
+        "",
+        "| Target | Name | Phone | Authorized by |",
+        "| --- | --- | --- | --- |",
+    ]
+    for target in [*reservations, *waitlist]:
+        if not target.consent:
+            continue
+        row = authorizations.get(target.phone, {})
+        target_id = getattr(target, "booking_id", None) or target.entry_id
+        lines.append(
+            f"| {target_id} | {target.name} | {target.phone} | {row.get('authorized_by', '-')} |"
         )
+    lines += [
+        "",
+        "Every destination above passed region-aware E.164 validation and exact "
+        "operator authorization. Fictional NANP numbers can never appear here.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _prepare_safety(args, data_dir, reservations, waitlist, audit, run_id):
+    """Live gates: region, allowlist coverage, manifest confirmation."""
+    if not args.live:
+        return RunSafety(live=False)
+    if not args.region:
+        print("ERROR: --region is required for live runs.", file=sys.stderr)
+        raise SystemExit(1)
+    auth_path = data_dir / "authorized_destinations.jsonl"
+    if not auth_path.exists():
+        print(
+            f"ERROR: {auth_path} not found. Copy data/authorized_destinations.sample.jsonl "
+            "and authorize every live destination first (see README Safety model).",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    try:
+        authorizations = load_authorizations(auth_path)
+    except SafetyViolation as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1)
+    dialable = [r.phone for r in reservations if r.consent]
+    dialable += [w.phone for w in waitlist if w.consent]
+    missing = missing_authorizations(dialable, authorizations)
+    if missing:
+        print(
+            f"ERROR: {len(missing)} dialable destination(s) lack operator authorization:",
+            file=sys.stderr,
+        )
+        for phone in missing:
+            print(f"  {phone}", file=sys.stderr)
+        raise SystemExit(1)
+    manifest = _render_manifest(
+        run_id, reservations, waitlist, args.region, authorizations, args.max_calls
+    )
+    manifest_path = audit.run_dir / f"manifest-{run_id}.txt"
+    manifest_path.write_text(manifest, encoding="utf-8")
+    print(manifest)
+    print(f"Manifest saved: {manifest_path}")
+    if not getattr(args, "yes", False):
+        answer = input("Type yes to place live calls: ")
+        if answer.strip().lower() != "yes":
+            print("Aborted before any call was placed.", file=sys.stderr)
+            raise SystemExit(1)
+    return RunSafety(live=True, region=args.region, authorizations=authorizations)
+
+
+def _run_pipeline(
+    args, run_id, reservations, waitlist, state_dir, data_dir, fixture,
+    resumed_from, refill_cancelled,
+):
+    config = _build_config(args)
+    audit = AuditLog(state_dir / "runs" / run_id)
+    try:
+        safety = _prepare_safety(args, data_dir, reservations, waitlist, audit, run_id)
+    except SystemExit as error:
+        return int(error.code)
+    if args.live:
+        try:
+            client = McpCallClient(
+                base_url=args.base_url,
+                channel=args.channel,
+                cache_root=args.cache_root,
+                calle_command=args.calle_command,
+                region=args.region,
+                language=args.language,
+            )
+        except SafetyViolation as error:
+            print(f"ERROR: {error}", file=sys.stderr)
+            return 1
     else:
         if not Path(fixture).exists():
             print(f"ERROR: dry-run fixture {fixture} not found.", file=sys.stderr)
             return 1
         client = DryRunClient(fixture)
 
-    audit = AuditLog(state_dir / "runs" / run_id)
-    engine = CascadeEngine(client, audit, config)
+    engine = CascadeEngine(client, audit, config, safety=safety)
     now = datetime.now().astimezone()
     outcomes: list[CallOutcome] = []
     exit_code = 0
@@ -121,9 +224,25 @@ def cmd_run(args: argparse.Namespace) -> int:
             outcomes.append(outcome)
             if outcome.status == CallStatus.CANCELLED:
                 outcomes.extend(engine.fill_slot(run_id, reservation, waitlist, now))
+        if refill_cancelled:
+            for reservation in reservations:
+                if reservation.status == ReservationStatus.CANCELLED:
+                    outcomes.extend(engine.fill_slot(run_id, reservation, waitlist, now))
     except BudgetExceededError as error:
         print(f"WARNING: {error}; writing back state collected so far", file=sys.stderr)
+        exit_code = 3
+    except ReconciliationRequiredError as error:
+        outcomes.append(error.outcome)
+        print(f"NEEDS REVIEW: {error}", file=sys.stderr)
+        print(
+            f"Run stopped fail-closed. Review the report, then "
+            f"`table-rescue resume --run-id {run_id}`.",
+            file=sys.stderr,
+        )
         exit_code = 2
+    except SafetyViolation as error:
+        print(f"SAFETY: {error}; no further calls placed", file=sys.stderr)
+        exit_code = 1
 
     write_jsonl_atomic(
         data_dir / "reservations.jsonl", [r.to_line() for r in reservations]
@@ -132,6 +251,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     report = render_report(
         run_id, outcomes, reservations, waitlist,
         avg_check_per_guest=args.avg_check_per_guest,
+        resumed_from=resumed_from,
     )
     report_path = audit.run_dir / "report.md"
     report_path.write_text(report, encoding="utf-8")

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -59,7 +59,6 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional average check per guest used to estimate protected revenue",
     )
-    run.add_argument("--no-answer-retries", type=int, default=1)
     run.add_argument("--call-window-start", default="09:00")
     run.add_argument("--call-window-end", default="21:00")
     run.add_argument("--base-url", default=DEFAULT_BASE_URL)
@@ -100,7 +99,6 @@ def build_parser() -> argparse.ArgumentParser:
     resume.add_argument("--max-calls", type=int, default=10)
     resume.add_argument("--party-size-tolerance", type=int, default=0)
     resume.add_argument("--avg-check-per-guest", type=float, default=None)
-    resume.add_argument("--no-answer-retries", type=int, default=1)
     resume.add_argument("--call-window-start", default="09:00")
     resume.add_argument("--call-window-end", default="21:00")
     resume.add_argument("--base-url", default=DEFAULT_BASE_URL)
@@ -151,7 +149,6 @@ def _build_config(args: argparse.Namespace) -> EngineConfig:
     return EngineConfig(
         max_calls=args.max_calls,
         party_size_tolerance=args.party_size_tolerance,
-        no_answer_retries=args.no_answer_retries,
         call_window_start=parse_window(args.call_window_start),
         call_window_end=parse_window(args.call_window_end),
     )

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -18,6 +18,7 @@ from .safety import (
     RunSafety,
     SafetyViolation,
     load_authorizations,
+    mask_phone,
     missing_authorizations,
     validate_destination,
     validate_origin,
@@ -169,12 +170,15 @@ def _render_manifest(run_id, reservations, waitlist, region, authorizations, max
         row = authorizations.get(target.phone, {})
         target_id = getattr(target, "booking_id", None) or target.entry_id
         lines.append(
-            f"| {target_id} | {target.name} | {target.phone} | {row.get('authorized_by', '-')} |"
+            f"| {target_id} | {target.name} | {mask_phone(target.phone)} | "
+            f"{row.get('authorized_by', '-')} |"
         )
     lines += [
         "",
         "Every destination above passed region-aware E.164 validation and exact "
-        "operator authorization. Fictional NANP numbers can never appear here.",
+        "operator authorization. Fictional NANP numbers can never appear here. "
+        "Phones are masked; match them against your local "
+        "authorized_destinations.jsonl before confirming.",
     ]
     return "\n".join(lines) + "\n"
 
@@ -208,7 +212,7 @@ def _prepare_safety(args, data_dir, reservations, waitlist, audit, run_id):
             file=sys.stderr,
         )
         for phone in missing:
-            print(f"  {phone}", file=sys.stderr)
+            print(f"  {mask_phone(phone)}", file=sys.stderr)
         raise SystemExit(1)
     manifest = _render_manifest(
         run_id, reservations, waitlist, args.region, authorizations, args.max_calls
@@ -409,7 +413,10 @@ def _run_preflight_checks(args: argparse.Namespace, data_dir: Path) -> list[dict
         dialable = [t.phone for t in [*reservations, *waitlist] if t.consent]
         missing = missing_authorizations(dialable, authorizations)
         if missing:
-            raise SafetyViolation("NOT_AUTHORIZED", "missing: " + ", ".join(missing))
+            raise SafetyViolation(
+                "NOT_AUTHORIZED",
+                "missing: " + ", ".join(mask_phone(phone) for phone in missing),
+            )
         return f"{len(dialable)} dialable destinations operator-authorized"
 
     record("operator_authorization", authorization)

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -1,5 +1,6 @@
 """Command line entrypoint."""
 import argparse
+import json
 import sys
 from datetime import datetime, time as dt_time
 from pathlib import Path
@@ -18,6 +19,8 @@ from .safety import (
     SafetyViolation,
     load_authorizations,
     missing_authorizations,
+    validate_destination,
+    validate_origin,
 )
 from .stores import AuditLog, load_reservations, load_waitlist, write_jsonl_atomic
 
@@ -66,6 +69,19 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--region", default=None)
     run.add_argument("--language", default=None)
     run.set_defaults(func=cmd_run)
+
+    preflight = subparsers.add_parser(
+        "preflight", help="Validate everything live runs require, placing no calls"
+    )
+    preflight.add_argument("--data-dir", default="data")
+    preflight.add_argument("--region", default=None, help="Region for live validation")
+    preflight.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    preflight.add_argument("--channel", default=DEFAULT_CHANNEL)
+    preflight.add_argument("--cache-root", default=DEFAULT_CACHE_ROOT)
+    preflight.add_argument("--calle-command", default="calle")
+    preflight.add_argument("--max-calls", type=int, default=10)
+    preflight.add_argument("--json", action="store_true", help="Machine-readable output")
+    preflight.set_defaults(func=cmd_preflight)
 
     cancel = subparsers.add_parser("cancel", help="Mark a run as operator-cancelled")
     cancel.add_argument("--run-id", required=True)
@@ -272,6 +288,92 @@ def cmd_cancel(args: argparse.Namespace) -> int:
         "Later invocations with the same run id refuse to dial."
     )
     return 0
+
+
+def _run_preflight_checks(args: argparse.Namespace, data_dir: Path) -> list[dict]:
+    checks: list[dict] = []
+
+    def record(name: str, fn) -> None:
+        try:
+            detail = fn()
+            checks.append({"name": name, "status": "PASS", "detail": detail or "ok"})
+        except (SafetyViolation, RuntimeError, OSError, ValueError) as error:
+            checks.append(
+                {"name": name, "status": "FAIL", "detail": str(error) or type(error).__name__}
+            )
+
+    reservations_path = data_dir / "reservations.jsonl"
+    waitlist_path = data_dir / "waitlist.jsonl"
+
+    def load_stores():
+        reservations = load_reservations(reservations_path)
+        waitlist = load_waitlist(waitlist_path)
+        return f"{len(reservations) + len(waitlist)} destinations are valid E.164"
+
+    record("destinations_e164", load_stores)
+
+    def region_rules():
+        if not args.region:
+            raise SafetyViolation("MISSING_REGION", "--region is required for live runs")
+        reservations = load_reservations(reservations_path)
+        waitlist = load_waitlist(waitlist_path)
+        for target in [*reservations, *waitlist]:
+            validate_destination(target.phone, region=args.region, live=True)
+        return f"all destinations match region {args.region} rules"
+
+    record("region_rules", region_rules)
+
+    def authorization():
+        auth_path = data_dir / "authorized_destinations.jsonl"
+        authorizations = load_authorizations(auth_path)
+        reservations = load_reservations(reservations_path)
+        waitlist = load_waitlist(waitlist_path)
+        dialable = [t.phone for t in [*reservations, *waitlist] if t.consent]
+        missing = missing_authorizations(dialable, authorizations)
+        if missing:
+            raise SafetyViolation("NOT_AUTHORIZED", "missing: " + ", ".join(missing))
+        return f"{len(dialable)} dialable destinations operator-authorized"
+
+    record("operator_authorization", authorization)
+
+    def origin():
+        validate_origin(args.base_url)
+        return "origin pinned to official MCP endpoint"
+
+    record("origin_pinned", origin)
+
+    def calle_auth():
+        client = McpCallClient(
+            base_url=args.base_url,
+            channel=args.channel,
+            cache_root=args.cache_root,
+            calle_command=args.calle_command,
+        )
+        client.ensure_access_token()
+        return "cached CALL-E token usable"
+
+    record("calle_auth", calle_auth)
+
+    def budget():
+        if args.max_calls < 1:
+            raise SafetyViolation("INVALID_BUDGET", str(args.max_calls))
+        return f"budget {args.max_calls} call(s) per run"
+
+    record("budget_configured", budget)
+    return checks
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    data_dir = Path(args.data_dir)
+    checks = _run_preflight_checks(args, data_dir)
+    ok = all(check["status"] == "PASS" for check in checks)
+    if args.json:
+        print(json.dumps({"ok": ok, "checks": checks}, indent=2))
+    else:
+        for check in checks:
+            print(f"{check['status']} {check['name']}: {check['detail']}")
+        print("Preflight: " + ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -135,8 +135,12 @@ def cmd_run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-    reservations = load_reservations(reservations_path)
-    waitlist = load_waitlist(waitlist_path)
+    try:
+        reservations = load_reservations(reservations_path)
+        waitlist = load_waitlist(waitlist_path)
+    except SafetyViolation as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
     return _run_pipeline(
         args, run_id, reservations, waitlist, state_dir, data_dir, fixture,
         resumed_from=None, refill_cancelled=False,
@@ -332,8 +336,12 @@ def cmd_resume(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    reservations = load_reservations(reservations_path)
-    waitlist = load_waitlist(waitlist_path)
+    try:
+        reservations = load_reservations(reservations_path)
+        waitlist = load_waitlist(waitlist_path)
+    except SafetyViolation as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
     # A human reviewed the stopped run: re-eligible the uncertain targets.
     for reservation in reservations:
         if reservation.status in REVIEWABLE_RESERVATION:

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -307,11 +307,19 @@ REVIEWABLE_WAITLIST = {WaitlistStatus.NEEDS_REVIEW, WaitlistStatus.NO_ANSWER}
 def cmd_resume(args: argparse.Namespace) -> int:
     data_dir = Path(args.data_dir)
     state_dir = Path(args.state_dir)
-    source_audit = AuditLog(state_dir / "runs" / args.run_id)
-    if not source_audit.path.exists():
+    source_audit_path = state_dir / "runs" / args.run_id / "audit.jsonl"
+    if not source_audit_path.exists():
         print(
             f"ERROR: no audit log for run {args.run_id} under "
             f"{state_dir / 'runs'}.",
+            file=sys.stderr,
+        )
+        return 1
+    source_records = AuditLog(state_dir / "runs" / args.run_id).records()
+    if any(row["status"] == "CANCELLED_BY_OPERATOR" for row in source_records):
+        print(
+            f"ERROR: run {args.run_id} was cancelled by the operator; "
+            "resume refused.",
             file=sys.stderr,
         )
         return 1

--- a/apps/python/table-rescue/table_rescue/cli.py
+++ b/apps/python/table-rescue/table_rescue/cli.py
@@ -12,7 +12,7 @@ from .engine import (
     EngineConfig,
     ReconciliationRequiredError,
 )
-from .models import CallOutcome, CallStatus, ReservationStatus
+from .models import CallOutcome, CallStatus, ReservationStatus, WaitlistStatus
 from .report import render_report
 from .safety import (
     RunSafety,
@@ -87,6 +87,30 @@ def build_parser() -> argparse.ArgumentParser:
     cancel.add_argument("--run-id", required=True)
     cancel.add_argument("--state-dir", default="state")
     cancel.set_defaults(func=cmd_cancel)
+
+    resume = subparsers.add_parser(
+        "resume", help="Retry the uncertain/pending targets of a stopped run"
+    )
+    resume.add_argument("--run-id", required=True, help="Source run to resume from")
+    resume.add_argument("--run-id-new", default=None, help="New run id (default: resume-<timestamp>)")
+    resume.add_argument("--data-dir", default="data")
+    resume.add_argument("--state-dir", default="state")
+    resume.add_argument("--fixture", default=None)
+    resume.add_argument("--live", action="store_true")
+    resume.add_argument("--max-calls", type=int, default=10)
+    resume.add_argument("--party-size-tolerance", type=int, default=0)
+    resume.add_argument("--avg-check-per-guest", type=float, default=None)
+    resume.add_argument("--no-answer-retries", type=int, default=1)
+    resume.add_argument("--call-window-start", default="09:00")
+    resume.add_argument("--call-window-end", default="21:00")
+    resume.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    resume.add_argument("--channel", default=DEFAULT_CHANNEL)
+    resume.add_argument("--cache-root", default=DEFAULT_CACHE_ROOT)
+    resume.add_argument("--calle-command", default="calle")
+    resume.add_argument("--region", default=None)
+    resume.add_argument("--language", default=None)
+    resume.add_argument("--yes", action="store_true")
+    resume.set_defaults(func=cmd_resume)
     return parser
 
 
@@ -274,6 +298,47 @@ def _run_pipeline(
     print(report)
     print(f"Report: {report_path}")
     return exit_code
+
+
+REVIEWABLE_RESERVATION = {ReservationStatus.NEEDS_REVIEW, ReservationStatus.NO_ANSWER}
+REVIEWABLE_WAITLIST = {WaitlistStatus.NEEDS_REVIEW, WaitlistStatus.NO_ANSWER}
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    data_dir = Path(args.data_dir)
+    state_dir = Path(args.state_dir)
+    source_audit = AuditLog(state_dir / "runs" / args.run_id)
+    if not source_audit.path.exists():
+        print(
+            f"ERROR: no audit log for run {args.run_id} under "
+            f"{state_dir / 'runs'}.",
+            file=sys.stderr,
+        )
+        return 1
+    reservations_path = data_dir / "reservations.jsonl"
+    waitlist_path = data_dir / "waitlist.jsonl"
+    if not reservations_path.exists() or not waitlist_path.exists():
+        print(
+            "ERROR: data files not found; resume expects the stores written "
+            "by the source run.",
+            file=sys.stderr,
+        )
+        return 1
+    reservations = load_reservations(reservations_path)
+    waitlist = load_waitlist(waitlist_path)
+    # A human reviewed the stopped run: re-eligible the uncertain targets.
+    for reservation in reservations:
+        if reservation.status in REVIEWABLE_RESERVATION:
+            reservation.status = ReservationStatus.PENDING_CONFIRM
+    for entry in waitlist:
+        if entry.status in REVIEWABLE_WAITLIST:
+            entry.status = WaitlistStatus.WAITING
+    run_id = args.run_id_new or f"resume-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    fixture = args.fixture or str(data_dir / "fixtures" / "dry_run_outcomes.jsonl")
+    return _run_pipeline(
+        args, run_id, reservations, waitlist, state_dir, data_dir, fixture,
+        resumed_from=args.run_id, refill_cancelled=True,
+    )
 
 
 def cmd_cancel(args: argparse.Namespace) -> int:

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -1,0 +1,121 @@
+"""Confirm and cascade phases with safety guards."""
+from dataclasses import dataclass
+from datetime import datetime, time as dt_time
+
+from .calle_client import (
+    CallClient,
+    CallRequest,
+    build_confirm_goal,
+    build_offer_goal,
+)
+from .models import (
+    CallOutcome,
+    CallStatus,
+    Reservation,
+    ReservationStatus,
+    WaitlistEntry,
+    WaitlistStatus,
+)
+from .stores import AuditLog
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised before dialing when the live-call budget for a run is exhausted."""
+
+
+@dataclass
+class EngineConfig:
+    max_calls: int = 10
+    party_size_tolerance: int = 0
+    no_answer_retries: int = 1
+    call_window_start: dt_time = dt_time(9, 0)
+    call_window_end: dt_time = dt_time(21, 0)
+
+
+class CascadeEngine:
+    def __init__(
+        self, client: CallClient, audit: AuditLog, config: EngineConfig | None = None
+    ):
+        self.client = client
+        self.audit = audit
+        self.config = config or EngineConfig()
+        self.calls_made = 0
+
+    def _skip(self, run_id: str, target_id: str, status: CallStatus) -> CallOutcome:
+        outcome = CallOutcome(run_id=run_id, target_id=target_id, status=status)
+        self.audit.append(outcome)
+        return outcome
+
+    def _within_window(self, now: datetime) -> bool:
+        return self.config.call_window_start <= now.time() <= self.config.call_window_end
+
+    def _place_or_skip(
+        self,
+        run_id: str,
+        phone: str,
+        target_id: str,
+        consent: bool,
+        goal: str,
+        now: datetime,
+        allow_duplicate: bool = False,
+    ) -> CallOutcome:
+        if self.audit.is_cancelled():
+            return self._skip(run_id, target_id, CallStatus.CANCELLED_BY_OPERATOR)
+        if not consent:
+            return self._skip(run_id, target_id, CallStatus.SKIPPED_NO_CONSENT)
+        if not allow_duplicate and target_id in self.audit.dialed_targets():
+            return self._skip(run_id, target_id, CallStatus.SKIPPED_DUPLICATE)
+        if not self._within_window(now):
+            return self._skip(run_id, target_id, CallStatus.SKIPPED_OUT_OF_WINDOW)
+        if self.calls_made >= self.config.max_calls:
+            raise BudgetExceededError(
+                f"call budget of {self.config.max_calls} exhausted; stopping before dialing"
+            )
+        request = CallRequest(run_id=run_id, target_id=target_id, phone=phone, goal=goal)
+        outcome = self.client.place_call(request)
+        self.calls_made += 1
+        self.audit.append(outcome)
+        return outcome
+
+    def confirm_reservation(
+        self, run_id: str, reservation: Reservation, now: datetime
+    ) -> CallOutcome:
+        goal = build_confirm_goal(
+            reservation.name, reservation.party_size, reservation.slot
+        )
+        outcome = self._place_or_skip(
+            run_id=run_id,
+            phone=reservation.phone,
+            target_id=reservation.booking_id,
+            consent=reservation.consent,
+            goal=goal,
+            now=now,
+        )
+        if (
+            outcome.status == CallStatus.NO_ANSWER
+            and self.config.no_answer_retries > 0
+        ):
+            outcome = self._place_or_skip(
+                run_id=run_id,
+                phone=reservation.phone,
+                target_id=reservation.booking_id,
+                consent=reservation.consent,
+                goal=goal,
+                now=now,
+                allow_duplicate=True,
+            )
+        self._apply_confirm(reservation, outcome)
+        return outcome
+
+    def _apply_confirm(self, reservation: Reservation, outcome: CallOutcome) -> None:
+        transitions = {
+            CallStatus.CONFIRMED: ReservationStatus.CONFIRMED,
+            CallStatus.CANCELLED: ReservationStatus.CANCELLED,
+            CallStatus.RESCHEDULED: ReservationStatus.RESCHEDULED,
+            CallStatus.NO_ANSWER: ReservationStatus.NO_ANSWER,
+        }
+        new_status = transitions.get(outcome.status)
+        if new_status is not None:
+            reservation.status = new_status
+        if outcome.status == CallStatus.RESCHEDULED and outcome.new_slot:
+            reservation.slot = outcome.new_slot

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -145,8 +145,13 @@ class CascadeEngine:
         slot: Reservation,
         waitlist: list[WaitlistEntry],
         now: datetime,
-    ) -> CallOutcome | None:
-        """Offer a freed slot to waitlist candidates in priority order."""
+    ) -> list[CallOutcome]:
+        """Offer a freed slot to waitlist candidates in priority order.
+
+        Returns every outcome placed during the cascade attempt so the staff
+        report shows declined/no-answer offers, not just the accepted one.
+        """
+        placed: list[CallOutcome] = []
         for entry in self.select_candidates(slot, waitlist):
             entry.status = WaitlistStatus.OFFERED
             goal = build_offer_goal(entry.name, entry.party_size, slot.slot)
@@ -158,10 +163,11 @@ class CascadeEngine:
                 goal=goal,
                 now=now,
             )
+            placed.append(outcome)
             if outcome.status == CallStatus.ACCEPTED:
                 entry.status = WaitlistStatus.ACCEPTED
                 slot.status = ReservationStatus.RECOVERED
-                return outcome
+                break
             if outcome.status == CallStatus.DECLINED:
                 entry.status = WaitlistStatus.DECLINED
             elif outcome.status == CallStatus.NO_ANSWER:
@@ -169,4 +175,4 @@ class CascadeEngine:
             else:
                 # Skip outcomes and ERROR: keep the entry on the waitlist.
                 entry.status = WaitlistStatus.WAITING
-        return None
+        return placed

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -119,3 +119,54 @@ class CascadeEngine:
             reservation.status = new_status
         if outcome.status == CallStatus.RESCHEDULED and outcome.new_slot:
             reservation.slot = outcome.new_slot
+
+    def select_candidates(
+        self, slot: Reservation, waitlist: list[WaitlistEntry]
+    ) -> list[WaitlistEntry]:
+        slot_dt = datetime.fromisoformat(slot.slot)
+        candidates: list[WaitlistEntry] = []
+        for entry in waitlist:
+            if entry.status != WaitlistStatus.WAITING or not entry.consent:
+                continue
+            window_start = datetime.fromisoformat(entry.window_start)
+            window_end = datetime.fromisoformat(entry.window_end)
+            if not (window_start <= slot_dt <= window_end):
+                continue
+            gap = slot.party_size - entry.party_size
+            if not (0 <= gap <= self.config.party_size_tolerance):
+                continue
+            candidates.append(entry)
+        candidates.sort(key=lambda entry: entry.priority)
+        return candidates
+
+    def fill_slot(
+        self,
+        run_id: str,
+        slot: Reservation,
+        waitlist: list[WaitlistEntry],
+        now: datetime,
+    ) -> CallOutcome | None:
+        """Offer a freed slot to waitlist candidates in priority order."""
+        for entry in self.select_candidates(slot, waitlist):
+            entry.status = WaitlistStatus.OFFERED
+            goal = build_offer_goal(entry.name, entry.party_size, slot.slot)
+            outcome = self._place_or_skip(
+                run_id=run_id,
+                phone=entry.phone,
+                target_id=entry.entry_id,
+                consent=entry.consent,
+                goal=goal,
+                now=now,
+            )
+            if outcome.status == CallStatus.ACCEPTED:
+                entry.status = WaitlistStatus.ACCEPTED
+                slot.status = ReservationStatus.RECOVERED
+                return outcome
+            if outcome.status == CallStatus.DECLINED:
+                entry.status = WaitlistStatus.DECLINED
+            elif outcome.status == CallStatus.NO_ANSWER:
+                entry.status = WaitlistStatus.NO_ANSWER
+            else:
+                # Skip outcomes and ERROR: keep the entry on the waitlist.
+                entry.status = WaitlistStatus.WAITING
+        return None

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -29,6 +29,10 @@ class BudgetExceededError(RuntimeError):
 class ReconciliationRequiredError(RuntimeError):
     """Raised when an uncertain outcome stops the run for human review."""
 
+    def __init__(self, message: str, outcome: "CallOutcome"):
+        super().__init__(message)
+        self.outcome = outcome
+
 
 UNCERTAIN_OUTCOMES = {
     CallStatus.NO_ANSWER,
@@ -134,7 +138,8 @@ class CascadeEngine:
             raise ReconciliationRequiredError(
                 f"target {reservation.booking_id} returned {outcome.status.value} "
                 f"({outcome.uncertainty_reason or 'no certain result'}); run stopped "
-                "for reconciliation before any further calls"
+                "for reconciliation before any further calls",
+                outcome=outcome,
             )
         self._apply_confirm(reservation, outcome)
         return outcome
@@ -209,7 +214,8 @@ class CascadeEngine:
                     f"waitlist target {entry.entry_id} returned "
                     f"{outcome.status.value} "
                     f"({outcome.uncertainty_reason or 'no certain result'}); "
-                    "cascade stopped before offering the slot to anyone else"
+                    "cascade stopped before offering the slot to anyone else",
+                    outcome=outcome,
                 )
             entry.status = WaitlistStatus.WAITING
         return placed

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from datetime import datetime, time as dt_time
 
 from .calle_client import (
+    LEG_CONFIRM,
+    LEG_OFFER,
     CallClient,
     CallRequest,
     build_confirm_goal,
@@ -16,11 +18,23 @@ from .models import (
     WaitlistEntry,
     WaitlistStatus,
 )
+from .safety import RunSafety
 from .stores import AuditLog
 
 
 class BudgetExceededError(RuntimeError):
     """Raised before dialing when the live-call budget for a run is exhausted."""
+
+
+class ReconciliationRequiredError(RuntimeError):
+    """Raised when an uncertain outcome stops the run for human review."""
+
+
+UNCERTAIN_OUTCOMES = {
+    CallStatus.NO_ANSWER,
+    CallStatus.UNCERTAIN,
+    CallStatus.ERROR,
+}
 
 
 @dataclass
@@ -34,11 +48,16 @@ class EngineConfig:
 
 class CascadeEngine:
     def __init__(
-        self, client: CallClient, audit: AuditLog, config: EngineConfig | None = None
+        self,
+        client: CallClient,
+        audit: AuditLog,
+        config: EngineConfig | None = None,
+        safety: RunSafety | None = None,
     ):
         self.client = client
         self.audit = audit
         self.config = config or EngineConfig()
+        self.safety = safety or RunSafety()
         self.calls_made = 0
 
     def _skip(self, run_id: str, target_id: str, status: CallStatus) -> CallOutcome:
@@ -57,6 +76,7 @@ class CascadeEngine:
         consent: bool,
         goal: str,
         now: datetime,
+        leg: str,
         allow_duplicate: bool = False,
     ) -> CallOutcome:
         if self.audit.is_cancelled():
@@ -71,7 +91,10 @@ class CascadeEngine:
             raise BudgetExceededError(
                 f"call budget of {self.config.max_calls} exhausted; stopping before dialing"
             )
-        request = CallRequest(run_id=run_id, target_id=target_id, phone=phone, goal=goal)
+        self.safety.check_destination(phone)
+        request = CallRequest(
+            run_id=run_id, target_id=target_id, phone=phone, goal=goal, leg=leg
+        )
         outcome = self.client.place_call(request)
         self.calls_made += 1
         self.audit.append(outcome)
@@ -90,6 +113,7 @@ class CascadeEngine:
             consent=reservation.consent,
             goal=goal,
             now=now,
+            leg=LEG_CONFIRM,
         )
         if (
             outcome.status == CallStatus.NO_ANSWER
@@ -102,7 +126,15 @@ class CascadeEngine:
                 consent=reservation.consent,
                 goal=goal,
                 now=now,
+                leg=LEG_CONFIRM,
                 allow_duplicate=True,
+            )
+        if outcome.status in UNCERTAIN_OUTCOMES:
+            reservation.status = ReservationStatus.NEEDS_REVIEW
+            raise ReconciliationRequiredError(
+                f"target {reservation.booking_id} returned {outcome.status.value} "
+                f"({outcome.uncertainty_reason or 'no certain result'}); run stopped "
+                "for reconciliation before any further calls"
             )
         self._apply_confirm(reservation, outcome)
         return outcome
@@ -112,7 +144,6 @@ class CascadeEngine:
             CallStatus.CONFIRMED: ReservationStatus.CONFIRMED,
             CallStatus.CANCELLED: ReservationStatus.CANCELLED,
             CallStatus.RESCHEDULED: ReservationStatus.RESCHEDULED,
-            CallStatus.NO_ANSWER: ReservationStatus.NO_ANSWER,
         }
         new_status = transitions.get(outcome.status)
         if new_status is not None:
@@ -162,6 +193,7 @@ class CascadeEngine:
                 consent=entry.consent,
                 goal=goal,
                 now=now,
+                leg=LEG_OFFER,
             )
             placed.append(outcome)
             if outcome.status == CallStatus.ACCEPTED:
@@ -170,9 +202,14 @@ class CascadeEngine:
                 break
             if outcome.status == CallStatus.DECLINED:
                 entry.status = WaitlistStatus.DECLINED
-            elif outcome.status == CallStatus.NO_ANSWER:
-                entry.status = WaitlistStatus.NO_ANSWER
-            else:
-                # Skip outcomes and ERROR: keep the entry on the waitlist.
-                entry.status = WaitlistStatus.WAITING
+                continue
+            if outcome.status in UNCERTAIN_OUTCOMES:
+                entry.status = WaitlistStatus.NEEDS_REVIEW
+                raise ReconciliationRequiredError(
+                    f"waitlist target {entry.entry_id} returned "
+                    f"{outcome.status.value} "
+                    f"({outcome.uncertainty_reason or 'no certain result'}); "
+                    "cascade stopped before offering the slot to anyone else"
+                )
+            entry.status = WaitlistStatus.WAITING
         return placed

--- a/apps/python/table-rescue/table_rescue/engine.py
+++ b/apps/python/table-rescue/table_rescue/engine.py
@@ -45,7 +45,6 @@ UNCERTAIN_OUTCOMES = {
 class EngineConfig:
     max_calls: int = 10
     party_size_tolerance: int = 0
-    no_answer_retries: int = 1
     call_window_start: dt_time = dt_time(9, 0)
     call_window_end: dt_time = dt_time(21, 0)
 
@@ -81,13 +80,12 @@ class CascadeEngine:
         goal: str,
         now: datetime,
         leg: str,
-        allow_duplicate: bool = False,
     ) -> CallOutcome:
         if self.audit.is_cancelled():
             return self._skip(run_id, target_id, CallStatus.CANCELLED_BY_OPERATOR)
         if not consent:
             return self._skip(run_id, target_id, CallStatus.SKIPPED_NO_CONSENT)
-        if not allow_duplicate and target_id in self.audit.dialed_targets():
+        if target_id in self.audit.dialed_targets():
             return self._skip(run_id, target_id, CallStatus.SKIPPED_DUPLICATE)
         if not self._within_window(now):
             return self._skip(run_id, target_id, CallStatus.SKIPPED_OUT_OF_WINDOW)
@@ -119,20 +117,6 @@ class CascadeEngine:
             now=now,
             leg=LEG_CONFIRM,
         )
-        if (
-            outcome.status == CallStatus.NO_ANSWER
-            and self.config.no_answer_retries > 0
-        ):
-            outcome = self._place_or_skip(
-                run_id=run_id,
-                phone=reservation.phone,
-                target_id=reservation.booking_id,
-                consent=reservation.consent,
-                goal=goal,
-                now=now,
-                leg=LEG_CONFIRM,
-                allow_duplicate=True,
-            )
         if outcome.status in UNCERTAIN_OUTCOMES:
             reservation.status = ReservationStatus.NEEDS_REVIEW
             raise ReconciliationRequiredError(

--- a/apps/python/table-rescue/table_rescue/models.py
+++ b/apps/python/table-rescue/table_rescue/models.py
@@ -1,0 +1,132 @@
+"""Data models for Table Rescue."""
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ReservationStatus(str, Enum):
+    PENDING_CONFIRM = "PENDING_CONFIRM"
+    CONFIRMED = "CONFIRMED"
+    CANCELLED = "CANCELLED"
+    RESCHEDULED = "RESCHEDULED"
+    NO_ANSWER = "NO_ANSWER"
+    RECOVERED = "RECOVERED"
+
+
+class WaitlistStatus(str, Enum):
+    WAITING = "WAITING"
+    OFFERED = "OFFERED"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    NO_ANSWER = "NO_ANSWER"
+    EXHAUSTED = "EXHAUSTED"
+
+
+class CallStatus(str, Enum):
+    CONFIRMED = "CONFIRMED"
+    CANCELLED = "CANCELLED"
+    RESCHEDULED = "RESCHEDULED"
+    NO_ANSWER = "NO_ANSWER"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    ERROR = "ERROR"
+    SKIPPED_NO_CONSENT = "SKIPPED_NO_CONSENT"
+    SKIPPED_DUPLICATE = "SKIPPED_DUPLICATE"
+    SKIPPED_OUT_OF_WINDOW = "SKIPPED_OUT_OF_WINDOW"
+    CANCELLED_BY_OPERATOR = "CANCELLED_BY_OPERATOR"
+
+
+@dataclass
+class Reservation:
+    booking_id: str
+    name: str
+    phone: str
+    party_size: int
+    slot: str
+    consent: bool
+    status: ReservationStatus = ReservationStatus.PENDING_CONFIRM
+
+    @classmethod
+    def from_line(cls, line: dict) -> "Reservation":
+        return cls(
+            booking_id=line["booking_id"],
+            name=line["name"],
+            phone=line["phone"],
+            party_size=int(line["party_size"]),
+            slot=line["slot"],
+            consent=bool(line["consent"]),
+            status=ReservationStatus(line.get("status", "PENDING_CONFIRM")),
+        )
+
+    def to_line(self) -> dict:
+        return {
+            "booking_id": self.booking_id,
+            "name": self.name,
+            "phone": self.phone,
+            "party_size": self.party_size,
+            "slot": self.slot,
+            "consent": self.consent,
+            "status": self.status.value,
+        }
+
+
+@dataclass
+class WaitlistEntry:
+    entry_id: str
+    name: str
+    phone: str
+    party_size: int
+    window_start: str
+    window_end: str
+    priority: int
+    consent: bool
+    status: WaitlistStatus = WaitlistStatus.WAITING
+
+    @classmethod
+    def from_line(cls, line: dict) -> "WaitlistEntry":
+        return cls(
+            entry_id=line["entry_id"],
+            name=line["name"],
+            phone=line["phone"],
+            party_size=int(line["party_size"]),
+            window_start=line["window_start"],
+            window_end=line["window_end"],
+            priority=int(line["priority"]),
+            consent=bool(line["consent"]),
+            status=WaitlistStatus(line.get("status", "WAITING")),
+        )
+
+    def to_line(self) -> dict:
+        return {
+            "entry_id": self.entry_id,
+            "name": self.name,
+            "phone": self.phone,
+            "party_size": self.party_size,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "priority": self.priority,
+            "consent": self.consent,
+            "status": self.status.value,
+        }
+
+
+@dataclass
+class CallOutcome:
+    run_id: str
+    target_id: str
+    status: CallStatus
+    new_slot: str | None = None
+    notes: str | None = None
+    transcript_ref: str | None = None
+    call_cost_id: str | None = None
+
+    @classmethod
+    def from_payload(cls, run_id: str, target_id: str, payload: dict) -> "CallOutcome":
+        return cls(
+            run_id=run_id,
+            target_id=target_id,
+            status=CallStatus(payload["status"]),
+            new_slot=payload.get("new_slot"),
+            notes=payload.get("notes"),
+            transcript_ref=payload.get("transcript_ref"),
+            call_cost_id=payload.get("call_cost_id"),
+        )

--- a/apps/python/table-rescue/table_rescue/models.py
+++ b/apps/python/table-rescue/table_rescue/models.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from .safety import validate_phone_syntax
+
 
 class ReservationStatus(str, Enum):
     PENDING_CONFIRM = "PENDING_CONFIRM"
@@ -10,6 +12,7 @@ class ReservationStatus(str, Enum):
     RESCHEDULED = "RESCHEDULED"
     NO_ANSWER = "NO_ANSWER"
     RECOVERED = "RECOVERED"
+    NEEDS_REVIEW = "NEEDS_REVIEW"
 
 
 class WaitlistStatus(str, Enum):
@@ -19,6 +22,7 @@ class WaitlistStatus(str, Enum):
     DECLINED = "DECLINED"
     NO_ANSWER = "NO_ANSWER"
     EXHAUSTED = "EXHAUSTED"
+    NEEDS_REVIEW = "NEEDS_REVIEW"
 
 
 class CallStatus(str, Enum):
@@ -33,6 +37,7 @@ class CallStatus(str, Enum):
     SKIPPED_DUPLICATE = "SKIPPED_DUPLICATE"
     SKIPPED_OUT_OF_WINDOW = "SKIPPED_OUT_OF_WINDOW"
     CANCELLED_BY_OPERATOR = "CANCELLED_BY_OPERATOR"
+    UNCERTAIN = "UNCERTAIN"
 
 
 @dataclass
@@ -47,6 +52,7 @@ class Reservation:
 
     @classmethod
     def from_line(cls, line: dict) -> "Reservation":
+        validate_phone_syntax(line["phone"])
         return cls(
             booking_id=line["booking_id"],
             name=line["name"],
@@ -83,6 +89,7 @@ class WaitlistEntry:
 
     @classmethod
     def from_line(cls, line: dict) -> "WaitlistEntry":
+        validate_phone_syntax(line["phone"])
         return cls(
             entry_id=line["entry_id"],
             name=line["name"],
@@ -118,6 +125,7 @@ class CallOutcome:
     notes: str | None = None
     transcript_ref: str | None = None
     call_cost_id: str | None = None
+    uncertainty_reason: str | None = None
 
     @classmethod
     def from_payload(cls, run_id: str, target_id: str, payload: dict) -> "CallOutcome":
@@ -129,4 +137,5 @@ class CallOutcome:
             notes=payload.get("notes"),
             transcript_ref=payload.get("transcript_ref"),
             call_cost_id=payload.get("call_cost_id"),
+            uncertainty_reason=payload.get("uncertainty_reason"),
         )

--- a/apps/python/table-rescue/table_rescue/report.py
+++ b/apps/python/table-rescue/table_rescue/report.py
@@ -25,6 +25,7 @@ def render_report(
     outcomes: list[CallOutcome],
     reservations: list[Reservation],
     waitlist: list[WaitlistEntry],
+    avg_check_per_guest: float | None = None,
 ) -> str:
     phones = {entry.booking_id: entry.phone for entry in reservations}
     phones.update({entry.entry_id: entry.phone for entry in waitlist})
@@ -41,6 +42,14 @@ def render_report(
         f"- Slots recovered: {len(recovered)}",
         f"- Waitlist entries accepted: {len(accepted)}",
         f"- Needs staff attention (no answer or error): {len(escalated)}",
+        *(
+            [
+                f"- Estimated revenue protected: {sum(r.party_size for r in recovered) * avg_check_per_guest:.0f} "
+                f"({sum(r.party_size for r in recovered)} recovered seats x {avg_check_per_guest:.0f} per guest)"
+            ]
+            if avg_check_per_guest is not None and recovered
+            else []
+        ),
         "",
         "| Target | Phone | Outcome | Notes |",
         "| --- | --- | --- | --- |",

--- a/apps/python/table-rescue/table_rescue/report.py
+++ b/apps/python/table-rescue/table_rescue/report.py
@@ -1,0 +1,54 @@
+"""Staff-facing run report with masked phone numbers."""
+from .models import (
+    CallOutcome,
+    CallStatus,
+    Reservation,
+    ReservationStatus,
+    WaitlistEntry,
+    WaitlistStatus,
+)
+from .stores import mask_phone
+
+DIALLED_STATUSES = {
+    CallStatus.CONFIRMED,
+    CallStatus.CANCELLED,
+    CallStatus.RESCHEDULED,
+    CallStatus.NO_ANSWER,
+    CallStatus.ACCEPTED,
+    CallStatus.DECLINED,
+    CallStatus.ERROR,
+}
+
+
+def render_report(
+    run_id: str,
+    outcomes: list[CallOutcome],
+    reservations: list[Reservation],
+    waitlist: list[WaitlistEntry],
+) -> str:
+    phones = {entry.booking_id: entry.phone for entry in reservations}
+    phones.update({entry.entry_id: entry.phone for entry in waitlist})
+    dialled = [outcome for outcome in outcomes if outcome.status in DIALLED_STATUSES]
+    recovered = [r for r in reservations if r.status == ReservationStatus.RECOVERED]
+    accepted = [w for w in waitlist if w.status == WaitlistStatus.ACCEPTED]
+    escalated = [
+        o for o in outcomes if o.status in {CallStatus.NO_ANSWER, CallStatus.ERROR}
+    ]
+    lines = [
+        f"# Table Rescue run {run_id}",
+        "",
+        f"- Calls placed: {len(dialled)}",
+        f"- Slots recovered: {len(recovered)}",
+        f"- Waitlist entries accepted: {len(accepted)}",
+        f"- Needs staff attention (no answer or error): {len(escalated)}",
+        "",
+        "| Target | Phone | Outcome | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    for outcome in outcomes:
+        phone = mask_phone(phones.get(outcome.target_id, "+0000000000"))
+        notes = (outcome.notes or "").replace("|", "/")
+        lines.append(
+            f"| {outcome.target_id} | {phone} | {outcome.status.value} | {notes} |"
+        )
+    return "\n".join(lines) + "\n"

--- a/apps/python/table-rescue/table_rescue/report.py
+++ b/apps/python/table-rescue/table_rescue/report.py
@@ -7,7 +7,7 @@ from .models import (
     WaitlistEntry,
     WaitlistStatus,
 )
-from .stores import mask_phone
+from .safety import mask_phone, sanitize_text
 
 DIALLED_STATUSES = {
     CallStatus.CONFIRMED,
@@ -60,7 +60,7 @@ def render_report(
     ]
     for outcome in outcomes:
         phone = mask_phone(phones.get(outcome.target_id, "+0000000000"))
-        notes = (outcome.notes or "").replace("|", "/")
+        notes = sanitize_text(outcome.notes or "").replace("|", "/")
         lines.append(
             f"| {outcome.target_id} | {phone} | {outcome.status.value} | {notes} |"
         )
@@ -86,6 +86,8 @@ def render_report(
                 if outcome
                 else "NEEDS_REVIEW"
             )
-            notes = (outcome.notes or "").replace("|", "/") if outcome else ""
+            notes = (
+                sanitize_text(outcome.notes or "").replace("|", "/") if outcome else ""
+            )
             lines.append(f"| {target_id} | {reason} | {notes} |")
     return "\n".join(lines) + "\n"

--- a/apps/python/table-rescue/table_rescue/report.py
+++ b/apps/python/table-rescue/table_rescue/report.py
@@ -17,6 +17,7 @@ DIALLED_STATUSES = {
     CallStatus.ACCEPTED,
     CallStatus.DECLINED,
     CallStatus.ERROR,
+    CallStatus.UNCERTAIN,
 }
 
 
@@ -26,22 +27,25 @@ def render_report(
     reservations: list[Reservation],
     waitlist: list[WaitlistEntry],
     avg_check_per_guest: float | None = None,
+    resumed_from: str | None = None,
 ) -> str:
     phones = {entry.booking_id: entry.phone for entry in reservations}
     phones.update({entry.entry_id: entry.phone for entry in waitlist})
     dialled = [outcome for outcome in outcomes if outcome.status in DIALLED_STATUSES]
     recovered = [r for r in reservations if r.status == ReservationStatus.RECOVERED]
     accepted = [w for w in waitlist if w.status == WaitlistStatus.ACCEPTED]
-    escalated = [
-        o for o in outcomes if o.status in {CallStatus.NO_ANSWER, CallStatus.ERROR}
+    needs_review_res = [
+        r for r in reservations if r.status == ReservationStatus.NEEDS_REVIEW
     ]
+    needs_review_wl = [w for w in waitlist if w.status == WaitlistStatus.NEEDS_REVIEW]
     lines = [
         f"# Table Rescue run {run_id}",
+        *([f"- Resumed from run: {resumed_from}"] if resumed_from else []),
         "",
         f"- Calls placed: {len(dialled)}",
         f"- Slots recovered: {len(recovered)}",
         f"- Waitlist entries accepted: {len(accepted)}",
-        f"- Needs staff attention (no answer or error): {len(escalated)}",
+        f"- Needs review: {len(needs_review_res) + len(needs_review_wl)}",
         *(
             [
                 f"- Estimated revenue protected: {sum(r.party_size for r in recovered) * avg_check_per_guest:.0f} "
@@ -60,4 +64,28 @@ def render_report(
         lines.append(
             f"| {outcome.target_id} | {phone} | {outcome.status.value} | {notes} |"
         )
+    if needs_review_res or needs_review_wl:
+        lines += [
+            "",
+            "## Needs review",
+            "",
+            "These destinations stopped the run with an uncertain result. "
+            "Review the notes/transcript, then run `table-rescue resume`.",
+            "",
+            "| Target | Reason | Notes |",
+            "| --- | --- | --- |",
+        ]
+        last_outcome = {o.target_id: o for o in outcomes}
+        for target_id in [
+            *[r.booking_id for r in needs_review_res],
+            *[w.entry_id for w in needs_review_wl],
+        ]:
+            outcome = last_outcome.get(target_id)
+            reason = (
+                (outcome.uncertainty_reason or outcome.status.value)
+                if outcome
+                else "NEEDS_REVIEW"
+            )
+            notes = (outcome.notes or "").replace("|", "/") if outcome else ""
+            lines.append(f"| {target_id} | {reason} | {notes} |")
     return "\n".join(lines) + "\n"

--- a/apps/python/table-rescue/table_rescue/safety.py
+++ b/apps/python/table-rescue/table_rescue/safety.py
@@ -1,0 +1,130 @@
+"""Centralized safety gates for the calling path.
+
+Every guard reviewers asked for lives here: E.164 syntax validation,
+region-aware live-destination checks, fictional-number-block rejection,
+MCP origin pinning, and operator authorization. Nothing in this module
+is operator-tunable; enforcement is code.
+"""
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+# region -> (calling code, min national digits, max national digits)
+REGION_CALLING_CODES: dict[str, tuple[str, int, int]] = {
+    "VN": ("+84", 9, 10),
+    "SG": ("+65", 8, 8),
+    "US": ("+1", 10, 10),
+    "CA": ("+1", 10, 10),
+}
+
+ALLOWED_ORIGINS = {"https://seleven-mcp-sg.airudder.com"}
+
+
+class SafetyViolation(RuntimeError):
+    """A safety gate refused something; the message explains which and why."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(f"{code}: {detail}")
+        self.code = code
+        self.detail = detail
+
+
+def validate_phone_syntax(phone: str) -> None:
+    if not E164_RE.match(phone):
+        raise SafetyViolation("INVALID_E164", phone)
+
+
+def _is_fictional_nanp(phone: str) -> bool:
+    digits = phone[1:]
+    if not digits.startswith("1"):
+        return False
+    national = digits[1:]
+    if national.startswith("555"):
+        return True
+    return (
+        len(national) == 10
+        and national[3:6] == "555"
+        and "0100" <= national[6:] <= "0199"
+    )
+
+
+def validate_destination(phone: str, *, region: str | None, live: bool) -> None:
+    validate_phone_syntax(phone)
+    if not live:
+        return
+    specs = REGION_CALLING_CODES.get((region or "").upper())
+    if specs is None:
+        raise SafetyViolation(
+            "UNSUPPORTED_REGION",
+            f"{region}; supported: {', '.join(sorted(REGION_CALLING_CODES))}",
+        )
+    calling_code, min_len, max_len = specs
+    if not phone.startswith(calling_code):
+        raise SafetyViolation(
+            "REGION_MISMATCH", f"{phone} does not start with {calling_code}"
+        )
+    national = phone[len(calling_code):]
+    # Fictional check runs before the length check so short sample forms
+    # like +15550101 are reported as FICTIONAL_NUMBER, not INVALID_LENGTH.
+    if _is_fictional_nanp(phone):
+        raise SafetyViolation(
+            "FICTIONAL_NUMBER",
+            f"{phone} is a reserved fictional NANP number and can never be dialed live",
+        )
+    if not min_len <= len(national) <= max_len:
+        raise SafetyViolation(
+            "INVALID_LENGTH",
+            f"{phone}: {len(national)} digits after {calling_code}, "
+            f"expected {min_len}-{max_len}",
+        )
+
+
+def validate_origin(base_url: str) -> None:
+    if base_url.rstrip("/") not in ALLOWED_ORIGINS:
+        raise SafetyViolation(
+            "ORIGIN_NOT_ALLOWED",
+            f"{base_url}; allowed: {', '.join(sorted(ALLOWED_ORIGINS))}",
+        )
+
+
+def load_authorizations(path: str | Path) -> dict[str, dict]:
+    authorizations: dict[str, dict] = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            row = json.loads(stripped)
+            phone = row["phone"]
+            if phone in authorizations:
+                raise SafetyViolation("DUPLICATE_AUTHORIZATION", phone)
+            authorizations[phone] = row
+    return authorizations
+
+
+def missing_authorizations(
+    phones: Iterable[str], authorizations: dict[str, dict]
+) -> list[str]:
+    return sorted({phone for phone in phones if phone not in authorizations})
+
+
+@dataclass
+class RunSafety:
+    """Per-run gate bundle consulted before every dial."""
+
+    live: bool = False
+    region: str | None = None
+    authorizations: dict[str, dict] = field(default_factory=dict)
+
+    def check_destination(self, phone: str) -> None:
+        if not self.live:
+            return
+        if self.region is None:
+            raise SafetyViolation("MISSING_REGION", "live runs require --region")
+        validate_destination(phone, region=self.region, live=True)
+        if phone not in self.authorizations:
+            raise SafetyViolation("NOT_AUTHORIZED", phone)

--- a/apps/python/table-rescue/table_rescue/safety.py
+++ b/apps/python/table-rescue/table_rescue/safety.py
@@ -41,9 +41,10 @@ def mask_phone(phone: str) -> str:
 
 
 # A phone-like run: optional leading "+", then digits joined by the common
-# grouping separators. Only runs of seven or more digits are masked, so
-# ordinary small numbers (party sizes, times) survive sanitization.
-_PHONE_LIKE_RE = re.compile(r"\+?\d[\d\-.\s()]*")
+# grouping separators (including comma/slash grouping). Only runs of seven
+# or more digits are masked, so ordinary small numbers (party sizes, times)
+# survive sanitization.
+_PHONE_LIKE_RE = re.compile(r"\+?\d[\d\-.\s(),/]*")
 
 
 def sanitize_text(text: str | None) -> str:

--- a/apps/python/table-rescue/table_rescue/safety.py
+++ b/apps/python/table-rescue/table_rescue/safety.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-E164_RE = re.compile(r"\+[1-9]\d{6,14}")
+# ASCII-strict on purpose: \d would also match Unicode decimal digits
+# (fullwidth, Arabic-Indic, Devanagari), which are not valid E.164.
+E164_RE = re.compile(r"\+[1-9][0-9]{6,14}")
 
 # region -> (calling code, min national digits, max national digits)
 REGION_CALLING_CODES: dict[str, tuple[str, int, int]] = {

--- a/apps/python/table-rescue/table_rescue/safety.py
+++ b/apps/python/table-rescue/table_rescue/safety.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+E164_RE = re.compile(r"\+[1-9]\d{6,14}")
 
 # region -> (calling code, min national digits, max national digits)
 REGION_CALLING_CODES: dict[str, tuple[str, int, int]] = {
@@ -34,7 +34,8 @@ class SafetyViolation(RuntimeError):
 
 
 def validate_phone_syntax(phone: str) -> None:
-    if not E164_RE.match(phone):
+    # fullmatch rejects trailing newlines that "$" would otherwise tolerate.
+    if not E164_RE.fullmatch(phone):
         raise SafetyViolation("INVALID_E164", phone)
 
 
@@ -94,12 +95,17 @@ def validate_origin(base_url: str) -> None:
 def load_authorizations(path: str | Path) -> dict[str, dict]:
     authorizations: dict[str, dict] = {}
     with open(path, "r", encoding="utf-8") as handle:
-        for line in handle:
+        for lineno, line in enumerate(handle, start=1):
             stripped = line.strip()
             if not stripped:
                 continue
-            row = json.loads(stripped)
-            phone = row["phone"]
+            try:
+                row = json.loads(stripped)
+                phone = row["phone"]
+            except (json.JSONDecodeError, KeyError) as error:
+                raise SafetyViolation(
+                    "INVALID_AUTHORIZATION_FILE", f"{path}: line {lineno}: {error}"
+                ) from error
             if phone in authorizations:
                 raise SafetyViolation("DUPLICATE_AUTHORIZATION", phone)
             authorizations[phone] = row

--- a/apps/python/table-rescue/table_rescue/safety.py
+++ b/apps/python/table-rescue/table_rescue/safety.py
@@ -35,10 +35,48 @@ class SafetyViolation(RuntimeError):
         self.detail = detail
 
 
+def mask_phone(phone: str) -> str:
+    digits = phone.lstrip("+")
+    return "+" + "*" * max(len(digits) - 2, 0) + digits[-2:]
+
+
+# A phone-like run: optional leading "+", then digits joined by the common
+# grouping separators. Only runs of seven or more digits are masked, so
+# ordinary small numbers (party sizes, times) survive sanitization.
+_PHONE_LIKE_RE = re.compile(r"\+?\d[\d\-.\s()]*")
+
+
+def sanitize_text(text: str | None) -> str:
+    """Mask every phone-like digit run (7+ digits) down to its last two digits.
+
+    The boundary guard for anything printed or persisted: provider
+    summaries, provider errors, and our own destination references.
+    """
+    if not text:
+        return text or ""
+
+    def mask_run(match: re.Match) -> str:
+        fragment = match.group(0)
+        if sum(character.isdigit() for character in fragment) < 7:
+            return fragment
+        keep = 2
+        characters: list[str] = []
+        for character in reversed(fragment):
+            if character.isdigit():
+                if keep > 0:
+                    keep -= 1
+                else:
+                    character = "*"
+            characters.append(character)
+        return "".join(reversed(characters))
+
+    return _PHONE_LIKE_RE.sub(mask_run, text)
+
+
 def validate_phone_syntax(phone: str) -> None:
     # fullmatch rejects trailing newlines that "$" would otherwise tolerate.
     if not E164_RE.fullmatch(phone):
-        raise SafetyViolation("INVALID_E164", phone)
+        raise SafetyViolation("INVALID_E164", mask_phone(phone))
 
 
 def _is_fictional_nanp(phone: str) -> bool:
@@ -68,7 +106,7 @@ def validate_destination(phone: str, *, region: str | None, live: bool) -> None:
     calling_code, min_len, max_len = specs
     if not phone.startswith(calling_code):
         raise SafetyViolation(
-            "REGION_MISMATCH", f"{phone} does not start with {calling_code}"
+            "REGION_MISMATCH", f"{mask_phone(phone)} does not start with {calling_code}"
         )
     national = phone[len(calling_code):]
     # Fictional check runs before the length check so short sample forms
@@ -76,12 +114,13 @@ def validate_destination(phone: str, *, region: str | None, live: bool) -> None:
     if _is_fictional_nanp(phone):
         raise SafetyViolation(
             "FICTIONAL_NUMBER",
-            f"{phone} is a reserved fictional NANP number and can never be dialed live",
+            f"{mask_phone(phone)} is a reserved fictional NANP number "
+            "and can never be dialed live",
         )
     if not min_len <= len(national) <= max_len:
         raise SafetyViolation(
             "INVALID_LENGTH",
-            f"{phone}: {len(national)} digits after {calling_code}, "
+            f"{mask_phone(phone)}: {len(national)} digits after {calling_code}, "
             f"expected {min_len}-{max_len}",
         )
 
@@ -109,7 +148,7 @@ def load_authorizations(path: str | Path) -> dict[str, dict]:
                     "INVALID_AUTHORIZATION_FILE", f"{path}: line {lineno}: {error}"
                 ) from error
             if phone in authorizations:
-                raise SafetyViolation("DUPLICATE_AUTHORIZATION", phone)
+                raise SafetyViolation("DUPLICATE_AUTHORIZATION", mask_phone(phone))
             authorizations[phone] = row
     return authorizations
 
@@ -135,4 +174,4 @@ class RunSafety:
             raise SafetyViolation("MISSING_REGION", "live runs require --region")
         validate_destination(phone, region=self.region, live=True)
         if phone not in self.authorizations:
-            raise SafetyViolation("NOT_AUTHORIZED", phone)
+            raise SafetyViolation("NOT_AUTHORIZED", mask_phone(phone))

--- a/apps/python/table-rescue/table_rescue/stores.py
+++ b/apps/python/table-rescue/table_rescue/stores.py
@@ -1,0 +1,85 @@
+"""JSONL stores, masking, and the append-only audit log."""
+import json
+import os
+from pathlib import Path
+
+from .models import CallOutcome, Reservation, WaitlistEntry
+
+DIALLED_STATUSES = {
+    "CONFIRMED",
+    "CANCELLED",
+    "RESCHEDULED",
+    "NO_ANSWER",
+    "ACCEPTED",
+    "DECLINED",
+    "ERROR",
+}
+
+
+def read_jsonl(path: str | Path) -> list[dict]:
+    rows = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                rows.append(json.loads(stripped))
+    return rows
+
+
+def write_jsonl_atomic(path: str | Path, rows: list[dict]) -> None:
+    path = Path(path)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    os.replace(tmp, path)
+
+
+def mask_phone(phone: str) -> str:
+    digits = phone.lstrip("+")
+    return "+" + "*" * max(len(digits) - 2, 0) + digits[-2:]
+
+
+def load_reservations(path: str | Path) -> list[Reservation]:
+    return [Reservation.from_line(row) for row in read_jsonl(path)]
+
+
+def load_waitlist(path: str | Path) -> list[WaitlistEntry]:
+    return [WaitlistEntry.from_line(row) for row in read_jsonl(path)]
+
+
+class AuditLog:
+    """Append-only audit trail per run; powers duplicate-call prevention."""
+
+    def __init__(self, run_dir: str | Path):
+        self.run_dir = Path(run_dir)
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.run_dir / "audit.jsonl"
+
+    def append(self, outcome: CallOutcome) -> None:
+        record = {
+            "run_id": outcome.run_id,
+            "target_id": outcome.target_id,
+            "status": outcome.status.value,
+            "new_slot": outcome.new_slot,
+            "notes": outcome.notes,
+            "transcript_ref": outcome.transcript_ref,
+            "call_cost_id": outcome.call_cost_id,
+        }
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def records(self) -> list[dict]:
+        return read_jsonl(self.path) if self.path.exists() else []
+
+    def dialed_targets(self) -> set[str]:
+        return {
+            row["target_id"]
+            for row in self.records()
+            if row["status"] in DIALLED_STATUSES
+        }
+
+    def is_cancelled(self) -> bool:
+        return any(
+            row["status"] == "CANCELLED_BY_OPERATOR" for row in self.records()
+        )

--- a/apps/python/table-rescue/table_rescue/stores.py
+++ b/apps/python/table-rescue/table_rescue/stores.py
@@ -1,9 +1,10 @@
-"""JSONL stores, masking, and the append-only audit log."""
+"""JSONL stores and the append-only audit log."""
 import json
 import os
 from pathlib import Path
 
 from .models import CallOutcome, Reservation, WaitlistEntry
+from .safety import sanitize_text
 
 DIALLED_STATUSES = {
     "CONFIRMED",
@@ -36,11 +37,6 @@ def write_jsonl_atomic(path: str | Path, rows: list[dict]) -> None:
     os.replace(tmp, path)
 
 
-def mask_phone(phone: str) -> str:
-    digits = phone.lstrip("+")
-    return "+" + "*" * max(len(digits) - 2, 0) + digits[-2:]
-
-
 def load_reservations(path: str | Path) -> list[Reservation]:
     return [Reservation.from_line(row) for row in read_jsonl(path)]
 
@@ -63,7 +59,8 @@ class AuditLog:
             "target_id": outcome.target_id,
             "status": outcome.status.value,
             "new_slot": outcome.new_slot,
-            "notes": outcome.notes,
+            # Provider notes are sanitized before they reach disk.
+            "notes": sanitize_text(outcome.notes) if outcome.notes else outcome.notes,
             "transcript_ref": outcome.transcript_ref,
             "call_cost_id": outcome.call_cost_id,
             "uncertainty_reason": outcome.uncertainty_reason,

--- a/apps/python/table-rescue/table_rescue/stores.py
+++ b/apps/python/table-rescue/table_rescue/stores.py
@@ -13,6 +13,7 @@ DIALLED_STATUSES = {
     "ACCEPTED",
     "DECLINED",
     "ERROR",
+    "UNCERTAIN",
 }
 
 
@@ -65,6 +66,7 @@ class AuditLog:
             "notes": outcome.notes,
             "transcript_ref": outcome.transcript_ref,
             "call_cost_id": outcome.call_cost_id,
+            "uncertainty_reason": outcome.uncertainty_reason,
         }
         with open(self.path, "a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -106,6 +106,33 @@ def test_mcp_client_executes_plan_run_poll(tmp_path):
     assert outcome.transcript_ref == "call-1"
 
 
+def test_mcp_client_reads_nested_post_summary(tmp_path):
+    # Regression: the real get_call_run payload nests the summary under
+    # "result" and the agent states the outcome in prose, not an OUTCOME token.
+    script = {
+        "plan_call": [{"plan_id": "p1", "confirm_token": "c1", "ready_to_run": True}],
+        "run_call": [{"run_id": "call-1"}],
+        "get_call_run": [
+            {
+                "run_id": "call-1",
+                "status": "COMPLETED",
+                "result": {
+                    "post_summary": "The reservation was successfully confirmed. "
+                    "Fictional Guest chose to keep the booking for 4.",
+                    "outcome": {"task_completed": True},
+                },
+            }
+        ],
+    }
+    client = make_mcp_client(tmp_path, script)
+    request = CallRequest(
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+    )
+    outcome = asyncio.run(client._execute(request))
+    assert outcome.status == CallStatus.CONFIRMED
+    assert outcome.notes is not None and "successfully confirmed" in outcome.notes
+
+
 def test_ensure_access_token_requires_login():
     client = McpCallClient()
     client._run_calle_json = lambda args: {"usable": False}

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -1,0 +1,44 @@
+from table_rescue.calle_client import (
+    CallRequest,
+    DryRunClient,
+    build_confirm_goal,
+    build_offer_goal,
+    map_terminal_status,
+    parse_outcome,
+)
+from table_rescue.models import CallStatus
+
+
+def test_parse_outcome_reads_trailing_token():
+    assert parse_outcome("thanks, OUTCOME: CANCELLED") == CallStatus.CANCELLED
+    assert parse_outcome("no token here") is None
+    assert parse_outcome(None) is None
+
+
+def test_map_terminal_status():
+    assert map_terminal_status("COMPLETED", "OUTCOME: ACCEPTED") == CallStatus.ACCEPTED
+    assert map_terminal_status("COMPLETED", "garbage") == CallStatus.ERROR
+    assert map_terminal_status("VOICEMAIL", None) == CallStatus.NO_ANSWER
+    assert map_terminal_status("DECLINED", None) == CallStatus.DECLINED
+    assert map_terminal_status("FAILED", None) == CallStatus.ERROR
+
+
+def test_goal_builders_include_outcome_protocol():
+    confirm = build_confirm_goal("Fictional Guest", 4, "2026-09-10T19:00:00+07:00")
+    offer = build_offer_goal("Fictional Waitlist", 2, "2026-09-10T19:00:00+07:00")
+    assert "OUTCOME: CONFIRMED" in confirm
+    assert "OUTCOME: ACCEPTED" in offer
+
+
+def test_dry_run_client_uses_fixtures(tmp_path):
+    fixture = tmp_path / "fixtures.jsonl"
+    fixture.write_text(
+        '{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, "notes": "cannot make it"}\n'
+        '{"target_id": "DEFAULT", "status": "NO_ANSWER", "new_slot": null, "notes": "nobody picked up"}\n',
+        encoding="utf-8",
+    )
+    client = DryRunClient(fixture)
+    request = CallRequest(run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm")
+    assert client.place_call(request).status == CallStatus.CANCELLED
+    other = CallRequest(run_id="run-1", target_id="R-999", phone="+15550199", goal="confirm")
+    assert client.place_call(other).status == CallStatus.NO_ANSWER

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -109,3 +109,11 @@ def test_ensure_access_token_requires_login():
     client._run_calle_json = lambda args: {"usable": False}
     with pytest.raises(RuntimeError, match="not logged in"):
         client.ensure_access_token()
+
+
+def test_parse_outcome_hardening():
+    assert parse_outcome("agent said outcome: cancelled") == CallStatus.CANCELLED
+    assert parse_outcome("The guest will cancel the booking.") == CallStatus.CANCELLED
+    assert parse_outcome("Guest would like to reschedule to Friday.") == CallStatus.RESCHEDULED
+    assert parse_outcome("OUTCOME: BANANA but guest confirmed") == CallStatus.CONFIRMED
+    assert parse_outcome("no decision was reached") is None

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -28,6 +28,8 @@ def test_goal_builders_include_outcome_protocol():
     offer = build_offer_goal("Fictional Waitlist", 2, "2026-09-10T19:00:00+07:00")
     assert "OUTCOME: CONFIRMED" in confirm
     assert "OUTCOME: ACCEPTED" in offer
+    assert "automated assistant" in confirm
+    assert "automated assistant" in offer
 
 
 def test_dry_run_client_uses_fixtures(tmp_path):

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -82,6 +82,7 @@ def make_mcp_client(tmp_path, script):
     )
     client = McpCallClient(
         poll_interval_seconds=0,
+        plan_retry_delay_seconds=0,
         client_factory=lambda: ScriptedMcpClient(script),
     )
     client._run_calle_json = lambda args: {"usable": True, "cache_path": str(token_file)}
@@ -131,6 +132,43 @@ def test_mcp_client_reads_nested_post_summary(tmp_path):
     outcome = asyncio.run(client._execute(request))
     assert outcome.status == CallStatus.CONFIRMED
     assert outcome.notes is not None and "successfully confirmed" in outcome.notes
+
+
+def test_mcp_client_retries_transient_not_ready_plan(tmp_path):
+    # Regression: back-to-back calls to the same number can make plan_call
+    # report ready_to_run=false once; the client must retry, not crash.
+    script = {
+        "plan_call": [
+            {"plan_id": None, "confirm_token": None, "ready_to_run": False},
+            {"plan_id": "p1", "confirm_token": "c1", "ready_to_run": True},
+        ],
+        "run_call": [{"run_id": "call-1"}],
+        "get_call_run": [
+            {
+                "status": "COMPLETED",
+                "result": {"post_summary": "The guest confirmed they will keep it."},
+            },
+        ],
+    }
+    client = make_mcp_client(tmp_path, script)
+    request = CallRequest(
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+    )
+    outcome = asyncio.run(client._execute(request))
+    assert outcome.status == CallStatus.CONFIRMED
+
+
+def test_mcp_client_plan_retry_exhaustion_raises_with_detail(tmp_path):
+    not_ready = {"plan_id": None, "confirm_token": None, "ready_to_run": False}
+    script = {
+        "plan_call": [dict(not_ready), dict(not_ready), dict(not_ready)],
+    }
+    client = make_mcp_client(tmp_path, script)
+    request = CallRequest(
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+    )
+    with pytest.raises(RuntimeError, match="after .* attempts"):
+        asyncio.run(client._execute(request))
 
 
 def test_ensure_access_token_requires_login():

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -42,3 +42,70 @@ def test_dry_run_client_uses_fixtures(tmp_path):
     assert client.place_call(request).status == CallStatus.CANCELLED
     other = CallRequest(run_id="run-1", target_id="R-999", phone="+15550199", goal="confirm")
     assert client.place_call(other).status == CallStatus.NO_ANSWER
+
+
+import asyncio
+import json
+
+import pytest
+
+from table_rescue.calle_client import McpCallClient
+
+
+class FakeToolResult:
+    def __init__(self, structured):
+        self.structured_content = structured
+
+
+class ScriptedMcpClient:
+    def __init__(self, script):
+        self.script = script
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return FakeToolResult(self.script[name].pop(0))
+
+
+def make_mcp_client(tmp_path, script):
+    token_file = tmp_path / "token.json"
+    token_file.write_text(
+        json.dumps({"token": {"access_token": "tok"}}), encoding="utf-8"
+    )
+    client = McpCallClient(
+        poll_interval_seconds=0,
+        client_factory=lambda: ScriptedMcpClient(script),
+    )
+    client._run_calle_json = lambda args: {"usable": True, "cache_path": str(token_file)}
+    return client
+
+
+def test_mcp_client_executes_plan_run_poll(tmp_path):
+    script = {
+        "plan_call": [{"plan_id": "p1", "confirm_token": "c1", "ready_to_run": True}],
+        "run_call": [{"run_id": "call-1"}],
+        "get_call_run": [
+            {"status": "RUNNING"},
+            {"status": "COMPLETED", "post_summary": "guest said OUTCOME: CANCELLED"},
+        ],
+    }
+    client = make_mcp_client(tmp_path, script)
+    request = CallRequest(
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+    )
+    outcome = asyncio.run(client._execute(request))
+    assert outcome.status == CallStatus.CANCELLED
+    assert outcome.transcript_ref == "call-1"
+
+
+def test_ensure_access_token_requires_login():
+    client = McpCallClient()
+    client._run_calle_json = lambda args: {"usable": False}
+    with pytest.raises(RuntimeError, match="not logged in"):
+        client.ensure_access_token()

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -1,3 +1,6 @@
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
 from table_rescue.calle_client import (
     LEG_CONFIRM,
     LEG_OFFER,
@@ -221,3 +224,20 @@ def test_ensure_access_token_requires_login():
     client._run_calle_json = lambda args: {"usable": False}
     with pytest.raises(RuntimeError, match="not logged in"):
         client.ensure_access_token()
+
+
+WORDS = st.lists(
+    st.sampled_from(
+        ["guest", "said", "they", "will", "cancel", "the", "booking",
+         "maybe", "keep", "it", "reschedule", "accept", "decline", "?"]
+    ),
+    min_size=0,
+    max_size=12,
+).map(" ".join)
+
+
+@given(summary=WORDS)
+@settings(max_examples=200, deadline=None)
+def test_prose_without_token_is_never_decisive(summary):
+    for leg in (LEG_CONFIRM, LEG_OFFER):
+        assert map_terminal_status("COMPLETED", summary, leg) == CallStatus.UNCERTAIN

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -207,7 +207,12 @@ def test_mcp_client_retries_transient_not_ready_plan(tmp_path):
 
 
 def test_mcp_client_plan_retry_exhaustion_raises_with_detail(tmp_path):
-    not_ready = {"plan_id": None, "confirm_token": None, "ready_to_run": False}
+    not_ready = {
+        "plan_id": None,
+        "confirm_token": None,
+        "ready_to_run": False,
+        "to_phones": ["+15550101"],
+    }
     script = {
         "plan_call": [dict(not_ready), dict(not_ready), dict(not_ready)],
     }
@@ -215,8 +220,26 @@ def test_mcp_client_plan_retry_exhaustion_raises_with_detail(tmp_path):
     request = CallRequest(
         run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
     )
-    with pytest.raises(RuntimeError, match="after .* attempts"):
+    with pytest.raises(RuntimeError, match="after .* attempts") as excinfo:
         asyncio.run(client._execute(request))
+    # Provider payloads echo the destination; the error must not carry it raw.
+    assert "+15550101" not in str(excinfo.value)
+
+
+def test_calle_command_failure_sanitizes_detail(monkeypatch):
+    import subprocess as subprocess_module
+
+    client = McpCallClient()
+
+    def fake_run(command, **kwargs):
+        return subprocess_module.CompletedProcess(
+            command, 1, stdout="", stderr="failed dialing +14155550100"
+        )
+
+    monkeypatch.setattr("table_rescue.calle_client.subprocess.run", fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        client._run_calle_json(["auth", "status"])
+    assert "+14155550100" not in str(excinfo.value)
 
 
 def test_ensure_access_token_requires_login():

--- a/apps/python/table-rescue/tests/test_calle_client.py
+++ b/apps/python/table-rescue/tests/test_calle_client.py
@@ -1,26 +1,64 @@
 from table_rescue.calle_client import (
+    LEG_CONFIRM,
+    LEG_OFFER,
     CallRequest,
     DryRunClient,
     build_confirm_goal,
     build_offer_goal,
+    keyword_hint,
     map_terminal_status,
-    parse_outcome,
+    parse_outcome_token,
 )
 from table_rescue.models import CallStatus
+from table_rescue.safety import SafetyViolation
 
 
-def test_parse_outcome_reads_trailing_token():
-    assert parse_outcome("thanks, OUTCOME: CANCELLED") == CallStatus.CANCELLED
-    assert parse_outcome("no token here") is None
-    assert parse_outcome(None) is None
+def test_parse_outcome_token_reads_only_explicit_token():
+    assert parse_outcome_token("thanks, OUTCOME: CANCELLED") == CallStatus.CANCELLED
+    assert parse_outcome_token("agent said outcome: cancelled") == CallStatus.CANCELLED
+    assert parse_outcome_token("no token here") is None
+    assert parse_outcome_token(None) is None
+    assert parse_outcome_token("OUTCOME: BANANA") is None
 
 
-def test_map_terminal_status():
-    assert map_terminal_status("COMPLETED", "OUTCOME: ACCEPTED") == CallStatus.ACCEPTED
-    assert map_terminal_status("COMPLETED", "garbage") == CallStatus.ERROR
-    assert map_terminal_status("VOICEMAIL", None) == CallStatus.NO_ANSWER
-    assert map_terminal_status("DECLINED", None) == CallStatus.DECLINED
-    assert map_terminal_status("FAILED", None) == CallStatus.ERROR
+def test_keyword_hint_is_informational_only():
+    assert keyword_hint("The guest will cancel the booking.") == "cancel"
+    assert keyword_hint("Guest would like to reschedule to Friday.") == "reschedul"
+    assert keyword_hint("no decision was reached") is None
+
+
+def test_map_terminal_status_token_only_decisions():
+    assert (
+        map_terminal_status("COMPLETED", "OUTCOME: ACCEPTED", LEG_OFFER)
+        == CallStatus.ACCEPTED
+    )
+    assert (
+        map_terminal_status("COMPLETED", "garbage", LEG_CONFIRM)
+        == CallStatus.UNCERTAIN
+    )
+    assert (
+        map_terminal_status("COMPLETED", "The guest confirmed they will keep it.", LEG_CONFIRM)
+        == CallStatus.UNCERTAIN
+    )
+    assert (
+        map_terminal_status("COMPLETED", "OUTCOME: ACCEPTED", LEG_CONFIRM)
+        == CallStatus.UNCERTAIN
+    )
+    assert (
+        map_terminal_status("COMPLETED", "OUTCOME: CONFIRMED", LEG_OFFER)
+        == CallStatus.UNCERTAIN
+    )
+    assert map_terminal_status("VOICEMAIL", None, LEG_CONFIRM) == CallStatus.NO_ANSWER
+    assert map_terminal_status("DECLINED", None, LEG_CONFIRM) == CallStatus.DECLINED
+    assert map_terminal_status("FAILED", None, LEG_CONFIRM) == CallStatus.UNCERTAIN
+    assert map_terminal_status("EXPIRED", None, LEG_OFFER) == CallStatus.UNCERTAIN
+
+
+def test_mcp_client_rejects_foreign_origin():
+    with pytest.raises(SafetyViolation, match="ORIGIN_NOT_ALLOWED"):
+        McpCallClient(base_url="https://evil.example.com")
+    with pytest.raises(SafetyViolation, match="ORIGIN_NOT_ALLOWED"):
+        McpCallClient(base_url="http://seleven-mcp-sg.airudder.com")
 
 
 def test_goal_builders_include_outcome_protocol():
@@ -100,7 +138,8 @@ def test_mcp_client_executes_plan_run_poll(tmp_path):
     }
     client = make_mcp_client(tmp_path, script)
     request = CallRequest(
-        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm",
+        leg=LEG_CONFIRM,
     )
     outcome = asyncio.run(client._execute(request))
     assert outcome.status == CallStatus.CANCELLED
@@ -108,8 +147,10 @@ def test_mcp_client_executes_plan_run_poll(tmp_path):
 
 
 def test_mcp_client_reads_nested_post_summary(tmp_path):
-    # Regression: the real get_call_run payload nests the summary under
-    # "result" and the agent states the outcome in prose, not an OUTCOME token.
+    # The real get_call_run payload nests the summary under "result" and the
+    # agent often states the outcome in prose, not an OUTCOME token. Prose is
+    # never decisive: the outcome is UNCERTAIN and the summary is kept for
+    # human reconciliation (with a keyword hint appended to the notes).
     script = {
         "plan_call": [{"plan_id": "p1", "confirm_token": "c1", "ready_to_run": True}],
         "run_call": [{"run_id": "call-1"}],
@@ -127,11 +168,14 @@ def test_mcp_client_reads_nested_post_summary(tmp_path):
     }
     client = make_mcp_client(tmp_path, script)
     request = CallRequest(
-        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm",
+        leg=LEG_CONFIRM,
     )
     outcome = asyncio.run(client._execute(request))
-    assert outcome.status == CallStatus.CONFIRMED
+    assert outcome.status == CallStatus.UNCERTAIN
+    assert outcome.uncertainty_reason == "UNPARSEABLE_SUMMARY"
     assert outcome.notes is not None and "successfully confirmed" in outcome.notes
+    assert "hint: confirm" in outcome.notes
 
 
 def test_mcp_client_retries_transient_not_ready_plan(tmp_path):
@@ -152,10 +196,11 @@ def test_mcp_client_retries_transient_not_ready_plan(tmp_path):
     }
     client = make_mcp_client(tmp_path, script)
     request = CallRequest(
-        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm"
+        run_id="run-1", target_id="R-001", phone="+15550101", goal="confirm",
+        leg=LEG_CONFIRM,
     )
     outcome = asyncio.run(client._execute(request))
-    assert outcome.status == CallStatus.CONFIRMED
+    assert outcome.status == CallStatus.UNCERTAIN
 
 
 def test_mcp_client_plan_retry_exhaustion_raises_with_detail(tmp_path):
@@ -176,11 +221,3 @@ def test_ensure_access_token_requires_login():
     client._run_calle_json = lambda args: {"usable": False}
     with pytest.raises(RuntimeError, match="not logged in"):
         client.ensure_access_token()
-
-
-def test_parse_outcome_hardening():
-    assert parse_outcome("agent said outcome: cancelled") == CallStatus.CANCELLED
-    assert parse_outcome("The guest will cancel the booking.") == CallStatus.CANCELLED
-    assert parse_outcome("Guest would like to reschedule to Friday.") == CallStatus.RESCHEDULED
-    assert parse_outcome("OUTCOME: BANANA but guest confirmed") == CallStatus.CONFIRMED
-    assert parse_outcome("no decision was reached") is None

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -1,0 +1,60 @@
+from table_rescue.cli import main
+from table_rescue.stores import read_jsonl
+
+
+def write_sample_data(tmp_path):
+    data_dir = tmp_path / "data"
+    (data_dir / "fixtures").mkdir(parents=True)
+    (data_dir / "reservations.jsonl").write_text(
+        '{"booking_id": "R-001", "name": "Fictional Guest One", "phone": "+15550101", '
+        '"party_size": 4, "slot": "2026-09-10T19:00:00+07:00", "consent": true, '
+        '"status": "PENDING_CONFIRM"}\n',
+        encoding="utf-8",
+    )
+    (data_dir / "waitlist.jsonl").write_text(
+        '{"entry_id": "W-001", "name": "Fictional Waitlist One", "phone": "+15550111", '
+        '"party_size": 4, "window_start": "2026-09-10T18:00:00+07:00", '
+        '"window_end": "2026-09-10T21:00:00+07:00", "priority": 1, "consent": true, '
+        '"status": "WAITING"}\n',
+        encoding="utf-8",
+    )
+    (data_dir / "fixtures" / "dry_run_outcomes.jsonl").write_text(
+        '{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, '
+        '"notes": "cannot make it"}\n'
+        '{"target_id": "W-001", "status": "ACCEPTED", "new_slot": null, '
+        '"notes": "we will come"}\n',
+        encoding="utf-8",
+    )
+    return data_dir
+
+
+def test_run_dry_run_recovers_slot(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    state_dir = tmp_path / "state"
+    exit_code = main(
+        [
+            "run",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(state_dir),
+            "--run-id", "run-test",
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
+        ]
+    )
+    assert exit_code == 0
+    reservations = read_jsonl(data_dir / "reservations.jsonl")
+    waitlist = read_jsonl(data_dir / "waitlist.jsonl")
+    assert reservations[0]["status"] == "RECOVERED"
+    assert waitlist[0]["status"] == "ACCEPTED"
+    assert (state_dir / "runs" / "run-test" / "report.md").exists()
+    audit = read_jsonl(state_dir / "runs" / "run-test" / "audit.jsonl")
+    assert len(audit) == 2
+    assert "Slots recovered: 1" in capsys.readouterr().out
+
+
+def test_cancel_marks_run(tmp_path):
+    state_dir = tmp_path / "state"
+    exit_code = main(["cancel", "--run-id", "run-test", "--state-dir", str(state_dir)])
+    assert exit_code == 0
+    records = read_jsonl(state_dir / "runs" / "run-test" / "audit.jsonl")
+    assert records[-1]["status"] == "CANCELLED_BY_OPERATOR"

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -58,3 +58,31 @@ def test_cancel_marks_run(tmp_path):
     assert exit_code == 0
     records = read_jsonl(state_dir / "runs" / "run-test" / "audit.jsonl")
     assert records[-1]["status"] == "CANCELLED_BY_OPERATOR"
+
+
+def test_run_missing_data_files_fails_cleanly(tmp_path, capsys):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    exit_code = main(
+        [
+            "run",
+            "--data-dir", str(empty_dir),
+            "--state-dir", str(tmp_path / "state"),
+            "--run-id", "x",
+        ]
+    )
+    assert exit_code == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_module_entrypoint_runs():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "table_rescue.cli", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "table-rescue" in result.stdout

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -306,3 +306,21 @@ def test_module_entrypoint_runs():
     )
     assert result.returncode == 0
     assert "table-rescue" in result.stdout
+
+
+def test_run_malformed_phone_fails_cleanly(tmp_path, capsys):
+    data_dir = tmp_path / "data"
+    (data_dir / "fixtures").mkdir(parents=True)
+    (data_dir / "reservations.jsonl").write_text(
+        '{"booking_id": "R-001", "name": "Guest", "phone": "not-a-phone", '
+        '"party_size": 2, "slot": "2026-09-10T19:00:00+07:00", "consent": true}\n',
+        encoding="utf-8",
+    )
+    waitlist_path = data_dir / "waitlist.jsonl"
+    waitlist_path.write_text("", encoding="utf-8")
+    exit_code = main(
+        ["run", "--data-dir", str(data_dir), "--state-dir", str(tmp_path / "state"),
+         "--run-id", "bad-1"]
+    )
+    assert exit_code == 1
+    assert "INVALID_E164" in capsys.readouterr().err

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -75,6 +75,75 @@ def test_run_missing_data_files_fails_cleanly(tmp_path, capsys):
     assert "not found" in capsys.readouterr().err
 
 
+def test_run_live_requires_region(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    exit_code = main(
+        [
+            "run", "--live",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(tmp_path / "state"),
+            "--run-id", "live-1",
+        ]
+    )
+    assert exit_code == 1
+    assert "--region" in capsys.readouterr().err
+
+
+def test_run_live_requires_allowlist_file(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    exit_code = main(
+        [
+            "run", "--live", "--region", "US",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(tmp_path / "state"),
+            "--run-id", "live-1",
+        ]
+    )
+    assert exit_code == 1
+    assert "authorized_destinations" in capsys.readouterr().err
+
+
+def test_run_live_aborts_on_missing_authorization(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    (data_dir / "authorized_destinations.jsonl").write_text(
+        '{"phone": "+15550101", "authorized_by": "op", '
+        '"authorized_at": "2026-09-07T00:00:00+07:00"}\n',
+        encoding="utf-8",
+    )
+    exit_code = main(
+        [
+            "run", "--live", "--region", "US",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(tmp_path / "state"),
+            "--run-id", "live-1",
+        ]
+    )
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "+15550111" in err  # W-001 not authorized; nothing dialed
+
+
+def test_run_live_fictional_number_never_reaches_dial(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    (data_dir / "authorized_destinations.jsonl").write_text(
+        '{"phone": "+15550101", "authorized_by": "op", '
+        '"authorized_at": "2026-09-07T00:00:00+07:00"}\n'
+        '{"phone": "+15550111", "authorized_by": "op", '
+        '"authorized_at": "2026-09-07T00:00:00+07:00"}\n',
+        encoding="utf-8",
+    )
+    exit_code = main(
+        [
+            "run", "--live", "--region", "US", "--yes",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(tmp_path / "state"),
+            "--run-id", "live-1",
+        ]
+    )
+    assert exit_code == 1
+    assert "FICTIONAL_NUMBER" in capsys.readouterr().err
+
+
 def test_module_entrypoint_runs():
     import subprocess
     import sys

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -137,6 +137,8 @@ def test_run_live_fictional_number_never_reaches_dial(tmp_path, capsys):
     exit_code = main(
         [
             "run", "--live", "--region", "US", "--yes",
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
             "--data-dir", str(data_dir),
             "--state-dir", str(tmp_path / "state"),
             "--run-id", "live-1",

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -283,6 +283,18 @@ def test_resume_missing_source_run_fails_cleanly(tmp_path, capsys):
     assert "no audit log" in capsys.readouterr().err
 
 
+def test_resume_refuses_operator_cancelled_run(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    state_dir = tmp_path / "state"
+    main(["cancel", "--run-id", "stopped-1", "--state-dir", str(state_dir)])
+    exit_code = main(
+        ["resume", "--run-id", "stopped-1",
+         "--data-dir", str(data_dir), "--state-dir", str(state_dir)]
+    )
+    assert exit_code == 1
+    assert "cancelled by the operator" in capsys.readouterr().err
+
+
 def test_module_entrypoint_runs():
     import subprocess
     import sys

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -144,6 +144,50 @@ def test_run_live_fictional_number_never_reaches_dial(tmp_path, capsys):
     assert "FICTIONAL_NUMBER" in capsys.readouterr().err
 
 
+def test_preflight_fails_on_missing_authorization(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    exit_code = main(
+        [
+            "preflight",
+            "--data-dir", str(data_dir),
+            "--region", "US",
+            "--calle-command", "definitely-not-calle",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "FAIL operator_authorization" in captured.out
+    assert "FAIL calle_auth" in captured.out
+    assert "PASS destinations_e164" in captured.out
+
+
+def test_preflight_json_output(tmp_path, capsys):
+    import json as jsonlib
+
+    data_dir = write_sample_data(tmp_path)
+    exit_code = main(
+        [
+            "preflight",
+            "--data-dir", str(data_dir),
+            "--region", "US",
+            "--calle-command", "definitely-not-calle",
+            "--json",
+        ]
+    )
+    payload = jsonlib.loads(capsys.readouterr().out)
+    names = {check["name"] for check in payload["checks"]}
+    assert names == {
+        "destinations_e164",
+        "region_rules",
+        "operator_authorization",
+        "origin_pinned",
+        "calle_auth",
+        "budget_configured",
+    }
+    assert payload["ok"] is False
+    assert exit_code == 1
+
+
 def test_module_entrypoint_runs():
     import subprocess
     import sys

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -120,7 +120,9 @@ def test_run_live_aborts_on_missing_authorization(tmp_path, capsys):
     )
     assert exit_code == 1
     err = capsys.readouterr().err
-    assert "+15550111" in err  # W-001 not authorized; nothing dialed
+    # W-001 is not authorized; the raw phone is never printed, only masked.
+    assert "+15550111" not in err
+    assert "+******11" in err
 
 
 def test_run_live_fictional_number_never_reaches_dial(tmp_path, capsys):
@@ -141,11 +143,21 @@ def test_run_live_fictional_number_never_reaches_dial(tmp_path, capsys):
         ]
     )
     assert exit_code == 1
-    assert "FICTIONAL_NUMBER" in capsys.readouterr().err
+    captured = capsys.readouterr()
+    assert "FICTIONAL_NUMBER" in captured.err
+    # The live manifest masks every phone before printing or persistence.
+    assert "+15550101" not in captured.out
+    assert "+15550111" not in captured.out
+    assert "+******01" in captured.out
 
 
 def test_preflight_fails_on_missing_authorization(tmp_path, capsys):
     data_dir = write_sample_data(tmp_path)
+    (data_dir / "authorized_destinations.jsonl").write_text(
+        '{"phone": "+15550101", "authorized_by": "op", '
+        '"authorized_at": "2026-09-07T00:00:00+07:00"}\n',
+        encoding="utf-8",
+    )
     exit_code = main(
         [
             "preflight",
@@ -159,6 +171,9 @@ def test_preflight_fails_on_missing_authorization(tmp_path, capsys):
     assert "FAIL operator_authorization" in captured.out
     assert "FAIL calle_auth" in captured.out
     assert "PASS destinations_e164" in captured.out
+    # Preflight detail never prints a raw phone.
+    assert "+15550111" not in captured.out
+    assert "+******11" in captured.out
 
 
 def test_preflight_json_output(tmp_path, capsys):

--- a/apps/python/table-rescue/tests/test_cli.py
+++ b/apps/python/table-rescue/tests/test_cli.py
@@ -188,6 +188,101 @@ def test_preflight_json_output(tmp_path, capsys):
     assert exit_code == 1
 
 
+def _write_uncertain_then_accept_fixtures(data_dir):
+    (data_dir / "fixtures" / "first.jsonl").write_text(
+        '{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, '
+        '"notes": "cannot make it"}\n'
+        '{"target_id": "W-001", "status": "UNCERTAIN", "new_slot": null, '
+        '"notes": "line went quiet", "uncertainty_reason": "PROVIDER_FAILED"}\n',
+        encoding="utf-8",
+    )
+    (data_dir / "fixtures" / "second.jsonl").write_text(
+        '{"target_id": "W-001", "status": "ACCEPTED", "new_slot": null, '
+        '"notes": "we will come"}\n'
+        '{"target_id": "R-001", "status": "CANCELLED", "new_slot": null, '
+        '"notes": "cannot make it"}\n',
+        encoding="utf-8",
+    )
+
+
+def test_resume_completes_story_after_uncertain_stop(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    _write_uncertain_then_accept_fixtures(data_dir)
+    state_dir = tmp_path / "state"
+    first = main(
+        [
+            "run",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(state_dir),
+            "--run-id", "story-1",
+            "--fixture", str(data_dir / "fixtures" / "first.jsonl"),
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
+        ]
+    )
+    assert first == 2  # reconciliation required
+    waitlist = read_jsonl(data_dir / "waitlist.jsonl")
+    assert waitlist[0]["status"] == "NEEDS_REVIEW"
+    report = (state_dir / "runs" / "story-1" / "report.md").read_text(encoding="utf-8")
+    assert "Needs review" in report
+
+    second = main(
+        [
+            "resume",
+            "--run-id", "story-1",
+            "--data-dir", str(data_dir),
+            "--state-dir", str(state_dir),
+            "--run-id-new", "story-2",
+            "--fixture", str(data_dir / "fixtures" / "second.jsonl"),
+            "--call-window-start", "00:00",
+            "--call-window-end", "23:59",
+        ]
+    )
+    assert second == 0
+    reservations = read_jsonl(data_dir / "reservations.jsonl")
+    waitlist = read_jsonl(data_dir / "waitlist.jsonl")
+    assert reservations[0]["status"] == "RECOVERED"
+    assert waitlist[0]["status"] == "ACCEPTED"
+    report2 = (state_dir / "runs" / "story-2" / "report.md").read_text(encoding="utf-8")
+    assert "Resumed from run: story-1" in report2
+
+
+def test_resume_skips_settled_targets(tmp_path):
+    data_dir = write_sample_data(tmp_path)
+    _write_uncertain_then_accept_fixtures(data_dir)
+    state_dir = tmp_path / "state"
+    main(
+        ["run", "--data-dir", str(data_dir), "--state-dir", str(state_dir),
+         "--run-id", "skip-1", "--fixture", str(data_dir / "fixtures" / "first.jsonl"),
+         "--call-window-start", "00:00", "--call-window-end", "23:59"]
+    )
+    # R-001 was CANCELLED (settled, certain) in run skip-1; the second fixture
+    # would return CANCELLED again if re-dialed. Resume must NOT dial R-001:
+    second = main(
+        ["resume", "--run-id", "skip-1",
+         "--data-dir", str(data_dir), "--state-dir", str(state_dir),
+         "--run-id-new", "skip-2",
+         "--fixture", str(data_dir / "fixtures" / "second.jsonl"),
+         "--call-window-start", "00:00", "--call-window-end", "23:59"]
+    )
+    assert second == 0
+    audit = read_jsonl(state_dir / "runs" / "skip-2" / "audit.jsonl")
+    dialed = [row["target_id"] for row in audit if row["status"] in
+              {"CONFIRMED", "CANCELLED", "RESCHEDULED", "ACCEPTED", "DECLINED",
+               "NO_ANSWER", "UNCERTAIN"}]
+    assert dialed == ["W-001"]  # only the needs-review target is retried
+
+
+def test_resume_missing_source_run_fails_cleanly(tmp_path, capsys):
+    data_dir = write_sample_data(tmp_path)
+    exit_code = main(
+        ["resume", "--run-id", "nope",
+         "--data-dir", str(data_dir), "--state-dir", str(tmp_path / "state")]
+    )
+    assert exit_code == 1
+    assert "no audit log" in capsys.readouterr().err
+
+
 def test_module_entrypoint_runs():
     import subprocess
     import sys

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -147,8 +147,8 @@ def test_fill_slot_walks_waitlist_in_priority_order_until_accepted(tmp_path):
     engine, client, _ = make_engine(tmp_path, payloads)
     slot = make_reservation()
     entries = [make_entry("W-002", priority=1), make_entry("W-001", priority=2)]
-    outcome = engine.fill_slot("run-1", slot, entries, NOW)
-    assert outcome.status == CallStatus.ACCEPTED
+    placed = engine.fill_slot("run-1", slot, entries, NOW)
+    assert [o.status for o in placed] == [CallStatus.DECLINED, CallStatus.ACCEPTED]
     assert slot.status == ReservationStatus.RECOVERED
     assert entries[0].status == WaitlistStatus.DECLINED
     assert entries[1].status == WaitlistStatus.ACCEPTED

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -137,3 +137,92 @@ def test_cancelled_run_refuses_to_dial(tmp_path):
     outcome = engine.confirm_reservation("run-1", make_reservation(), NOW)
     assert outcome.status == CallStatus.CANCELLED_BY_OPERATOR
     assert client.dialed == []
+
+
+def test_fill_slot_walks_waitlist_in_priority_order_until_accepted(tmp_path):
+    payloads = {
+        "W-002": [{"status": "DECLINED", "new_slot": None, "notes": "no"}],
+        "W-001": [{"status": "ACCEPTED", "new_slot": None, "notes": "yes"}],
+    }
+    engine, client, _ = make_engine(tmp_path, payloads)
+    slot = make_reservation()
+    entries = [make_entry("W-002", priority=1), make_entry("W-001", priority=2)]
+    outcome = engine.fill_slot("run-1", slot, entries, NOW)
+    assert outcome.status == CallStatus.ACCEPTED
+    assert slot.status == ReservationStatus.RECOVERED
+    assert entries[0].status == WaitlistStatus.DECLINED
+    assert entries[1].status == WaitlistStatus.ACCEPTED
+    assert client.dialed == ["W-002", "W-001"]
+
+
+def test_select_candidates_filters_party_size_and_window(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path, {"W-001": [{"status": "ACCEPTED", "new_slot": None, "notes": "yes"}]}
+    )
+    slot = make_reservation(party_size=4)
+    too_small = make_entry("W-001", party_size=2)
+    assert engine.select_candidates(slot, [too_small]) == []
+    out_of_window = make_entry("W-001")
+    out_of_window.window_end = "2026-09-10T17:00:00+07:00"
+    assert engine.select_candidates(slot, [out_of_window]) == []
+    no_consent = make_entry("W-001", consent=False)
+    assert engine.select_candidates(slot, [no_consent]) == []
+    matching = make_entry("W-001")
+    assert engine.select_candidates(slot, [matching]) == [matching]
+    assert client.dialed == []
+
+
+def test_party_size_tolerance_allows_smaller_parties(tmp_path):
+    engine, _, _ = make_engine(tmp_path, {}, EngineConfig(party_size_tolerance=2))
+    slot = make_reservation(party_size=4)
+    smaller = make_entry("W-001", party_size=2)
+    assert engine.select_candidates(slot, [smaller]) == [smaller]
+    bigger = make_entry("W-002", party_size=6)
+    assert engine.select_candidates(slot, [bigger]) == []
+
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+DIAL_STATUSES = ["CONFIRMED", "CANCELLED", "NO_ANSWER"]
+
+
+@given(
+    statuses=st.lists(st.sampled_from(DIAL_STATUSES), min_size=0, max_size=6),
+    max_calls=st.integers(min_value=1, max_value=4),
+)
+@settings(max_examples=50, deadline=None)
+def test_engine_never_exceeds_budget(tmp_path_factory, statuses, max_calls):
+    tmp_path = tmp_path_factory.mktemp("prop")
+    payloads = {
+        f"R-{i:03d}": [{"status": status, "new_slot": None, "notes": ""}]
+        for i, status in enumerate(statuses)
+    }
+    engine, client, _ = make_engine(
+        tmp_path, payloads, EngineConfig(max_calls=max_calls, no_answer_retries=0)
+    )
+    try:
+        for i in range(len(statuses)):
+            engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
+    except BudgetExceededError:
+        pass
+    assert engine.calls_made <= max_calls
+    assert len(client.dialed) <= max_calls
+
+
+@given(
+    statuses=st.lists(st.sampled_from(DIAL_STATUSES), min_size=1, max_size=6),
+)
+@settings(max_examples=50, deadline=None)
+def test_engine_never_dials_a_target_twice_in_one_run(tmp_path_factory, statuses):
+    tmp_path = tmp_path_factory.mktemp("prop")
+    payloads = {
+        f"R-{i:03d}": [{"status": status, "new_slot": None, "notes": ""}]
+        for i, status in enumerate(statuses)
+    }
+    engine, client, _ = make_engine(tmp_path, payloads, EngineConfig(no_answer_retries=0))
+    for i in range(len(statuses)):
+        engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
+        second = engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
+        assert second.status == CallStatus.SKIPPED_DUPLICATE
+    assert len(client.dialed) == len(set(client.dialed))

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -1,0 +1,139 @@
+from datetime import datetime, time as dt_time, timezone
+
+import pytest
+
+from table_rescue.engine import BudgetExceededError, CascadeEngine, EngineConfig
+from table_rescue.models import (
+    CallOutcome,
+    CallStatus,
+    Reservation,
+    ReservationStatus,
+    WaitlistEntry,
+    WaitlistStatus,
+)
+from table_rescue.stores import AuditLog
+
+NOW = datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc)
+SLOT = "2026-09-10T19:00:00+07:00"
+WINDOW_START = "2026-09-10T18:00:00+07:00"
+WINDOW_END = "2026-09-10T21:00:00+07:00"
+
+
+class FakeClient:
+    def __init__(self, payloads):
+        self.payloads = payloads  # target_id -> list[dict], popped per call
+        self.dialed = []
+
+    def place_call(self, request):
+        self.dialed.append(request.target_id)
+        payload = self.payloads[request.target_id].pop(0)
+        return CallOutcome.from_payload(request.run_id, request.target_id, payload)
+
+
+def make_reservation(booking_id="R-001", party_size=4, consent=True):
+    return Reservation(
+        booking_id=booking_id,
+        name="Fictional Guest",
+        phone="+15550101",
+        party_size=party_size,
+        slot=SLOT,
+        consent=consent,
+    )
+
+
+def make_entry(entry_id="W-001", party_size=4, priority=1, consent=True):
+    return WaitlistEntry(
+        entry_id=entry_id,
+        name="Fictional Waitlist",
+        phone="+15550111",
+        party_size=party_size,
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        priority=priority,
+        consent=consent,
+    )
+
+
+def make_engine(tmp_path, payloads, config=None):
+    audit = AuditLog(tmp_path / "runs" / "run-1")
+    client = FakeClient(payloads)
+    engine = CascadeEngine(client, audit, config)
+    return engine, client, audit
+
+
+def test_confirm_reservation_transitions_status(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path,
+        {"R-001": [{"status": "CANCELLED", "new_slot": None, "notes": "cannot make it"}]},
+    )
+    reservation = make_reservation()
+    outcome = engine.confirm_reservation("run-1", reservation, NOW)
+    assert outcome.status == CallStatus.CANCELLED
+    assert reservation.status == ReservationStatus.CANCELLED
+    assert client.dialed == ["R-001"]
+
+
+def test_confirm_reservation_retries_no_answer_once(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path,
+        {
+            "R-001": [
+                {"status": "NO_ANSWER", "new_slot": None, "notes": "nobody"},
+                {"status": "CONFIRMED", "new_slot": None, "notes": "second try"},
+            ]
+        },
+    )
+    reservation = make_reservation()
+    outcome = engine.confirm_reservation("run-1", reservation, NOW)
+    assert outcome.status == CallStatus.CONFIRMED
+    assert reservation.status == ReservationStatus.CONFIRMED
+    assert client.dialed == ["R-001", "R-001"]
+
+
+def test_non_consented_reservation_is_never_dialed(tmp_path):
+    engine, client, _ = make_engine(tmp_path, {})
+    outcome = engine.confirm_reservation("run-1", make_reservation(consent=False), NOW)
+    assert outcome.status == CallStatus.SKIPPED_NO_CONSENT
+    assert client.dialed == []
+
+
+def test_duplicate_run_target_is_skipped(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path,
+        {"R-001": [{"status": "CONFIRMED", "new_slot": None, "notes": "ok"}]},
+    )
+    engine.confirm_reservation("run-1", make_reservation(), NOW)
+    second = engine.confirm_reservation("run-1", make_reservation(), NOW)
+    assert second.status == CallStatus.SKIPPED_DUPLICATE
+    assert client.dialed == ["R-001"]
+
+
+def test_calls_outside_window_are_skipped(tmp_path):
+    config = EngineConfig(call_window_start=dt_time(13, 0), call_window_end=dt_time(14, 0))
+    engine, client, _ = make_engine(tmp_path, {}, config)
+    outcome = engine.confirm_reservation("run-1", make_reservation(), NOW)
+    assert outcome.status == CallStatus.SKIPPED_OUT_OF_WINDOW
+    assert client.dialed == []
+
+
+def test_budget_guard_raises_before_dialing(tmp_path):
+    config = EngineConfig(max_calls=1)
+    payloads = {
+        "R-001": [{"status": "CONFIRMED", "new_slot": None, "notes": "ok"}],
+        "R-002": [{"status": "CONFIRMED", "new_slot": None, "notes": "ok"}],
+    }
+    engine, client, _ = make_engine(tmp_path, payloads, config)
+    engine.confirm_reservation("run-1", make_reservation("R-001"), NOW)
+    with pytest.raises(BudgetExceededError):
+        engine.confirm_reservation("run-1", make_reservation("R-002"), NOW)
+    assert client.dialed == ["R-001"]
+
+
+def test_cancelled_run_refuses_to_dial(tmp_path):
+    engine, client, audit = make_engine(tmp_path, {})
+    audit.append(
+        CallOutcome(run_id="run-1", target_id="-", status=CallStatus.CANCELLED_BY_OPERATOR)
+    )
+    outcome = engine.confirm_reservation("run-1", make_reservation(), NOW)
+    assert outcome.status == CallStatus.CANCELLED_BY_OPERATOR
+    assert client.dialed == []

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -2,7 +2,12 @@ from datetime import datetime, time as dt_time, timezone
 
 import pytest
 
-from table_rescue.engine import BudgetExceededError, CascadeEngine, EngineConfig
+from table_rescue.engine import (
+    BudgetExceededError,
+    CascadeEngine,
+    EngineConfig,
+    ReconciliationRequiredError,
+)
 from table_rescue.models import (
     CallOutcome,
     CallStatus,
@@ -12,6 +17,7 @@ from table_rescue.models import (
     WaitlistStatus,
 )
 from table_rescue.stores import AuditLog
+from table_rescue.safety import RunSafety, SafetyViolation
 
 NOW = datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc)
 SLOT = "2026-09-10T19:00:00+07:00"
@@ -181,10 +187,87 @@ def test_party_size_tolerance_allows_smaller_parties(tmp_path):
     assert engine.select_candidates(slot, [bigger]) == []
 
 
+def test_confirm_uncertain_marks_needs_review_and_stops(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path,
+        {"R-001": [{"status": "UNCERTAIN", "uncertainty_reason": "UNPARSEABLE_SUMMARY"}]},
+    )
+    reservation = make_reservation()
+    with pytest.raises(ReconciliationRequiredError, match="R-001"):
+        engine.confirm_reservation("run-1", reservation, NOW)
+    assert reservation.status == ReservationStatus.NEEDS_REVIEW
+
+
+def test_confirm_no_answer_after_retries_stops(tmp_path):
+    engine, client, _ = make_engine(
+        tmp_path,
+        {"R-001": [{"status": "NO_ANSWER"}, {"status": "NO_ANSWER"}]},
+    )
+    reservation = make_reservation()
+    with pytest.raises(ReconciliationRequiredError):
+        engine.confirm_reservation("run-1", reservation, NOW)
+    assert client.dialed == ["R-001", "R-001"]
+    assert reservation.status == ReservationStatus.NEEDS_REVIEW
+
+
+def test_waitlist_no_answer_never_advances_to_next_recipient(tmp_path):
+    payloads = {
+        "W-001": [{"status": "NO_ANSWER"}],
+        "W-002": [{"status": "ACCEPTED"}],
+    }
+    engine, client, _ = make_engine(tmp_path, payloads)
+    slot = make_reservation()
+    slot.status = ReservationStatus.CANCELLED
+    entries = [make_entry("W-001", priority=1), make_entry("W-002", priority=2)]
+    with pytest.raises(ReconciliationRequiredError):
+        engine.fill_slot("run-1", slot, entries, NOW)
+    assert client.dialed == ["W-001"]
+    assert entries[0].status == WaitlistStatus.NEEDS_REVIEW
+    assert entries[1].status == WaitlistStatus.WAITING
+
+
+def test_waitlist_declined_still_advances(tmp_path):
+    payloads = {
+        "W-001": [{"status": "DECLINED"}],
+        "W-002": [{"status": "ACCEPTED"}],
+    }
+    engine, client, _ = make_engine(tmp_path, payloads)
+    slot = make_reservation()
+    entries = [make_entry("W-001", priority=1), make_entry("W-002", priority=2)]
+    placed = engine.fill_slot("run-1", slot, entries, NOW)
+    assert [o.status for o in placed] == [CallStatus.DECLINED, CallStatus.ACCEPTED]
+
+
+def test_live_gate_blocks_unvalidated_destination_before_dialing(tmp_path):
+    audit = AuditLog(tmp_path / "runs" / "run-1")
+    client = FakeClient({})
+    safety = RunSafety(live=True, region="VN", authorizations={})
+    engine = CascadeEngine(client, audit, safety=safety)
+    # A VN run dialing a NANP sample number is blocked as REGION_MISMATCH,
+    # an earlier gate than authorization; any SafetyViolation before dialing
+    # satisfies the fail-closed property.
+    with pytest.raises(
+        SafetyViolation, match="FICTIONAL_NUMBER|NOT_AUTHORIZED|REGION_MISMATCH"
+    ):
+        engine.confirm_reservation("run-1", make_reservation(), NOW)
+    assert client.dialed == []
+
+
+def test_live_gate_blocks_authorized_but_fictional(tmp_path):
+    audit = AuditLog(tmp_path / "runs" / "run-1")
+    client = FakeClient({})
+    safety = RunSafety(
+        live=True, region="US", authorizations={"+15550101": {"authorized_by": "op"}}
+    )
+    engine = CascadeEngine(client, audit, safety=safety)
+    with pytest.raises(SafetyViolation, match="FICTIONAL_NUMBER"):
+        engine.confirm_reservation("run-1", make_reservation(), NOW)
+
+
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-DIAL_STATUSES = ["CONFIRMED", "CANCELLED", "NO_ANSWER"]
+DIAL_STATUSES = ["CONFIRMED", "CANCELLED", "NO_ANSWER", "UNCERTAIN"]
 
 
 @given(
@@ -204,7 +287,7 @@ def test_engine_never_exceeds_budget(tmp_path_factory, statuses, max_calls):
     try:
         for i in range(len(statuses)):
             engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
-    except BudgetExceededError:
+    except (BudgetExceededError, ReconciliationRequiredError):
         pass
     assert engine.calls_made <= max_calls
     assert len(client.dialed) <= max_calls
@@ -222,7 +305,10 @@ def test_engine_never_dials_a_target_twice_in_one_run(tmp_path_factory, statuses
     }
     engine, client, _ = make_engine(tmp_path, payloads, EngineConfig(no_answer_retries=0))
     for i in range(len(statuses)):
-        engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
+        try:
+            engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
+        except ReconciliationRequiredError:
+            break
         second = engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)
         assert second.status == CallStatus.SKIPPED_DUPLICATE
     assert len(client.dialed) == len(set(client.dialed))

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -79,21 +79,17 @@ def test_confirm_reservation_transitions_status(tmp_path):
     assert client.dialed == ["R-001"]
 
 
-def test_confirm_reservation_retries_no_answer_once(tmp_path):
+def test_confirm_first_no_answer_stops_for_reconciliation(tmp_path):
     engine, client, _ = make_engine(
         tmp_path,
-        {
-            "R-001": [
-                {"status": "NO_ANSWER", "new_slot": None, "notes": "nobody"},
-                {"status": "CONFIRMED", "new_slot": None, "notes": "second try"},
-            ]
-        },
+        {"R-001": [{"status": "NO_ANSWER", "new_slot": None, "notes": "nobody"}]},
     )
     reservation = make_reservation()
-    outcome = engine.confirm_reservation("run-1", reservation, NOW)
-    assert outcome.status == CallStatus.CONFIRMED
-    assert reservation.status == ReservationStatus.CONFIRMED
-    assert client.dialed == ["R-001", "R-001"]
+    with pytest.raises(ReconciliationRequiredError, match="R-001"):
+        engine.confirm_reservation("run-1", reservation, NOW)
+    # The same recipient is never auto-redialed; a human resumes instead.
+    assert client.dialed == ["R-001"]
+    assert reservation.status == ReservationStatus.NEEDS_REVIEW
 
 
 def test_non_consented_reservation_is_never_dialed(tmp_path):
@@ -209,18 +205,6 @@ def test_reconciliation_error_carries_triggering_outcome(tmp_path):
     assert excinfo.value.outcome.uncertainty_reason == "PROVIDER_FAILED"
 
 
-def test_confirm_no_answer_after_retries_stops(tmp_path):
-    engine, client, _ = make_engine(
-        tmp_path,
-        {"R-001": [{"status": "NO_ANSWER"}, {"status": "NO_ANSWER"}]},
-    )
-    reservation = make_reservation()
-    with pytest.raises(ReconciliationRequiredError):
-        engine.confirm_reservation("run-1", reservation, NOW)
-    assert client.dialed == ["R-001", "R-001"]
-    assert reservation.status == ReservationStatus.NEEDS_REVIEW
-
-
 def test_waitlist_no_answer_never_advances_to_next_recipient(tmp_path):
     payloads = {
         "W-001": [{"status": "NO_ANSWER"}],
@@ -293,7 +277,7 @@ def test_engine_never_exceeds_budget(tmp_path_factory, statuses, max_calls):
         for i, status in enumerate(statuses)
     }
     engine, client, _ = make_engine(
-        tmp_path, payloads, EngineConfig(max_calls=max_calls, no_answer_retries=0)
+        tmp_path, payloads, EngineConfig(max_calls=max_calls)
     )
     try:
         for i in range(len(statuses)):
@@ -314,7 +298,7 @@ def test_engine_never_dials_a_target_twice_in_one_run(tmp_path_factory, statuses
         f"R-{i:03d}": [{"status": status, "new_slot": None, "notes": ""}]
         for i, status in enumerate(statuses)
     }
-    engine, client, _ = make_engine(tmp_path, payloads, EngineConfig(no_answer_retries=0))
+    engine, client, _ = make_engine(tmp_path, payloads)
     for i in range(len(statuses)):
         try:
             engine.confirm_reservation("run-1", make_reservation(f"R-{i:03d}"), NOW)

--- a/apps/python/table-rescue/tests/test_engine.py
+++ b/apps/python/table-rescue/tests/test_engine.py
@@ -198,6 +198,17 @@ def test_confirm_uncertain_marks_needs_review_and_stops(tmp_path):
     assert reservation.status == ReservationStatus.NEEDS_REVIEW
 
 
+def test_reconciliation_error_carries_triggering_outcome(tmp_path):
+    engine, _, _ = make_engine(
+        tmp_path,
+        {"R-001": [{"status": "UNCERTAIN", "uncertainty_reason": "PROVIDER_FAILED"}]},
+    )
+    with pytest.raises(ReconciliationRequiredError) as excinfo:
+        engine.confirm_reservation("run-1", make_reservation(), NOW)
+    assert excinfo.value.outcome.target_id == "R-001"
+    assert excinfo.value.outcome.uncertainty_reason == "PROVIDER_FAILED"
+
+
 def test_confirm_no_answer_after_retries_stops(tmp_path):
     engine, client, _ = make_engine(
         tmp_path,

--- a/apps/python/table-rescue/tests/test_models.py
+++ b/apps/python/table-rescue/tests/test_models.py
@@ -1,0 +1,47 @@
+from table_rescue.models import (
+    CallOutcome,
+    CallStatus,
+    Reservation,
+    ReservationStatus,
+    WaitlistEntry,
+    WaitlistStatus,
+)
+
+
+def test_reservation_roundtrip():
+    line = {
+        "booking_id": "R-001",
+        "name": "Fictional Guest",
+        "phone": "+15550101",
+        "party_size": 4,
+        "slot": "2026-09-10T19:00:00+07:00",
+        "consent": True,
+    }
+    reservation = Reservation.from_line(line)
+    assert reservation.status == ReservationStatus.PENDING_CONFIRM
+    assert Reservation.from_line(reservation.to_line()) == reservation
+
+
+def test_waitlist_entry_roundtrip():
+    line = {
+        "entry_id": "W-001",
+        "name": "Fictional Waitlist",
+        "phone": "+15550111",
+        "party_size": 4,
+        "window_start": "2026-09-10T18:00:00+07:00",
+        "window_end": "2026-09-10T21:00:00+07:00",
+        "priority": 1,
+        "consent": True,
+    }
+    entry = WaitlistEntry.from_line(line)
+    assert entry.status == WaitlistStatus.WAITING
+    assert WaitlistEntry.from_line(entry.to_line()) == entry
+
+
+def test_call_outcome_from_payload():
+    payload = {"status": "CANCELLED", "new_slot": None, "notes": "cannot make it"}
+    outcome = CallOutcome.from_payload("run-1", "R-001", payload)
+    assert outcome.status == CallStatus.CANCELLED
+    assert outcome.run_id == "run-1"
+    assert outcome.target_id == "R-001"
+    assert outcome.new_slot is None

--- a/apps/python/table-rescue/tests/test_models.py
+++ b/apps/python/table-rescue/tests/test_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from table_rescue.models import (
     CallOutcome,
     CallStatus,
@@ -6,6 +8,7 @@ from table_rescue.models import (
     WaitlistEntry,
     WaitlistStatus,
 )
+from table_rescue.safety import SafetyViolation
 
 
 def test_reservation_roundtrip():
@@ -45,3 +48,31 @@ def test_call_outcome_from_payload():
     assert outcome.run_id == "run-1"
     assert outcome.target_id == "R-001"
     assert outcome.new_slot is None
+
+
+def test_reservation_from_line_rejects_non_e164_phone():
+    line = {
+        "booking_id": "R-001", "name": "Guest", "phone": "0304 not a phone",
+        "party_size": 2, "slot": "2026-09-10T19:00:00+07:00", "consent": True,
+    }
+    with pytest.raises(SafetyViolation, match="INVALID_E164"):
+        Reservation.from_line(line)
+
+
+def test_waitlist_from_line_rejects_non_e164_phone():
+    line = {
+        "entry_id": "W-001", "name": "Guest", "phone": "555-0101",
+        "party_size": 2, "window_start": "2026-09-10T18:00:00+07:00",
+        "window_end": "2026-09-10T21:00:00+07:00", "priority": 1, "consent": True,
+    }
+    with pytest.raises(SafetyViolation, match="INVALID_E164"):
+        WaitlistEntry.from_line(line)
+
+
+def test_call_outcome_carries_uncertainty_reason():
+    outcome = CallOutcome.from_payload(
+        "run-1", "R-001",
+        {"status": "UNCERTAIN", "uncertainty_reason": "UNPARSEABLE_SUMMARY"},
+    )
+    assert outcome.status == CallStatus.UNCERTAIN
+    assert outcome.uncertainty_reason == "UNPARSEABLE_SUMMARY"

--- a/apps/python/table-rescue/tests/test_report.py
+++ b/apps/python/table-rescue/tests/test_report.py
@@ -1,0 +1,43 @@
+from table_rescue.models import (
+    CallOutcome,
+    CallStatus,
+    Reservation,
+    ReservationStatus,
+    WaitlistEntry,
+    WaitlistStatus,
+)
+from table_rescue.report import render_report
+
+
+def test_render_report_masks_phones_and_counts():
+    reservation = Reservation(
+        booking_id="R-001",
+        name="Fictional Guest",
+        phone="+15550101",
+        party_size=4,
+        slot="2026-09-10T19:00:00+07:00",
+        consent=True,
+        status=ReservationStatus.RECOVERED,
+    )
+    entry = WaitlistEntry(
+        entry_id="W-001",
+        name="Fictional Waitlist",
+        phone="+15550111",
+        party_size=4,
+        window_start="2026-09-10T18:00:00+07:00",
+        window_end="2026-09-10T21:00:00+07:00",
+        priority=1,
+        consent=True,
+        status=WaitlistStatus.ACCEPTED,
+    )
+    outcomes = [
+        CallOutcome(run_id="run-1", target_id="R-001", status=CallStatus.CANCELLED,
+                    notes="cannot make it"),
+        CallOutcome(run_id="run-1", target_id="W-001", status=CallStatus.ACCEPTED,
+                    notes="we will come"),
+    ]
+    report = render_report("run-1", outcomes, [reservation], [entry])
+    assert "Slots recovered: 1" in report
+    assert "Waitlist entries accepted: 1" in report
+    assert "+15550101" not in report
+    assert "+******01" in report

--- a/apps/python/table-rescue/tests/test_report.py
+++ b/apps/python/table-rescue/tests/test_report.py
@@ -41,3 +41,23 @@ def test_render_report_masks_phones_and_counts():
     assert "Waitlist entries accepted: 1" in report
     assert "+15550101" not in report
     assert "+******01" in report
+
+
+def test_render_report_estimates_protected_revenue():
+    reservation = Reservation(
+        booking_id="R-001",
+        name="Fictional Guest",
+        phone="+15550101",
+        party_size=4,
+        slot="2026-09-10T19:00:00+07:00",
+        consent=True,
+        status=ReservationStatus.RECOVERED,
+    )
+    report = render_report(
+        "run-1", [], [reservation], [], avg_check_per_guest=25.0
+    )
+    assert (
+        "Estimated revenue protected: 100 (4 recovered seats x 25 per guest)" in report
+    )
+    plain = render_report("run-1", [], [reservation], [])
+    assert "Estimated revenue protected" not in plain

--- a/apps/python/table-rescue/tests/test_report.py
+++ b/apps/python/table-rescue/tests/test_report.py
@@ -63,6 +63,24 @@ def test_render_report_estimates_protected_revenue():
     assert "Estimated revenue protected" not in plain
 
 
+def test_report_notes_never_contain_raw_phones():
+    reservation = Reservation(
+        booking_id="R-001", name="Guest", phone="+15550101", party_size=2,
+        slot="2026-09-10T19:00:00+07:00", consent=True,
+        status=ReservationStatus.NEEDS_REVIEW,
+    )
+    outcomes = [
+        CallOutcome(
+            run_id="run-1", target_id="R-001", status=CallStatus.UNCERTAIN,
+            notes="callback +14155550100 after 6pm",
+            uncertainty_reason="UNPARSEABLE_SUMMARY",
+        )
+    ]
+    report = render_report("run-1", outcomes, [reservation], [])
+    assert "+14155550100" not in report
+    assert "callback" in report
+
+
 def test_report_needs_review_section_and_resumed_from():
     reservation = Reservation(
         booking_id="R-001", name="Guest", phone="+15550101", party_size=2,

--- a/apps/python/table-rescue/tests/test_report.py
+++ b/apps/python/table-rescue/tests/test_report.py
@@ -61,3 +61,26 @@ def test_render_report_estimates_protected_revenue():
     )
     plain = render_report("run-1", [], [reservation], [])
     assert "Estimated revenue protected" not in plain
+
+
+def test_report_needs_review_section_and_resumed_from():
+    reservation = Reservation(
+        booking_id="R-001", name="Guest", phone="+15550101", party_size=2,
+        slot="2026-09-10T19:00:00+07:00", consent=True,
+        status=ReservationStatus.NEEDS_REVIEW,
+    )
+    outcomes = [
+        CallOutcome(
+            run_id="run-2", target_id="R-001", status=CallStatus.UNCERTAIN,
+            notes="guest mumbled [hint: confirm]",
+            uncertainty_reason="UNPARSEABLE_SUMMARY",
+        )
+    ]
+    report = render_report(
+        "run-2", outcomes, [reservation], [], resumed_from="run-1"
+    )
+    assert "Resumed from run: run-1" in report
+    assert "Needs review" in report
+    assert "R-001" in report
+    assert "UNPARSEABLE_SUMMARY" in report
+    assert "hint: confirm" in report

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -36,11 +36,14 @@ class TestSyntax:
 
 
 class TestRegionRules:
-    def test_vn_mobile_passes(self):
-        validate_destination("+14155550100", region="VN", live=True)
+    def test_us_test_hotline_passes(self):
+        # Reserved 555-01xx numbers are (correctly) refused by the fictional
+        # gate below, so the live pass path is exercised with a standards-reserved fictional number
+        # (patched for live path testing).
+        validate_destination("+14155550132", region="US", live=True)
 
     def test_region_lookup_is_case_insensitive(self):
-        validate_destination("+14155550100", region="vn", live=True)
+        validate_destination("+14155550132", region="us", live=True)
 
     def test_wrong_prefix_rejected(self):
         with pytest.raises(SafetyViolation, match="REGION_MISMATCH"):
@@ -71,11 +74,10 @@ class TestFictionalBlock:
         with pytest.raises(SafetyViolation, match="FICTIONAL_NUMBER"):
             validate_destination("+12125550199", region="US", live=True)
 
-    def test_normal_us_number_passes(self):
-        # a standards-reserved fictional number (patched for live path testing) exercises
-        # the live pass path; reserved 555-01xx numbers are refused by the FICTIONAL gate.
-        validate_destination("+14155550132", region="US", live=True)
-        validate_destination("+14155550132", region="US", live=True)
+    def test_live_pass_path_uses_call_e_test_hotline(self):
+        # a standards-reserved fictional number (patched for live path testing).
+        with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
+            validate_destination("+14155550132", region="US", live=True)
 
     def test_fictional_allowed_in_dry_run(self):
         validate_destination("+15550101", region=None, live=False)
@@ -149,8 +151,8 @@ class TestSanitize:
 
     def test_masks_comma_and_slash_grouped_forms(self):
         masked = sanitize_text("dialed +1,415,555,0100 then 415/555/0100")
-        assert "961" not in masked
-        assert "567" not in masked
+        assert "415" not in masked
+        assert "555" not in masked
 
     def test_masks_unicode_digit_runs(self):
         masked = sanitize_text("number +８４９００００００００ there")
@@ -182,10 +184,10 @@ class TestMaskedViolations:
 
     def test_not_authorized_message_masks_phone(self):
         with pytest.raises(SafetyViolation) as exc:
-            RunSafety(live=True, region="VN", authorizations={}).check_destination(
-                "+14155550100"
+            RunSafety(live=True, region="US", authorizations={}).check_destination(
+                "+14155550132"
             )
-        assert "+14155550100" not in str(exc.value)
+        assert "+14155550132" not in str(exc.value)
 
 
 class TestRunSafety:
@@ -194,20 +196,20 @@ class TestRunSafety:
 
     def test_live_requires_region(self):
         with pytest.raises(SafetyViolation, match="MISSING_REGION"):
-            RunSafety(live=True, region=None).check_destination("+14155550100")
+            RunSafety(live=True, region=None).check_destination("+14155550132")
 
     def test_live_happy_path(self):
         safety = RunSafety(
             live=True,
-            region="VN",
-            authorizations={"+14155550100": {"authorized_by": "op"}},
+            region="US",
+            authorizations={"+14155550132": {"authorized_by": "op"}},
         )
-        safety.check_destination("+14155550100")
+        safety.check_destination("+14155550132")
 
     def test_live_unauthorized_rejected(self):
-        safety = RunSafety(live=True, region="VN", authorizations={})
+        safety = RunSafety(live=True, region="US", authorizations={})
         with pytest.raises(SafetyViolation, match="NOT_AUTHORIZED"):
-            safety.check_destination("+14155550100")
+            safety.check_destination("+14155550132")
 
 
 @given(

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -40,10 +40,12 @@ class TestRegionRules:
         # Reserved 555-01xx numbers are (correctly) refused by the fictional
         # gate below, so the live pass path is exercised with a standards-reserved fictional number
         # (patched for live path testing).
-        validate_destination("+14155550132", region="US", live=True)
+        with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
+            validate_destination("+14155550132", region="US", live=True)
 
     def test_region_lookup_is_case_insensitive(self):
-        validate_destination("+14155550132", region="us", live=True)
+        with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
+            validate_destination("+14155550132", region="us", live=True)
 
     def test_wrong_prefix_rejected(self):
         with pytest.raises(SafetyViolation, match="REGION_MISMATCH"):
@@ -78,7 +80,6 @@ class TestFictionalBlock:
         # a standards-reserved fictional number (patched for live path testing).
         with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
             validate_destination("+14155550132", region="US", live=True)
-
     def test_fictional_allowed_in_dry_run(self):
         validate_destination("+15550101", region=None, live=False)
 
@@ -204,12 +205,14 @@ class TestRunSafety:
             region="US",
             authorizations={"+14155550132": {"authorized_by": "op"}},
         )
-        safety.check_destination("+14155550132")
+        with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
+            safety.check_destination("+14155550132")
 
     def test_live_unauthorized_rejected(self):
         safety = RunSafety(live=True, region="US", authorizations={})
-        with pytest.raises(SafetyViolation, match="NOT_AUTHORIZED"):
-            safety.check_destination("+14155550132")
+        with mock.patch("table_rescue.safety._is_fictional_nanp", return_value=False):
+            with pytest.raises(SafetyViolation, match="NOT_AUTHORIZED"):
+                safety.check_destination("+14155550132")
 
 
 @given(

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -8,7 +8,9 @@ from table_rescue.safety import (
     RunSafety,
     SafetyViolation,
     load_authorizations,
+    mask_phone,
     missing_authorizations,
+    sanitize_text,
     validate_destination,
     validate_origin,
     validate_phone_syntax,
@@ -127,6 +129,55 @@ class TestAuthorization:
         path.write_text('{"name": "Guest"}\n', encoding="utf-8")
         with pytest.raises(SafetyViolation, match="INVALID_AUTHORIZATION_FILE"):
             load_authorizations(path)
+
+
+class TestSanitize:
+    def test_masks_e164_and_separated_forms(self):
+        masked = sanitize_text("call +14155550100 now")
+        assert "+14155550100" not in masked
+        assert mask_phone("+14155550100") in masked
+        assert masked.endswith("now")
+
+    def test_masks_local_separated_forms(self):
+        masked = sanitize_text("said (415) 555-0100 twice")
+        assert "415" not in masked
+        assert "555" not in masked
+        assert masked.endswith("00 twice")
+
+    def test_masks_unicode_digit_runs(self):
+        masked = sanitize_text("number +８４９００００００００ there")
+        assert "８４" not in masked
+
+    def test_short_digit_runs_untouched(self):
+        assert sanitize_text("party of 4 at 19:00") == "party of 4 at 19:00"
+
+    def test_idempotent_and_empty_safe(self):
+        text = "call +14155550100 or 415 555 0100"
+        once = sanitize_text(text)
+        assert sanitize_text(once) == once
+        assert sanitize_text(None) == ""
+        assert sanitize_text("") == ""
+
+
+class TestMaskedViolations:
+    def test_invalid_e164_message_masks_input(self):
+        with pytest.raises(SafetyViolation) as exc:
+            validate_phone_syntax("+1 415 555 0100")
+        assert "+1 415 555 0100" not in str(exc.value)
+        assert mask_phone("+1 415 555 0100") in str(exc.value)
+
+    def test_region_mismatch_message_masks_phone(self):
+        with pytest.raises(SafetyViolation) as exc:
+            validate_destination("+14155550100", region="SG", live=True)
+        assert "+14155550100" not in str(exc.value)
+        assert mask_phone("+14155550100") in str(exc.value)
+
+    def test_not_authorized_message_masks_phone(self):
+        with pytest.raises(SafetyViolation) as exc:
+            RunSafety(live=True, region="VN", authorizations={}).check_destination(
+                "+14155550100"
+            )
+        assert "+14155550100" not in str(exc.value)
 
 
 class TestRunSafety:

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -147,6 +147,11 @@ class TestSanitize:
         assert "555" not in masked
         assert masked.endswith("00 twice")
 
+    def test_masks_comma_and_slash_grouped_forms(self):
+        masked = sanitize_text("dialed +1,415,555,0100 then 415/555/0100")
+        assert "961" not in masked
+        assert "567" not in masked
+
     def test_masks_unicode_digit_runs(self):
         masked = sanitize_text("number +８４９００００００００ there")
         assert "８４" not in masked

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -19,7 +19,7 @@ class TestSyntax:
     @pytest.mark.parametrize(
         "phone",
         ["", "14155550100", "+04155550100", "+1 415 555 0100", "+1415555010?",
-        "0012345", "+abc"],
+        "0012345", "+abc", "+14155550100\n"],
     )
     def test_rejects_non_e164(self, phone):
         with pytest.raises(SafetyViolation, match="INVALID_E164"):
@@ -29,6 +29,9 @@ class TestSyntax:
 class TestRegionRules:
     def test_vn_mobile_passes(self):
         validate_destination("+14155550100", region="VN", live=True)
+
+    def test_region_lookup_is_case_insensitive(self):
+        validate_destination("+14155550100", region="vn", live=True)
 
     def test_wrong_prefix_rejected(self):
         with pytest.raises(SafetyViolation, match="REGION_MISMATCH"):
@@ -105,6 +108,18 @@ class TestAuthorization:
         row = '{"phone": "+14155550100", "authorized_by": "op"}\n'
         path.write_text(row + row, encoding="utf-8")
         with pytest.raises(SafetyViolation, match="DUPLICATE_AUTHORIZATION"):
+            load_authorizations(path)
+
+    def test_malformed_json_line_rejected(self, tmp_path):
+        path = tmp_path / "authorized_destinations.jsonl"
+        path.write_text("not json\n", encoding="utf-8")
+        with pytest.raises(SafetyViolation, match="INVALID_AUTHORIZATION_FILE"):
+            load_authorizations(path)
+
+    def test_row_missing_phone_rejected(self, tmp_path):
+        path = tmp_path / "authorized_destinations.jsonl"
+        path.write_text('{"name": "Guest"}\n', encoding="utf-8")
+        with pytest.raises(SafetyViolation, match="INVALID_AUTHORIZATION_FILE"):
             load_authorizations(path)
 
 

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import re
 
 import pytest
@@ -71,8 +72,10 @@ class TestFictionalBlock:
             validate_destination("+12125550199", region="US", live=True)
 
     def test_normal_us_number_passes(self):
-        validate_destination("+14155550100", region="US", live=True)
-        validate_destination("+12025550142", region="US", live=True)
+        # a standards-reserved fictional number (patched for live path testing) exercises
+        # the live pass path; reserved 555-01xx numbers are refused by the FICTIONAL gate.
+        validate_destination("+14155550132", region="US", live=True)
+        validate_destination("+14155550132", region="US", live=True)
 
     def test_fictional_allowed_in_dry_run(self):
         validate_destination("+15550101", region=None, live=False)

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -1,0 +1,130 @@
+import pytest
+
+from table_rescue.safety import (
+    RunSafety,
+    SafetyViolation,
+    load_authorizations,
+    missing_authorizations,
+    validate_destination,
+    validate_origin,
+    validate_phone_syntax,
+)
+
+
+class TestSyntax:
+    def test_accepts_valid_e164(self):
+        validate_phone_syntax("+14155550100")
+        validate_phone_syntax("+18005550187")
+
+    @pytest.mark.parametrize(
+        "phone",
+        ["", "14155550100", "+04155550100", "+1 415 555 0100", "+1415555010?",
+        "0012345", "+abc"],
+    )
+    def test_rejects_non_e164(self, phone):
+        with pytest.raises(SafetyViolation, match="INVALID_E164"):
+            validate_phone_syntax(phone)
+
+
+class TestRegionRules:
+    def test_vn_mobile_passes(self):
+        validate_destination("+14155550100", region="VN", live=True)
+
+    def test_wrong_prefix_rejected(self):
+        with pytest.raises(SafetyViolation, match="REGION_MISMATCH"):
+            validate_destination("+14155550100", region="SG", live=True)
+
+    def test_bad_national_length_rejected(self):
+        with pytest.raises(SafetyViolation, match="INVALID_LENGTH"):
+            validate_destination("+84155500", region="VN", live=True)
+
+    def test_unsupported_region_rejected(self):
+        with pytest.raises(SafetyViolation, match="UNSUPPORTED_REGION"):
+            validate_destination("+14155550100", region="XX", live=True)
+
+    def test_dry_run_skips_region_rules(self):
+        validate_destination("+15550101", region=None, live=False)
+
+
+class TestFictionalBlock:
+    def test_short_sample_form_rejected_live(self):
+        with pytest.raises(SafetyViolation, match="FICTIONAL_NUMBER"):
+            validate_destination("+15550101", region="US", live=True)
+
+    def test_full_npa_555_rejected_live(self):
+        with pytest.raises(SafetyViolation, match="FICTIONAL_NUMBER"):
+            validate_destination("+15552125501", region="US", live=True)
+
+    def test_full_555_01xx_block_rejected_live(self):
+        with pytest.raises(SafetyViolation, match="FICTIONAL_NUMBER"):
+            validate_destination("+12125550199", region="US", live=True)
+
+    def test_normal_us_number_passes(self):
+        validate_destination("+14155550100", region="US", live=True)
+        validate_destination("+12025550142", region="US", live=True)
+
+    def test_fictional_allowed_in_dry_run(self):
+        validate_destination("+15550101", region=None, live=False)
+
+
+class TestOrigin:
+    def test_official_origin_passes(self):
+        validate_origin("https://seleven-mcp-sg.airudder.com")
+        validate_origin("https://seleven-mcp-sg.airudder.com/")
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "http://seleven-mcp-sg.airudder.com",
+            "https://evil.example.com",
+            "https://seleven-mcp-sg.airudder.com.evil.com",
+            "",
+        ],
+    )
+    def test_other_origins_rejected(self, origin):
+        with pytest.raises(SafetyViolation, match="ORIGIN_NOT_ALLOWED"):
+            validate_origin(origin)
+
+
+class TestAuthorization:
+    def test_load_and_missing(self, tmp_path):
+        path = tmp_path / "authorized_destinations.jsonl"
+        path.write_text(
+            '{"phone": "+14155550100", "name": "Guest", '
+            '"authorized_by": "op", "authorized_at": "2026-09-07T00:00:00+07:00"}\n',
+            encoding="utf-8",
+        )
+        authorizations = load_authorizations(path)
+        assert missing_authorizations(["+14155550100"], authorizations) == []
+        assert missing_authorizations(
+            ["+14155550100", "+14155550190"], authorizations
+        ) == ["+14155550190"]
+
+    def test_duplicate_rows_rejected(self, tmp_path):
+        path = tmp_path / "authorized_destinations.jsonl"
+        row = '{"phone": "+14155550100", "authorized_by": "op"}\n'
+        path.write_text(row + row, encoding="utf-8")
+        with pytest.raises(SafetyViolation, match="DUPLICATE_AUTHORIZATION"):
+            load_authorizations(path)
+
+
+class TestRunSafety:
+    def test_dry_run_is_noop(self):
+        RunSafety(live=False).check_destination("+15550101")
+
+    def test_live_requires_region(self):
+        with pytest.raises(SafetyViolation, match="MISSING_REGION"):
+            RunSafety(live=True, region=None).check_destination("+14155550100")
+
+    def test_live_happy_path(self):
+        safety = RunSafety(
+            live=True,
+            region="VN",
+            authorizations={"+14155550100": {"authorized_by": "op"}},
+        )
+        safety.check_destination("+14155550100")
+
+    def test_live_unauthorized_rejected(self):
+        safety = RunSafety(live=True, region="VN", authorizations={})
+        with pytest.raises(SafetyViolation, match="NOT_AUTHORIZED"):
+            safety.check_destination("+14155550100")

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -23,7 +23,9 @@ class TestSyntax:
     @pytest.mark.parametrize(
         "phone",
         ["", "14155550100", "+04155550100", "+1 415 555 0100", "+1415555010?",
-        "0012345", "+abc", "+14155550100\n"],
+        "0012345", "+abc", "+14155550100\n",
+        # Unicode decimal digits must never pass ASCII-strict E.164.
+        "+84１２３４５６７", "+8٤١٢٣٤٥٦٧", "+84९८७६५४३२"],
     )
     def test_rejects_non_e164(self, phone):
         with pytest.raises(SafetyViolation, match="INVALID_E164"):
@@ -163,5 +165,5 @@ def test_arbitrary_text_is_never_a_valid_destination(text):
         validate_phone_syntax(text)
     except SafetyViolation:
         return
-    # Anything accepted must satisfy the E.164 grammar itself.
-    assert re.fullmatch(r"\+[1-9]\d{6,14}", text) is not None
+    # Anything accepted must satisfy the ASCII-strict E.164 grammar itself.
+    assert re.fullmatch(r"\+[1-9][0-9]{6,14}", text) is not None

--- a/apps/python/table-rescue/tests/test_safety.py
+++ b/apps/python/table-rescue/tests/test_safety.py
@@ -1,4 +1,8 @@
+import re
+
 import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
 
 from table_rescue.safety import (
     RunSafety,
@@ -143,3 +147,21 @@ class TestRunSafety:
         safety = RunSafety(live=True, region="VN", authorizations={})
         with pytest.raises(SafetyViolation, match="NOT_AUTHORIZED"):
             safety.check_destination("+14155550100")
+
+
+@given(
+    st.text(
+        alphabet=st.characters(blacklist_categories=("Cs",)),
+        min_size=0,
+        max_size=18,
+    )
+)
+@settings(max_examples=200, deadline=None)
+def test_arbitrary_text_is_never_a_valid_destination(text):
+    assume(text != "")
+    try:
+        validate_phone_syntax(text)
+    except SafetyViolation:
+        return
+    # Anything accepted must satisfy the E.164 grammar itself.
+    assert re.fullmatch(r"\+[1-9]\d{6,14}", text) is not None

--- a/apps/python/table-rescue/tests/test_stores.py
+++ b/apps/python/table-rescue/tests/test_stores.py
@@ -1,0 +1,34 @@
+from table_rescue.models import CallOutcome, CallStatus
+from table_rescue.stores import (
+    AuditLog,
+    mask_phone,
+    read_jsonl,
+    write_jsonl_atomic,
+)
+
+
+def test_jsonl_roundtrip_and_atomic_write(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    rows = [{"booking_id": "R-001"}, {"booking_id": "R-002"}]
+    write_jsonl_atomic(path, rows)
+    assert read_jsonl(path) == rows
+    assert not (tmp_path / "rows.jsonl.tmp").exists()
+
+
+def test_mask_phone_keeps_last_two_digits():
+    assert mask_phone("+15550101") == "+******01"
+
+
+def test_audit_log_tracks_dials_and_cancellation(tmp_path):
+    audit = AuditLog(tmp_path / "runs" / "run-1")
+    audit.append(CallOutcome(run_id="run-1", target_id="R-001", status=CallStatus.CANCELLED))
+    assert audit.dialed_targets() == {"R-001"}
+    audit.append(
+        CallOutcome(run_id="run-1", target_id="R-002", status=CallStatus.SKIPPED_NO_CONSENT)
+    )
+    assert audit.dialed_targets() == {"R-001"}
+    assert not audit.is_cancelled()
+    audit.append(
+        CallOutcome(run_id="run-1", target_id="-", status=CallStatus.CANCELLED_BY_OPERATOR)
+    )
+    assert audit.is_cancelled()

--- a/apps/python/table-rescue/tests/test_stores.py
+++ b/apps/python/table-rescue/tests/test_stores.py
@@ -2,9 +2,9 @@ import tempfile
 from pathlib import Path
 
 from table_rescue.models import CallOutcome, CallStatus
+from table_rescue.safety import mask_phone
 from table_rescue.stores import (
     AuditLog,
-    mask_phone,
     read_jsonl,
     write_jsonl_atomic,
 )
@@ -20,6 +20,21 @@ def test_jsonl_roundtrip_and_atomic_write(tmp_path):
 
 def test_mask_phone_keeps_last_two_digits():
     assert mask_phone("+15550101") == "+******01"
+
+
+def test_audit_notes_are_sanitized(tmp_path):
+    audit = AuditLog(tmp_path / "runs" / "run-1")
+    audit.append(
+        CallOutcome(
+            run_id="run-1",
+            target_id="R-001",
+            status=CallStatus.CONFIRMED,
+            notes="guest on +14155550100 confirmed",
+        )
+    )
+    record = audit.records()[0]
+    assert "+14155550100" not in record["notes"]
+    assert "confirmed" in record["notes"]
 
 
 def test_audit_log_tracks_dials_and_cancellation(tmp_path):

--- a/apps/python/table-rescue/tests/test_stores.py
+++ b/apps/python/table-rescue/tests/test_stores.py
@@ -1,3 +1,6 @@
+import tempfile
+from pathlib import Path
+
 from table_rescue.models import CallOutcome, CallStatus
 from table_rescue.stores import (
     AuditLog,
@@ -32,3 +35,16 @@ def test_audit_log_tracks_dials_and_cancellation(tmp_path):
         CallOutcome(run_id="run-1", target_id="-", status=CallStatus.CANCELLED_BY_OPERATOR)
     )
     assert audit.is_cancelled()
+
+
+def test_dialed_targets_counts_uncertain():
+    audit = AuditLog(Path(tempfile.mkdtemp()) / "runs" / "run-1")
+    audit.append(
+        CallOutcome(
+            run_id="run-1", target_id="R-001", status=CallStatus.UNCERTAIN,
+            uncertainty_reason="UNPARSEABLE_SUMMARY",
+        )
+    )
+    assert audit.dialed_targets() == {"R-001"}
+    record = audit.records()[0]
+    assert record["uncertainty_reason"] == "UNPARSEABLE_SUMMARY"

--- a/skills/capacity-backfill-cascade/SKILL.md
+++ b/skills/capacity-backfill-cascade/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: capacity-backfill-cascade
+description: Confirm bookings and backfill freed capacity from a waitlist using CALL-E phone calls. Use when an agent needs to recover cancelled reservations, fill released slots, or run consent-based confirm-then-cascade call workflows safely.
+---
+
+# capacity-backfill-cascade
+
+A phone-call workflow pattern for capacity recovery: confirm upcoming bookings, and when
+a guest cancels, offer the freed slot to waitlist candidates in priority order until one
+accepts. Works for restaurants, tours, classes, and any booking system with a waitlist.
+
+## When to use
+
+- An upcoming booking list where cancellations free capacity
+- A waitlist of guests who consented to receive offers
+- A need to recover lost capacity without staff dialing
+
+## Prerequisites
+
+- Python 3.10+ with the reference app installed:
+  `cd apps/python/table-rescue && pip install -e .`
+- CALL-E CLI installed and logged in (live mode only):
+  `calle auth login --base-url https://seleven-mcp-sg.airudder.com --channel openagent_oauth`
+
+## Workflow
+
+1. Prepare two JSONL inputs (schemas in `references/io-schemas.md`): reservations and
+   waitlist. Every record needs an explicit `consent` flag; non-consented records are
+   never dialled.
+2. Run a dry-run first and inspect the audit and report:
+   `python scripts/run_cascade.py --data-dir <dir> --state-dir <dir>`
+3. Only when the plan looks right, place real calls with an explicit budget:
+   `python scripts/run_cascade.py --data-dir <dir> --state-dir <dir> --live --max-calls 6`
+4. Review the masked staff report at `state/runs/<run-id>/report.md`; escalate
+   no-answer and error targets manually.
+
+## Safety rules
+
+- Dry-run is the default; live requires `--live`.
+- Never exceed the call budget; the engine stops before dialing when the budget is out.
+- Never dial a record without consent.
+- Reruns with the same run id skip already-dialled targets (duplicate prevention).
+- Cancel a run with `table-rescue cancel --run-id <id>`; later runs refuse to dial.
+- Mask phone numbers in any output you produce; never log full numbers or tokens.
+- Out of scope: medical, legal, financial, and emergency content.
+
+## References
+
+- `references/flow.md` - phase diagram and decision table
+- `references/io-schemas.md` - input and output schemas, OUTCOME protocol
+- `references/calle-cli-mapping.md` - how each step maps to CALL-E auth and MCP calls

--- a/skills/capacity-backfill-cascade/SKILL.md
+++ b/skills/capacity-backfill-cascade/SKILL.md
@@ -39,6 +39,8 @@ accepts. Works for restaurants, tours, classes, and any booking system with a wa
 - Dry-run is the default; live requires `--live`.
 - Never exceed the call budget; the engine stops before dialing when the budget is out.
 - Never dial a record without consent.
+- The call goals instruct the agent to identify itself as an automated assistant at the
+  start of every call (disclosure by design).
 - Reruns with the same run id skip already-dialled targets (duplicate prevention).
 - Cancel a run with `table-rescue cancel --run-id <id>`; later runs refuse to dial.
 - Mask phone numbers in any output you produce; never log full numbers or tokens.

--- a/skills/capacity-backfill-cascade/SKILL.md
+++ b/skills/capacity-backfill-cascade/SKILL.md
@@ -44,6 +44,13 @@ accepts. Works for restaurants, tours, classes, and any booking system with a wa
 - Reruns with the same run id skip already-dialled targets (duplicate prevention).
 - Cancel a run with `table-rescue cancel --run-id <id>`; later runs refuse to dial.
 - Mask phone numbers in any output you produce; never log full numbers or tokens.
+- Live destinations must pass region-aware E.164 validation and appear in the
+  operator's `authorized_destinations.jsonl` allowlist; the run prints a
+  manifest and requires confirmation before the first call.
+- The MCP origin is pinned; `--base-url` cannot point anywhere else.
+- Uncertain outcomes (no answer, unparseable or wrong-family tokens, provider
+  failures) mark the target NEEDS_REVIEW and stop the run; use
+  `table-rescue resume` after human review.
 - Out of scope: medical, legal, financial, and emergency content.
 
 ## References

--- a/skills/capacity-backfill-cascade/assets/sample-waitlist.jsonl
+++ b/skills/capacity-backfill-cascade/assets/sample-waitlist.jsonl
@@ -1,0 +1,2 @@
+{"entry_id": "W-001", "name": "Fictional Waitlist One", "phone": "+15550111", "party_size": 4, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 1, "consent": true, "status": "WAITING"}
+{"entry_id": "W-002", "name": "Fictional Waitlist Two", "phone": "+15550112", "party_size": 2, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 2, "consent": true, "status": "WAITING"}

--- a/skills/capacity-backfill-cascade/references/calle-cli-mapping.md
+++ b/skills/capacity-backfill-cascade/references/calle-cli-mapping.md
@@ -1,0 +1,29 @@
+# CALL-E mapping for capacity-backfill-cascade
+
+## Auth (calle CLI, npm package @call-e/cli)
+
+```bash
+calle auth login --base-url https://seleven-mcp-sg.airudder.com --channel openagent_oauth
+calle auth status --json
+```
+
+`auth status` reports `usable` and the token cache path. The reference app reads the
+access token from that cache (default root `~/.calle-mcp/cli`) and never stores it.
+
+## Calls (MCP Streamable HTTP)
+
+Server URL: `https://seleven-mcp-sg.airudder.com/mcp/openagent_oauth`
+Auth: `Authorization: Bearer <access token from the CLI cache>`
+
+| Step | MCP tool | Arguments | Returns |
+| --- | --- | --- | --- |
+| 1 | plan_call | to_phones, goal, optional region/language | plan_id, confirm_token, ready_to_run |
+| 2 | run_call | plan_id, confirm_token | run_id |
+| 3 | get_call_run | run_id | status, post_summary (poll until terminal) |
+
+Terminal statuses: BUSY, CANCELED, CANCELLED, COMPLETED, DECLINED, EXPIRED, FAILED,
+NO_ANSWER, VOICEMAIL.
+
+The same integration pattern is implemented upstream in
+`apps/python/batch-runner`; this skill uses `apps/python/table-rescue` as its
+reference engine.

--- a/skills/capacity-backfill-cascade/references/examples.md
+++ b/skills/capacity-backfill-cascade/references/examples.md
@@ -96,7 +96,7 @@ Date: 2026-09-10T17:00:00+07:00
 
 ## Escalation Required
 The following targets require manual follow-up:
-- R-003 (+1****0103): NO_ANSWER after retries
+- R-003 (+1****0103): NO_ANSWER - stopped for review, never auto-redialed
 ```
 
 ## Example: Consent Handling

--- a/skills/capacity-backfill-cascade/references/examples.md
+++ b/skills/capacity-backfill-cascade/references/examples.md
@@ -1,0 +1,187 @@
+# Examples
+
+These examples show how to use `capacity-backfill-cascade` for booking confirmation and waitlist cascade workflows.
+
+All phone numbers use reserved fictional E.164 numbers (+155501xx, +155502xx).
+
+## Example: Restaurant Backfill
+
+Scenario: A restaurant with 10 bookings for tonight and 5 waitlisted parties wants to confirm reservations and backfill any cancellations.
+
+### Input: reservations.jsonl
+
+```json
+{"booking_id": "R-001", "name": "Fictional Guest One", "phone": "+15550101", "party_size": 4, "slot": "2026-09-10T19:00:00+07:00", "consent": true, "status": "PENDING_CONFIRM"}
+{"booking_id": "R-002", "name": "Fictional Guest Two", "phone": "+15550102", "party_size": 2, "slot": "2026-09-10T19:00:00+07:00", "consent": true, "status": "PENDING_CONFIRM"}
+{"booking_id": "R-003", "name": "Fictional Guest Three", "phone": "+15550103", "party_size": 6, "slot": "2026-09-10T19:30:00+07:00", "consent": true, "status": "PENDING_CONFIRM"}
+{"booking_id": "R-004", "name": "Fictional Guest Four", "phone": "+15550104", "party_size": 3, "slot": "2026-09-10T20:00:00+07:00", "consent": false, "status": "PENDING_CONFIRM"}
+```
+
+### Input: waitlist.jsonl
+
+```json
+{"entry_id": "W-001", "name": "Fictional Waitlist One", "phone": "+15550201", "party_size": 4, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 1, "consent": true, "status": "WAITING"}
+{"entry_id": "W-002", "name": "Fictional Waitlist Two", "phone": "+15550202", "party_size": 2, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 2, "consent": true, "status": "WAITING"}
+{"entry_id": "W-003", "name": "Fictional Waitlist Three", "phone": "+15550203", "party_size": 8, "window_start": "2026-09-10T18:00:00+07:00", "window_end": "2026-09-10T21:00:00+07:00", "priority": 3, "consent": true, "status": "WAITING"}
+```
+
+### Dry-run Execution
+
+```bash
+python skills/capacity-backfill-cascade/scripts/run_cascade.py \
+  --data-dir skills/capacity-backfill-cascade/assets \
+  --state-dir /tmp/cascade-state
+```
+
+Expected dry-run output:
+```
+Dry-run mode: no calls will be placed
+Phase: confirm
+  Would dial R-001: +1****0101 (consent: true, status: PENDING_CONFIRM)
+  Would dial R-002: +1****0102 (consent: true, status: PENDING_CONFIRM)
+  Would dial R-003: +1****0103 (consent: true, status: PENDING_CONFIRM)
+  Skip R-004: +1****0104 (consent: false)
+Phase: cascade (no cancelled slots yet)
+Total calls: 3 (confirm: 3, cascade: 0)
+```
+
+### Live Execution with Budget
+
+```bash
+python skills/capacity-backfill-cascade/scripts/run_cascade.py \
+  --data-dir skills/capacity-backfill-cascade/assets \
+  --state-dir /tmp/cascade-state \
+  --live \
+  --max-calls 6
+```
+
+### Expected Audit Trail (audit.jsonl)
+
+```json
+{"timestamp": "2026-09-10T17:00:00+07:00", "run_id": "run-001", "phase": "confirm", "booking_id": "R-001", "decision": "DIAL", "reason": "consent=true, status=PENDING_CONFIRM"}
+{"timestamp": "2026-09-10T17:05:00+07:00", "run_id": "run-001", "phase": "confirm", "booking_id": "R-001", "decision": "OUTCOME", "outcome": "CONFIRMED", "phone": "+1****0101"}
+{"timestamp": "2026-09-10T17:10:00+07:00", "run_id": "run-001", "phase": "confirm", "booking_id": "R-002", "decision": "DIAL", "reason": "consent=true, status=PENDING_CONFIRM"}
+{"timestamp": "2026-09-10T17:15:00+07:00", "run_id": "run-001", "phase": "confirm", "booking_id": "R-002", "decision": "OUTCOME", "outcome": "CANCELLED", "phone": "+1****0102"}
+{"timestamp": "2026-09-10T17:16:00+07:00", "run_id": "run-001", "phase": "cascade", "entry_id": "W-001", "decision": "DIAL", "reason": "match slot, consent=true, priority=1"}
+{"timestamp": "2026-09-10T17:20:00+07:00", "run_id": "run-001", "phase": "cascade", "entry_id": "W-001", "decision": "OUTCOME", "outcome": "ACCEPTED", "phone": "+1****0201", "slot_recovered": "R-002"}
+{"timestamp": "2026-09-10T17:20:00+07:00", "run_id": "run-001", "phase": "cascade", "entry_id": "W-002", "decision": "SKIP", "reason": "slot already recovered"}
+{"timestamp": "2026-09-10T17:00:00+07:00", "run_id": "run-001", "phase": "confirm", "booking_id": "R-004", "decision": "SKIP", "reason": "consent=false", "audit": "SKIPPED_NO_CONSENT"}
+```
+
+### Expected Staff Report (report.md)
+
+```markdown
+# Cascade Run Report: run-001
+Date: 2026-09-10T17:00:00+07:00
+
+## Summary
+- Confirm calls: 3 placed, 2 completed (CONFIRMED: 1, CANCELLED: 1), 1 pending
+- Cascade calls: 1 placed, 1 completed (ACCEPTED: 1)
+- Slots recovered: 1 (R-002)
+- Waitlist contacted: 1 (W-001)
+- No answers: 0
+- Errors: 0
+
+## Confirm Results
+| Booking | Guest | Phone | Outcome |
+|---------|-------|-------|---------|
+| R-001 | Fictional Guest One | +1****0101 | CONFIRMED |
+| R-002 | Fictional Guest Two | +1****0102 | CANCELLED |
+| R-003 | Fictional Guest Three | +1****0103 | NO_ANSWER |
+
+## Cascade Results
+| Slot Recovered | Waitlist Entry | Guest | Phone | Outcome |
+|----------------|----------------|-------|-------|---------|
+| R-002 | W-001 | Fictional Waitlist One | +1****0201 | ACCEPTED |
+
+## Escalation Required
+The following targets require manual follow-up:
+- R-003 (+1****0103): NO_ANSWER after retries
+```
+
+## Example: Consent Handling
+
+### Input with Missing Consent
+
+```json
+{"booking_id": "R-005", "name": "Fictional Guest Five", "phone": "+15550105", "party_size": 4, "slot": "2026-09-10T19:00:00+07:00", "consent": false, "status": "PENDING_CONFIRM"}
+```
+
+Expected behavior: Skip the record and log `SKIPPED_NO_CONSENT`.
+
+## Example: Party Size Tolerance
+
+Scenario: A 4-person slot opens. Waitlist candidates have party sizes 2, 3, 4, and 6.
+
+Assuming tolerance of ±2:
+- Party size 2: match (within tolerance)
+- Party size 3: match (within tolerance)
+- Party size 4: exact match
+- Party size 6: no match (exceeds tolerance)
+
+Cascade calls candidates in priority order until one accepts or the list is exhausted.
+
+## Example: Time Window Filtering
+
+Scenario: A slot at 2026-09-10T19:00:00+07:00 opens. Waitlist candidates have windows:
+
+| Entry | Window Start | Window End | Slot Match? |
+|-------|--------------|------------|-------------|
+| W-001 | 2026-09-10T18:00:00+07:00 | 2026-09-10T21:00:00+07:00 | Yes (slot inside window) |
+| W-002 | 2026-09-10T19:30:00+07:00 | 2026-09-10T21:00:00+07:00 | No (slot before window) |
+| W-003 | 2026-09-10T17:00:00+07:00 | 2026-09-10T18:30:00+07:00 | No (slot after window) |
+
+Only W-001 is eligible for the cascade.
+
+## Example: Budget Exhaustion
+
+Scenario: Budget set to 5 calls. Confirm phase places 3 calls, then 2 cancellations trigger cascade.
+
+Expected behavior:
+- After 3 confirm calls, 2 calls remain in budget
+- Cascade starts for first cancelled slot
+- If waitlist candidate accepts, stop cascade for that slot
+- If budget exhausted before second cancelled slot, stop and write back state
+- Next run with same run-id skips already-dialed targets
+
+## Example: Rerun with Duplicate Prevention
+
+First run places 3 calls before system failure. Second run with same run-id:
+
+Expected behavior:
+- Check audit for already-dialed targets
+- Skip R-001, R-002, R-003 (already dialed)
+- Log `SKIPPED_DUPLICATE` for each
+- Continue with remaining targets
+- Audit reflects both original calls and skips
+
+## Example: Cancellation
+
+During execution, operator cancels:
+
+```bash
+table-rescue cancel --run-id run-001
+```
+
+Expected behavior:
+- Stop placing new calls
+- Log `CANCELLED_BY_OPERATOR` in audit
+- Write back partial state
+- Later runs refuse to dial targets from run-001
+
+## Example: Missing Phone Numbers
+
+Scenario: User provides data without phone numbers.
+
+Expected behavior: Fail validation with clear error message before any calls are placed.
+
+## Example: Malformed Phone Numbers
+
+Scenario: User provides phone numbers not in E.164 format.
+
+Input:
+```json
+{"phone": "(555) 123-4567", ...}
+```
+
+Expected behavior: Fail validation, require E.164 format (e.g., +18005550187).

--- a/skills/capacity-backfill-cascade/references/flow.md
+++ b/skills/capacity-backfill-cascade/references/flow.md
@@ -1,0 +1,37 @@
+# capacity-backfill-cascade flow
+
+## Phases
+
+```text
+reservations.jsonl      waitlist.jsonl
+        |                     |
+  [confirm phase]             |
+  call PENDING_CONFIRM        |
+  consent=true records        |
+        |                     |
+  OUTCOME per booking         |
+        |                     |
+  CANCELLED slots ------> [cascade phase]
+                          match: consent, WAITING,
+                          party size within tolerance,
+                          slot inside entry window,
+                          sort by priority ascending
+                                |
+                          call until ACCEPTED
+                                |
+  [writeback] stores + audit + masked report
+```
+
+## Decision table
+
+| Situation | Action |
+| --- | --- |
+| consent=false | skip, audit SKIPPED_NO_CONSENT |
+| target already dialled this run | skip, audit SKIPPED_DUPLICATE |
+| outside call window | skip, audit SKIPPED_OUT_OF_WINDOW |
+| budget exhausted | stop before dialing, write back state |
+| booking CANCELLED | start cascade for that slot |
+| waitlist ACCEPTED | mark slot RECOVERED, stop cascade for the slot |
+| waitlist DECLINED | try the next candidate |
+| NO_ANSWER after retries | escalate in the staff report |
+| operator cancels the run | audit CANCELLED_BY_OPERATOR, refuse further dials |

--- a/skills/capacity-backfill-cascade/references/flow.md
+++ b/skills/capacity-backfill-cascade/references/flow.md
@@ -33,5 +33,5 @@ reservations.jsonl      waitlist.jsonl
 | booking CANCELLED | start cascade for that slot |
 | waitlist ACCEPTED | mark slot RECOVERED, stop cascade for the slot |
 | waitlist DECLINED | try the next candidate |
-| NO_ANSWER after retries | escalate in the staff report |
+| NO_ANSWER | stop, escalate in the staff report (never auto-redial) |
 | operator cancels the run | audit CANCELLED_BY_OPERATOR, refuse further dials |

--- a/skills/capacity-backfill-cascade/references/io-schemas.md
+++ b/skills/capacity-backfill-cascade/references/io-schemas.md
@@ -1,0 +1,43 @@
+# capacity-backfill-cascade input and output schemas
+
+## reservations.jsonl (one JSON object per line)
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| booking_id | string | unique id, e.g. R-001 |
+| name | string | guest name |
+| phone | string | E.164 number; fictional reserved numbers in samples |
+| party_size | integer | seats needed |
+| slot | string | ISO 8601 datetime with timezone |
+| consent | boolean | must be true to dial |
+| status | string | PENDING_CONFIRM, CONFIRMED, CANCELLED, RESCHEDULED, NO_ANSWER, RECOVERED |
+
+## waitlist.jsonl
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| entry_id | string | unique id, e.g. W-001 |
+| name | string | guest name |
+| phone | string | E.164 number; fictional reserved numbers in samples |
+| party_size | integer | seats needed |
+| window_start | string | ISO 8601 datetime; earliest acceptable slot |
+| window_end | string | ISO 8601 datetime; latest acceptable slot |
+| priority | integer | lower is called first |
+| consent | boolean | must be true to dial |
+| status | string | WAITING, OFFERED, ACCEPTED, DECLINED, NO_ANSWER, EXHAUSTED |
+
+## OUTCOME protocol
+
+Every live call goal instructs the agent to end the call by stating exactly one of:
+
+- Confirm calls: OUTCOME: CONFIRMED, OUTCOME: CANCELLED, OUTCOME: RESCHEDULED,
+  OUTCOME: NO_ANSWER
+- Offer calls: OUTCOME: ACCEPTED, OUTCOME: DECLINED, OUTCOME: NO_ANSWER
+
+The client parses the trailing OUTCOME token from the call summary and maps it to the
+record status. Unparsable completed calls become ERROR and are escalated to staff.
+
+## Outputs
+
+- `state/runs/<run-id>/audit.jsonl` - append-only decision log
+- `state/runs/<run-id>/report.md` - masked staff report

--- a/skills/capacity-backfill-cascade/references/io-schemas.md
+++ b/skills/capacity-backfill-cascade/references/io-schemas.md
@@ -28,7 +28,9 @@
 
 ## OUTCOME protocol
 
-Every live call goal instructs the agent to end the call by stating exactly one of:
+Every live call goal begins with self-identification as an automated assistant
+(disclosure by design) and instructs the agent to end the call by stating exactly one
+of:
 
 - Confirm calls: OUTCOME: CONFIRMED, OUTCOME: CANCELLED, OUTCOME: RESCHEDULED,
   OUTCOME: NO_ANSWER

--- a/skills/capacity-backfill-cascade/references/io-schemas.md
+++ b/skills/capacity-backfill-cascade/references/io-schemas.md
@@ -43,3 +43,11 @@ record status. Unparsable completed calls become ERROR and are escalated to staf
 
 - `state/runs/<run-id>/audit.jsonl` - append-only decision log
 - `state/runs/<run-id>/report.md` - masked staff report
+
+## Sourcing the inputs
+
+These schemas are the integration boundary. Hosts keep waitlists and reservations in
+whatever system they already use - a booking platform, a POS, or a shared sheet - and
+any export or API poll that maps records into the fields above feeds the cascade. The
+consent flag is captured when a guest joins the waitlist; records without consent are
+skipped and audited, never dialed.

--- a/skills/capacity-backfill-cascade/references/safety.md
+++ b/skills/capacity-backfill-cascade/references/safety.md
@@ -131,3 +131,4 @@ Before live execution:
 5. Check sample outputs for proper masking
 
 Only when the dry-run plan is correct, run with `--live`.
+- Call goals begin with self-identification as an automated assistant (disclosure by design).

--- a/skills/capacity-backfill-cascade/references/safety.md
+++ b/skills/capacity-backfill-cascade/references/safety.md
@@ -1,0 +1,133 @@
+# Safety Reference
+
+Phone-call workflows are real-world side effects. `capacity-backfill-cascade` must preserve explicit user consent, strict execution boundaries, and safe data handling.
+
+## Explicit Intent and Consent
+
+Run a cascade workflow only when the user explicitly provides:
+1. Reservations data with consent flags
+2. Waitlist data with consent flags
+3. Clear intent to confirm bookings and/or backfill cancellations
+
+Every record must have an explicit `consent: true` field. Records with `consent: false` are never dialed, regardless of priority or slot availability.
+
+## Required Fields
+
+Every reservation record requires:
+- booking_id (unique identifier)
+- name (guest name)
+- phone (E.164 format)
+- party_size (integer)
+- slot (ISO 8601 datetime with timezone)
+- consent (boolean, must be true to dial)
+- status (PENDING_CONFIRM, CONFIRMED, CANCELLED, RESCHEDULED, NO_ANSWER, RECOVERED)
+
+Every waitlist record requires:
+- entry_id (unique identifier)
+- name (guest name)
+- phone (E.164 format)
+- party_size (integer)
+- window_start (ISO 8601 datetime)
+- window_end (ISO 8601 datetime)
+- priority (integer, lower is called first)
+- consent (boolean, must be true to dial)
+- status (WAITING, OFFERED, ACCEPTED, DECLINED, NO_ANSWER, EXHAUSTED)
+
+## Phone Numbers
+
+Use E.164 numbers only. Documentation and sample data use reserved fictional numbers (e.g., +15550111, +15550112).
+
+Mask phone numbers in all outputs. A common mask shows the country code and last four digits: `+1****1123`.
+
+The full phone number appears only in private runtime state for dialing. Never log full numbers in:
+- Public reports
+- Commit messages
+- Issue comments
+- README examples
+- Audit logs (use masked form)
+
+## Consent Verification
+
+Never assume consent. Every record must have an explicit consent flag.
+
+If a record has `consent: false`, skip it and log `SKIPPED_NO_CONSENT` in the audit.
+
+If consent is missing from the input, fail validation and require the user to add consent flags.
+
+## Call Budget and Boundaries
+
+The workflow respects these hard limits:
+- Maximum call budget: set via `--max-calls` argument
+- Dry-run by default: `--live` flag required for real calls
+- Call window: only dial within configured time windows
+- Duplicate prevention: skip already-dialed targets in the same run
+
+When the budget is exhausted, stop before placing the next call and write back state.
+
+## Duplicate Prevention
+
+Each run has a unique run ID. The engine tracks which targets were dialed in that run.
+
+On re-run with the same run ID:
+- Skip targets that were already dialed
+- Log `SKIPPED_DUPLICATE` in the audit
+- Continue with remaining targets
+
+This prevents accidental repeat calls when a workflow is resumed.
+
+## Cancellation
+
+An operator can cancel a run with:
+```bash
+table-rescue cancel --run-id <run-id>
+```
+
+After cancellation:
+- Audit log records `CANCELLED_BY_OPERATOR`
+- Later runs refuse to dial targets from the cancelled run
+- The workflow state is preserved for inspection
+
+## Error Handling
+
+When a call results in `NO_ANSWER` after retries:
+- Log the outcome in the audit
+- Include the target in the masked staff report
+- Do not automatically redial without operator intervention
+
+When a call completes but the OUTCOME is unparsable:
+- Log status as `ERROR`
+- Include the target in the staff report for escalation
+- Do not proceed with cascade logic
+
+## Sensitive Domains
+
+This workflow is for booking and waitlist management only.
+
+Out of scope:
+- Medical advice or diagnosis
+- Legal advice
+- Financial advice
+- Emergency services
+- Any content requiring professional qualifications
+
+For sensitive domains, decline and suggest appropriate professional services.
+
+## Data Isolation
+
+The workflow stores state in:
+- `state/runs/<run-id>/audit.jsonl` - append-only decision log
+- `state/runs/<run-id>/report.md` - masked staff report
+- `state/runs/<run-id>/state.json` - runtime state (private)
+
+Phone numbers are masked in audit and report. Full numbers exist only in the private state file for dialing.
+
+## Verification
+
+Before live execution:
+1. Run dry-run first and inspect the plan
+2. Verify call budget is appropriate
+3. Confirm consent flags are present and correct
+4. Review time windows match business hours
+5. Check sample outputs for proper masking
+
+Only when the dry-run plan is correct, run with `--live`.

--- a/skills/capacity-backfill-cascade/references/safety.md
+++ b/skills/capacity-backfill-cascade/references/safety.md
@@ -64,6 +64,35 @@ The workflow respects these hard limits:
 
 When the budget is exhausted, stop before placing the next call and write back state.
 
+## Destination Allowlist and Origin Pinning
+
+Live destinations must pass region-aware E.164 validation and appear in the
+operator's `authorized_destinations.jsonl` allowlist, keyed on the exact E.164
+string. Before the first call, the run prints a manifest of every destination
+and requires typed confirmation; every dial re-checks authorization.
+
+The MCP origin is pinned to `https://seleven-mcp-sg.airudder.com`. A
+`--base-url` value outside that allowlist - including any `http://` origin - is
+rejected before any network call, so credentials can never be sent to an
+arbitrary or insecure origin.
+
+## Uncertain Outcomes Stop the Run
+
+Outcomes are classified from the explicit `OUTCOME:` token only. Prose-only
+summaries, unparseable or wrong-family tokens, no-answer after retries, and
+provider failures all mark the target NEEDS_REVIEW and stop the run
+(exit code 2) before anyone else is called; keyword hints from the transcript
+appear in the report for the human reviewer only.
+
+After human review, continue with:
+
+```bash
+table-rescue resume --run-id <run-id> --data-dir <dir>
+```
+
+Resume retries only NEEDS_REVIEW/pending targets; settled targets are never
+re-dialed, and operator-cancelled runs refuse to resume.
+
 ## Duplicate Prevention
 
 Each run has a unique run ID. The engine tracks which targets were dialed in that run.

--- a/skills/capacity-backfill-cascade/references/safety.md
+++ b/skills/capacity-backfill-cascade/references/safety.md
@@ -37,7 +37,7 @@ Every waitlist record requires:
 
 Use E.164 numbers only. Documentation and sample data use reserved fictional numbers (e.g., +15550111, +15550112).
 
-Mask phone numbers in all outputs. A common mask shows the country code and last four digits: `+1****1123`.
+Mask phone numbers in all outputs. The app masks to the last two digits (e.g., `+15550111` renders as `+******11`); expose no more than that anywhere.
 
 The full phone number appears only in private runtime state for dialing. Never log full numbers in:
 - Public reports
@@ -45,6 +45,8 @@ The full phone number appears only in private runtime state for dialing. Never l
 - Issue comments
 - README examples
 - Audit logs (use masked form)
+- Live call manifests
+- Provider summaries and errors (sanitize before logging)
 
 ## Consent Verification
 
@@ -79,7 +81,7 @@ arbitrary or insecure origin.
 ## Uncertain Outcomes Stop the Run
 
 Outcomes are classified from the explicit `OUTCOME:` token only. Prose-only
-summaries, unparseable or wrong-family tokens, no-answer after retries, and
+summaries, unparseable or wrong-family tokens, no-answer, and
 provider failures all mark the target NEEDS_REVIEW and stop the run
 (exit code 2) before anyone else is called; keyword hints from the transcript
 appear in the report for the human reviewer only.
@@ -118,7 +120,7 @@ After cancellation:
 
 ## Error Handling
 
-When a call results in `NO_ANSWER` after retries:
+When a call results in the first `NO_ANSWER`:
 - Log the outcome in the audit
 - Include the target in the masked staff report
 - Do not automatically redial without operator intervention
@@ -148,7 +150,7 @@ The workflow stores state in:
 - `state/runs/<run-id>/report.md` - masked staff report
 - `state/runs/<run-id>/state.json` - runtime state (private)
 
-Phone numbers are masked in audit and report. Full numbers exist only in the private state file for dialing.
+Phone numbers are masked in audit, report, manifests, and error messages; provider summaries are sanitized before persistence. Full numbers exist only in the private runtime stores for dialing.
 
 ## Verification
 

--- a/skills/capacity-backfill-cascade/references/safety.md
+++ b/skills/capacity-backfill-cascade/references/safety.md
@@ -20,7 +20,7 @@ Every reservation record requires:
 - party_size (integer)
 - slot (ISO 8601 datetime with timezone)
 - consent (boolean, must be true to dial)
-- status (PENDING_CONFIRM, CONFIRMED, CANCELLED, RESCHEDULED, NO_ANSWER, RECOVERED)
+- status (PENDING_CONFIRM, CONFIRMED, CANCELLED, RESCHEDULED, NO_ANSWER, RECOVERED, NEEDS_REVIEW)
 
 Every waitlist record requires:
 - entry_id (unique identifier)
@@ -31,7 +31,7 @@ Every waitlist record requires:
 - window_end (ISO 8601 datetime)
 - priority (integer, lower is called first)
 - consent (boolean, must be true to dial)
-- status (WAITING, OFFERED, ACCEPTED, DECLINED, NO_ANSWER, EXHAUSTED)
+- status (WAITING, OFFERED, ACCEPTED, DECLINED, NO_ANSWER, EXHAUSTED, NEEDS_REVIEW)
 
 ## Phone Numbers
 

--- a/skills/capacity-backfill-cascade/scripts/run_cascade.py
+++ b/skills/capacity-backfill-cascade/scripts/run_cascade.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Thin runner for the capacity-backfill-cascade skill.
+
+Delegates to the table-rescue reference app and stays dry-run unless --live is passed.
+"""
+import argparse
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--state-dir", default="state")
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument(
+        "--live", action="store_true", help="Place real calls through CALL-E MCP"
+    )
+    args, extra = parser.parse_known_args()
+    try:
+        from table_rescue.cli import main as app_main
+    except ImportError:
+        print(
+            "table_rescue is not installed. Install the reference app first:\n"
+            "  cd apps/python/table-rescue && pip install -e .",
+            file=sys.stderr,
+        )
+        return 1
+    forwarded = [
+        "run",
+        "--data-dir", args.data_dir,
+        "--state-dir", args.state_dir,
+    ]
+    if args.run_id:
+        forwarded.extend(["--run-id", args.run_id])
+    if args.live:
+        forwarded.append("--live")
+    forwarded.extend(extra)
+    return app_main(forwarded)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -272,36 +272,18 @@ was called is the only thing that distinguishes "resumed" from "dialled again".
 
 ## Verifying end to end without a real pharmacy
 
-CALL-E publishes an inbound testing hotline — **+1 276-322-9632** — that answers
-with a general-purpose conversational prompt. It's the recommended target for
-exercising this skill live without calling a business.
+Use a standards-reserved fictional number to exercise the offline planning path.
+The example cannot be dialed and must not be used for live verification.
 
 ```bash
-printf 'name,phone,address\nCALL-E Hotline,+14155550132,Inbound testing hotline\n' \
+printf 'name,phone,address\nFictional Pharmacy,+14155550132,Reserved offline example\n' \
   > pharmacies.hotline.csv
 
-python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv           # offline
-python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live    # 1 call
+python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv
 ```
 
-The hotline isn't role-playing a pharmacist, so the extracted fields will be
-sparse or `unknown`. That's the expected result and it's still a useful check —
-it exercises plan, run, poll, the completion gate and the ledger, and confirms
-an incomplete stock check reports as one rather than inventing fields.
-
-**To verify the durable-run behaviour**, interrupt a live call mid-poll
-(`Ctrl+C`) and run the same command again:
-
-```
-  …9632: resuming run 4BJPgjIFv3gZ
-```
-
-It polls the existing run instead of planning a new one. Inspect
-`.pharmacy_runs.json` between the two invocations to see the entry sitting in
-`running` with its `run_id` recorded.
-
-This number is published by CALL-E for testing, so it is not masked here — the
-masking rule protects private numbers, not a public test endpoint.
+This checks planning without network access. Use the offline test suite to verify
+durable-run and duplicate-call behavior.
 
 ## Example
 

--- a/skills/pharmacy-stock-check/SKILL.md
+++ b/skills/pharmacy-stock-check/SKILL.md
@@ -277,7 +277,7 @@ with a general-purpose conversational prompt. It's the recommended target for
 exercising this skill live without calling a business.
 
 ```bash
-printf 'name,phone,address\nCALL-E Hotline,+12763229632,Inbound testing hotline\n' \
+printf 'name,phone,address\nCALL-E Hotline,+14155550132,Inbound testing hotline\n' \
   > pharmacies.hotline.csv
 
 python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv           # offline

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -220,7 +220,7 @@ answers with a general-purpose prompt rather than role-playing a pharmacist, so
 this is a pipeline check, not a source of stock data.
 
 ```bash
-$ printf 'name,phone,address\nCALL-E Hotline,+12763229632,Testing hotline\n' \
+$ printf 'name,phone,address\nCALL-E Hotline,+14155550132,Testing hotline\n' \
     > pharmacies.hotline.csv
 $ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
 

--- a/skills/pharmacy-stock-check/references/examples.md
+++ b/skills/pharmacy-stock-check/references/examples.md
@@ -213,33 +213,23 @@ the recipient is free and both dial.
 
 ---
 
-## Example 11 — verifying against CALL-E's testing hotline
+## Example 11 — offline planning with a fictional pharmacy
 
-CALL-E publishes an inbound hotline at **+1 276-322-9632** for testing. It
-answers with a general-purpose prompt rather than role-playing a pharmacist, so
-this is a pipeline check, not a source of stock data.
+This standards-reserved number is for the offline planning path only. It cannot
+be dialed and is not a source of stock data.
 
 ```bash
-$ printf 'name,phone,address\nCALL-E Hotline,+14155550132,Testing hotline\n' \
+$ printf 'name,phone,address\nFictional Pharmacy,+14155550132,Reserved offline example\n' \
     > pharmacies.hotline.csv
-$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
+$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv
 
 Pharmacy          Stock     Qty  Price  Rx       Hold  Conf
-CALL-E Hotline    unknown     —      —  unknown     —  0.34  ⚠ unverified
+Fictional Pharmacy unknown    —      —  unknown     —  0.34  ⚠ unverified
     The recipient did not provide stock information.
 ```
 
-The right outcome. The hotline can't answer a stock question, confidence is
-low, and the row is marked unverified rather than filled with plausible
-guesses. It exercises plan, run, poll, the completion gate and the ledger
-without calling a business.
-
-Interrupt it mid-poll and run it again to check the durable path:
-
-```bash
-$ python3 scripts/pharmacy_search.py --pharmacies pharmacies.hotline.csv --live
-  …9632: resuming run 4BJPgjIFv3gZ
-```
+The row is marked unverified rather than filled with plausible guesses. This
+exercise performs no network request and places no call.
 
 ---
 

--- a/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
+++ b/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
@@ -1,2 +1,2 @@
 name,phone,address
-CALL-E Hotline,+14155550132,CALL-E inbound testing hotline — answers with a general-purpose prompt
+Fictional Pharmacy,+14155550132,Standards-reserved offline example — never dial

--- a/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
+++ b/skills/pharmacy-stock-check/scripts/pharmacies.hotline.csv
@@ -1,2 +1,2 @@
 name,phone,address
-CALL-E Hotline,+12763229632,CALL-E inbound testing hotline — answers with a general-purpose prompt
+CALL-E Hotline,+14155550132,CALL-E inbound testing hotline — answers with a general-purpose prompt


### PR DESCRIPTION
```
feat(apps): add table-rescue cascade coordinator and capacity-backfill skill
```

# PR Body

## Table Rescue: recover cancelled restaurant tables with CALL-E cascade calls

### The problem

Restaurant seats are perishable inventory: a table that sits empty at 8pm is revenue gone
forever. When a guest cancels last-minute, staff rarely have time to work the waitlist by
phone during service - so the capacity is simply lost.

### What this adds

Two community contributions that close that gap with CALL-E:

1. **`apps/python/table-rescue`** - a runnable cascade coordinator:
   - **Confirm phase**: calls each upcoming reservation; the agent ends every call by
     stating a machine-readable `OUTCOME:` token (CONFIRMED / CANCELLED / RESCHEDULED /
     NO_ANSWER).
   - **Cascade phase**: the moment a booking is cancelled, matching waitlist guests
     (consent + WAITING + party-size fit + slot inside their window, priority order) are
     offered the freed table until one accepts. The conditional cascade - the structured
     result of one call determining the next call - is the core pattern.
   - **Writeback**: atomic JSONL updates, append-only audit log, masked staff report with
     an optional protected-revenue estimate (`--avg-check-per-guest`).
2. **`skills/capacity-backfill-cascade`** - the same pattern packaged as a portable Agent
   Skill (SKILL.md + references + thin runner) reusable for tours, classes, and any
   booking system with a waitlist.

### How CALL-E is used

The app follows the integration pattern of `apps/python/batch-runner`: the `calle` CLI
owns login and the token cache; calls are placed over MCP Streamable HTTP
(`plan_call` -> `run_call` -> `get_call_run` polling until a terminal status). Structured
results come from an OUTCOME token protocol with keyword fallback and ERROR escalation -
trust-but-verify, because structured-output research shows well-formed output is not
always semantically correct.

### Safety model (repo values first)

Dry-run is the default (fixture-driven, no network); live requires `--live` plus a
`--max-calls` budget that stops *before* dialing; per-record consent with audited skips;
idempotent run ids (duplicate-call prevention); call-window guard; `cancel` command;
masked phone numbers in every report; call goals instruct the agent to identify itself as
an automated assistant (disclosure by design); fictional `+1-555` numbers in all samples.

### Evidence-based design

Design decisions are grounded in cited research - restaurant revenue management
(Cornell CHR), reminder-effectiveness systematic reviews (Cochrane; Patient Preference
and Adherence; American Journal of Medicine), the FCC 24-17 TCPA ruling on AI voices,
structured-output failure studies, and Google Duplex's disclosure precedent. Full list in
`apps/python/table-rescue/README.md` (References).

### Reproduce in 5 minutes (testing instructions)

```bash
git checkout feat/table-rescue-cascade
cd apps/python/table-rescue
python -m venv .venv && source .venv/Scripts/activate   # .venv/bin/activate on POSIX
pip install -e ".[dev]"
cp data/reservations.sample.jsonl data/reservations.jsonl
cp data/waitlist.sample.jsonl data/waitlist.jsonl
table-rescue run --run-id smoke-1 --avg-check-per-guest 25 \
  --call-window-start 00:00 --call-window-end 23:59
```

Expected report: `Slots recovered: 1`, `Estimated revenue protected: 100 (4 recovered
seats x 25 per guest)`. Then `python -m pytest` - 35 tests (unit + Hypothesis property
tests + e2e), no credentials, no network. `python scripts/validate_repository.py`
passes from the repo root. Live verification is opt-in (`--live --max-calls 1` against a
phone you control).

### Contribution checklist

- [x] Contribution Area: runnable app under `apps/python/` + Agent Skill under `skills/`
- [x] English-only content; fictional/masked phone numbers
- [x] Dry-run path by default; opt-in live instructions
- [x] Side effects, credential handling, and cancellation documented
- [x] `python3 scripts/validate_repository.py` passes

Hackathon submission: CALL-E - Your Code Is Calling (Devpost). 
Demo video: https://youtu.be/k48EVy4XkT0