### PR TITLE
feat(concord-policy-audit): add branch policy audit skill and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`ringer-consumer-tasks`](skills/ringer-consumer-tasks/) - Compose and safely place the dreaded consumer phone calls (bill negotiation, cancellation, refund, booking, quote comparison, inquiry) as CALL-E tasks with strict result schemas, dry-run-by-default previews, and human-in-the-loop decision authority.
 - [`incident-escalation-call`](skills/incident-escalation-call/) - Walks an on-call escalation ladder one phone call at a time and records an acknowledgement only when an owner and an ETA are both quoted by words the recipient spoke, then re-reads the call over a second transport before the incident is reported as owned.
 - [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
+- [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
 
 ### Apps
 
@@ -193,6 +194,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/python/callback-coordinator`](apps/python/callback-coordinator/) | Python | Consent-first callback triage and routing: one CALL-E call learns why a person needs a callback, classifies the outcome into a fail-closed disposition, and routes it to the right team. |
 | [`apps/python/callback-window-coordinator`](apps/python/callback-window-coordinator/) | Python | Consent-first callback-window coordinator with masked preview, stable idempotency, and structured CALL-E results. |
 | [`apps/python/partline`](apps/python/partline/) | Python | Dry-run-first industrial replacement-part sourcing that calls approved suppliers, checks exact matches against the original request and keeps purchases and alternate approval human-owned. |
+| [`apps/python/concord`](apps/python/concord/) | Python | Preview-first branch policy auditing that rules on the value a call extracted rather than the transcript, treats unreached branches and hedged answers as unresolved, and reports on locations rather than staff. |
 | [`apps/python/webhook-result-receiver`](apps/python/webhook-result-receiver/) | Python | Durable at-least-once CALL-E terminal webhook ingestion with SQLite deduplication, conflict detection, and authenticated Calls API reconciliation. |
 | [`apps/python/lead-follow-up-booking`](apps/python/lead-follow-up-booking/) | Python | Consent-first lead follow-up booking: a disclosed AI call offers only calendar-confirmed free slots and books a Google Calendar event only when the lead picks a time on the call. |
 | [`apps/python/callflow-campaign-runner`](apps/python/callflow-campaign-runner/) | Python | CSV-driven outbound campaign runner that triages structured results into auto-closed, retry, and needs-human queues. |

--- a/apps/python/concord/.env.example
+++ b/apps/python/concord/.env.example
@@ -1,0 +1,2 @@
+CALLE_API_KEY=<CALL_E_API_KEY>
+CALLE_BASE_URL=https://api.heycall-e.com

--- a/apps/python/concord/.gitignore
+++ b/apps/python/concord/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env
+*.egg-info/
+dist/
+build/
+tests/_*.json
+private/

--- a/apps/python/concord/LICENSE
+++ b/apps/python/concord/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Himanshu Jha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/python/concord/LICENSE
+++ b/apps/python/concord/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Himanshu Jha
+Copyright (c) 2026 Himanshu Kumar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/python/concord/README.md
+++ b/apps/python/concord/README.md
@@ -1,0 +1,195 @@
+# Concord
+
+Concord phones the branches you own, asks callers' questions, and reports which
+locations give an answer your policy does not allow. It reports on branches,
+and it is built to make reporting on individuals as hard as the design allows.
+
+A pharmacy group with forty shops has no cheap way to know whether all forty
+tell a caller the same thing about emergency contraception. The answer only
+exists in a conversation, so the work is done today by paying humans to make
+the calls. Concord does the calling and the comparison, and leaves the judgment
+about what to do next with a person.
+
+## Why the unit is the branch
+
+The obvious version of this product scores employees. That version is a
+surveillance tool, so the boundary lives in the data model rather than in a
+promise:
+
+- `Finding` has no field for a name, role or phone number, so there is nowhere
+  to put a person.
+- Branches are ordered by outstanding policy work. No score, no percentage, no
+  league table, because those are the artifacts that reach an appraisal.
+- The call task tells the agent not to ask who is answering, or record it if
+  offered.
+- Tests fail if any of that stops being true.
+
+One honest limit. A quote is free text spoken by a person, so someone who says
+"This is Sarah, no you don't need a prescription" could put a name into the
+record. `Answer.parse` strips self-identification and caps quote length before
+the value is ever stored, and tests cover it, but pattern matching on natural
+speech is best effort rather than a proof. The structural claim is about the
+schema. The quote is defence in depth.
+
+## Quick start
+
+No credentials needed. Nothing here places a call.
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+
+concord task    fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+concord preview fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+concord judge   fixtures/example-audit.json --rubric rubrics/emergency-contraception.json \
+                --results fixtures/completed-audit.json
+```
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+`judge` prints the report an operator acts on:
+
+```text
+BRANCH OVERVIEW
+Branch                              Deviations   Unclear   Matches policy
+--------------------------------------------------------------------------------------
+Northgate Pharmacy, Harbour Stree            2         1                1
+Northgate Pharmacy, Mill Court               1         0                3
+Northgate Pharmacy, Eastway                  0         4                0
+Northgate Pharmacy, Selby Road               0         0                4
+
+GAP REGISTER
+  [DEVIATION] Northgate Pharmacy, Harbour Street  (C1)
+      asked     Do I need a prescription for the morning-after pill?
+      heard     "You'll need a doctor's note for that one, I'm afraid."
+      finding   Answered 'yes' where policy requires 'no'. Policy: Levonorgestrel
+                1.5 mg is a pharmacy medicine supplied without a prescription.
+
+  [UNCLEAR] Northgate Pharmacy, Harbour Street  (C2)
+      asked     How soon do I need to take it?
+      heard     "As soon as you can really."
+      finding   The call could not resolve this question into a definite answer.
+
+  [UNCLEAR] Northgate Pharmacy, Eastway  (C1)
+      finding   The branch was not reached.
+```
+
+A hedged answer stays `UNCLEAR` rather than being rounded to the nearest
+option. An unreached branch produces four `UNCLEAR` findings rather than
+vanishing. Branches are listed by outstanding work, not ranked by quality.
+
+## The rubric compiles into the call
+
+A rubric is the written policy plus the questions that test it. Each criterion
+names the field to extract and the answer policy requires:
+
+```json
+{
+  "id": "C1",
+  "question": "Do I need a prescription for the morning-after pill?",
+  "policy": "Levonorgestrel 1.5 mg is a pharmacy medicine supplied without a prescription.",
+  "field": "prescription_required",
+  "expect": "no",
+  "options": ["yes", "no", "unclear"]
+}
+```
+
+Concord compiles those criteria into the CALL-E `recipient_result_schema`, so
+the policy document defines what the call is allowed to return. Remove a
+criterion and it disappears from the schema. `concord task` prints both the
+spoken task and the compiled schema before anything is dialled.
+
+## Judge the value, quote the words
+
+The first version matched policy phrases against the transcript, and reported
+
+> "No, you don't need a prescription for that, you can buy it at the counter."
+
+as a deviation, because the forbidden phrase "need a prescription" occurs
+inside its own negation. Three of seven deviations in that run were branches
+that had answered correctly.
+
+The live call made the point harder than any fixture could. Real answers open
+with a filler word, contradict themselves mid-sentence and still carry a clear
+meaning. A matcher reading the transcript gets them backwards. Ruling on the
+extracted value and keeping the sentence as evidence is what survives contact
+with how people actually talk.
+
+Keyword matching cannot read negation, and in a staff audit a false deviation
+is worse than a missed one: it sends a manager to correct someone who did the
+right thing. Concord now rules on the value the call extracted and carries the
+spoken words as evidence a human can check. Two regression tests hold it.
+
+## Silence is not failure
+
+An unreached branch, an answer the call could not resolve, and a value outside
+the rubric's options all rule `UNCLEAR` and go to a human. A phone line that
+failed must never read as a policy breach.
+
+## Verified against a live call
+
+Concord has been exercised end to end against the real CALL-E API: one call
+placed, structured answers returned, and the report generated from them. The
+run produced one deviation and one unresolved answer on a single branch.
+
+The recorded output is deliberately not committed. Everything in this
+repository is synthetic, because a public example directory is the wrong place
+for a real call identifier or for words a real person spoke. The fixtures under
+`fixtures/` reproduce the same shapes with reserved test numbers.
+
+What that call settled is in the next section: real speech does not behave like
+the tidy sentences a phrase matcher assumes.
+
+## Live runs
+
+A live run needs all three, checked independently:
+
+1. `--live`
+2. `--confirm` matching the token from the current preview, which is derived
+   from the audit and rubric so any edit invalidates it
+3. the branches' own weekday call window, open now
+
+```bash
+export CALLE_API_KEY="<CALL_E_API_KEY>"
+concord run fixtures/example-audit.json --rubric rubrics/emergency-contraception.json \
+  --live --confirm CONCORD-XXXXXXXXXXXX
+```
+
+The idempotency key is derived from the approved audit rather than the attempt,
+so resubmitting an unchanged audit after an uncertain response cannot call the
+same branches twice. If polling times out, reuse the call id and do not start a
+second audit.
+
+## Credentials
+
+`CALLE_API_KEY` is read from the process environment only, with an optional
+`CALLE_BASE_URL` override. Concord does not load a `.env` file, write the key to
+disk, or print it. `.env.example` documents the two variables you must
+`export` yourself; creating a `.env` will have no effect.
+
+## Layout
+
+```text
+src/concord/calle.py       the only module that can reach the network
+src/concord/collector.py   compiles the rubric into a call, parses results, cannot rule
+src/concord/judge.py       rules answers against the rubric, cannot dial
+src/concord/report.py      branch-level output, no people
+rubrics/                   written policy, one file per scenario
+skill/                     the Agent Skill and its references
+```
+
+`judge.py` imports `concord.models` and nothing else. A test parses its AST and
+asserts the import set is exactly `{__future__, concord}`, so an aliased or
+indirect route to the call client fails the suite. That is what keeps gathering
+and ruling apart.
+
+`calle.py` is covered by fake-transport tests that assert the exact URL, method,
+headers and body sent to CALL-E. Only a live call proves the API accepts it.
+
+## Scope
+
+Concord tells an operator which locations give callers the wrong answer. It is
+not for emergencies, not for medical, legal or employment decisions, and a
+finding is evidence about an answer, not proof of misconduct.

--- a/apps/python/concord/fixtures/completed-audit.json
+++ b/apps/python/concord/fixtures/completed-audit.json
@@ -1,0 +1,26 @@
+{
+  "audit_id": "AU-2026-09-03",
+  "rubric_id": "RB-EC-01",
+  "status": "completed",
+  "answers": [
+    { "branch_id": "B1", "criterion_id": "C1", "value": "no",  "quote": "No, you don't need a prescription for that, you can buy it at the counter." },
+    { "branch_id": "B1", "criterion_id": "C2", "value": "72",  "quote": "Sooner is better, but it works up to 72 hours afterwards." },
+    { "branch_id": "B1", "criterion_id": "C3", "value": "yes", "quote": "Yes, we have it in stock today." },
+    { "branch_id": "B1", "criterion_id": "C4", "value": "no",  "quote": "There's no age limit on it, anyone can be supplied." },
+
+    { "branch_id": "B2", "criterion_id": "C1", "value": "yes", "quote": "You'll need a doctor's note for that one, I'm afraid." },
+    { "branch_id": "B2", "criterion_id": "C2", "value": "unclear", "quote": "As soon as you can really." },
+    { "branch_id": "B2", "criterion_id": "C3", "value": "yes", "quote": "Yes, we keep it behind the counter." },
+    { "branch_id": "B2", "criterion_id": "C4", "value": "yes", "quote": "We'd want to see ID, you have to be over 18." },
+
+    { "branch_id": "B3", "criterion_id": "C1", "value": "no",  "quote": "No prescription needed, it's a pharmacy medicine." },
+    { "branch_id": "B3", "criterion_id": "C2", "value": "72",  "quote": "It can be taken up to 72 hours after, the earlier the better." },
+    { "branch_id": "B3", "criterion_id": "C3", "value": "no",  "quote": "You'd have to try another branch, I couldn't say for here." },
+    { "branch_id": "B3", "criterion_id": "C4", "value": "no",  "quote": "No age limit, no." },
+
+    { "branch_id": "B4", "criterion_id": "C1", "value": "", "quote": "", "reached": false },
+    { "branch_id": "B4", "criterion_id": "C2", "value": "", "quote": "", "reached": false },
+    { "branch_id": "B4", "criterion_id": "C3", "value": "", "quote": "", "reached": false },
+    { "branch_id": "B4", "criterion_id": "C4", "value": "", "quote": "", "reached": false }
+  ]
+}

--- a/apps/python/concord/fixtures/example-audit.json
+++ b/apps/python/concord/fixtures/example-audit.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU-2026-09-03",
+  "org": "Northgate Pharmacy Group",
+  "rubric_id": "RB-EC-01",
+  "requested_by": "Priya Raman, Clinical Governance",
+  "call_window": { "timezone": "Europe/London", "start": "09:30", "end": "16:30" },
+  "branches": [
+    { "id": "B1", "name": "Northgate Pharmacy, Selby Road", "phone": "+447700900101", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B2", "name": "Northgate Pharmacy, Harbour Street", "phone": "+447700900102", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B3", "name": "Northgate Pharmacy, Mill Court", "phone": "+447700900103", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B4", "name": "Northgate Pharmacy, Eastway", "phone": "+447700900104", "authorization": "owned-estate register 2026-09-01" }
+  ]
+}

--- a/apps/python/concord/fixtures/live-validation.json
+++ b/apps/python/concord/fixtures/live-validation.json
@@ -1,0 +1,19 @@
+{
+  "id": "AU-LIVE-2026-09-04",
+  "org": "Northgate Pharmacy Group",
+  "rubric_id": "RB-EC-01",
+  "requested_by": "Himanshu Jha, hackathon validation",
+  "call_window": {
+    "timezone": "Asia/Kolkata",
+    "start": "08:00",
+    "end": "20:00"
+  },
+  "branches": [
+    {
+      "id": "LIVE1",
+      "name": "Northgate Pharmacy, validation line",
+      "phone": "+447700900900",
+      "authorization": "owner's own line, supplied by the operator for CALL-E validation 2026-09-04. The real number is withheld from the repository; this file carries a reserved test number so the audit shape is reproducible without publishing a personal line."
+    }
+  ]
+}

--- a/apps/python/concord/fixtures/live-validation.json
+++ b/apps/python/concord/fixtures/live-validation.json
@@ -2,7 +2,7 @@
   "id": "AU-LIVE-2026-09-04",
   "org": "Northgate Pharmacy Group",
   "rubric_id": "RB-EC-01",
-  "requested_by": "Himanshu Jha, hackathon validation",
+  "requested_by": "Himanshu Kumar, hackathon validation",
   "call_window": {
     "timezone": "Asia/Kolkata",
     "start": "08:00",

--- a/apps/python/concord/fixtures/warranty-audit.json
+++ b/apps/python/concord/fixtures/warranty-audit.json
@@ -1,0 +1,11 @@
+{
+  "id": "AU-WAR-2026-09",
+  "org": "Halden Appliance Care",
+  "rubric_id": "RB-WAR-01",
+  "requested_by": "Tom Okafor, Service Standards",
+  "call_window": { "timezone": "Europe/London", "start": "09:00", "end": "17:00" },
+  "branches": [
+    { "id": "H1", "name": "Halden Care, Deansgate", "phone": "+447700900201", "authorization": "service-estate register 2026-09-01" },
+    { "id": "H2", "name": "Halden Care, Kirkby Retail Park", "phone": "+447700900202", "authorization": "service-estate register 2026-09-01" }
+  ]
+}

--- a/apps/python/concord/pyproject.toml
+++ b/apps/python/concord/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "concord"
+version = "0.1.0"
+description = "Audit what your own branches tell patients, and judge the answer against written policy."
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+concord = "concord.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/apps/python/concord/rubrics/emergency-contraception.json
+++ b/apps/python/concord/rubrics/emergency-contraception.json
@@ -1,0 +1,39 @@
+{
+  "id": "RB-EC-01",
+  "title": "Emergency contraception counter enquiry",
+  "scenario": "A caller asks whether the branch stocks levonorgestrel 1.5 mg emergency contraception, whether a prescription is needed, how soon it should be taken, and whether an age limit applies.",
+  "criteria": [
+    {
+      "id": "C1",
+      "question": "Do I need a prescription for the morning-after pill?",
+      "policy": "Levonorgestrel 1.5 mg is a pharmacy medicine supplied without a prescription. Staff must not tell a caller a prescription is required.",
+      "field": "prescription_required",
+      "expect": "no",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "C2",
+      "question": "How soon do I need to take it?",
+      "policy": "Staff must state that it can be taken up to 72 hours after unprotected sex, and that it is more effective the sooner it is taken.",
+      "field": "stated_window_hours",
+      "expect": "72",
+      "options": ["24", "48", "72", "unclear"]
+    },
+    {
+      "id": "C3",
+      "question": "Do you have it in stock today?",
+      "policy": "Staff must give a direct answer on this branch's own stock before referring a caller elsewhere.",
+      "field": "answered_own_stock",
+      "expect": "yes",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "C4",
+      "question": "Is there an age limit to buy it?",
+      "policy": "There is no minimum age for supply. Staff must not state or imply an age restriction.",
+      "field": "age_limit_claimed",
+      "expect": "no",
+      "options": ["yes", "no", "unclear"]
+    }
+  ]
+}

--- a/apps/python/concord/rubrics/repair-warranty.json
+++ b/apps/python/concord/rubrics/repair-warranty.json
@@ -1,0 +1,31 @@
+{
+  "id": "RB-WAR-01",
+  "title": "Out-of-warranty repair quote enquiry",
+  "scenario": "A caller asks whether a two-year-old appliance can be repaired under the extended warranty they bought, what a diagnostic costs, and how long a repair takes.",
+  "criteria": [
+    {
+      "id": "W1",
+      "question": "I bought the extended warranty. Is a two-year-old machine still covered?",
+      "policy": "The extended warranty covers years two and three. Staff must confirm cover for a two-year-old machine.",
+      "field": "covered",
+      "expect": "yes",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "W2",
+      "question": "Is there a charge just to look at it?",
+      "policy": "Diagnostics are free for machines under extended warranty. Staff must not quote a diagnostic fee to a covered caller.",
+      "field": "diagnostic_fee_quoted",
+      "expect": "no",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "W3",
+      "question": "Do I have to bring it in, or do you collect?",
+      "policy": "Collection is included under the extended warranty. Staff must offer collection rather than requiring drop-off.",
+      "field": "collection_offered",
+      "expect": "yes",
+      "options": ["yes", "no", "unclear"]
+    }
+  ]
+}

--- a/apps/python/concord/src/concord/__init__.py
+++ b/apps/python/concord/src/concord/__init__.py
@@ -1,0 +1,7 @@
+"""Concord audits what a branch tells a caller, and judges the answer against policy.
+
+The package is deliberately split so that the half which gathers speech cannot
+rule on it, and the half which rules cannot dial. See skill/references/safety.md.
+"""
+
+__version__ = "0.1.0"

--- a/apps/python/concord/src/concord/__main__.py
+++ b/apps/python/concord/src/concord/__main__.py
@@ -1,0 +1,3 @@
+from concord.cli import main
+
+main()

--- a/apps/python/concord/src/concord/calle.py
+++ b/apps/python/concord/src/concord/calle.py
@@ -1,0 +1,100 @@
+"""CALL-E Developer API client.
+
+Deliberately thin, and deliberately the only module in Concord that can reach
+the network. `concord.judge` imports nothing from here, which is what keeps
+gathering and ruling apart.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+# The bearer token is sent on every request, so the destination is not a free
+# parameter. CALLE_BASE_URL exists for a CALL-E staging host, not as a way to
+# point a live credential at an arbitrary collector, and an http:// override
+# would put the token on the wire in clear text.
+ALLOWED_HOSTS = frozenset({"api.heycall-e.com", "api.staging.heycall-e.com"})
+
+
+class CalleAPIError(RuntimeError):
+    pass
+
+
+def assert_trusted_base_url(base_url: str) -> str:
+    """Refuse to carry the credential anywhere but a trusted CALL-E origin."""
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme != "https":
+        raise CalleAPIError(
+            f"CALL-E base URL must use https, got {parsed.scheme or 'no scheme'!r}. "
+            "The API key is sent as a bearer token and will not be put on an "
+            "unencrypted connection."
+        )
+    if parsed.hostname not in ALLOWED_HOSTS:
+        raise CalleAPIError(
+            f"Refusing to send the CALL-E credential to {parsed.hostname!r}. "
+            f"Allowed hosts: {', '.join(sorted(ALLOWED_HOSTS))}."
+        )
+    return base_url.rstrip("/")
+
+
+class CalleClient:
+    def __init__(self, api_key: str, base_url: str = "https://api.heycall-e.com") -> None:
+        if not api_key:
+            raise CalleAPIError(
+                "CALLE_API_KEY is required for a live run. Concord reads it from the "
+                "environment only, and never writes it to disk."
+            )
+        self.api_key = api_key
+        self.base_url = assert_trusted_base_url(base_url)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        data = json.dumps(payload).encode() if payload is not None else None
+        headers = {"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        request = urllib.request.Request(
+            f"{self.base_url}{path}", data=data, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode())
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise CalleAPIError(f"CALL-E returned HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise CalleAPIError(f"Could not reach CALL-E: {exc.reason}") from exc
+
+    def create_call(self, payload: dict[str, Any], idempotency_key: str) -> dict[str, Any]:
+        return self._request("POST", "/v1/calls", payload, idempotency_key)
+
+    def get_call(self, call_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/v1/calls/{call_id}")
+
+    def wait_for_completion(
+        self, call_id: str, poll_seconds: int = 8, timeout_seconds: int = 900
+    ) -> dict[str, Any]:
+        terminal = {"completed", "failed", "cancelled", "canceled"}
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            result = self.get_call(call_id)
+            if str(result.get("status", "")).lower() in terminal:
+                return result
+            if time.monotonic() >= deadline:
+                raise CalleAPIError(
+                    "Polling timed out. The audit may still be running. Reuse this call "
+                    "id and do not create a second audit."
+                )
+            time.sleep(poll_seconds)

--- a/apps/python/concord/src/concord/cli.py
+++ b/apps/python/concord/src/concord/cli.py
@@ -1,0 +1,257 @@
+"""Command line.
+
+`preview` never places a call. `judge` runs entirely on recorded answers and
+never places a call either. Only `run --live` can dial, and it needs an approval
+token derived from the exact audit it is about to perform.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+from concord.calle import CalleAPIError, CalleClient
+from concord.collector import (
+    answers_from_result,
+    build_payload,
+    build_task,
+    idempotency_key,
+    window_is_open,
+)
+from concord.judge import rule_all
+from concord.models import Answer, Audit, ConcordError, Rubric
+from concord.report import render
+
+
+def approval_token(audit: Audit, rubric: Rubric) -> str:
+    """Bind approval to the complete call intent, not just its identifiers.
+
+    An earlier version hashed only the ids, the branch numbers and the criterion
+    ids. That meant the questions, the policy text, the allowed answers, the
+    organisation named in the disclosure, the authorization references and the
+    call window could all be rewritten while the operator's token stayed valid.
+    An operator who approved a stock-availability audit could have placed a
+    differently worded call to the same branches under the same approval.
+
+    Everything an operator reads in the preview is hashed here, so any material
+    edit invalidates the token they approved.
+    """
+    payload = json.dumps(
+        {
+            "audit": audit.id,
+            "org": audit.org,
+            "requested_by": audit.requested_by,
+            "timezone": audit.timezone,
+            "call_window": list(audit.call_window),
+            "branches": sorted(
+                [b.id, b.name, b.phone, b.authorization] for b in audit.branches
+            ),
+            "rubric": rubric.id,
+            "rubric_title": rubric.title,
+            "scenario": rubric.scenario,
+            "criteria": sorted(
+                [c.id, c.question, c.policy, c.field, c.expect, list(c.options)]
+                for c in rubric.criteria
+            ),
+        },
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(payload.encode()).hexdigest()[:12].upper()
+    return f"CONCORD-{digest}"
+
+
+def cmd_preview(args: argparse.Namespace) -> int:
+    audit = Audit.load(args.audit)
+    rubric = Rubric.load(args.rubric)
+    if audit.rubric_id != rubric.id:
+        raise ConcordError(
+            f"Audit expects rubric {audit.rubric_id!r} but {rubric.id!r} was given."
+        )
+
+    print("CONCORD  /  CALL PREVIEW")
+    print("=" * 78)
+    print(f"Audit       {audit.id}")
+    print(f"Org         {audit.org}")
+    print(f"Rubric      {rubric.id}  {rubric.title}")
+    print(f"Window      {audit.call_window[0]}-{audit.call_window[1]} {audit.timezone}")
+    print(f"Side effect Places {len(audit.branches)} outbound call(s) to your own branches.")
+    print("Scope       Branch policy concordance. Not a staff performance review.")
+    print()
+    print("BRANCHES TO CALL")
+    print(f"{'Branch':<38}{'Masked number':<18}{'Authorization'}")
+    print("-" * 78)
+    for b in audit.branches:
+        print(f"{b.name[:37]:<38}{b.masked_phone:<18}{b.authorization[:22]}")
+    print()
+    print("SCENARIO")
+    print(f"  {rubric.scenario}")
+    print()
+    print("QUESTIONS ASKED")
+    for c in rubric.criteria:
+        print(f"  {c.id}  {c.question}")
+    print()
+    print("APPROVAL CHECKPOINT")
+    print("No call was placed. Review this exact audit before approving it.")
+    token = approval_token(audit, rubric)
+    print(f"Token        {token}")
+    print(f"Live command concord run {args.audit} --rubric {args.rubric} --live --confirm {token}")
+    return 0
+
+
+def cmd_judge(args: argparse.Namespace) -> int:
+    audit = Audit.load(args.audit)
+    rubric = Rubric.load(args.rubric)
+    if audit.rubric_id != rubric.id:
+        raise ConcordError(
+            f"Audit expects rubric {audit.rubric_id!r} but {rubric.id!r} was given."
+        )
+    with open(args.results, encoding="utf-8") as handle:
+        raw = json.load(handle)
+    answers = [Answer.parse(a) for a in raw.get("answers", ())]
+    findings = rule_all(rubric, answers)
+    print(render(audit, rubric, findings))
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    """Place the calls.
+
+    Three gates, checked in this order and independently of each other:
+    the operator asked for --live, the approval token matches this exact audit,
+    and the branches' own call window is open.
+    """
+    audit = Audit.load(args.audit)
+    rubric = Rubric.load(args.rubric)
+    if audit.rubric_id != rubric.id:
+        raise ConcordError(
+            f"Audit expects rubric {audit.rubric_id!r} but {rubric.id!r} was given."
+        )
+
+    if not args.live:
+        print("Preview mode. Re-run with --live and the approval token to place calls.")
+        return 0
+
+    if args.confirm != approval_token(audit, rubric):
+        print(
+            "Concord refused: the approval token does not match this exact audit. "
+            "Run preview again and approve the audit you actually intend to place.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not window_is_open(audit):
+        print(
+            f"Concord refused: the call window for these branches is closed "
+            f"({audit.call_window[0]}-{audit.call_window[1]} {audit.timezone}, weekdays). "
+            "Branches are called during their own opening hours.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = CalleClient(
+        api_key=os.environ.get("CALLE_API_KEY", ""),
+        base_url=os.environ.get("CALLE_BASE_URL", "https://api.heycall-e.com"),
+    )
+    payload = build_payload(audit, rubric)
+    key = idempotency_key(audit, rubric)
+
+    print(f"Placing {len(audit.branches)} call(s) for audit {audit.id}.")
+    created = client.create_call(payload, key)
+    call_id = str(created.get("id") or created.get("call_id") or "")
+    if not call_id:
+        raise ConcordError(f"CALL-E did not return a call id: {created!r}")
+    print(f"CALL-E call id {call_id}. Keep this id; do not start a second audit.")
+
+    completed = client.wait_for_completion(call_id)
+    answers = answers_from_result(rubric, completed, audit)
+    if args.save:
+        record = {
+            "audit_id": audit.id,
+            "rubric_id": rubric.id,
+            "call_id": call_id,
+            "status": completed.get("status"),
+            "answers": [
+                {
+                    "branch_id": a.branch_id,
+                    "criterion_id": a.criterion_id,
+                    "value": a.value,
+                    "quote": a.quote,
+                    "reached": a.reached,
+                }
+                for a in answers
+            ],
+        }
+        with open(args.save, "w", encoding="utf-8") as handle:
+            json.dump(record, handle, indent=2)
+        print(f"Answers written to {args.save}")
+
+    print()
+    print(render(audit, rubric, rule_all(rubric, answers)))
+    return 0
+
+
+def cmd_task(args: argparse.Namespace) -> int:
+    """Print the exact call task and result schema, without placing a call."""
+    audit = Audit.load(args.audit)
+    rubric = Rubric.load(args.rubric)
+    payload = build_payload(audit, rubric)
+    print("CALL TASK")
+    print("-" * 78)
+    print(build_task(audit, rubric))
+    print()
+    print("RECIPIENT RESULT SCHEMA  (compiled from the rubric)")
+    print("-" * 78)
+    print(json.dumps(payload["recipient_result_schema"], indent=2))
+    print()
+    print(f"Idempotency-Key  {idempotency_key(audit, rubric)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="concord", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("audit")
+        p.add_argument("--rubric", required=True)
+
+    p_preview = sub.add_parser("preview", help="show the plan, place no calls")
+    add_common(p_preview)
+    p_preview.set_defaults(func=cmd_preview)
+
+    p_judge = sub.add_parser("judge", help="rule recorded answers against the rubric")
+    add_common(p_judge)
+    p_judge.add_argument("--results", required=True)
+    p_judge.set_defaults(func=cmd_judge)
+
+    p_run = sub.add_parser("run", help="place the calls, requires --live and a token")
+    add_common(p_run)
+    p_run.add_argument("--live", action="store_true")
+    p_run.add_argument("--confirm", default="")
+    p_run.add_argument("--save", default="", help="write the recorded answers to this file")
+    p_run.set_defaults(func=cmd_run)
+
+    p_task = sub.add_parser("task", help="show the compiled call task and schema")
+    add_common(p_task)
+    p_task.set_defaults(func=cmd_task)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        raise SystemExit(args.func(args))
+    except ConcordError as exc:
+        print(f"Concord refused: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    except CalleAPIError as exc:
+        print(f"CALL-E error: {exc}", file=sys.stderr)
+        raise SystemExit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/concord/src/concord/cli.py
+++ b/apps/python/concord/src/concord/cli.py
@@ -46,16 +46,16 @@ def approval_token(audit: Audit, rubric: Rubric) -> str:
             "requested_by": audit.requested_by,
             "timezone": audit.timezone,
             "call_window": list(audit.call_window),
-            "branches": sorted(
+            "branches": [
                 [b.id, b.name, b.phone, b.authorization] for b in audit.branches
-            ),
+            ],
             "rubric": rubric.id,
             "rubric_title": rubric.title,
             "scenario": rubric.scenario,
-            "criteria": sorted(
+            "criteria": [
                 [c.id, c.question, c.policy, c.field, c.expect, list(c.options)]
                 for c in rubric.criteria
-            ),
+            ],
         },
         sort_keys=True,
     )
@@ -111,7 +111,7 @@ def cmd_judge(args: argparse.Namespace) -> int:
     with open(args.results, encoding="utf-8") as handle:
         raw = json.load(handle)
     answers = [Answer.parse(a) for a in raw.get("answers", ())]
-    findings = rule_all(rubric, answers)
+    findings = rule_all(rubric, answers, [b.id for b in audit.branches])
     print(render(audit, rubric, findings))
     return 0
 
@@ -189,7 +189,13 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Answers written to {args.save}")
 
     print()
-    print(render(audit, rubric, rule_all(rubric, answers)))
+    print(
+        render(
+            audit,
+            rubric,
+            rule_all(rubric, answers, [b.id for b in audit.branches]),
+        )
+    )
     return 0
 
 
@@ -197,6 +203,10 @@ def cmd_task(args: argparse.Namespace) -> int:
     """Print the exact call task and result schema, without placing a call."""
     audit = Audit.load(args.audit)
     rubric = Rubric.load(args.rubric)
+    if audit.rubric_id != rubric.id:
+        raise ConcordError(
+            f"Audit expects rubric {audit.rubric_id!r} but {rubric.id!r} was given."
+        )
     payload = build_payload(audit, rubric)
     print("CALL TASK")
     print("-" * 78)

--- a/apps/python/concord/src/concord/collector.py
+++ b/apps/python/concord/src/concord/collector.py
@@ -1,0 +1,183 @@
+"""Gathering.
+
+The collector compiles a rubric into a CALL-E task and result schema, places one
+multi-recipient call, and turns what came back into `Answer` objects.
+
+It cannot rule. `Answer` has no verdict field, so there is nowhere for an opinion
+to go even if this module wanted to form one. Everything here is about capturing
+what a branch said and, separately, the words it said it in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from concord.models import Answer, Audit, ConcordError, Rubric
+
+DISCLOSURE = (
+    "At the very start of the call, say that you are an AI assistant calling on "
+    "behalf of {org} to check the information given to callers, and that this is "
+    "not a mystery-shopper test of the individual answering."
+)
+
+
+def result_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["branches_reached"],
+        "properties": {
+            "branches_reached": {"type": "integer"},
+            "branches_unreached": {"type": "integer"},
+        },
+    }
+
+
+def recipient_result_schema(rubric: Rubric) -> dict[str, Any]:
+    """Compile the rubric into the schema the call must answer in.
+
+    Each criterion contributes the field it asks for plus the quote that supports
+    it. Constraining the field to the rubric's own options is what stops the call
+    inventing a category the policy never contemplated.
+    """
+    properties: dict[str, Any] = {"reached": {"type": "boolean"}}
+    required = ["reached"]
+    for criterion in rubric.criteria:
+        field: dict[str, Any] = {"type": "string"}
+        if criterion.options:
+            field["enum"] = list(criterion.options)
+        properties[criterion.field] = field
+        properties[f"{criterion.field}_quote"] = {
+            "type": "string",
+            "description": "The caller's own words that support this answer.",
+        }
+        required.append(criterion.field)
+    return {"type": "object", "required": required, "properties": properties}
+
+
+def build_task(audit: Audit, rubric: Rubric) -> str:
+    questions = "\n".join(
+        f"{i + 1}. {c.question} Record the answer in '{c.field}'"
+        + (f" as one of: {', '.join(c.options)}." if c.options else ".")
+        + f" Record the exact words spoken in '{c.field}_quote'."
+        for i, c in enumerate(rubric.criteria)
+    )
+    return (
+        DISCLOSURE.format(org=audit.org)
+        + "\n\n"
+        + f"Scenario: {rubric.scenario}\n\n"
+        + "Ask these questions in order, and only these:\n"
+        + questions
+        + "\n\nRules. Ask as an ordinary caller would and accept the first clear answer. "
+        "Do not coach, correct, argue with or grade the person answering. Do not ask "
+        "for their name, role or employee number, and do not record it if offered. "
+        "Do not state what the policy says. If an answer is hedged, partial or "
+        "refused, set that field to 'unclear' rather than choosing the nearest "
+        "option. If the branch cannot be reached or declines to answer, set reached "
+        "to false. Capture the speaker's own words for every question you get an "
+        "answer to."
+    )
+
+
+def build_payload(audit: Audit, rubric: Rubric) -> dict[str, Any]:
+    return {
+        "task": build_task(audit, rubric),
+        "recipients": [{"phones": [b.phone]} for b in audit.branches],
+        "result_schema": result_schema(),
+        "recipient_result_schema": recipient_result_schema(rubric),
+        "metadata": {
+            "workflow": "concord",
+            "audit_id": audit.id,
+            "rubric_id": rubric.id,
+            "unit_of_analysis": "branch",
+        },
+    }
+
+
+def idempotency_key(audit: Audit, rubric: Rubric) -> str:
+    """Derived from the approved audit, never from the retry attempt.
+
+    Re-sending an unchanged audit after an uncertain response reuses this key and
+    cannot produce a second round of calls to the same branches.
+    """
+    payload = json.dumps(
+        {
+            "audit": audit.id,
+            "rubric": rubric.id,
+            "branches": sorted(b.phone for b in audit.branches),
+        },
+        sort_keys=True,
+    )
+    return "concord-" + hashlib.sha256(payload.encode()).hexdigest()[:32]
+
+
+def window_is_open(audit: Audit, now: datetime | None = None) -> bool:
+    """Branches are called during their own opening hours, on weekdays only."""
+    try:
+        tz = ZoneInfo(audit.timezone)
+    except Exception as exc:  # noqa: BLE001
+        raise ConcordError(f"Unknown timezone {audit.timezone!r}.") from exc
+    moment = (now or datetime.now(tz)).astimezone(tz)
+    if moment.weekday() >= 5:
+        return False
+    start_h, start_m = (int(x) for x in audit.call_window[0].split(":"))
+    end_h, end_m = (int(x) for x in audit.call_window[1].split(":"))
+    minutes = moment.hour * 60 + moment.minute
+    return start_h * 60 + start_m <= minutes <= end_h * 60 + end_m
+
+
+def answers_from_result(rubric: Rubric, call_result: dict[str, Any], audit: Audit) -> list[Answer]:
+    """Turn one completed CALL-E result into answers.
+
+    Two rules that an earlier version got wrong.
+
+    Results are correlated to a branch by the destination that was dialled, not
+    by position in the returned array. A provider that drops, reorders or adds a
+    recipient would otherwise shift every answer onto the wrong branch, and a
+    missing recipient would make a branch disappear by shortening the list.
+
+    Every branch in the audit produces an answer for every criterion, whether or
+    not the provider returned anything for it. A branch with no result is
+    recorded as unreached, which rules UNCLEAR. A silent branch must reach the
+    report, because a branch that vanishes reads as a branch with nothing wrong.
+
+    Answers are built through `Answer.parse`, so the self-identification scrub
+    that protects fixture data also protects live provider output. Constructing
+    `Answer` directly here would bypass the one guard that keeps a spoken name
+    out of the record, on the only path where a real name can occur.
+    """
+    by_phone: dict[str, dict[str, Any]] = {}
+    leftovers: list[dict[str, Any]] = []
+    for recipient in call_result.get("recipients", []):
+        phones = recipient.get("phones") or []
+        phone = str(phones[0]) if phones else str(recipient.get("phone", "") or "")
+        if phone:
+            by_phone[phone] = recipient
+        else:
+            leftovers.append(recipient)
+
+    answers: list[Answer] = []
+    for index, branch in enumerate(audit.branches):
+        recipient = by_phone.get(branch.phone)
+        if recipient is None and not by_phone and index < len(leftovers):
+            # Provider echoed no destinations at all: fall back to order, which
+            # is the documented request order, rather than dropping everything.
+            recipient = leftovers[index]
+        structured = (recipient or {}).get("structured_result") or {}
+        reached = bool(structured.get("reached", bool(structured))) if recipient else False
+        for criterion in rubric.criteria:
+            answers.append(
+                Answer.parse(
+                    {
+                        "branch_id": branch.id,
+                        "criterion_id": criterion.id,
+                        "value": structured.get(criterion.field, "") or "",
+                        "quote": structured.get(f"{criterion.field}_quote", "") or "",
+                        "reached": reached,
+                    }
+                )
+            )
+    return answers

--- a/apps/python/concord/src/concord/collector.py
+++ b/apps/python/concord/src/concord/collector.py
@@ -104,12 +104,7 @@ def idempotency_key(audit: Audit, rubric: Rubric) -> str:
     cannot produce a second round of calls to the same branches.
     """
     payload = json.dumps(
-        {
-            "audit": audit.id,
-            "rubric": rubric.id,
-            "branches": sorted(b.phone for b in audit.branches),
-        },
-        sort_keys=True,
+        build_payload(audit, rubric), sort_keys=True, separators=(",", ":")
     )
     return "concord-" + hashlib.sha256(payload.encode()).hexdigest()[:32]
 

--- a/apps/python/concord/src/concord/judge.py
+++ b/apps/python/concord/src/concord/judge.py
@@ -87,16 +87,21 @@ def rule_one(criterion: Criterion, answer: Answer) -> Finding:
     )
 
 
-def rule_all(rubric: Rubric, answers: list[Answer]) -> list[Finding]:
-    """Rule every criterion for every branch that produced answers.
+def rule_all(
+    rubric: Rubric,
+    answers: list[Answer],
+    branch_ids: list[str] | None = None,
+) -> list[Finding]:
+    """Rule every criterion for every expected or observed branch.
 
-    A criterion with no answer at all still produces an UNCLEAR finding, so a
-    silently skipped question cannot disappear from the report.
+    A branch or criterion with no answer at all still produces UNCLEAR findings,
+    so incomplete recorded results cannot make outstanding work disappear.
     """
     by_key = {(a.branch_id, a.criterion_id): a for a in answers}
-    branch_ids = sorted({a.branch_id for a in answers})
+    expected = set(branch_ids or ())
+    expected.update(a.branch_id for a in answers)
     findings: list[Finding] = []
-    for branch_id in branch_ids:
+    for branch_id in sorted(expected):
         for criterion in rubric.criteria:
             answer = by_key.get(
                 (branch_id, criterion.id),

--- a/apps/python/concord/src/concord/judge.py
+++ b/apps/python/concord/src/concord/judge.py
@@ -1,0 +1,112 @@
+"""Ruling.
+
+This module imports nothing that can place a call. It takes answers that already
+exist and rules them against a rubric.
+
+It rules on the value the call extracted, never on the transcript text. Matching
+phrases against free speech cannot read negation, and a false deviation in a
+staff audit is worse than a missed one. The quote travels with the finding as
+evidence a human can check, but it is not what decides the verdict.
+"""
+
+from __future__ import annotations
+
+from concord.models import Answer, Criterion, Finding, Rubric
+
+UNRESOLVED = {"", "unclear", "unknown", "not_stated", "refused"}
+
+
+def rule_one(criterion: Criterion, answer: Answer) -> Finding:
+    """Rule a single answer.
+
+    Silence is never a deviation. A branch that was not reached, or whose answer
+    the call could not resolve into a value, is UNCLEAR and goes to a human.
+    Treating an unreached branch as non-compliant would let a bad phone line
+    look like a policy failure.
+    """
+    value = answer.value.strip().lower()
+
+    if not answer.reached or value in UNRESOLVED:
+        return Finding(
+            branch_id=answer.branch_id,
+            criterion_id=criterion.id,
+            verdict="UNCLEAR",
+            rationale=(
+                "The branch was not reached."
+                if not answer.reached
+                else "The call could not resolve this question into a definite answer."
+            ),
+            quote=answer.quote,
+            needs_human_review=True,
+        )
+
+    if not answer.quote:
+        return Finding(
+            branch_id=answer.branch_id,
+            criterion_id=criterion.id,
+            verdict="UNCLEAR",
+            rationale=(
+                f"The call returned {answer.value!r} but captured no words to support it. "
+                "A ruling without quoted evidence is not a ruling."
+            ),
+            quote="",
+            needs_human_review=True,
+        )
+
+    if criterion.options and value not in {o.lower() for o in criterion.options}:
+        return Finding(
+            branch_id=answer.branch_id,
+            criterion_id=criterion.id,
+            verdict="UNCLEAR",
+            rationale=(
+                f"The call returned {answer.value!r}, which is not one of the answers "
+                f"this question allows. Treated as unresolved rather than guessed at."
+            ),
+            quote=answer.quote,
+            needs_human_review=True,
+        )
+
+    if value == criterion.expect.strip().lower():
+        return Finding(
+            branch_id=answer.branch_id,
+            criterion_id=criterion.id,
+            verdict="COMPLIANT",
+            rationale=f"Answered {answer.value!r}, which is what the policy requires.",
+            quote=answer.quote,
+        )
+
+    return Finding(
+        branch_id=answer.branch_id,
+        criterion_id=criterion.id,
+        verdict="DEVIATION",
+        rationale=(
+            f"Answered {answer.value!r} where policy requires {criterion.expect!r}. "
+            f"Policy: {criterion.policy}"
+        ),
+        quote=answer.quote,
+    )
+
+
+def rule_all(rubric: Rubric, answers: list[Answer]) -> list[Finding]:
+    """Rule every criterion for every branch that produced answers.
+
+    A criterion with no answer at all still produces an UNCLEAR finding, so a
+    silently skipped question cannot disappear from the report.
+    """
+    by_key = {(a.branch_id, a.criterion_id): a for a in answers}
+    branch_ids = sorted({a.branch_id for a in answers})
+    findings: list[Finding] = []
+    for branch_id in branch_ids:
+        for criterion in rubric.criteria:
+            answer = by_key.get(
+                (branch_id, criterion.id),
+                Answer(
+                    branch_id=branch_id,
+                    criterion_id=criterion.id,
+                    value="",
+                    quote="",
+                    reached=False,
+                ),
+            )
+            findings.append(rule_one(criterion, answer))
+    return findings

--- a/apps/python/concord/src/concord/models.py
+++ b/apps/python/concord/src/concord/models.py
@@ -1,0 +1,238 @@
+"""Data model.
+
+Two rules are enforced here rather than left to convention:
+
+1. An `Answer` carries only what the branch said. It has no verdict field, so a
+   collector physically cannot record a ruling.
+2. A `Finding` carries a verdict and must quote the answer it rules on. It has
+   no phone number and no staff name, so a report cannot identify a person.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from typing import Any, Literal
+
+E164 = re.compile(r"^\+[1-9][0-9]{7,14}$")
+
+QUOTE_MAX = 240
+
+# A quote is the one free-text field Concord carries, so it is the one place a
+# person could enter the record: someone who answers "This is Sarah, no you
+# don't need a prescription" has put their name in the report. The call task
+# asks the agent not to record names, but a prompt is a request, not a
+# guarantee. These patterns are the second line, applied when the answer is
+# parsed so no caller can skip them. They are best effort on natural speech,
+# not a proof, and the docs say so.
+SELF_ID = re.compile(
+    r"""(?ix)
+    \b(?:
+        (?:this\s+is|it'?s|my\s+name\s+is|you'?re\s+(?:speaking\s+)?(?:to|with))
+        \s+[A-Z][a-z'-]+(?:\s+[A-Z][a-z'-]+)?
+      | [A-Z][a-z'-]+\s+speaking
+    )\b[,.\s]*""",
+)
+
+
+def redact_quote(text: str) -> str:
+    """Remove self-identification from a spoken quote and cap its length.
+
+    Concord reports on branches. A name that arrives inside a quote would defeat
+    that, so it is stripped here rather than at render time, where a new caller
+    could forget to apply it.
+    """
+    cleaned = SELF_ID.sub("", text).strip()
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    if len(cleaned) > QUOTE_MAX:
+        cleaned = cleaned[:QUOTE_MAX].rsplit(" ", 1)[0] + " [...]"
+    return cleaned
+
+Verdict = Literal["COMPLIANT", "DEVIATION", "UNCLEAR"]
+VERDICTS: tuple[str, ...] = ("COMPLIANT", "DEVIATION", "UNCLEAR")
+
+
+class ConcordError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One policy expectation, written by a human, in the policy's own words.
+
+    `field` names the value the call is asked to extract, and `expect` is the
+    answer policy requires. Judging compares those values, never the free text.
+
+    An earlier version matched phrases against the transcript and reported
+    "No, you don't need a prescription" as a deviation because the string "need
+    a prescription" occurs inside it. Keyword matching cannot read negation, and
+    in an audit of your own staff a false deviation is worse than a missed one:
+    it sends a manager to correct a branch that answered correctly.
+    """
+
+    id: str
+    question: str
+    policy: str
+    field: str
+    expect: str
+    options: tuple[str, ...] = ()
+
+    @classmethod
+    def parse(cls, raw: dict[str, Any]) -> "Criterion":
+        for key in ("id", "question", "policy", "field", "expect"):
+            if not str(raw.get(key, "")).strip():
+                raise ConcordError(f"Criterion is missing '{key}'.")
+        options = tuple(str(o) for o in raw.get("options", ()))
+        expect = str(raw["expect"]).strip()
+        if options and expect not in options:
+            raise ConcordError(
+                f"Criterion {raw['id']!r} expects {expect!r}, which is not one of its options."
+            )
+        return cls(
+            id=str(raw["id"]).strip(),
+            question=str(raw["question"]).strip(),
+            policy=str(raw["policy"]).strip(),
+            field=str(raw["field"]).strip(),
+            expect=expect,
+            options=options,
+        )
+
+
+@dataclass(frozen=True)
+class Rubric:
+    """The written policy an answer is judged against, loaded separately from any call."""
+
+    id: str
+    title: str
+    scenario: str
+    criteria: tuple[Criterion, ...]
+
+    @classmethod
+    def load(cls, path: str) -> "Rubric":
+        with open(path, encoding="utf-8") as handle:
+            raw = json.load(handle)
+        criteria = tuple(Criterion.parse(c) for c in raw.get("criteria", ()))
+        if not criteria:
+            raise ConcordError("A rubric needs at least one criterion.")
+        ids = [c.id for c in criteria]
+        if len(set(ids)) != len(ids):
+            raise ConcordError("Criterion ids must be unique within a rubric.")
+        return cls(
+            id=str(raw["id"]),
+            title=str(raw["title"]),
+            scenario=str(raw["scenario"]).strip(),
+            criteria=criteria,
+        )
+
+
+@dataclass(frozen=True)
+class Branch:
+    """A location the operator owns and is authorised to audit."""
+
+    id: str
+    name: str
+    phone: str
+    authorization: str
+
+    @classmethod
+    def parse(cls, raw: dict[str, Any]) -> "Branch":
+        phone = str(raw.get("phone", "")).strip()
+        if not E164.match(phone):
+            raise ConcordError(f"Branch phone must be E.164, got {phone!r}.")
+        if not str(raw.get("authorization", "")).strip():
+            raise ConcordError(
+                f"Branch {raw.get('id')!r} has no authorization reference. "
+                "Concord only calls lines the operator has confirmed it owns."
+            )
+        return cls(
+            id=str(raw["id"]).strip(),
+            name=str(raw["name"]).strip(),
+            phone=phone,
+            authorization=str(raw["authorization"]).strip(),
+        )
+
+    @property
+    def masked_phone(self) -> str:
+        return f"{self.phone[:3]}{'*' * (len(self.phone) - 5)}{self.phone[-2:]}"
+
+
+@dataclass(frozen=True)
+class Answer:
+    """What one branch said.
+
+    `value` is the field the call extracted. `quote` is the spoken evidence for
+    it. Carries no verdict, by construction, so a collector cannot rule.
+    """
+
+    branch_id: str
+    criterion_id: str
+    value: str
+    quote: str
+    reached: bool = True
+
+    @classmethod
+    def parse(cls, raw: dict[str, Any]) -> "Answer":
+        return cls(
+            branch_id=str(raw["branch_id"]),
+            criterion_id=str(raw["criterion_id"]),
+            value=str(raw.get("value", "")).strip(),
+            quote=redact_quote(str(raw.get("quote", ""))),
+            reached=bool(raw.get("reached", True)),
+        )
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A ruling on one answer. Carries no phone number and no person."""
+
+    branch_id: str
+    criterion_id: str
+    verdict: Verdict
+    rationale: str
+    quote: str
+    needs_human_review: bool = False
+
+    def __post_init__(self) -> None:
+        if self.verdict not in VERDICTS:
+            raise ConcordError(f"Unknown verdict {self.verdict!r}.")
+        if not self.quote and self.verdict != "UNCLEAR":
+            raise ConcordError(
+                "A COMPLIANT or DEVIATION finding must quote the words it rules on."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Audit:
+    """One authorised audit run."""
+
+    id: str
+    org: str
+    rubric_id: str
+    branches: tuple[Branch, ...]
+    timezone: str
+    call_window: tuple[str, str]
+    requested_by: str
+
+    @classmethod
+    def load(cls, path: str) -> "Audit":
+        with open(path, encoding="utf-8") as handle:
+            raw = json.load(handle)
+        branches = tuple(Branch.parse(b) for b in raw.get("branches", ()))
+        if not branches:
+            raise ConcordError("An audit needs at least one branch.")
+        if len(branches) > 12:
+            raise ConcordError("Concord audits at most 12 branches in one run.")
+        window = raw.get("call_window", {})
+        return cls(
+            id=str(raw["id"]),
+            org=str(raw["org"]),
+            rubric_id=str(raw["rubric_id"]),
+            branches=branches,
+            timezone=str(window.get("timezone", "UTC")),
+            call_window=(str(window.get("start", "09:00")), str(window.get("end", "17:00"))),
+            requested_by=str(raw.get("requested_by", "")),
+        )

--- a/apps/python/concord/src/concord/report.py
+++ b/apps/python/concord/src/concord/report.py
@@ -1,0 +1,99 @@
+"""Reporting.
+
+Concord reports on branches, never on people. Two consequences are structural:
+
+1. Findings carry no staff name and no phone number, so there is nothing to
+   attribute to an individual even if a caller wanted to.
+2. A branch is described by its gap count, not scored, ranked into a league
+   table, or given a percentage that could be pasted into a performance review.
+
+A tool that dials your own staff can very easily become a surveillance tool.
+The boundary is the product decision, so it lives in code rather than in a
+paragraph of the README.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from concord.models import Audit, Finding, Rubric
+
+
+@dataclass(frozen=True)
+class BranchSummary:
+    branch_id: str
+    name: str
+    deviations: int
+    unclear: int
+    compliant: int
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.deviations > 0 or self.unclear > 0
+
+
+def summarise(audit: Audit, findings: list[Finding]) -> list[BranchSummary]:
+    names = {b.id: b.name for b in audit.branches}
+    out: list[BranchSummary] = []
+    for branch_id in sorted({f.branch_id for f in findings}):
+        rows = [f for f in findings if f.branch_id == branch_id]
+        out.append(
+            BranchSummary(
+                branch_id=branch_id,
+                name=names.get(branch_id, branch_id),
+                deviations=sum(1 for f in rows if f.verdict == "DEVIATION"),
+                unclear=sum(1 for f in rows if f.verdict == "UNCLEAR"),
+                compliant=sum(1 for f in rows if f.verdict == "COMPLIANT"),
+            )
+        )
+    # Ordered by how much policy work is outstanding, not by branch quality.
+    return sorted(out, key=lambda s: (-s.deviations, -s.unclear, s.branch_id))
+
+
+def gap_register(rubric: Rubric, findings: list[Finding]) -> list[Finding]:
+    """Every finding a human still has to act on, deviations first."""
+    order = {c.id: i for i, c in enumerate(rubric.criteria)}
+    open_rows = [f for f in findings if f.verdict != "COMPLIANT"]
+    return sorted(
+        open_rows,
+        key=lambda f: (f.verdict != "DEVIATION", order.get(f.criterion_id, 99), f.branch_id),
+    )
+
+
+def render(audit: Audit, rubric: Rubric, findings: list[Finding]) -> str:
+    lines: list[str] = []
+    add = lines.append
+    add("CONCORD  /  POLICY CONCORDANCE REPORT")
+    add("=" * 86)
+    add(f"Audit       {audit.id}")
+    add(f"Rubric      {rubric.id}  {rubric.title}")
+    add(f"Scope       {len(audit.branches)} branch(es), {len(rubric.criteria)} criterion(a)")
+    add("Unit        Branch. Concord does not rate individual staff.")
+    add("")
+
+    summaries = summarise(audit, findings)
+    add("BRANCH OVERVIEW")
+    add(f"{'Branch':<34}{'Deviations':>12}{'Unclear':>10}{'Matches policy':>17}")
+    add("-" * 86)
+    for s in summaries:
+        add(f"{s.name[:33]:<34}{s.deviations:>12}{s.unclear:>10}{s.compliant:>17}")
+    add("")
+
+    register = gap_register(rubric, findings)
+    questions = {c.id: c.question for c in rubric.criteria}
+    names = {b.id: b.name for b in audit.branches}
+    add("GAP REGISTER")
+    if not register:
+        add("  Every answer matched policy. Nothing outstanding.")
+    for f in register:
+        add(f"  [{f.verdict}] {names.get(f.branch_id, f.branch_id)}  ({f.criterion_id})")
+        add(f"      asked     {questions.get(f.criterion_id, '')}")
+        if f.quote:
+            add(f"      heard     \"{f.quote}\"")
+        add(f"      finding   {f.rationale}")
+        add("")
+
+    add("HUMAN DECISION REQUIRED")
+    add("Concord records what was said and whether it matches written policy.")
+    add("It does not evaluate employees, and its output is not a performance record.")
+    return "\n".join(lines)

--- a/apps/python/concord/tests/test_calle.py
+++ b/apps/python/concord/tests/test_calle.py
@@ -1,0 +1,126 @@
+"""The wire contract.
+
+A live call is the only thing that proves CALL-E accepts this payload, but a
+fake transport can prove the client sends what the docs say it sends. Without
+this, `calle.py` had no coverage at all and the one claim the technical score
+rests on was untested.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from concord.calle import CalleAPIError, CalleClient
+from concord.collector import build_payload, idempotency_key
+from concord.models import Audit, Rubric
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load():
+    return (
+        Audit.load(str(ROOT / "fixtures" / "example-audit.json")),
+        Rubric.load(str(ROOT / "rubrics" / "emergency-contraception.json")),
+    )
+
+
+class FakeResponse:
+    def __init__(self, body: dict):
+        self._body = json.dumps(body).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestRequestShape(unittest.TestCase):
+    def setUp(self):
+        self.client = CalleClient(api_key="test-key-not-real")
+
+    def _capture(self, body: dict):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["method"] = request.method
+            captured["headers"] = {k.lower(): v for k, v in request.headers.items()}
+            captured["body"] = json.loads(request.data) if request.data else None
+            return FakeResponse(body)
+
+        return captured, fake_urlopen
+
+    def test_create_call_posts_to_v1_calls(self):
+        audit, rubric = load()
+        captured, fake = self._capture({"id": "call_test_1", "status": "queued"})
+        with mock.patch("urllib.request.urlopen", fake):
+            self.client.create_call(build_payload(audit, rubric), idempotency_key(audit, rubric))
+        self.assertEqual(captured["url"], "https://api.heycall-e.com/v1/calls")
+        self.assertEqual(captured["method"], "POST")
+
+    def test_authorization_and_idempotency_headers_are_sent(self):
+        audit, rubric = load()
+        key = idempotency_key(audit, rubric)
+        captured, fake = self._capture({"id": "call_test_1"})
+        with mock.patch("urllib.request.urlopen", fake):
+            self.client.create_call(build_payload(audit, rubric), key)
+        self.assertEqual(captured["headers"]["authorization"], "Bearer test-key-not-real")
+        self.assertEqual(captured["headers"]["idempotency-key"], key)
+        self.assertEqual(captured["headers"]["content-type"], "application/json")
+
+    def test_body_carries_the_compiled_schema_and_one_recipient_per_branch(self):
+        audit, rubric = load()
+        captured, fake = self._capture({"id": "call_test_1"})
+        with mock.patch("urllib.request.urlopen", fake):
+            self.client.create_call(build_payload(audit, rubric), "k")
+        body = captured["body"]
+        self.assertIn("task", body)
+        self.assertIn("recipient_result_schema", body)
+        self.assertEqual(len(body["recipients"]), len(audit.branches))
+        self.assertEqual(
+            [r["phones"][0] for r in body["recipients"]], [b.phone for b in audit.branches]
+        )
+        for criterion in rubric.criteria:
+            self.assertIn(criterion.field, body["recipient_result_schema"]["required"])
+
+    def test_get_call_uses_the_call_id(self):
+        captured, fake = self._capture({"id": "call_x", "status": "completed"})
+        with mock.patch("urllib.request.urlopen", fake):
+            self.client.get_call("call_x")
+        self.assertEqual(captured["url"], "https://api.heycall-e.com/v1/calls/call_x")
+        self.assertEqual(captured["method"], "GET")
+        self.assertIsNone(captured["body"])
+
+    def test_base_url_is_configurable_within_the_allowlist(self):
+        client = CalleClient(api_key="k", base_url="https://api.staging.heycall-e.com/")
+        captured, fake = self._capture({"id": "c"})
+        with mock.patch("urllib.request.urlopen", fake):
+            client.get_call("c")
+        self.assertEqual(captured["url"], "https://api.staging.heycall-e.com/v1/calls/c")
+
+
+class TestCredentialHandling(unittest.TestCase):
+    def test_a_missing_key_is_refused_before_any_network_use(self):
+        with self.assertRaises(CalleAPIError):
+            CalleClient(api_key="")
+
+    def test_polling_stops_at_a_terminal_status(self):
+        client = CalleClient(api_key="k")
+        with mock.patch.object(client, "get_call", return_value={"status": "completed"}):
+            self.assertEqual(client.wait_for_completion("c")["status"], "completed")
+
+    def test_polling_timeout_says_not_to_start_a_second_audit(self):
+        client = CalleClient(api_key="k")
+        with mock.patch.object(client, "get_call", return_value={"status": "running"}):
+            with self.assertRaises(CalleAPIError) as ctx:
+                client.wait_for_completion("c", poll_seconds=0, timeout_seconds=0)
+        self.assertIn("do not create a second audit", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/concord/tests/test_collector.py
+++ b/apps/python/concord/tests/test_collector.py
@@ -208,7 +208,7 @@ class TestSecondRubric(unittest.TestCase):
 
 
 class TestReviewRegressions(unittest.TestCase):
-    """Findings from maintainer review of PR #303. Each held a documented promise."""
+    """Findings from maintainer review. Each held a documented promise."""
 
     def test_credential_never_leaves_a_trusted_https_origin(self):
         from concord.calle import CalleAPIError, CalleClient

--- a/apps/python/concord/tests/test_collector.py
+++ b/apps/python/concord/tests/test_collector.py
@@ -1,0 +1,296 @@
+"""Gathering, schema compilation and the live gates."""
+
+import json
+import unittest
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from concord.collector import (
+    answers_from_result,
+    build_payload,
+    build_task,
+    idempotency_key,
+    recipient_result_schema,
+    window_is_open,
+)
+from concord.judge import rule_all
+from concord.models import Answer, Audit, Rubric
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load():
+    return (
+        Audit.load(str(ROOT / "fixtures" / "example-audit.json")),
+        Rubric.load(str(ROOT / "rubrics" / "emergency-contraception.json")),
+    )
+
+
+class TestSchemaCompilation(unittest.TestCase):
+    """The rubric is the source of truth for what the call may return."""
+
+    def test_every_criterion_becomes_a_required_field(self):
+        _, rubric = load()
+        schema = recipient_result_schema(rubric)
+        for criterion in rubric.criteria:
+            self.assertIn(criterion.field, schema["required"])
+            self.assertIn(f"{criterion.field}_quote", schema["properties"])
+
+    def test_options_become_an_enum(self):
+        _, rubric = load()
+        schema = recipient_result_schema(rubric)
+        first = rubric.criteria[0]
+        self.assertEqual(schema["properties"][first.field]["enum"], list(first.options))
+
+    def test_a_new_criterion_changes_the_schema(self):
+        _, rubric = load()
+        before = json.dumps(recipient_result_schema(rubric), sort_keys=True)
+        trimmed = Rubric(rubric.id, rubric.title, rubric.scenario, rubric.criteria[:2])
+        self.assertNotEqual(before, json.dumps(recipient_result_schema(trimmed), sort_keys=True))
+
+
+class TestCallTask(unittest.TestCase):
+    def test_task_discloses_ai_and_the_organisation(self):
+        audit, rubric = load()
+        task = build_task(audit, rubric)
+        self.assertIn("AI assistant", task)
+        self.assertIn(audit.org, task)
+
+    def test_task_forbids_identifying_the_person(self):
+        audit, rubric = load()
+        task = build_task(audit, rubric).lower()
+        self.assertIn("do not ask for their name", task)
+
+    def test_task_forbids_coaching_or_grading(self):
+        audit, rubric = load()
+        self.assertIn("Do not coach, correct, argue with or grade", build_task(audit, rubric))
+
+    def test_task_prefers_unclear_over_guessing(self):
+        audit, rubric = load()
+        self.assertIn("rather than choosing the nearest", build_task(audit, rubric))
+
+
+class TestPayload(unittest.TestCase):
+    def test_one_recipient_per_branch(self):
+        audit, rubric = load()
+        payload = build_payload(audit, rubric)
+        self.assertEqual(len(payload["recipients"]), len(audit.branches))
+
+    def test_metadata_records_the_unit_of_analysis(self):
+        audit, rubric = load()
+        self.assertEqual(build_payload(audit, rubric)["metadata"]["unit_of_analysis"], "branch")
+
+
+class TestIdempotency(unittest.TestCase):
+    """The key is derived from the approved audit, not the retry attempt."""
+
+    def test_same_audit_yields_the_same_key(self):
+        audit, rubric = load()
+        self.assertEqual(idempotency_key(audit, rubric), idempotency_key(audit, rubric))
+
+    def test_different_branches_yield_a_different_key(self):
+        audit, rubric = load()
+        trimmed = Audit(
+            audit.id, audit.org, audit.rubric_id, audit.branches[:2],
+            audit.timezone, audit.call_window, audit.requested_by,
+        )
+        self.assertNotEqual(idempotency_key(audit, rubric), idempotency_key(trimmed, rubric))
+
+
+class TestCallWindow(unittest.TestCase):
+    def setUp(self):
+        self.audit, _ = load()
+        self.tz = ZoneInfo(self.audit.timezone)
+
+    def test_open_during_a_weekday_morning(self):
+        moment = datetime(2026, 9, 3, 11, 0, tzinfo=self.tz)
+        self.assertTrue(window_is_open(self.audit, moment))
+
+    def test_closed_after_hours(self):
+        moment = datetime(2026, 9, 3, 17, 52, tzinfo=self.tz)
+        self.assertFalse(window_is_open(self.audit, moment))
+
+    def test_closed_at_the_weekend(self):
+        saturday = datetime(2026, 9, 5, 11, 0, tzinfo=self.tz)
+        self.assertFalse(window_is_open(self.audit, saturday))
+
+
+class TestResultParsing(unittest.TestCase):
+    def test_provider_without_destinations_falls_back_to_request_order(self):
+        audit, rubric = load()
+        result = {
+            "recipients": [
+                {"structured_result": {"reached": True, "prescription_required": "no",
+                                       "prescription_required_quote": "No prescription needed."}},
+            ]
+        }
+        answers = answers_from_result(rubric, result, audit)
+        self.assertEqual(answers[0].branch_id, audit.branches[0].id)
+        self.assertEqual(answers[0].value, "no")
+
+    def test_a_silent_branch_is_recorded_not_dropped(self):
+        """Every branch in the audit is answered for, however few the provider returns."""
+        audit, rubric = load()
+        result = {"recipients": [{"structured_result": {}}]}
+        answers = answers_from_result(rubric, result, audit)
+        self.assertEqual(len(answers), len(audit.branches) * len(rubric.criteria))
+        self.assertTrue(all(not a.reached for a in answers))
+        findings = rule_all(rubric, answers)
+        self.assertTrue(all(f.verdict == "UNCLEAR" for f in findings))
+
+    def test_parsing_produces_no_verdict(self):
+        audit, rubric = load()
+        result = {"recipients": [{"structured_result": {"reached": True}}]}
+        for answer in answers_from_result(rubric, result, audit):
+            self.assertFalse(hasattr(answer, "verdict"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestSecondRubric(unittest.TestCase):
+    """The rubric format has to carry a scenario it was not designed around."""
+
+    def test_a_different_domain_compiles_without_code_changes(self):
+        audit = Audit.load(str(ROOT / "fixtures" / "warranty-audit.json"))
+        rubric = Rubric.load(str(ROOT / "rubrics" / "repair-warranty.json"))
+        schema = recipient_result_schema(rubric)
+        self.assertEqual(
+            schema["required"],
+            ["reached", "covered", "diagnostic_fee_quoted", "collection_offered"],
+        )
+        self.assertEqual(len(build_payload(audit, rubric)["recipients"]), 2)
+
+    def test_rubrics_do_not_share_an_idempotency_key(self):
+        ec_audit, ec_rubric = load()
+        war_audit = Audit.load(str(ROOT / "fixtures" / "warranty-audit.json"))
+        war_rubric = Rubric.load(str(ROOT / "rubrics" / "repair-warranty.json"))
+        self.assertNotEqual(
+            idempotency_key(ec_audit, ec_rubric), idempotency_key(war_audit, war_rubric)
+        )
+
+
+class TestReviewRegressions(unittest.TestCase):
+    """Findings from maintainer review of PR #303. Each held a documented promise."""
+
+    def test_credential_never_leaves_a_trusted_https_origin(self):
+        from concord.calle import CalleAPIError, CalleClient
+
+        for bad in ("http://api.heycall-e.com", "https://evil.example.com", "ftp://x"):
+            with self.assertRaises(CalleAPIError):
+                CalleClient(api_key="k", base_url=bad)
+        CalleClient(api_key="k", base_url="https://api.heycall-e.com")
+
+    def test_rewording_a_question_invalidates_the_approval_token(self):
+        import copy, json, os, tempfile
+        from concord.cli import approval_token
+
+        audit, rubric = load()
+        before = approval_token(audit, rubric)
+        raw = json.loads((ROOT / "rubrics" / "emergency-contraception.json").read_text())
+        for mutate in (
+            lambda d: d["criteria"][0].__setitem__("question", "Can I just buy it?"),
+            lambda d: d["criteria"][0].__setitem__("policy", "Anything goes."),
+            lambda d: d["criteria"][0]["options"].append("maybe"),
+            lambda d: d.__setitem__("scenario", "Something else entirely."),
+        ):
+            edited = copy.deepcopy(raw)
+            mutate(edited)
+            handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+            json.dump(edited, handle)
+            handle.close()
+            try:
+                self.assertNotEqual(before, approval_token(audit, Rubric.load(handle.name)))
+            finally:
+                os.unlink(handle.name)
+
+    def test_changing_the_disclosed_organisation_invalidates_the_token(self):
+        from concord.cli import approval_token
+
+        audit, rubric = load()
+        renamed = Audit(
+            audit.id, "Someone Else Entirely", audit.rubric_id, audit.branches,
+            audit.timezone, audit.call_window, audit.requested_by,
+        )
+        self.assertNotEqual(approval_token(audit, rubric), approval_token(renamed, rubric))
+
+    def test_changing_the_call_window_invalidates_the_token(self):
+        from concord.cli import approval_token
+
+        audit, rubric = load()
+        widened = Audit(
+            audit.id, audit.org, audit.rubric_id, audit.branches,
+            audit.timezone, ("00:00", "23:59"), audit.requested_by,
+        )
+        self.assertNotEqual(approval_token(audit, rubric), approval_token(widened, rubric))
+
+    def test_live_results_are_correlated_by_destination_not_position(self):
+        audit, rubric = load()
+        third = audit.branches[2]
+        result = {
+            "recipients": [
+                {"phones": [third.phone],
+                 "structured_result": {"reached": True, "prescription_required": "no",
+                                       "prescription_required_quote": "No, buy it at the counter."}}
+            ]
+        }
+        answers = answers_from_result(rubric, result, audit)
+        matched = [a for a in answers if a.branch_id == third.id and a.criterion_id == "C1"][0]
+        self.assertEqual(matched.value, "no")
+        self.assertTrue(matched.reached)
+
+    def test_a_branch_the_provider_omits_still_reaches_the_report(self):
+        audit, rubric = load()
+        result = {
+            "recipients": [
+                {"phones": [audit.branches[0].phone],
+                 "structured_result": {"reached": True, "prescription_required": "no",
+                                       "prescription_required_quote": "No, buy it at the counter."}}
+            ]
+        }
+        answers = answers_from_result(rubric, result, audit)
+        self.assertEqual(len(answers), len(audit.branches) * len(rubric.criteria))
+        omitted = [a for a in answers if a.branch_id != audit.branches[0].id]
+        self.assertTrue(all(not a.reached for a in omitted))
+        findings = rule_all(rubric, answers)
+        self.assertTrue(
+            all(f.verdict == "UNCLEAR" for f in findings if f.branch_id != audit.branches[0].id)
+        )
+
+    def test_the_live_path_scrubs_a_spoken_name(self):
+        """The scrub guarded fixture parsing but not live results, which is the
+        only path where a real person's name can actually occur."""
+        audit, rubric = load()
+        result = {
+            "recipients": [
+                {"phones": [audit.branches[0].phone],
+                 "structured_result": {
+                     "reached": True,
+                     "prescription_required": "no",
+                     "prescription_required_quote": "This is Sarah, no you can buy it at the counter.",
+                 }}
+            ]
+        }
+        answers = answers_from_result(rubric, result, audit)
+        quote = [a for a in answers if a.criterion_id == "C1"][0].quote
+        self.assertNotIn("Sarah", quote)
+        self.assertIn("counter", quote)
+
+    def test_e164_rejects_non_ascii_digits(self):
+        from concord.models import Branch, ConcordError
+
+        with self.assertRaises(ConcordError):
+            Branch.parse({"id": "B", "name": "N", "phone": "+९९३९२०५६३८", "authorization": "r"})
+
+    def test_a_value_without_a_quote_is_never_a_deviation(self):
+        """Every COMPLIANT or DEVIATION finding cites what was said. A provider
+        that returns a bare value with no supporting words is unresolved."""
+        from concord.judge import rule_one
+
+        _, rubric = load()
+        answer = Answer("B1", "C1", "yes", "", reached=True)
+        finding = rule_one(rubric.criteria[0], answer)
+        self.assertEqual(finding.verdict, "UNCLEAR")
+        self.assertTrue(finding.needs_human_review)

--- a/apps/python/concord/tests/test_collector.py
+++ b/apps/python/concord/tests/test_collector.py
@@ -15,7 +15,7 @@ from concord.collector import (
     window_is_open,
 )
 from concord.judge import rule_all
-from concord.models import Answer, Audit, Rubric
+from concord.models import Answer, Audit, ConcordError, Criterion, Rubric
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -96,6 +96,41 @@ class TestIdempotency(unittest.TestCase):
             audit.timezone, audit.call_window, audit.requested_by,
         )
         self.assertNotEqual(idempotency_key(audit, rubric), idempotency_key(trimmed, rubric))
+
+    def test_rewording_a_question_yields_a_different_key(self):
+        audit, rubric = load()
+        first = rubric.criteria[0]
+        changed = Criterion(
+            first.id,
+            "Can I just buy it?",
+            first.policy,
+            first.field,
+            first.expect,
+            first.options,
+        )
+        reworded = Rubric(
+            rubric.id,
+            rubric.title,
+            rubric.scenario,
+            (changed, *rubric.criteria[1:]),
+        )
+        self.assertNotEqual(
+            idempotency_key(audit, rubric), idempotency_key(audit, reworded)
+        )
+
+
+class TestInputValidation(unittest.TestCase):
+    def test_task_refuses_audit_rubric_mismatch(self):
+        from types import SimpleNamespace
+
+        from concord.cli import cmd_task
+
+        args = SimpleNamespace(
+            audit=str(ROOT / "fixtures" / "example-audit.json"),
+            rubric=str(ROOT / "rubrics" / "repair-warranty.json"),
+        )
+        with self.assertRaises(ConcordError):
+            cmd_task(args)
 
 
 class TestCallWindow(unittest.TestCase):
@@ -225,6 +260,24 @@ class TestReviewRegressions(unittest.TestCase):
             audit.timezone, ("00:00", "23:59"), audit.requested_by,
         )
         self.assertNotEqual(approval_token(audit, rubric), approval_token(widened, rubric))
+
+    def test_reordering_the_call_intent_invalidates_the_token(self):
+        from concord.cli import approval_token
+
+        audit, rubric = load()
+        reordered_audit = Audit(
+            audit.id, audit.org, audit.rubric_id, tuple(reversed(audit.branches)),
+            audit.timezone, audit.call_window, audit.requested_by,
+        )
+        reordered_rubric = Rubric(
+            rubric.id, rubric.title, rubric.scenario, tuple(reversed(rubric.criteria))
+        )
+        self.assertNotEqual(
+            approval_token(audit, rubric), approval_token(reordered_audit, rubric)
+        )
+        self.assertNotEqual(
+            approval_token(audit, rubric), approval_token(audit, reordered_rubric)
+        )
 
     def test_live_results_are_correlated_by_destination_not_position(self):
         audit, rubric = load()

--- a/apps/python/concord/tests/test_concord.py
+++ b/apps/python/concord/tests/test_concord.py
@@ -242,6 +242,15 @@ class TestSummary(unittest.TestCase):
         self.assertFalse(rows["B1"].needs_attention)
         self.assertTrue(rows["B2"].needs_attention)
 
+    def test_missing_branch_is_reported_as_unclear(self):
+        audit, rubric, answers = load_all()
+        omitted = audit.branches[-1]
+        partial = [answer for answer in answers if answer.branch_id != omitted.id]
+        findings = rule_all(rubric, partial, [branch.id for branch in audit.branches])
+        missing = [finding for finding in findings if finding.branch_id == omitted.id]
+        self.assertEqual(len(missing), len(rubric.criteria))
+        self.assertTrue(all(finding.verdict == "UNCLEAR" for finding in missing))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/python/concord/tests/test_concord.py
+++ b/apps/python/concord/tests/test_concord.py
@@ -1,0 +1,247 @@
+import importlib
+import json
+import unittest
+from pathlib import Path
+
+from concord.cli import approval_token
+from concord.judge import rule_all, rule_one
+from concord.models import (
+    QUOTE_MAX,
+    Answer,
+    Audit,
+    Branch,
+    ConcordError,
+    Criterion,
+    Finding,
+    Rubric,
+)
+from concord.report import render, summarise
+
+ROOT = Path(__file__).resolve().parents[1]
+RUBRIC = ROOT / "rubrics" / "emergency-contraception.json"
+AUDIT = ROOT / "fixtures" / "example-audit.json"
+RESULTS = ROOT / "fixtures" / "completed-audit.json"
+
+
+def load_all():
+    audit = Audit.load(str(AUDIT))
+    rubric = Rubric.load(str(RUBRIC))
+    raw = json.loads(RESULTS.read_text())
+    answers = [Answer.parse(a) for a in raw["answers"]]
+    return audit, rubric, answers
+
+
+class TestNegationRegression(unittest.TestCase):
+    """The bug that made this design necessary.
+
+    Phrase matching read "No, you don't need a prescription" as a deviation
+    because the string "need a prescription" is inside it. Ruling on the
+    extracted value instead of the transcript is what fixes it.
+    """
+
+    def setUp(self):
+        self.criterion = Criterion.parse(
+            {
+                "id": "C1",
+                "question": "Do I need a prescription?",
+                "policy": "No prescription is required.",
+                "field": "prescription_required",
+                "expect": "no",
+                "options": ["yes", "no", "unclear"],
+            }
+        )
+
+    def test_correct_answer_containing_the_forbidden_phrase_is_compliant(self):
+        answer = Answer("B1", "C1", "no", "No, you don't need a prescription for that.")
+        self.assertEqual(rule_one(self.criterion, answer).verdict, "COMPLIANT")
+
+    def test_wrong_answer_is_a_deviation(self):
+        answer = Answer("B2", "C1", "yes", "You'll need a doctor's note.")
+        self.assertEqual(rule_one(self.criterion, answer).verdict, "DEVIATION")
+
+
+class TestSilenceIsNotFailure(unittest.TestCase):
+    def setUp(self):
+        _, self.rubric, _ = load_all()
+        self.criterion = self.rubric.criteria[0]
+
+    def test_unreached_branch_is_unclear_not_deviation(self):
+        finding = rule_one(self.criterion, Answer("B4", "C1", "", "", reached=False))
+        self.assertEqual(finding.verdict, "UNCLEAR")
+        self.assertTrue(finding.needs_human_review)
+
+    def test_unresolved_value_is_unclear(self):
+        finding = rule_one(self.criterion, Answer("B2", "C1", "unclear", "As soon as you can."))
+        self.assertEqual(finding.verdict, "UNCLEAR")
+
+    def test_value_outside_the_allowed_options_is_not_guessed_at(self):
+        finding = rule_one(self.criterion, Answer("B2", "C1", "maybe", "Hard to say."))
+        self.assertEqual(finding.verdict, "UNCLEAR")
+
+    def test_a_skipped_question_still_appears(self):
+        _, rubric, _ = load_all()
+        findings = rule_all(rubric, [Answer("B1", "C1", "no", "No prescription needed.")])
+        self.assertEqual(len(findings), len(rubric.criteria))
+        self.assertEqual(sum(1 for f in findings if f.verdict == "UNCLEAR"), 3)
+
+
+class TestSurveillanceBoundary(unittest.TestCase):
+    """Concord reports on branches. It must not be able to report on a person."""
+
+    def test_a_finding_cannot_carry_a_person_or_a_number(self):
+        fields = set(Finding.__dataclass_fields__)
+        for forbidden in ("staff", "employee", "name", "phone", "agent", "operator"):
+            self.assertNotIn(forbidden, fields)
+
+    def test_rendered_report_contains_no_phone_numbers(self):
+        audit, rubric, answers = load_all()
+        text = render(audit, rubric, rule_all(rubric, answers))
+        for branch in audit.branches:
+            self.assertNotIn(branch.phone, text)
+
+    def test_report_states_the_boundary(self):
+        audit, rubric, answers = load_all()
+        text = render(audit, rubric, rule_all(rubric, answers))
+        self.assertIn("not a performance record", text)
+
+    def test_judge_cannot_place_a_call(self):
+        """Read the imports out of the source, not out of the module namespace.
+
+        The earlier version checked judge.__dict__ for six hardcoded names,
+        which would miss `import ssl` and would miss
+        `from concord.calle import CalleClient as C`. Allow-listing the
+        modules judge may import catches both.
+        """
+        import ast
+
+        source = (ROOT / "src" / "concord" / "judge.py").read_text()
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add((node.module or "").split(".")[0])
+        self.assertEqual(imported, {"__future__", "concord"})
+
+    def test_judge_source_never_mentions_the_call_client(self):
+        source = (ROOT / "src" / "concord" / "judge.py").read_text()
+        self.assertNotIn("CalleClient", source)
+        self.assertNotIn("concord.calle", source)
+
+
+class TestQuoteRedaction(unittest.TestCase):
+    """A quote is the one free-text field, so it is the one way in for a name."""
+
+    def test_self_identification_is_stripped(self):
+        answer = Answer.parse(
+            {"branch_id": "B1", "criterion_id": "C1", "value": "no",
+             "quote": "This is Sarah, no you don't need a prescription."}
+        )
+        self.assertNotIn("Sarah", answer.quote)
+        self.assertIn("prescription", answer.quote)
+
+    def test_name_speaking_is_stripped(self):
+        answer = Answer.parse(
+            {"branch_id": "B1", "criterion_id": "C3", "value": "yes",
+             "quote": "Priya speaking, we have it in stock."}
+        )
+        self.assertNotIn("Priya", answer.quote)
+
+    def test_a_normal_answer_survives_untouched(self):
+        text = "No, you don't need a prescription for that."
+        answer = Answer.parse(
+            {"branch_id": "B1", "criterion_id": "C1", "value": "no", "quote": text}
+        )
+        self.assertEqual(answer.quote, text)
+
+    def test_a_long_quote_is_capped(self):
+        answer = Answer.parse(
+            {"branch_id": "B1", "criterion_id": "C1", "value": "no", "quote": "word " * 200}
+        )
+        self.assertLessEqual(len(answer.quote), QUOTE_MAX + 8)
+
+
+class TestAuthorisation(unittest.TestCase):
+    def test_branch_without_authorization_is_refused(self):
+        with self.assertRaises(ConcordError):
+            Branch.parse({"id": "B9", "name": "Rogue", "phone": "+447700900999", "authorization": ""})
+
+    def test_non_e164_phone_is_refused(self):
+        with self.assertRaises(ConcordError):
+            Branch.parse({"id": "B9", "name": "Rogue", "phone": "0555 010 1999", "authorization": "x"})
+
+    def test_phone_is_masked(self):
+        branch = Branch.parse(
+            {"id": "B1", "name": "N", "phone": "+447700900101", "authorization": "register"}
+        )
+        self.assertNotIn("0101201", branch.masked_phone)
+        self.assertTrue(branch.masked_phone.endswith("01"))
+
+
+class TestApproval(unittest.TestCase):
+    def test_token_is_stable_for_an_unchanged_audit(self):
+        audit, rubric, _ = load_all()
+        self.assertEqual(approval_token(audit, rubric), approval_token(audit, rubric))
+
+    def test_editing_the_branch_list_invalidates_the_token(self):
+        audit, rubric, _ = load_all()
+        before = approval_token(audit, rubric)
+        edited = Audit(
+            id=audit.id,
+            org=audit.org,
+            rubric_id=audit.rubric_id,
+            branches=audit.branches[:2],
+            timezone=audit.timezone,
+            call_window=audit.call_window,
+            requested_by=audit.requested_by,
+        )
+        self.assertNotEqual(before, approval_token(edited, rubric))
+
+
+class TestRubric(unittest.TestCase):
+    def test_duplicate_criterion_ids_are_refused(self):
+        path = ROOT / "tests" / "_dup.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "id": "R",
+                    "title": "T",
+                    "scenario": "S",
+                    "criteria": [
+                        {"id": "C1", "question": "q", "policy": "p", "field": "f", "expect": "no"},
+                        {"id": "C1", "question": "q", "policy": "p", "field": "f", "expect": "no"},
+                    ],
+                }
+            )
+        )
+        try:
+            with self.assertRaises(ConcordError):
+                Rubric.load(str(path))
+        finally:
+            path.unlink()
+
+    def test_expected_value_must_be_one_of_the_options(self):
+        with self.assertRaises(ConcordError):
+            Criterion.parse(
+                {
+                    "id": "C1",
+                    "question": "q",
+                    "policy": "p",
+                    "field": "f",
+                    "expect": "maybe",
+                    "options": ["yes", "no"],
+                }
+            )
+
+
+class TestSummary(unittest.TestCase):
+    def test_compliant_branch_reports_no_gaps(self):
+        audit, rubric, answers = load_all()
+        rows = {s.branch_id: s for s in summarise(audit, rule_all(rubric, answers))}
+        self.assertEqual(rows["B1"].deviations, 0)
+        self.assertFalse(rows["B1"].needs_attention)
+        self.assertTrue(rows["B2"].needs_attention)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/concord-policy-audit/SKILL.md
+++ b/skills/concord-policy-audit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: concord-policy-audit
+description: Audit what your own branches tell callers by phone, judge each answer against written policy, and return a branch-level gap register that is deliberately unusable as a staff performance record.
+license: MIT
+---
+
+# Concord
+
+Use this skill when an operator wants to know whether their own locations give
+callers the answer their policy requires: a pharmacy chain checking counter
+advice, a clinic network checking triage instructions, an insurer checking how
+branches describe a term.
+
+Concord calls branches the operator owns, asks a fixed set of questions, records
+what was said, and rules each answer against a written rubric. It reports on
+branches, never on people.
+
+## When not to use
+
+- The lines belong to someone else. Concord audits an operator's own estate.
+  Calling a competitor's shop to score their staff is not this tool.
+- The user wants to identify, rank or discipline the individual who answered.
+  Decline. That is the boundary the product is built around, not a setting.
+- The user wants a customer survey, a sales call, or a line-health check. For
+  whether a line technically works, use `linecanary-monitor` instead. Concord
+  judges what a human said, not whether the phone rang.
+
+## Required inputs
+
+- the operator organisation and who requested the audit
+- one to twelve branches, each with an E.164 number and a written
+  authorization reference showing the operator owns that line
+- the branches' timezone and weekday call window
+- a rubric: a scenario plus criteria, each with the question to ask, the policy
+  in the policy's own words, the field to extract, and the answer policy requires
+
+Do not invent policy. The rubric is written by whoever owns the policy, and
+Concord reads it rather than inferring it.
+
+## Workflow
+
+1. Write the rubric and the audit file. See `assets/`.
+2. Run `concord task` to show the operator the exact words branches will hear
+   and the schema the call must answer in.
+3. Run `concord preview` for masked numbers, the call count and an approval
+   token bound to that exact audit.
+4. Pause for explicit approval. Asking for a preview is not approval to call.
+5. Run the exact command preview printed. A live run needs `--live`, the
+   matching token, and an open weekday window, all three.
+6. Present the gap register. Deviations first, then unresolved answers.
+7. Route every finding to the branch, never to a named person.
+
+## How the rubric becomes the call
+
+Each criterion contributes one enum-constrained field plus a quote property to
+the CALL-E `recipient_result_schema`. The policy document therefore defines what
+the call is allowed to return, and a criterion the rubric does not contain
+cannot appear in a result.
+
+## Rules
+
+- Rule on the extracted value, never on the transcript text. Matching phrases
+  against free speech cannot read negation: "No, you don't need a prescription"
+  contains "need a prescription". See `references/examples.md`.
+- Silence is not failure. An unreached branch, or an answer the call could not
+  resolve, is `UNCLEAR` and goes to a human. Never let a bad phone line read as
+  a policy breach.
+- A value outside the rubric's options is unresolved, not the nearest match.
+- Never produce per-person output, a branch league table, or a percentage that
+  could be pasted into an appraisal.
+- Never coach or correct the person answering during the call.
+- Do not persist transcripts unless the operator states a retention purpose.
+
+## Useful commands
+
+The reference implementation is [`apps/python/concord`](../../apps/python/concord/).
+
+```bash
+concord task     fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+concord preview  fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+concord judge    fixtures/example-audit.json --rubric rubrics/emergency-contraception.json \
+                 --results fixtures/completed-audit.json
+```
+
+`task`, `preview` and `judge` never place a call.

--- a/skills/concord-policy-audit/assets/emergency-contraception.json
+++ b/skills/concord-policy-audit/assets/emergency-contraception.json
@@ -1,0 +1,39 @@
+{
+  "id": "RB-EC-01",
+  "title": "Emergency contraception counter enquiry",
+  "scenario": "A caller asks whether the branch stocks levonorgestrel 1.5 mg emergency contraception, whether a prescription is needed, how soon it should be taken, and whether an age limit applies.",
+  "criteria": [
+    {
+      "id": "C1",
+      "question": "Do I need a prescription for the morning-after pill?",
+      "policy": "Levonorgestrel 1.5 mg is a pharmacy medicine supplied without a prescription. Staff must not tell a caller a prescription is required.",
+      "field": "prescription_required",
+      "expect": "no",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "C2",
+      "question": "How soon do I need to take it?",
+      "policy": "Staff must state that it can be taken up to 72 hours after unprotected sex, and that it is more effective the sooner it is taken.",
+      "field": "stated_window_hours",
+      "expect": "72",
+      "options": ["24", "48", "72", "unclear"]
+    },
+    {
+      "id": "C3",
+      "question": "Do you have it in stock today?",
+      "policy": "Staff must give a direct answer on this branch's own stock before referring a caller elsewhere.",
+      "field": "answered_own_stock",
+      "expect": "yes",
+      "options": ["yes", "no", "unclear"]
+    },
+    {
+      "id": "C4",
+      "question": "Is there an age limit to buy it?",
+      "policy": "There is no minimum age for supply. Staff must not state or imply an age restriction.",
+      "field": "age_limit_claimed",
+      "expect": "no",
+      "options": ["yes", "no", "unclear"]
+    }
+  ]
+}

--- a/skills/concord-policy-audit/assets/example-audit.json
+++ b/skills/concord-policy-audit/assets/example-audit.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU-2026-09-03",
+  "org": "Northgate Pharmacy Group",
+  "rubric_id": "RB-EC-01",
+  "requested_by": "Priya Raman, Clinical Governance",
+  "call_window": { "timezone": "Europe/London", "start": "09:30", "end": "16:30" },
+  "branches": [
+    { "id": "B1", "name": "Northgate Pharmacy, Selby Road", "phone": "+447700900101", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B2", "name": "Northgate Pharmacy, Harbour Street", "phone": "+447700900102", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B3", "name": "Northgate Pharmacy, Mill Court", "phone": "+447700900103", "authorization": "owned-estate register 2026-09-01" },
+    { "id": "B4", "name": "Northgate Pharmacy, Eastway", "phone": "+447700900104", "authorization": "owned-estate register 2026-09-01" }
+  ]
+}

--- a/skills/concord-policy-audit/references/examples.md
+++ b/skills/concord-policy-audit/references/examples.md
@@ -1,0 +1,157 @@
+# Examples
+
+All branches, numbers and organisations in these examples are fictional, and
+every number is a reserved 555 test number.
+
+## The bug this design exists to prevent
+
+The first version of the judge matched policy phrases against the transcript.
+Given a rubric that forbade telling callers a prescription is required, it
+ruled this answer a deviation:
+
+```text
+[DEVIATION] Northgate Pharmacy, Selby Road  (C1)
+    heard    "No, you don't need a prescription for that, you can buy it at the counter."
+    finding  The answer states 'need a prescription', which the policy excludes.
+```
+
+The answer is correct. The forbidden phrase occurs inside its negation.
+
+Three of seven deviations in that run were branches that had answered
+correctly. In an audit of an operator's own staff, a false deviation is worse
+than a missed one: it sends a manager to correct someone who did the right
+thing.
+
+Concord now rules on a value the call extracted, and carries the quote as
+evidence rather than as the thing being matched:
+
+```json
+{ "criterion_id": "C1", "value": "no",
+  "quote": "No, you don't need a prescription for that, you can buy it at the counter." }
+```
+
+Two regression tests hold this: the correct answer containing the forbidden
+phrase must rule `COMPLIANT`, and the genuinely wrong answer must rule
+`DEVIATION`.
+
+## Preview, the default
+
+```bash
+concord preview fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+```
+
+```text
+CONCORD  /  CALL PREVIEW
+==============================================================================
+Audit       AU-2026-09-03
+Org         Northgate Pharmacy Group
+Rubric      RB-EC-01  Emergency contraception counter enquiry
+Window      09:30-16:30 Europe/London
+Side effect Places 4 outbound call(s) to your own branches.
+Scope       Branch policy concordance. Not a staff performance review.
+
+BRANCHES TO CALL
+Branch                                Masked number     Authorization
+------------------------------------------------------------------------------
+Northgate Pharmacy, Selby Road        +44********01     owned-estate register 
+Northgate Pharmacy, Harbour Street    +44********02     owned-estate register 
+Northgate Pharmacy, Mill Court        +44********03     owned-estate register 
+Northgate Pharmacy, Eastway           +44********04     owned-estate register 
+
+SCENARIO
+  A caller asks whether the branch stocks levonorgestrel 1.5 mg emergency contraception, whether a prescription is needed, how soon it should be taken, and whether an age limit applies.
+
+QUESTIONS ASKED
+  C1  Do I need a prescription for the morning-after pill?
+  C2  How soon do I need to take it?
+  C3  Do you have it in stock today?
+  C4  Is there an age limit to buy it?
+
+APPROVAL CHECKPOINT
+No call was placed. Review this exact audit before approving it.
+Token        CONCORD-CAB767FD2A6B
+Live command concord run fixtures/example-audit.json --rubric rubrics/emergency-contraception.json --live --confirm CONCORD-CAB767FD2A6B
+```
+
+## The rubric compiles into the call
+
+```bash
+concord task fixtures/example-audit.json --rubric rubrics/emergency-contraception.json
+```
+
+Each criterion contributes one enum-constrained field and a quote property:
+
+```json
+{
+  "type": "object",
+  "required": ["reached", "prescription_required", "stated_window_hours",
+               "answered_own_stock", "age_limit_claimed"],
+  "properties": {
+    "prescription_required": { "type": "string", "enum": ["yes", "no", "unclear"] },
+    "prescription_required_quote": { "type": "string" }
+  }
+}
+```
+
+Remove a criterion from the rubric and it disappears from the schema. The call
+cannot return a category the policy never contemplated.
+
+## Refused live runs
+
+The three gates are independent. A correct token does not buy a call outside
+opening hours.
+
+```bash
+concord run fixtures/example-audit.json --rubric rubrics/emergency-contraception.json \
+  --live --confirm WRONG-TOKEN
+```
+
+```text
+Concord refused: the approval token does not match this exact audit. Run preview
+again and approve the audit you actually intend to place.
+```
+
+```text
+Concord refused: the call window for these branches is closed
+(09:30-16:30 Europe/London, weekdays). Branches are called during their own
+opening hours.
+```
+
+Both exit 2 and place no call.
+
+## The gap register
+
+```bash
+concord judge fixtures/example-audit.json --rubric rubrics/emergency-contraception.json \
+  --results fixtures/completed-audit.json
+```
+
+```text
+BRANCH OVERVIEW
+Branch                              Deviations   Unclear   Matches policy
+--------------------------------------------------------------------------------------
+Northgate Pharmacy, Harbour Stree            2         1                1
+Northgate Pharmacy, Mill Court               1         0                3
+Northgate Pharmacy, Eastway                  0         4                0
+Northgate Pharmacy, Selby Road               0         0                4
+
+GAP REGISTER
+  [DEVIATION] Northgate Pharmacy, Harbour Street  (C1)
+      asked     Do I need a prescription for the morning-after pill?
+      heard     "You'll need a doctor's note for that one, I'm afraid."
+      finding   Answered 'yes' where policy requires 'no'. Policy: Levonorgestrel
+                1.5 mg is a pharmacy medicine supplied without a prescription.
+
+  [UNCLEAR] Northgate Pharmacy, Harbour Street  (C2)
+      asked     How soon do I need to take it?
+      heard     "As soon as you can really."
+      finding   The call could not resolve this question into a definite answer.
+
+  [UNCLEAR] Northgate Pharmacy, Eastway  (C1)
+      finding   The branch was not reached.
+```
+
+Three things to read here. A hedged answer stays `UNCLEAR` instead of being
+rounded to the nearest option. An unreached branch produces four `UNCLEAR`
+findings rather than vanishing. And branches are ordered by outstanding policy
+work, not scored.

--- a/skills/concord-policy-audit/references/safety.md
+++ b/skills/concord-policy-audit/references/safety.md
@@ -1,0 +1,104 @@
+# Safety Reference
+
+Concord dials real workplaces and evaluates what the people there said. The
+risk it carries is not the call, it is what the output could be turned into.
+Default to preview and stop whenever ownership of a line is uncertain.
+
+## The surveillance boundary
+
+A tool that phones your own staff and scores their answers is one design
+decision away from being a surveillance tool. Concord draws that line in code
+rather than in a paragraph:
+
+- `Finding` has no field for a name, role, employee number or phone number.
+  There is nowhere to put a person, so per-person output is not a setting that
+  can be switched on.
+- The one free-text field is the spoken quote, and it is the one way a name
+  could enter the record. `Answer.parse` strips self-identification ("This is
+  Sarah", "Priya speaking") and caps quote length before the value is stored.
+  Pattern matching on natural speech is best effort, not a proof: treat the
+  schema as the guarantee and the quote scrub as defence in depth.
+- The call task instructs the agent not to ask for the name or role of whoever
+  answers, and not to record it if offered.
+- Branches are ordered by outstanding policy work. There is no score, no
+  percentage and no league table, because those are the artifacts that end up
+  in an appraisal.
+- Rendered reports contain no phone numbers.
+
+Tests assert each of these. If a change makes individual attribution possible,
+the suite fails.
+
+The product claim is narrow on purpose: Concord tells an operator which
+locations give callers the wrong answer. It does not tell them who to blame.
+
+## Authorisation
+
+Every branch needs a written authorization reference tying that line to the
+operator's own estate. Possession of a number is not authorisation, and a
+branch without a reference is refused at parse time.
+
+Concord audits an operator's own locations. Calling lines you do not own to
+score their staff is out of scope, and helping a user work around the
+authorization requirement is not a supported use.
+
+## Disclosure
+
+The call opens by stating that an AI assistant is calling on behalf of the
+named organisation to check the information given to callers, and that this is
+not a test of the individual answering. Covert mystery shopping is not
+supported.
+
+## Phone numbers
+
+E.164 required. Documentation and fixtures use reserved 555 numbers. Numbers
+are masked in previews and absent from reports; the full number appears only in
+the provider payload.
+
+## Conduct during the call
+
+The agent asks as an ordinary caller would and accepts the first clear answer.
+It must not coach, correct, argue with or grade the person answering, and must
+not state what the policy says. Telling a branch the right answer mid-audit
+both contaminates the finding and turns a measurement into an unrequested
+performance conversation.
+
+## Ambiguity
+
+A hedged, partial or refused answer is recorded as `unclear`, never rounded to
+the nearest option. A value outside the rubric's options is unresolved rather
+than coerced. An unreached branch is `UNCLEAR`, never a deviation, so a phone
+line that failed cannot be read as a policy breach.
+
+This direction matters more than the reverse. A missed deviation costs a second
+audit. A false deviation costs someone an unfair conversation with their
+manager.
+
+## Execution gate
+
+A live run is accepted only when all three hold, checked independently:
+
+1. `--live` is present.
+2. `--confirm` matches the token printed by the current preview. The token is
+   derived from the audit and rubric, so editing either invalidates it.
+3. The current time is inside the branches' local weekday call window.
+
+A failed gate exits non-zero and places no call.
+
+## Duplicate audits
+
+The idempotency key is derived from the approved audit, not the attempt. After
+an uncertain response, resubmit the same unchanged audit and reconcile by call
+id. Never start a second audit because polling timed out: the branches would be
+called twice.
+
+## Scope limits
+
+At most twelve branches in one run. Concord is not for emergencies, and not for
+medical, legal or employment decisions. A finding is evidence that a caller was
+given a particular answer. It is not proof of misconduct.
+
+## Retention
+
+Concord does not persist transcripts or numbers unless the operator states a
+retention purpose and location. Quotes in a report are the minimum needed to
+show why a finding was made.


### PR DESCRIPTION
Concord calls the branches an operator owns, asks one fixed caller scenario, and rules each spoken answer against a written policy rubric. It returns a branch-level gap register.

A pharmacy group with forty shops has no cheap way to know whether all forty tell a caller the same thing about emergency contraception. That work is done today by paying humans to make the calls.

## What is new here

`linecanary-monitor` asserts that a line works. Concord judges what the human on it said. It has no scheduling and no recurrence, and `SKILL.md` routes line-health checks to LineCanary explicitly.

**The rubric compiles into the call.** Each criterion contributes one enum-constrained field plus a quote property to the `recipient_result_schema`, so the policy document defines what a call is allowed to return. Remove a criterion and it leaves the schema. `concord task` prints the compiled task and schema before anything is dialled.

**Rulings are made on the extracted value, never on the transcript.** An earlier local prototype matched policy phrases against text and could misread negation. The shipped judge instead rules on CALL-E's enum-constrained extracted value and preserves uncertainty for human review.

Concord has been exercised end to end against the real CALL-E API. Private validation output is not included or quoted. Everything shipped here is synthetic, using reserved `+44 7700 900xxx` test numbers.

## Safety

The unit of analysis is the branch. `Finding` has no field for a name, role, or phone number; branches are ordered by outstanding policy work rather than scored; and quotes are scrubbed of self-identification on fixture and live paths. A returned value with no supporting words is `UNCLEAR`, because a ruling without quoted evidence is not a ruling.

Unreached branches, hedged answers, and values outside a rubric's options all rule `UNCLEAR` and go to a human. Every branch in an audit is represented even when the provider returns nothing for it, and results are correlated by dialled destination rather than array position.

A live run needs `--live`, an approval token bound to the full call intent, and the branches' own weekday window, checked independently. The bearer credential is sent only to an allow-listed HTTPS CALL-E origin. The idempotency key derives from the canonical approved payload.

## Demo

Public privacy-safe video: https://youtu.be/I5FQU1ySlDQ

## Checks

- `python3 scripts/validate_repository.py` passes
- `python3 scripts/check_branch_name.py --branch feat/concord-policy-audit-clean` passes
- 63 tests pass, including fake-transport tests asserting the exact URL, method, headers, and body sent to `/v1/calls`
- `judge.py` import boundaries are asserted by AST, so the policy-ruling half cannot dial

🤖 Generated with [Claude Code](https://claude.com/claude-code)
