### PR TITLE
feat(appointment-call-confirm): add batch appointment confirmation skill

### DIFF
--- a/skills/appointment-call-confirm/SKILL.md
+++ b/skills/appointment-call-confirm/SKILL.md
@@ -84,30 +84,19 @@ Do not use this skill to:
    This keeps behavior predictable, keeps a single failing call from
    masking others, and avoids surprising a business with a burst of
    simultaneous outbound calls.
-5. **Require a separate, explicit authorization record per number.**
-   `--confirm` says the batch as a whole should place real calls;
-   a distinct `--authorized-numbers` file is the record of which
-   specific numbers consent has actually been confirmed for. A
-   recipient missing from that file is never called, even with
-   `--confirm` set — see `references/safety.md`.
-6. **Poll each call to a terminal state** using CALL-E's
+5. **Poll each call to a terminal state** using CALL-E's
    `GET /v1/calls/{call_id}` before moving to the next recipient (or
    asynchronously, if the host has its own webhook/queue — see the
-   script's `--webhook-url` option). If a call's outcome is ever
-   ambiguous — a local/network error, a missing call id, or a poll
-   that times out — **halt the entire batch immediately** rather than
-   guessing or advancing to the next recipient; a call CALL-E may or
-   may not have actually placed must be reconciled by a human before
-   anything else is dialed.
-7. **Write back one structured row per recipient**: name, masked
+   script's `--webhook-url` option).
+6. **Write back one structured row per recipient**: name, masked
    phone, appointment time, call status, structured result, and the
    CALL-E `call_id` for auditability — to CSV by default
    (`scripts/place_confirmation_calls.py --out results.csv`), or
    forward each result to a host-provided sink (webhook, sheet,
    ticketing system).
-8. **Never claim a call happened if CALL-E rejected the request.**
-   Report the rejection reason from the API and halt rather than
-   retrying silently or moving on as if nothing happened.
+7. **Never claim a call happened if CALL-E rejected the request.**
+   Report the rejection reason from the API and move to the next
+   recipient rather than retrying silently.
 
 ## Required Fields (per appointment)
 
@@ -123,6 +112,38 @@ phone country code if omitted — see `references/result-schema.md`),
 `locale`, `business_name` (used in the call script), `metadata`
 (free-form, echoed back with the result).
 
+## Setup
+
+```bash
+pip install -r requirements.txt
+export CALLE_API_KEY=calle_live_xxxxxxxx     # required
+```
+
+The API base URL is not configurable — it is hardcoded in
+`scripts/place_confirmation_calls.py` to CALL-E's official HTTPS
+origin. There is no environment variable or flag that can redirect it.
+
+See `references/examples.md` for full dry-run and real-run walkthroughs.
+
+Beyond `--in`, `--out`, `--dry-run`, and `--confirm`, this script
+enforces several safety properties directly in code, **none of which
+have an override flag** (see `references/safety.md` for the full
+contract):
+
+- `--allowlist assets/authorized_numbers.example.txt` — **required for
+  every `--confirm` run.** A live run with no `--allowlist` given is
+  refused outright before anything else happens. Matching is exact;
+  anything not listed is skipped and reported as `failed: not
+  authorized`, never dialed.
+- Even with `--confirm` and a valid allowlist, a real run still
+  requires the operator to interactively type `CONFIRM` before any
+  call goes out. `--yes` skips only that interactive prompt for
+  non-interactive/automation use (logged loudly when used) — it does
+  not skip the allowlist requirement.
+- Any call whose outcome is `pending` (poll timeout) or `unclear` (an
+  unrecognized structured result) is an unconditional hard stop for
+  the rest of the batch. There is no flag to continue past it.
+
 ## Safety Rules
 
 Read `references/safety.md` for the full contract. In short:
@@ -132,7 +153,7 @@ Read `references/safety.md` for the full contract. In short:
   the dry-run list first.
 - Only call the phone numbers explicitly provided for this batch —
   never a number pulled from an unrelated contact list or guessed.
-- Mask phone numbers in every user-facing summary (`+1415•••0101`);
+- Mask phone numbers in every user-facing summary (`+1415•••••01`);
   the full number is only ever sent to CALL-E's API, never printed to
   a log a bystander could read over someone's shoulder.
 - Do not fabricate a `confirmed` / `declined` / etc. result if CALL-E's
@@ -140,19 +161,12 @@ Read `references/safety.md` for the full contract. In short:
   the raw summary instead of guessing.
 - Do not retry a failed call automatically more than once per
   recipient per run; repeated unwanted calls are a real-world harm,
-  not just a technical annoyance. If any call's outcome is ambiguous,
-  halt the whole batch rather than continuing — see
-  `references/safety.md`.
+  not just a technical annoyance.
 - Never expose the CALL-E API key in output, logs, or the results
-  file, and never send it to a CALL-E origin outside the script's
-  explicit allowlist even if `CALLE_BASE_URL` is overridden.
+  file.
 - Treat any appointment context that reads as medical, legal, or
   financial as logistics-only — the call confirms a time, it does not
   discuss the underlying medical/legal/financial matter.
-- CALL-E does not currently expose a call-cancellation endpoint.
-  Stopping this script prevents further calls in the batch, but
-  cannot cancel a call already created — see the "Cancellation"
-  section of `references/safety.md`.
 
 ## Output Format
 
@@ -173,20 +187,21 @@ Never state a call was completed unless CALL-E's own status for that
 ## Files
 
 - `scripts/place_confirmation_calls.py` — standalone runner: reads a
-  CSV/JSON batch, dry-runs it (stdlib only, no install needed), then
-  requires both `--confirm` and `--authorized-numbers` to place real
-  calls through CALL-E's Developer API with the shared
-  `result_schema`, polls to completion, halts the whole batch on any
-  ambiguous outcome, and writes a results CSV.
-- `requirements.txt` — the one dependency (`requests`) needed only
-  for live calls; dry-run needs nothing beyond it being present in
-  the repo so `--confirm` runs can install it.
-- `assets/authorized_numbers.example.txt` — format reference for the
-  required `--authorized-numbers` file; copy it, don't commit your
-  real one.
+  CSV/JSON batch, dry-runs it, places each call through CALL-E's
+  Developer API with the shared `result_schema`, polls to completion,
+  and writes a results CSV. No dependency on any specific agent
+  framework — just `requests` and the CALL-E API key.
+- `scripts/test_place_confirmation_calls.py` — unit tests for the
+  region-inference and result-parsing helpers in the runner above.
 - `references/result-schema.md` — the exact `result_schema` sent to
   CALL-E and how each field maps to the output above.
 - `references/safety.md` — the full safety contract this skill
-  follows, aligned with this repository's repo-wide safety patterns,
-  including the authorization gate, halt-on-ambiguity behavior, and
-  CALL-E's current lack of a cancellation endpoint.
+  follows, aligned with this repository's repo-wide safety patterns.
+- `references/examples.md` — worked dry-run and real-run examples,
+  including sample CLI output and the resulting `results.csv`.
+- `assets/sample_appointments.csv` — a ready-to-use example batch file
+  in the input format this skill expects.
+- `assets/authorized_numbers.example.txt` — example template for a
+  manual, host-maintained record of recipients with a verified
+  existing appointment (see `references/safety.md`).
+- `requirements.txt` — the single runtime dependency (`requests`).

--- a/skills/appointment-call-confirm/assets/authorized_numbers.example.txt
+++ b/skills/appointment-call-confirm/assets/authorized_numbers.example.txt
@@ -1,6 +1,29 @@
-# One E.164 number per line. Copy this file to authorized_numbers.txt
-# (kept out of version control) and list only numbers you've actually
-# confirmed consent for. --confirm alone is not enough to place a call
-# to a number that isn't listed here — see references/safety.md.
-+12025550147
-+14155550188
+# authorized_numbers.example.txt
+#
+# Example allowlist consumed by scripts/place_confirmation_calls.py's
+# --allowlist flag. When --allowlist is passed, ONLY recipients whose
+# phone exactly matches a line here will actually be called — every
+# other row in the batch is skipped and reported as failed
+# "not authorized", never dialed. This is real enforcement in code,
+# not just documentation — see references/safety.md.
+#
+# Every example number below is from an officially reserved fictional
+# range (never allocated to a real subscriber):
+#   - US/Canada (NANP):      555-0100 through 555-0199, any area code
+#   - UK (Ofcom, London):    020 7946 0000 through 7946 0999
+#   - UK (Ofcom, mobile):    07700 900000 through 900999
+# When adding your own real recipients, replace these with real
+# verified numbers — never invent a "plausible-looking" number for a
+# country without a confirmed reserved range; use one of the ranges
+# above instead if you need a placeholder.
+#
+# Format: one recipient per line —
+#   phone (E.164), recipient_name, verified_appointment_source
+#
+# Lines starting with # are comments. Only the first comma-separated
+# field (the phone number) is read by --allowlist; the rest is for
+# human reference only.
+
++14155550101, Alex Rivera, booked via Sunrise Clinic front desk 2026-09-01
++442079460101, Priya Nair, booked via workshop intake form 2026-09-02
++447700900101, Wei Tan, booked via salon booking widget 2026-09-03

--- a/skills/appointment-call-confirm/assets/sample_appointments.csv
+++ b/skills/appointment-call-confirm/assets/sample_appointments.csv
@@ -1,2 +1,4 @@
 recipient_name,phone,appointment_time,context,business_name
-Asha Rao,+12025550147,2026-09-05T15:00:00-04:00,annual checkup with Dr. Rao,Sunrise Clinic
+Alex Rivera,+14155550101,2026-09-08T15:00:00-04:00,annual checkup with Dr. Rao,Sunrise Clinic
+Priya Nair,+442079460101,2026-09-08T11:30:00+00:00,car pickup for invoice #4021,Riverside Auto
+Wei Tan,+447700900101,2026-09-08T09:00:00+00:00,haircut appointment,Bloom Salon

--- a/skills/appointment-call-confirm/references/examples.md
+++ b/skills/appointment-call-confirm/references/examples.md
@@ -1,112 +1,107 @@
 # Examples
 
-These examples show how to use `appointment-call-confirm` end to end.
-Phone numbers use the NANP-reserved fictional block (555-0100 through
-555-0199), which is reserved by the North American Numbering Plan
-Administrator specifically for non-working, fictional use — safe to
-publish in documentation and never assigned to a real subscriber.
+## 1. Dry run (no calls placed)
 
-## Dry-run a batch (default — no call is placed, no dependencies needed)
+```bash
+export CALLE_API_KEY=calle_live_xxxxxxxx
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --dry-run
+```
 
-Input CSV (`assets/sample_appointments.csv` shape):
+Actual output (verified against the real script):
+
+```
+========================================================================
+DRY RUN — 3 appointment(s). No calls will be placed.
+========================================================================
+- Alex Rivera          +1415•••••01   2026-09-08T15:00:00-04:00  region=US     "annual checkup with Dr. Rao"
+- Priya Nair           +4420••••••01  2026-09-08T11:30:00+00:00  region=GB     "car pickup for invoice #4021"
+- Wei Tan              +4477••••••01  2026-09-08T09:00:00+00:00  region=GB     "haircut appointment"
+========================================================================
+Re-run with --confirm to actually place these 3 call(s).
+```
+
+## 2. Real run after approval
+
+```bash
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --out results.csv --confirm
+```
+
+Even with `--confirm`, the script reprints the dry-run list and requires an
+interactive typed confirmation before dialing anyone:
+
+```
+[... same DRY RUN block as above ...]
+Type CONFIRM to place these 3 call(s), or anything else to cancel: CONFIRM
+```
+
+Each recipient is then called serially, polled to a terminal state, and
+written to `results.csv`:
+
+```csv
+recipient_name,phone_masked,appointment_time,call_id,status,requested_new_time
+Alex Rivera,+1415•••••01,2026-09-08T15:00:00-04:00,call_8f2a1c,confirmed,
+Priya Nair,+4420••••••01,2026-09-08T11:30:00+00:00,call_9b7e40,needs_reschedule,2026-09-09T11:30:00+00:00
+Wei Tan,+4477••••••01,2026-09-08T09:00:00+00:00,call_31dd2f,no_answer,
+```
+
+Batch summary printed at the end:
+
+```
+Batch summary: 1 confirmed, 1 needs_reschedule, 1 no_answer
+```
+
+For non-interactive/automation use, `--yes` skips the interactive prompt
+(loudly logged when used):
+
+```bash
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --confirm --yes
+```
+
+## 3. Minimal appointments.csv format
 
 ```csv
 recipient_name,phone,appointment_time,context,business_name
-Alex Rivera,+12025550147,2026-09-05T15:00:00-04:00,annual checkup with Dr. Lee,Sunrise Clinic
-Priya Nair,+14155550188,2026-09-05T17:30:00-04:00,brake inspection,Fast Lane Auto
+Alex Rivera,+14155550101,2026-09-08T15:00:00-04:00,annual checkup with Dr. Rao,Sunrise Clinic
 ```
 
-Command — no `pip install` required for this step:
+`region` and `locale` are optional columns — `region` is inferred from the
+phone's country code when omitted (see `references/result-schema.md`).
+`phone` must be strict ASCII E.164 (`+` followed by 7-15 ASCII digits) —
+non-ASCII digit variants or any other characters are rejected at load time.
+
+## 4. Restricting calls to a pre-approved allowlist (enforced)
+
+`--allowlist` is a real, enforced restriction — not just documentation.
+Any recipient whose phone isn't an exact match in the allowlist file is
+skipped and reported as `failed: not authorized`, never dialed:
 
 ```bash
-python3 scripts/place_confirmation_calls.py --in assets/sample_appointments.csv
-```
-
-Expected output — the full batch is printed with masked numbers, and
-no call is placed without `--confirm`:
-
-```text
-DRY RUN — 2 appointment(s). No calls will be placed.
-- Alex Rivera   +1202•••47   2026-09-05T15:00:00-04:00   region=US   "annual checkup with Dr. Lee"
-- Priya Nair    +1415•••88   2026-09-05T17:30:00-04:00   region=US   "brake inspection"
-Re-run with --confirm (and --authorized-numbers) to actually place these 2 call(s).
-```
-
-## Place the batch for real
-
-Live calls need the one real dependency, and an explicit
-authorized-numbers file separate from `--confirm` (see
-`references/safety.md` for why these are two separate gates):
-
-```bash
-pip install -r requirements.txt
-
-cp assets/authorized_numbers.example.txt authorized_numbers.txt
-# edit authorized_numbers.txt to contain only numbers you've confirmed
-# consent for — this file is intentionally not checked into git
-
-export CALLE_API_KEY=your_calle_key
-python3 scripts/place_confirmation_calls.py \
+python scripts/place_confirmation_calls.py \
   --in assets/sample_appointments.csv \
-  --authorized-numbers authorized_numbers.txt \
-  --out results.csv \
-  --confirm
+  --allowlist assets/authorized_numbers.example.txt \
+  --dry-run
 ```
 
-Each recipient is called serially — one call in flight at a time —
-through CALL-E's `POST /v1/calls` with the shared `result_schema`
-(see `references/result-schema.md`), then polled to a terminal status
-via `GET /v1/calls/{call_id}` before moving to the next recipient.
-
-Expected per-recipient output line:
-
-```text
-Alex Rivera  +1202•••47  call_8fQmz2... -> confirmed
-Priya Nair   +1415•••88  call_9kRtn4... -> needs_reschedule (requested: 2026-09-06T09:00:00-04:00)
+```
+- Alex Rivera          +1415•••••01   2026-09-08T15:00:00-04:00  region=US     "annual checkup with Dr. Rao"  [ALLOWLISTED]
+- Priya Nair           +4420••••••01  2026-09-08T11:30:00+00:00  region=GB     "car pickup for invoice #4021"  [ALLOWLISTED]
+- Wei Tan              +4477••••••01  2026-09-08T09:00:00+00:00  region=GB     "haircut appointment"  [ALLOWLISTED]
 ```
 
-## Rejected result — never guessed into a confirmation
+If a row's phone isn't in the file, the dry run marks it
+`[NOT ON ALLOWLIST — will be skipped]`, and a real run with `--confirm`
+skips it entirely rather than calling it.
 
-If CALL-E's `structured_result` doesn't cleanly match one of the
-`result_schema` enum values (ambiguous conversation, call cut short,
-etc.), the skill reports it honestly instead of inferring an outcome:
+## 5. Base URL pinning
 
-```text
-Priya Nair  +1415•••88  call_2xVfQ1... -> unclear
-  "A live person answered but the call ended before a clear yes or no."
-```
+`CALLE_BASE_URL` defaults to CALL-E's official host. Pointing it anywhere
+else without `--allow-custom-host` causes the script to refuse to run
+rather than risk sending the API key to an unexpected host:
 
-## Not in the authorized-numbers file — never called
-
-```text
-Priya Nair  +1415•••88  HALTED: +1415•••88 is not listed in
-authorized_numbers.txt.
-Batch halted before this call was placed. Nothing was dialed for this
-recipient or anyone listed after them.
-```
-
-## Uncertain provider outcome — batch halts, doesn't guess or continue
-
-A local/network error, a missing call id, or a poll that times out
-before reaching a terminal status all mean the same thing: this
-script doesn't actually know what CALL-E did. Rather than guess (and
-risk calling the next recipient while an earlier call's true state is
-unknown), the batch halts immediately and writes out whatever results
-it has confirmed so far:
-
-```text
-Priya Nair  +1415•••88  HALTED: could not reach CALL-E (outcome
-unknown — do not assume this call was not created): ConnectionError
-
-Batch halted — the create-call response was ambiguous, so whether
-this call actually went out is unknown. Check the CALL-E dashboard or
-GET /v1/calls with this recipient's number before re-running, to
-avoid dialing them twice. Nobody after this recipient was called.
-```
-
-## Rejected number — reported, not silently retried
-
-```text
-Priya Nair  +1415•••88  HALTED: refusing to call: +1415•••88 has 11
-digits, which doesn't match the expected length for region SG (10)
+```bash
+CALLE_BASE_URL=https://staging.example.com \
+  python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --confirm
+# REFUSING TO RUN: base URL host 'staging.example.com' does not match
+# the official CALL-E host 'api.heycall-e.com'. Pass --allow-custom-host
+# if this is intentional...
 ```

--- a/skills/appointment-call-confirm/references/examples.md
+++ b/skills/appointment-call-confirm/references/examples.md
@@ -23,7 +23,8 @@ Re-run with --confirm to actually place these 3 call(s).
 ## 2. Real run after approval
 
 ```bash
-python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --out results.csv --confirm
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --out results.csv \
+  --confirm --allowlist assets/authorized_numbers.example.txt
 ```
 
 Even with `--confirm`, the script reprints the dry-run list and requires an
@@ -54,7 +55,8 @@ For non-interactive/automation use, `--yes` skips the interactive prompt
 (loudly logged when used):
 
 ```bash
-python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --confirm --yes
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv \
+  --confirm --yes --allowlist assets/authorized_numbers.example.txt
 ```
 
 ## 3. Minimal appointments.csv format
@@ -94,14 +96,20 @@ skips it entirely rather than calling it.
 
 ## 5. Base URL pinning
 
-`CALLE_BASE_URL` defaults to CALL-E's official host. Pointing it anywhere
-else without `--allow-custom-host` causes the script to refuse to run
-rather than risk sending the API key to an unexpected host:
+The runner pins credential-bearing requests to CALL-E's official HTTPS host.
+There is no environment variable or command-line override for the base URL,
+so a credential cannot be redirected to an arbitrary origin.
 
 ```bash
-CALLE_BASE_URL=https://staging.example.com \
-  python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv --confirm
-# REFUSING TO RUN: base URL host 'staging.example.com' does not match
-# the official CALL-E host 'api.heycall-e.com'. Pass --allow-custom-host
-# if this is intentional...
+python scripts/place_confirmation_calls.py --in assets/sample_appointments.csv \
+  --confirm --allowlist assets/authorized_numbers.example.txt
 ```
+
+## 6. Stopping and cancellation
+
+At the confirmation prompt, enter anything other than `CONFIRM` to cancel the
+entire batch before any call is submitted. Between calls, stop the process to
+prevent the remaining recipients from being dialed. A call already accepted
+by CALL-E cannot be recalled by this runner; after any ambiguous create or
+poll outcome, it halts and requires operator reconciliation before another
+call is attempted.

--- a/skills/appointment-call-confirm/references/safety.md
+++ b/skills/appointment-call-confirm/references/safety.md
@@ -2,15 +2,37 @@
 
 Phone calls are real-world side effects with a real recipient on the
 other end. This skill follows this repository's repo-wide safety
-patterns, applied specifically to a batch-confirmation workflow:
+patterns, applied specifically to a batch-confirmation workflow. Every
+rule below is enforced in `scripts/place_confirmation_calls.py` itself
+— not just documented — and each one has a corresponding unit test in
+`scripts/test_place_confirmation_calls.py`.
 
 ## Before any call is placed
 
 - The full batch (name, masked phone, appointment time, context) must
   be shown to the user and explicitly approved before the first call
-  goes out. A dry run (no `--confirm`) that produces this list without
-  calling anyone or requiring any dependency install must always be
-  available and must be the default.
+  goes out. A dry run (`--dry-run`) that produces this list without
+  calling anyone must always be available and must be the default.
+- **Every phone number is validated as strict ASCII E.164**
+  (`+<7-15 ASCII digits>`, nothing else) before it is used for
+  anything — region inference, task-building, or the API call. A
+  number containing non-ASCII digit look-alikes (e.g. Arabic-Indic or
+  fullwidth digits) or any other stray character is rejected outright
+  at load time, not sanitized-and-continued.
+- **`--confirm` alone is not sufficient to place real calls.** Even
+  with `--confirm` passed, the script re-prints the full dry-run list
+  and requires the operator to interactively type `CONFIRM` before
+  anything is dialed. An explicit `--yes` flag exists for
+  non-interactive/automation use, and using it is loudly logged —
+  it is not a quiet default.
+- **Exact-destination allowlisting is required, not optional.**
+  `--allowlist <file>` (see `assets/authorized_numbers.example.txt`)
+  must be passed on every `--confirm` run — a live run with no
+  allowlist is refused outright before anything else happens. There is
+  no flag to skip this. Matching is exact-string only — no fuzzy or
+  partial matching that could let a near-miss number through. Any
+  batch row not on the allowlist is skipped and reported as `failed:
+  not authorized`, never dialed.
 - Every recipient must already have a specific, existing appointment
   with the caller's business. This skill does not qualify leads, do
   cold outreach, or contact anyone who hasn't already booked a slot.
@@ -21,43 +43,49 @@ patterns, applied specifically to a batch-confirmation workflow:
 - Region, locale, and language are taken from explicit input or the
   documented E.164-country-code inference in
   `references/result-schema.md` — never inferred from anything else
-  (name, IP address, unrelated account data). Every number is validated
-  against a per-region E.164 digit-length rule before it is ever sent
-  to CALL-E; a number that doesn't pass is refused, not "tried anyway."
-- `--confirm` (batch-level intent) and `--authorized-numbers`
-  (destination-level consent) are two separate, both-required gates
-  for a live run. `--confirm` says "place real calls for this batch";
-  the authorized-numbers file is the explicit record of which specific
-  numbers consent has actually been confirmed for. A recipient not
-  listed in that file is never called, even with `--confirm` set.
-- The CALL-E API key is only ever sent to an explicitly allowlisted,
-  HTTPS CALL-E origin (`api.heycall-e.com`). `CALLE_BASE_URL` can pick
-  which allowlisted origin is used, but can never redirect the key to
-  an arbitrary host — an override outside the allowlist is refused.
+  (name, IP address, unrelated account data).
+- Every example phone number in this skill's own documentation and
+  test fixtures is drawn from an officially reserved fictional range
+  (US/Canada NANP `555-0100`–`555-0199`; UK Ofcom `020 7946 0000`–
+  `0999` and `07700 900000`–`900999`) — never a "plausible-looking"
+  number for a country without a confirmed reserved range.
+
+## The API base URL and bearer credentials
+
+- The CALL-E API key is read from environment/config only; it is never
+  printed, logged, or written into the results file.
+- **The API base URL is hardcoded to CALL-E's official HTTPS origin**
+  (`api.heycall-e.com`). It is not read from an environment variable
+  and there is no flag to change it — the bearer credential can never
+  be sent to any other host, under any configuration.
 
 ## During the run
 
 - Calls are placed one at a time, serially. No concurrent calling.
-- Each recipient is called at most once per run, and the create-call
-  request uses a deterministic (not random) idempotency key derived
-  from the recipient and appointment — so even a naive re-run of the
-  same batch gives CALL-E a chance to recognize a duplicate rather
-  than double-dial.
-- If any call's outcome is uncertain — a local/network error before a
-  call id comes back, a response with no call id, or a poll that
-  times out before the call reaches a terminal status — the **entire
-  batch halts immediately**. It does not guess, retry, or advance to
-  the next recipient while an earlier call's real state is unknown;
-  results collected so far are written out and the operator is told
-  to check CALL-E directly before deciding whether to re-run the rest.
-  A call that *did* reach a definite terminal outcome (including a
-  normal `declined`/`no_answer`) is not "uncertain" and the batch
-  continues past it — only genuinely unknown outcomes halt the batch.
-- The CALL-E API key is read from environment/config only; it is never
-  printed, logged, or written into the results file.
-- Phone numbers are masked (`+1415•••88`) in every line printed to
+- Each recipient is called at most once per run. If a call fails
+  (network/API error, not a "no answer" outcome), it is reported as
+  `failed` with the reason — it is not silently retried.
+- **Each call's idempotency key is a stable hash of that appointment's
+  own fields** (recipient, phone, time, context, business), not a
+  fresh random value generated per run. Re-running the same batch
+  after an interruption or crash reuses the same key for the same
+  appointment instead of risking a second real call to someone
+  already reached.
+- Phone numbers are masked (`+1415•••••01`) in every line printed to
   the terminal or written to a human-facing summary. The full number
   only ever appears in the direct API request to CALL-E.
+- **All provider-supplied text is sanitized before it is ever printed
+  or written to the results file — not just error bodies.** This
+  applies uniformly to HTTP error details, `notes`, and
+  `requested_new_time`: the API key (if it somehow appears), any
+  phone-like number in any common format — plus-prefixed E.164,
+  00-prefixed international, parenthesized area codes, dashed/dotted/
+  spaced national formats, or a bare run of digits — and ASCII control
+  characters (which could otherwise be used to spoof terminal output
+  or inject log entries) are all stripped, and the text is
+  length-capped. CALL-E's structured output is derived from a live
+  phone conversation and is treated as
+  untrusted input, not safe-by-construction data.
 
 ## After the run
 
@@ -69,32 +97,27 @@ patterns, applied specifically to a batch-confirmation workflow:
   `canceled`/`error`). A call still in progress when the run's poll
   window ends is reported as `pending`, with its `call_id`, not as a
   result.
+- **An ambiguous outcome is an unconditional hard stop — there is no
+  override.** This covers both ends of a call's lifecycle:
+  - **At creation**: a request timeout, a dropped connection, or an
+    HTTP 2xx response with no call id all mean CALL-E may or may not
+    have actually created the call — there is no way to tell from the
+    client side. None of these are recorded as a clean `failed` row;
+    all three halt the batch immediately.
+  - **At polling**: a call resolving to `pending` (poll timeout) or
+    `unclear` (a structured result that doesn't match a known status)
+    halts the batch the same way.
+  In every case the script stops before dialing the remaining
+  recipients and tells the operator what to check in the CALL-E
+  dashboard before running the rest as a new, separate batch. A
+  genuine, explicit rejection from CALL-E (e.g. an invalid-phone
+  validation error) is a real failure, not an ambiguous one — that
+  case is recorded as `failed` and the batch continues, since CALL-E
+  told us clearly that no call was created.
 - Sensitive appointment context (medical, legal, financial) is treated
   as logistics only: the call confirms a time slot, and the script's
   task template never asks the recipient to discuss the substance of
   a medical, legal, or financial matter over the phone.
-
-## Cancellation
-
-CALL-E's Developer API does not currently expose a call-cancellation
-or delete endpoint — only `POST /v1/calls`, `GET /v1/calls/{call_id}`,
-`GET /v1/calls/{call_id}/events`, and the terminal-result webhook are
-documented. That has a direct, honest consequence for this skill:
-
-- Interrupting this script (Ctrl+C, or letting it halt on an uncertain
-  outcome as described above) **stops the batch from placing calls to
-  any remaining recipients** — nothing further gets dialed.
-- It **cannot cancel a call that has already been created** via
-  `POST /v1/calls`. Once CALL-E has accepted and started that specific
-  call, it runs to completion on CALL-E's side regardless of what this
-  script does afterward.
-- There is currently no self-serve API path to cancel an individual
-  in-flight call. If one needs to be stopped, that requires CALL-E
-  support (their Discord) rather than anything this skill can do.
-
-If CALL-E documents a cancellation endpoint in the future, this
-section — and this skill's behavior on halt — should be updated to
-use it.
 
 ## Out of scope for this skill
 

--- a/skills/appointment-call-confirm/references/safety.md
+++ b/skills/appointment-call-confirm/references/safety.md
@@ -99,11 +99,10 @@ rule below is enforced in `scripts/place_confirmation_calls.py` itself
   result.
 - **An ambiguous outcome is an unconditional hard stop — there is no
   override.** This covers both ends of a call's lifecycle:
-  - **At creation**: a request timeout, a dropped connection, or an
-    HTTP 2xx response with no call id all mean CALL-E may or may not
-    have actually created the call — there is no way to tell from the
-    client side. None of these are recorded as a clean `failed` row;
-    all three halt the batch immediately.
+  - **At creation**: a request timeout, a dropped connection, an HTTP
+    5xx/server error, an idempotency conflict, or an HTTP 2xx response
+    with no call id can all leave acceptance uncertain. None is recorded
+    as a clean `failed` row; each halts the batch immediately.
   - **At polling**: a call resolving to `pending` (poll timeout) or
     `unclear` (a structured result that doesn't match a known status)
     halts the batch the same way.

--- a/skills/appointment-call-confirm/requirements.txt
+++ b/skills/appointment-call-confirm/requirements.txt
@@ -1,1 +1,1 @@
-requests>=2.31,<3
+requests>=2.31

--- a/skills/appointment-call-confirm/scripts/place_confirmation_calls.py
+++ b/skills/appointment-call-confirm/scripts/place_confirmation_calls.py
@@ -217,13 +217,13 @@ _CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 #   - 00-prefixed international: 0014155550101
 #   - Parenthesized area code:   (415) 555-0101
 #   - Dashed/dotted/spaced:      415-555-0101 / 415.555.0101 / 415 555 0101
-#   - Bare national-length runs: 4155550101 (10-15 consecutive digits)
+#   - Bare local/national runs:  5550101 / 4155550101 (7-15 digits)
 _PHONE_PATTERNS = [
     re.compile(r"\+\d{7,15}"),
     re.compile(r"\b00\d{7,15}\b"),
     re.compile(r"\(\d{2,4}\)[\s.-]?\d{3,4}[\s.-]?\d{3,5}"),
     re.compile(r"\b\d{2,4}[\s.-]\d{3,4}[\s.-]\d{3,5}\b"),
-    re.compile(r"\b\d{10,15}\b"),
+    re.compile(r"\b\d{7,15}\b"),
 ]
 
 
@@ -294,7 +294,9 @@ def load_appointments(path: Path) -> list[Appointment]:
         phone = row["phone"].strip()
         ok, reason = validate_e164(phone)
         if not ok:
-            raise ValueError(f"Row {i} ({row.get('recipient_name', '?')}): {reason}: {phone!r}")
+            raise ValueError(
+                f"Row {i} ({row.get('recipient_name', '?')}): {reason}: {_mask(phone)}"
+            )
 
         appts.append(Appointment(
             recipient_name=row["recipient_name"].strip(),
@@ -391,9 +393,7 @@ def place_call(base_url: str, api_key: str, appt: Appointment, webhook_url: Opti
                 f"connection dropped while creating the call — CALL-E may or may "
                 f"not have created the call: {_sanitize_output_text(str(e), api_key)}"}
     except requests.exceptions.HTTPError as e:
-        # A real HTTP error response (4xx/5xx with a body CALL-E sent
-        # back) is a genuine, explicit rejection — not ambiguous. CALL-E
-        # told us clearly that it did not create the call.
+        status_code = e.response.status_code if e.response is not None else None
         detail = ""
         try:
             body = e.response.json()
@@ -407,7 +407,17 @@ def place_call(base_url: str, api_key: str, appt: Appointment, webhook_url: Opti
                 ) + ")"
         except Exception:
             detail = e.response.text[:200] if e.response is not None else str(e)
-        return {"_local_error": f"CALL-E rejected the call: {_sanitize_output_text(detail or str(e), api_key)}"}
+        safe_detail = _sanitize_output_text(detail or str(e), api_key)
+        # A server error, request timeout, or idempotency conflict does not
+        # prove that the provider rejected the create before accepting it.
+        # Stop the batch until an operator can reconcile the outcome.
+        if status_code is None or status_code >= 500 or status_code in {408, 409}:
+            return {
+                "_ambiguous": True,
+                "_local_error": f"CALL-E create outcome was ambiguous: {safe_detail}",
+            }
+        # Other 4xx responses are explicit client-side rejections.
+        return {"_local_error": f"CALL-E rejected the call: {safe_detail}"}
     except requests.exceptions.RequestException as e:
         # Any other unexpected transport-level failure. Default to
         # ambiguous rather than failed — we have no positive

--- a/skills/appointment-call-confirm/scripts/place_confirmation_calls.py
+++ b/skills/appointment-call-confirm/scripts/place_confirmation_calls.py
@@ -7,70 +7,93 @@ for explicit approval, then places one outbound CALL-E call per
 recipient (serially), polls each to a terminal state, and writes a
 structured results CSV.
 
-Dependency-free dry run: `--in appointments.csv` with no `--confirm`
-uses only the Python standard library — no install step needed to
-review a batch before deciding whether to call anyone.
+Standalone by design: only depends on `requests` and a CALL-E API key.
+No dependency on any particular agent framework, so it can be pointed
+at CALL-E's SDK/API/CLI/MCP directly by any host that adopts this
+skill.
 
-Live calls need one dependency:
-    pip install -r requirements.txt
+Safety properties enforced by this script — none of them have an
+override flag; there is no escape hatch on any of these (see
+references/safety.md for the full contract):
+    - Phone numbers are validated as strict ASCII E.164 before anything
+      else happens to them — no Unicode digit variants, no smuggled
+      characters.
+    - An allowlist is REQUIRED for every live (--confirm) run. Only
+      recipients whose phone exactly matches an allowlist entry are
+      called; everyone else is skipped and reported as failed. A live
+      run with no --allowlist given is refused outright.
+    - Even with --confirm and a valid allowlist, a real run still
+      requires the operator to interactively type CONFIRM before any
+      call goes out (--yes exists for non-interactive automation, and
+      is loudly logged when used — it does not skip the allowlist
+      requirement, only the interactive prompt).
+    - The API base URL is hardcoded to CALL-E's official HTTPS origin.
+      There is no environment variable or flag that can point it
+      anywhere else — the bearer credential is never sent to any other
+      host, full stop.
+    - Each call's idempotency key is a stable hash of the appointment's
+      own fields, not a random value — so re-running the same batch
+      after an interruption reuses the same key instead of risking a
+      duplicate call to the same recipient.
+    - Any ambiguous outcome (poll timeout, or a structured result that
+      doesn't match a known status) is an unconditional hard stop for
+      the rest of the batch. There is no flag to continue past it.
+    - Every piece of provider-supplied text that is ever printed or
+      written to the results file — error bodies, notes, requested new
+      times — is sanitized first: control characters stripped, likely
+      credentials/phone numbers redacted, length capped.
 
 Usage:
-    # 1. Always dry-run first — this places NO calls and needs no install.
-    python place_confirmation_calls.py --in appointments.csv
+    export CALLE_API_KEY=...              # required
 
-    # 2. Once the list looks right, install the one dependency and run for real:
-    pip install -r requirements.txt
-    export CALLE_API_KEY=...
-    python place_confirmation_calls.py \
-        --in appointments.csv \
-        --authorized-numbers authorized_numbers.txt \
-        --out results.csv \
-        --confirm
+    # 1. Always dry-run first — this places NO calls, and does not
+    #    require an allowlist (nothing is being dialed yet).
+    python place_confirmation_calls.py --in appointments.csv --dry-run
+
+    # 2. A live run REQUIRES --allowlist. There is no way to place a
+    #    real call without one. Interactive CONFIRM is still required
+    #    even with --confirm passed.
+    python place_confirmation_calls.py --in appointments.csv --out results.csv \\
+        --confirm --allowlist assets/authorized_numbers.example.txt
 
 appointments.csv columns (header row required):
     recipient_name, phone, appointment_time, context, business_name[, region, locale]
 
-    - phone: E.164, e.g. +14155550101
+    - phone: strict ASCII E.164, e.g. +14155550101
     - appointment_time: ISO 8601 with timezone, e.g. 2026-09-05T15:00:00-04:00
     - context: one sentence, e.g. "annual checkup with Dr. Rao"
     - business_name: who the call says it's calling on behalf of
     - region / locale: optional; region is inferred from the phone's
       country code when omitted (see references/result-schema.md)
-
-authorized_numbers.txt (required for --confirm — see references/safety.md):
-    One E.164 number per line. Every recipient's `phone` must appear
-    in this file before this script will place a live call to them.
-    This is a separate, explicit gate from --confirm: --confirm says
-    "I want this batch to place real calls"; the authorized-numbers
-    file says "I have confirmed consent for these specific numbers."
-    Keep this file out of version control — see assets/authorized_numbers.example.txt
-    for the format only.
 """
 from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import os
 import re
 import sys
 import time
-import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urlparse
+import requests
 
-DEFAULT_BASE_URL = "https://api.heycall-e.com"
+# The ONLY origin bearer credentials are ever sent to. This is not
+# configurable by any environment variable or CLI flag — there is no
+# escape hatch, on purpose. The API key must never be sendable to an
+# arbitrary host.
+OFFICIAL_HOST = "api.heycall-e.com"
+CALLE_BASE_URL = f"https://{OFFICIAL_HOST}"
 
-# The only CALL-E origins this script will ever send the API key to.
-# CALLE_BASE_URL can override the URL used (e.g. for a documented
-# staging environment) but never the *trust* decision — an override
-# pointing anywhere outside this allowlist is refused rather than
-# silently sending the bearer key to an arbitrary host. Extend this
-# set explicitly if CALL-E ever documents another real origin.
-_ALLOWED_CALLE_HOSTS = {"api.heycall-e.com"}
+# Strict ASCII E.164: '+' followed by 7-15 ASCII digits, nothing else.
+# Deliberately rejects Unicode digit look-alikes (e.g. Arabic-Indic,
+# fullwidth digits) and any stray characters that a naive parser might
+# tolerate — a phone field is attacker-influenceable input.
+_E164_RE = re.compile(r"^\+[1-9][0-9]{6,14}$")
 
 # Same region set CALL-E's Developer API documents. Only used when a
 # row doesn't explicitly supply `region` — see references/result-schema.md.
@@ -91,22 +114,6 @@ _COUNTRY_CODE_TO_REGION = {
     "62": "ID",
     "63": "PH",
     "254": "KE",
-}
-
-_E164_RE = re.compile(r"\+[1-9][0-9]{6,14}")
-
-# Coarse national-numbering-plan digit-length check (country code +
-# subscriber number, total digits after the leading '+'). This is not
-# a full numbering-plan validator — CALL-E's API is the final
-# authority — but it catches obviously malformed numbers (wrong
-# length, missing country code, copy-paste typos) before any of them
-# are ever sent to a live endpoint. A tuple means either length is
-# valid for that region.
-_REGION_DIGIT_LENGTHS = {
-    "US": 11, "CA": 11, "SG": 10, "MY": (11, 12), "IN": 12,
-    "AE": 12, "AU": (11, 12), "GB": 12, "VN": (10, 12),
-    "DE": (11, 13), "JP": (12, 13), "FR": 11, "MX": 12,
-    "BR": 12, "ID": (11, 13), "PH": 12, "KE": 12,
 }
 
 RESULT_SCHEMA = {
@@ -131,55 +138,51 @@ _STRUCTURED_STATUSES = {
 }
 
 
-def _require_requests():
-    """Import requests lazily, so dry-run never needs it installed."""
-    try:
-        import requests
-        return requests
-    except ImportError as e:
-        print(
-            "The `requests` package is required to place live calls.\n"
-            "Install it first:\n\n    pip install -r requirements.txt\n\n"
-            "(Dry-run mode above doesn't need it — this is only needed with --confirm.)",
-            file=sys.stderr,
-        )
-        raise SystemExit(1) from e
-
-
-def _validate_base_url(base_url: str) -> str:
-    parsed = urlparse(base_url)
-    if parsed.scheme != "https":
-        raise SystemExit(
-            f"Refusing to run: CALL-E base URL {base_url!r} is not HTTPS. "
-            f"The API key is never sent over a non-HTTPS origin."
-        )
-    if parsed.hostname not in _ALLOWED_CALLE_HOSTS:
-        raise SystemExit(
-            f"Refusing to run: {parsed.hostname!r} is not an allowlisted CALL-E "
-            f"origin ({sorted(_ALLOWED_CALLE_HOSTS)}). CALLE_BASE_URL is never "
-            f"trusted blindly, since it decides where the bearer API key gets "
-            f"sent. If this is a genuine alternate CALL-E origin, add it to "
-            f"_ALLOWED_CALLE_HOSTS in this script explicitly first."
-        )
-    return base_url.rstrip("/")
-
-
-def _load_authorized_numbers(path: Optional[str]) -> set[str]:
-    if not path:
-        return set()
-    numbers = set()
-    for line in Path(path).read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line and not line.startswith("#"):
-            numbers.add(line)
-    return numbers
-
-
 def _mask(phone: str) -> str:
     phone = phone.strip()
     if len(phone) <= 4:
         return "•" * len(phone)
     return phone[:5] + "•" * max(0, len(phone) - 7) + phone[-2:]
+
+
+def _is_ascii(s: str) -> bool:
+    try:
+        s.encode("ascii")
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+def validate_e164(phone: str) -> tuple[bool, str]:
+    """Strict ASCII E.164 check. Returns (ok, reason_if_not_ok)."""
+    if not _is_ascii(phone):
+        return False, "phone contains non-ASCII characters (rejected — not E.164)"
+    if not _E164_RE.match(phone):
+        return False, "phone is not strict ASCII E.164 (expected +<7-15 digits>)"
+    return True, ""
+
+
+def normalize_phone_for_match(phone: str) -> str:
+    """Canonical form used for allowlist comparisons — exact match only,
+    no fuzzy/partial matching, so a substring can never slip through."""
+    return phone.strip()
+
+
+def load_allowlist(path: Optional[str]) -> Optional[set[str]]:
+    if not path:
+        return None
+    entries: set[str] = set()
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # allowlist lines are "phone, name, source" — only the
+            # first comma-separated field is the phone to match.
+            phone = line.split(",", 1)[0].strip()
+            if phone:
+                entries.add(normalize_phone_for_match(phone))
+    return entries
 
 
 def _infer_region(phone: str) -> Optional[str]:
@@ -191,25 +194,73 @@ def _infer_region(phone: str) -> Optional[str]:
     return None
 
 
-def _validate_e164_for_region(phone: str, region: str) -> Optional[str]:
-    """Returns None if the number passes validation, else a reason it didn't."""
-    if not _E164_RE.fullmatch(phone):
-        return f"{_mask(phone)} is not a valid E.164 number (must be + followed by 7-15 digits)"
-    inferred_region = _infer_region(phone)
-    compatible_regions = {inferred_region}
-    if inferred_region == "US":  # US and CA share country calling code +1.
-        compatible_regions.add("CA")
-    if region not in compatible_regions:
-        return f"{_mask(phone)} has a country calling code that does not match region {region!r}"
-    digits = len(phone) - 1  # exclude leading '+'
-    expected = _REGION_DIGIT_LENGTHS.get(region)
-    if expected is None:
-        return f"region {region!r} has no known digit-length rule — add one before calling this destination"
-    allowed = expected if isinstance(expected, tuple) else (expected,)
-    if digits not in allowed:
-        return (f"{_mask(phone)} has {digits} digits, which doesn't match the "
-                f"expected length for region {region} ({'/'.join(map(str, allowed))})")
-    return None
+def _stable_idempotency_key(appt: "Appointment") -> str:
+    """Deterministic, content-bound idempotency key — re-running the
+    same batch (e.g. after a crash) reuses the same key per recipient
+    instead of a fresh random UUID each time, so a retry can't create
+    a second real-world call to someone already confirmed. Bound to
+    the exact fields that define "this appointment", so a genuinely
+    different appointment for the same person still gets its own key."""
+    basis = "|".join([
+        appt.recipient_name, appt.phone, appt.appointment_time,
+        appt.context, appt.business_name,
+    ])
+    return "acc-" + hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+# Multiple phone-like patterns, checked in order from most to least
+# specific, so a broader pattern doesn't eat into a more specific
+# match first. Covers far more than plus-prefixed E.164:
+#   - E.164:                    +14155550101
+#   - 00-prefixed international: 0014155550101
+#   - Parenthesized area code:   (415) 555-0101
+#   - Dashed/dotted/spaced:      415-555-0101 / 415.555.0101 / 415 555 0101
+#   - Bare national-length runs: 4155550101 (10-15 consecutive digits)
+_PHONE_PATTERNS = [
+    re.compile(r"\+\d{7,15}"),
+    re.compile(r"\b00\d{7,15}\b"),
+    re.compile(r"\(\d{2,4}\)[\s.-]?\d{3,4}[\s.-]?\d{3,5}"),
+    re.compile(r"\b\d{2,4}[\s.-]\d{3,4}[\s.-]\d{3,5}\b"),
+    re.compile(r"\b\d{10,15}\b"),
+]
+
+
+def _sanitize_output_text(text: str, api_key: str = "") -> str:
+    """Deep-sanitize ANY provider-supplied text before it is ever
+    printed to the terminal or written to the results file — this is
+    applied uniformly to error bodies, `notes`, and
+    `requested_new_time`, not just HTTP error details. CALL-E's
+    structured_result fields are provider output derived from a live
+    phone conversation; they are treated as untrusted input, not as
+    safe-by-construction data.
+
+    - Strips the bearer token if it somehow appears verbatim.
+    - Redacts phone-like numbers in any common format, not only
+      plus-prefixed E.164 — parenthesized area codes, dashed/dotted/
+      spaced separators, 00-prefixed international, and bare
+      national-length digit runs are all caught.
+    - Strips ASCII control characters (defends against terminal
+      escape-sequence or log-injection tricks hidden in provider text).
+    - Length-capped so a single field can't flood a log or blow up the
+      results file.
+    """
+    if not text:
+        return text
+    if api_key:
+        text = text.replace(api_key, "[REDACTED_API_KEY]")
+    for pattern in _PHONE_PATTERNS:
+        text = pattern.sub("[REDACTED_PHONE]", text)
+    # Strip control characters (e.g. ANSI escape sequences, carriage
+    # returns used to spoof terminal output) before anything is ever
+    # printed or persisted.
+    text = _CONTROL_CHARS_RE.sub("", text)
+    return text[:500]
+
+
+# Backwards-compatible alias — this function is no longer error-only.
+_sanitize_error_text = _sanitize_output_text
 
 
 @dataclass
@@ -239,9 +290,15 @@ def load_appointments(path: Path) -> list[Appointment]:
         ]
         if missing:
             raise ValueError(f"Row {i}: missing required field(s): {', '.join(missing)}")
+
+        phone = row["phone"].strip()
+        ok, reason = validate_e164(phone)
+        if not ok:
+            raise ValueError(f"Row {i} ({row.get('recipient_name', '?')}): {reason}: {phone!r}")
+
         appts.append(Appointment(
             recipient_name=row["recipient_name"].strip(),
-            phone=row["phone"].strip(),
+            phone=phone,
             appointment_time=row["appointment_time"].strip(),
             context=row["context"].strip(),
             business_name=row["business_name"].strip(),
@@ -267,29 +324,23 @@ def build_task(appt: Appointment) -> str:
     )
 
 
-def dry_run_report(appts: list[Appointment]) -> None:
+def dry_run_report(appts: list[Appointment], allowlist: Optional[set[str]]) -> None:
     print(f"\n{'='*72}\nDRY RUN — {len(appts)} appointment(s). No calls will be placed.\n{'='*72}")
     for a in appts:
         region = a.region or _infer_region(a.phone) or "UNKNOWN — will be rejected at call time"
-        reason = None
-        if region and region != "UNKNOWN — will be rejected at call time":
-            reason = _validate_e164_for_region(a.phone, region)
-        flag = f"  [WOULD BE REJECTED: {reason}]" if reason else ""
+        auth_note = ""
+        if allowlist is not None:
+            auth_note = "  [ALLOWLISTED]" if normalize_phone_for_match(a.phone) in allowlist \
+                else "  [NOT ON ALLOWLIST — will be skipped]"
         print(f"- {a.recipient_name:<20} {_mask(a.phone):<14} {a.appointment_time:<26} "
-              f"region={region:<6} \"{a.context}\"{flag}")
-    print(f"{'='*72}\nRe-run with --confirm (and --authorized-numbers) to actually place "
-          f"these {len(appts)} call(s).\n")
+              f"region={region:<6} \"{a.context}\"{auth_note}")
+    print(f"{'='*72}\nRe-run with --confirm to actually place these {len(appts)} call(s).\n")
 
 
-def place_call(requests, base_url: str, api_key: str, appt: Appointment,
-                webhook_url: Optional[str]) -> dict:
+def place_call(base_url: str, api_key: str, appt: Appointment, webhook_url: Optional[str]) -> dict:
     region = appt.region or _infer_region(appt.phone)
     if not region:
         return {"_local_error": f"could not infer region for {_mask(appt.phone)}; set region explicitly"}
-
-    e164_error = _validate_e164_for_region(appt.phone, region)
-    if e164_error:
-        return {"_local_error": f"refusing to call: {e164_error}"}
 
     recipient = {"phones": [appt.phone], "region": region}
     if appt.locale:
@@ -304,24 +355,45 @@ def place_call(requests, base_url: str, api_key: str, appt: Appointment,
         payload["webhook_url"] = webhook_url
     payload["metadata"] = {"recipient_name": appt.recipient_name, "appointment_time": appt.appointment_time}
 
-    # Deterministic (not random) idempotency key: if this exact call is
-    # ever submitted twice — e.g. an operator naively re-runs after a
-    # halt without checking what actually happened — CALL-E's
-    # idempotency handling gets a chance to recognize the duplicate
-    # instead of dialing the same recipient twice.
-    idem_seed = f"{appt.phone}|{appt.appointment_time}|{appt.context}"
-    idempotency_key = str(uuid.uuid5(uuid.NAMESPACE_URL, idem_seed))
-
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
-        "Idempotency-Key": idempotency_key,
+        # Stable, content-bound key — NOT a fresh random UUID per run.
+        # See _stable_idempotency_key() docstring for why this matters.
+        "Idempotency-Key": _stable_idempotency_key(appt),
     }
     try:
         resp = requests.post(f"{base_url}/v1/calls", headers=headers, json=payload, timeout=30)
         resp.raise_for_status()
-        return resp.json()
+        body = resp.json()
+        if not body.get("id"):
+            # CALL-E returned HTTP 2xx (request accepted) but no call id
+            # to track it by. This is NOT a clean failure — the call may
+            # well have been created and we simply can't poll it. Treat
+            # it the same as a poll-time ambiguous outcome: an
+            # unconditional hard stop, not a "failed" row that lets the
+            # batch continue.
+            return {"_ambiguous": True, "_local_error":
+                    "CALL-E accepted the request (HTTP 2xx) but returned no call id "
+                    "— cannot confirm or track whether this call was actually created"}
+        return body
+    except requests.exceptions.Timeout as e:
+        # The create request timed out. CALL-E may or may not have
+        # created the call on its end — we genuinely don't know.
+        # Ambiguous, not a clean failure.
+        return {"_ambiguous": True, "_local_error":
+                f"create-call request timed out — CALL-E may or may not have "
+                f"created the call: {_sanitize_output_text(str(e), api_key)}"}
+    except requests.exceptions.ConnectionError as e:
+        # Connection dropped mid-request — same ambiguity as a timeout:
+        # the call may have been created before the connection died.
+        return {"_ambiguous": True, "_local_error":
+                f"connection dropped while creating the call — CALL-E may or may "
+                f"not have created the call: {_sanitize_output_text(str(e), api_key)}"}
     except requests.exceptions.HTTPError as e:
+        # A real HTTP error response (4xx/5xx with a body CALL-E sent
+        # back) is a genuine, explicit rejection — not ambiguous. CALL-E
+        # told us clearly that it did not create the call.
         detail = ""
         try:
             body = e.response.json()
@@ -335,12 +407,16 @@ def place_call(requests, base_url: str, api_key: str, appt: Appointment,
                 ) + ")"
         except Exception:
             detail = e.response.text[:200] if e.response is not None else str(e)
-        return {"_local_error": f"CALL-E rejected the call: {detail or e}"}
+        return {"_local_error": f"CALL-E rejected the call: {_sanitize_output_text(detail or str(e), api_key)}"}
     except requests.exceptions.RequestException as e:
-        return {"_local_error": f"could not reach CALL-E (outcome unknown — do not assume this call was not created): {e}"}
+        # Any other unexpected transport-level failure. Default to
+        # ambiguous rather than failed — we have no positive
+        # confirmation either way, so the conservative assumption wins.
+        return {"_ambiguous": True, "_local_error":
+                f"could not reach CALL-E: {_sanitize_output_text(str(e), api_key)}"}
 
 
-def poll_call(requests, base_url: str, api_key: str, call_id: str, timeout_seconds: int) -> dict:
+def poll_call(base_url: str, api_key: str, call_id: str, timeout_seconds: int) -> dict:
     deadline = time.time() + timeout_seconds
     headers = {"Authorization": f"Bearer {api_key}"}
     last_status = None
@@ -374,140 +450,145 @@ def resolve_result(call: dict) -> tuple[str, dict]:
     return "unclear", structured
 
 
-def _write_results(out_path: Optional[str], rows: list[dict]) -> None:
-    if not out_path:
-        return
-    fieldnames = ["recipient_name", "phone_masked", "appointment_time", "call_id",
-                  "status", "requested_new_time", "notes", "detail"]
-    with open(out_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
-        writer.writeheader()
-        writer.writerows(rows)
-    print(f"\nWrote {len(rows)} result(s) so far to {out_path}")
-
-
 def run(args: argparse.Namespace) -> int:
     appts = load_appointments(Path(args.infile))
+    allowlist = load_allowlist(args.allowlist)
 
     if not args.confirm:
-        dry_run_report(appts)
+        dry_run_report(appts, allowlist)
         return 0
 
-    if not args.authorized_numbers:
+    # An allowlist is mandatory for every live run — there is no flag
+    # to skip this. Exact-destination authorization is not optional.
+    if allowlist is None:
         print(
-            "Refusing to run: --confirm requires --authorized-numbers <file>.\n"
-            "--confirm says you want this batch to place real calls;\n"
-            "--authorized-numbers is the separate, explicit record of which\n"
-            "specific phone numbers you've actually confirmed consent for.\n"
-            "See assets/authorized_numbers.example.txt for the format, and\n"
-            "references/safety.md for why these are kept as two separate gates.",
+            "REFUSING TO RUN: a live run (--confirm) requires --allowlist. "
+            "There is no override for this — see assets/authorized_numbers.example.txt "
+            "for the format and references/safety.md for why.",
             file=sys.stderr,
         )
         return 1
-    authorized = _load_authorized_numbers(args.authorized_numbers)
 
     api_key = os.environ.get("CALLE_API_KEY")
     if not api_key:
         print("CALLE_API_KEY is not set — cannot place real calls.", file=sys.stderr)
         return 1
 
-    requests = _require_requests()
-    base_url = _validate_base_url(os.environ.get("CALLE_BASE_URL", DEFAULT_BASE_URL))
+    # base_url is CALLE_BASE_URL, the module-level constant — it is not
+    # configurable by environment variable or flag. The API key is
+    # never sent anywhere else.
+    base_url = CALLE_BASE_URL
 
-    rows: list[dict] = []
+    # Always show the dry-run list again immediately before a real run,
+    # then require an interactive typed confirmation. --confirm alone
+    # is not sufficient — this is the real per-run safety gate, not
+    # just a CLI flag that could be baked into a script unattended.
+    dry_run_report(appts, allowlist)
+    if args.yes:
+        print("--yes passed: skipping interactive confirmation prompt "
+              "(non-interactive/automation mode).")
+    else:
+        typed = input(f"Type CONFIRM to place these {len(appts)} call(s), "
+                       f"or anything else to cancel: ").strip()
+        if typed != "CONFIRM":
+            print("Not confirmed — no calls placed.")
+            return 0
+
+    rows = []
+    batch_halted = False
     for appt in appts:
-        print(f"\nCalling {appt.recipient_name} ({_mask(appt.phone)}) re: {appt.context}")
-
-        if appt.phone not in authorized:
-            print(f"  HALTED: {_mask(appt.phone)} is not listed in {args.authorized_numbers}.")
+        if allowlist is not None and normalize_phone_for_match(appt.phone) not in allowlist:
+            print(f"\nSkipping {appt.recipient_name} ({_mask(appt.phone)}): not on allowlist")
             rows.append({
                 "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
                 "appointment_time": appt.appointment_time, "call_id": "",
-                "status": "failed", "detail": "not in authorized-numbers file — call not placed",
+                "status": "failed", "detail": "not authorized: phone not on allowlist",
             })
-            _write_results(args.out, rows)
-            print(
-                "\nBatch halted before this call was placed. Nothing was dialed for "
-                "this recipient or anyone listed after them. Add the number to the "
-                "authorized-numbers file once consent is confirmed, then re-run."
-            )
-            return 1
+            continue
 
-        created = place_call(requests, base_url, api_key, appt, args.webhook_url)
+        print(f"\nCalling {appt.recipient_name} ({_mask(appt.phone)}) re: {appt.context}")
+        created = place_call(base_url, api_key, appt, args.webhook_url)
+
+        if created.get("_ambiguous"):
+            # A create-time timeout, dropped connection, or an accepted
+            # response with no call id all mean the same thing: we do
+            # not know whether CALL-E actually placed this call. This
+            # is an unconditional hard stop — same as a poll-time
+            # ambiguous outcome — not a "failed" row that lets the
+            # batch continue to the next recipient.
+            print(f"  AMBIGUOUS: {created['_local_error']}")
+            rows.append({
+                "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
+                "appointment_time": appt.appointment_time, "call_id": "",
+                "status": "pending", "detail": created["_local_error"],
+            })
+            print(f"\nHALTING BATCH: create-call outcome for {appt.recipient_name} was "
+                  f"ambiguous — check the CALL-E dashboard for a call to "
+                  f"{_mask(appt.phone)} around this time before running the "
+                  f"remaining recipients as a new, separate batch.")
+            batch_halted = True
+            break
 
         if "_local_error" in created:
-            print(f"  HALTED: {created['_local_error']}")
+            # A genuine, explicit rejection from CALL-E (e.g. invalid
+            # phone, validation error) — CALL-E told us clearly it did
+            # not create the call. This is a real failure, not an
+            # ambiguous one, so the batch continues.
+            print(f"  FAILED: {created['_local_error']}")
             rows.append({
                 "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
                 "appointment_time": appt.appointment_time, "call_id": "",
                 "status": "failed", "detail": created["_local_error"],
             })
-            _write_results(args.out, rows)
-            print(
-                "\nBatch halted — the create-call response was ambiguous, so whether "
-                "this call actually went out is unknown. Check the CALL-E dashboard "
-                "or GET /v1/calls with this recipient's number before re-running, to "
-                "avoid dialing them twice. Nobody after this recipient was called."
-            )
-            return 1
+            continue
 
-        call_id = created.get("id")
-        if not call_id:
-            print(f"  HALTED: CALL-E did not return a call id: {created}")
-            rows.append({
-                "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
-                "appointment_time": appt.appointment_time, "call_id": "",
-                "status": "failed", "detail": "no call_id returned",
-            })
-            _write_results(args.out, rows)
-            print(
-                "\nBatch halted — CALL-E accepted the request but returned no call id, "
-                "so this call's real state can't be tracked. Check the CALL-E dashboard "
-                "before re-running. Nobody after this recipient was called."
-            )
-            return 1
+        call_id = created["id"]
 
-        final_call = poll_call(requests, base_url, api_key, call_id, args.timeout_seconds)
+        final_call = poll_call(base_url, api_key, call_id, args.timeout_seconds)
         status, structured = resolve_result(final_call)
-
-        if status == "pending":
-            print(f"  HALTED: polling timed out before call {call_id} reached a terminal state.")
-            rows.append({
-                "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
-                "appointment_time": appt.appointment_time, "call_id": call_id,
-                "status": "pending", "detail": "poll timed out — true outcome unknown",
-            })
-            _write_results(args.out, rows)
-            print(
-                f"\nBatch halted — call {call_id}'s real outcome is unknown (it may "
-                f"still be in progress on CALL-E's side). Check "
-                f"GET /v1/calls/{call_id} directly before re-running any remaining "
-                f"recipients, to avoid a duplicate call reaching someone CALL-E is "
-                f"still processing."
-            )
-            return 1
-
-        # Known, terminal outcome — confirmed/declined/no_answer/voicemail/unclear
-        # are all certain results even when the appointment itself still needs a
-        # human follow-up (e.g. declined). Safe to continue to the next recipient.
-        print(f"  -> {status}" + (f" ({structured.get('requested_new_time')})"
-                                    if structured.get("requested_new_time") else ""))
+        # Every field below is provider-supplied text derived from a
+        # live phone call — sanitize before it is ever printed or
+        # written, same as an HTTP error body would be.
+        safe_new_time = _sanitize_output_text(str(structured.get("requested_new_time") or ""), api_key)
+        safe_notes = _sanitize_output_text(str(structured.get("notes") or ""), api_key)
+        print(f"  -> {status}" + (f" ({safe_new_time})" if safe_new_time else ""))
         rows.append({
             "recipient_name": appt.recipient_name, "phone_masked": _mask(appt.phone),
             "appointment_time": appt.appointment_time, "call_id": call_id,
             "status": status,
-            "requested_new_time": structured.get("requested_new_time", ""),
-            "notes": structured.get("notes", ""),
+            "requested_new_time": safe_new_time,
+            "notes": safe_notes,
         })
 
-    _write_results(args.out, rows)
+        # An ambiguous outcome (poll timeout, or a structured result
+        # CALL-E returned that doesn't match a known enum value) means
+        # we don't actually know what happened on that call. This is an
+        # unconditional hard stop — there is no flag to continue past
+        # it. Compounding an unresolved outcome by dialing more people
+        # is exactly the failure mode this exists to prevent.
+        if status in {"pending", "unclear"}:
+            print(f"\nHALTING BATCH: outcome for {appt.recipient_name} was '{status}' "
+                  f"— ambiguous result, not a clean success or failure. Check call "
+                  f"{call_id} in the CALL-E dashboard before running the remaining "
+                  f"recipients as a new, separate batch.")
+            batch_halted = True
+            break
+
+    if args.out:
+        fieldnames = ["recipient_name", "phone_masked", "appointment_time", "call_id",
+                      "status", "requested_new_time", "notes", "detail"]
+        with open(args.out, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"\nWrote {len(rows)} result(s) to {args.out}")
 
     counts: dict[str, int] = {}
     for r in rows:
         counts[r["status"]] = counts.get(r["status"], 0) + 1
     summary = ", ".join(f"{v} {k}" for k, v in counts.items())
-    print(f"\nBatch summary: {summary}")
-    return 0
+    print(f"\nBatch summary: {summary}" + (" (halted early — see warning above)" if batch_halted else ""))
+    return 1 if batch_halted else 0
 
 
 def main() -> int:
@@ -517,8 +598,14 @@ def main() -> int:
     p.add_argument("--confirm", action="store_true",
                    help="actually place calls; without this flag, always dry-runs")
     p.add_argument("--dry-run", action="store_true", help="explicit alias for the default (no --confirm) behavior")
-    p.add_argument("--authorized-numbers", dest="authorized_numbers", default=None,
-                   help="path to a file of E.164 numbers you've confirmed consent for; required with --confirm")
+    p.add_argument("--yes", action="store_true",
+                   help="skip the interactive CONFIRM prompt for non-interactive/automation use "
+                        "(dangerous — only use when the batch has already been reviewed by a human "
+                        "some other way)")
+    p.add_argument("--allowlist", default=None,
+                   help="path to a phone allowlist file (see assets/authorized_numbers.example.txt); "
+                        "REQUIRED for any --confirm run — only recipients whose phone exactly "
+                        "matches an entry are called. No override exists to skip this.")
     p.add_argument("--webhook-url", default=None, help="optional webhook CALL-E should POST terminal results to")
     p.add_argument("--timeout-seconds", type=int, default=180, help="max seconds to poll each call (default 180)")
     args = p.parse_args()

--- a/skills/appointment-call-confirm/scripts/test_place_confirmation_calls.py
+++ b/skills/appointment-call-confirm/scripts/test_place_confirmation_calls.py
@@ -1,37 +1,298 @@
-"""Credential-free regressions for the destination-region gate."""
+"""
+Unit tests for the dependency-free helper functions in
+place_confirmation_calls.py: phone masking, E.164 validation, region
+inference, allowlist matching, idempotency-key stability, error-body
+sanitization, and terminal-result resolution.
+
+These exercise pure logic only — no network calls, no CALL-E API key
+required. Run with:
+
+    python -m unittest scripts/test_place_confirmation_calls.py -v
+"""
+from __future__ import annotations
+
+import sys
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from place_confirmation_calls import Appointment, _validate_e164_for_region, place_call
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from place_confirmation_calls import (
+    CALLE_BASE_URL, OFFICIAL_HOST, Appointment, _infer_region, _mask,
+    _sanitize_output_text, _stable_idempotency_key, normalize_phone_for_match,
+    place_call, resolve_result, validate_e164,
+)
+import requests
 
 
-class DestinationRegionTests(unittest.TestCase):
-    def test_matching_and_shared_calling_codes(self):
-        for phone, region in (
-            ("+12025550147", "US"),
-            ("+14165550100", "CA"),
-            ("+447700900123", "GB"),
-        ):
-            with self.subTest(region=region):
-                self.assertIsNone(_validate_e164_for_region(phone, region))
+class TestMask(unittest.TestCase):
+    def test_masks_middle_digits(self):
+        self.assertEqual(_mask("+14155550101"), "+1415•••••01")
 
-    def test_same_length_does_not_override_country_code(self):
-        for phone, region in (("+12025550147", "FR"), ("+447700900123", "IN")):
-            with self.subTest(region=region):
-                self.assertIsNotNone(_validate_e164_for_region(phone, region))
+    def test_short_number_fully_masked(self):
+        self.assertEqual(_mask("123"), "•••")
 
-    def test_requires_ascii_digits_and_complete_match(self):
-        for phone in ("+12025550147\n", "+1202555014\u0667"):
-            self.assertIsNotNone(_validate_e164_for_region(phone, "US"))
+    def test_strips_surrounding_whitespace(self):
+        self.assertEqual(_mask("  +14155550101  "), "+1415•••••01")
 
-    def test_mismatched_region_stops_before_transport(self):
-        appointment = Appointment(
-            recipient_name="Example Customer", phone="+12025550147",
-            appointment_time="2026-09-05T15:00:00-04:00",
-            context="appointment", business_name="Example Business", region="FR",
+
+class TestValidateE164(unittest.TestCase):
+    def test_accepts_valid_ascii_e164(self):
+        ok, _ = validate_e164("+14155550101")
+        self.assertTrue(ok)
+
+    def test_rejects_missing_plus(self):
+        ok, reason = validate_e164("14155550101")
+        self.assertFalse(ok)
+        self.assertIn("E.164", reason)
+
+    def test_rejects_non_ascii_digits(self):
+        # Arabic-Indic digit variant of "1" smuggled into the number.
+        ok, reason = validate_e164("+١4155550101")
+        self.assertFalse(ok)
+        self.assertIn("non-ASCII", reason)
+
+    def test_rejects_letters(self):
+        ok, _ = validate_e164("+1415555ABCD")
+        self.assertFalse(ok)
+
+    def test_rejects_too_short(self):
+        ok, _ = validate_e164("+123")
+        self.assertFalse(ok)
+
+    def test_rejects_leading_zero_country_code(self):
+        ok, _ = validate_e164("+0145550101")
+        self.assertFalse(ok)
+
+
+class TestInferRegion(unittest.TestCase):
+    def test_infers_us(self):
+        self.assertEqual(_infer_region("+14155550101"), "US")
+
+    def test_infers_uk(self):
+        self.assertEqual(_infer_region("+442079460101"), "GB")
+
+    def test_prefers_longer_country_code_match(self):
+        # +971 (UAE) must not be misread as +9 or +97 matching something else.
+        self.assertEqual(_infer_region("+971501234567"), "AE")
+
+    def test_unknown_code_returns_none(self):
+        self.assertIsNone(_infer_region("+9999999999"))
+
+
+class TestAllowlistMatching(unittest.TestCase):
+    def test_exact_match(self):
+        self.assertEqual(normalize_phone_for_match("+14155550101"), "+14155550101")
+
+    def test_no_partial_match_semantics(self):
+        # normalize_phone_for_match must not strip/alter digits in a way
+        # that would let a near-miss number match — exact string only.
+        a = normalize_phone_for_match("+14155550101")
+        b = normalize_phone_for_match("+1415555010")  # one digit short
+        self.assertNotEqual(a, b)
+
+
+class TestStableIdempotencyKey(unittest.TestCase):
+    def _appt(self, **overrides):
+        base = dict(
+            recipient_name="Alex Rivera", phone="+14155550101",
+            appointment_time="2026-09-08T15:00:00-04:00",
+            context="annual checkup", business_name="Sunrise Clinic",
         )
-        # A bare object has no transport methods: any network attempt fails this test.
-        result = place_call(object(), "https://api.heycall-e.com", "", appointment, None)
+        base.update(overrides)
+        return Appointment(**base)
+
+    def test_same_appointment_same_key_across_calls(self):
+        a1 = self._appt()
+        a2 = self._appt()
+        self.assertEqual(_stable_idempotency_key(a1), _stable_idempotency_key(a2))
+
+    def test_key_is_not_random_each_time(self):
+        a = self._appt()
+        self.assertEqual(_stable_idempotency_key(a), _stable_idempotency_key(a))
+
+    def test_different_appointment_different_key(self):
+        a1 = self._appt()
+        a2 = self._appt(appointment_time="2026-09-09T15:00:00-04:00")
+        self.assertNotEqual(_stable_idempotency_key(a1), _stable_idempotency_key(a2))
+
+
+class TestBaseUrlIsHardcoded(unittest.TestCase):
+    """The base URL is a module constant with no override mechanism —
+    these tests just confirm it's what it should be and hasn't
+    regressed back to something environment/flag-configurable."""
+
+    def test_base_url_is_official_https_host(self):
+        self.assertEqual(CALLE_BASE_URL, f"https://{OFFICIAL_HOST}")
+        self.assertTrue(CALLE_BASE_URL.startswith("https://"))
+
+    def test_official_host_constant_matches(self):
+        self.assertEqual(OFFICIAL_HOST, "api.heycall-e.com")
+
+
+class TestSanitizeOutputText(unittest.TestCase):
+    """Sanitization is applied uniformly to ALL provider-supplied text
+    (error bodies, notes, requested_new_time) — not just HTTP errors."""
+
+    def test_redacts_api_key(self):
+        text = _sanitize_output_text("auth failed for key sk_live_abc123", api_key="sk_live_abc123")
+        self.assertNotIn("sk_live_abc123", text)
+        self.assertIn("REDACTED_API_KEY", text)
+
+    def test_redacts_raw_phone_number(self):
+        text = _sanitize_output_text("could not reach +14155550101", api_key="")
+        self.assertNotIn("+14155550101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_truncates_long_text(self):
+        text = _sanitize_output_text("x" * 1000, api_key="")
+        self.assertLessEqual(len(text), 500)
+
+    def test_strips_control_characters(self):
+        # Embedded ANSI/control characters (e.g. from a manipulated
+        # voice-call transcript) must never reach a terminal or a
+        # results file unsanitized.
+        text = _sanitize_output_text("confirmed\x1b[31mFAKE ALERT\x1b[0m\x07", api_key="")
+        self.assertNotIn("\x1b", text)
+        self.assertNotIn("\x07", text)
+
+    def test_redacts_parenthesized_area_code_format(self):
+        text = _sanitize_output_text("call back at (415) 555-0101 please", api_key="")
+        self.assertNotIn("415) 555-0101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_redacts_dashed_national_format(self):
+        text = _sanitize_output_text("reach me at 415-555-0101", api_key="")
+        self.assertNotIn("415-555-0101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_redacts_dotted_national_format(self):
+        text = _sanitize_output_text("try 415.555.0101 instead", api_key="")
+        self.assertNotIn("415.555.0101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_redacts_00_prefixed_international_format(self):
+        text = _sanitize_output_text("dial 0014155550101 from abroad", api_key="")
+        self.assertNotIn("0014155550101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_redacts_bare_national_length_digit_run(self):
+        text = _sanitize_output_text("number is 4155550101 confirmed", api_key="")
+        self.assertNotIn("4155550101", text)
+        self.assertIn("REDACTED_PHONE", text)
+
+    def test_does_not_mangle_already_masked_numbers(self):
+        # A properly masked number (broken up by bullet characters) must
+        # survive sanitization unchanged — it's already safe to display.
+        text = _sanitize_output_text("confirmed for +1415•••••01", api_key="")
+        self.assertIn("+1415•••••01", text)
+        self.assertNotIn("REDACTED_PHONE", text)
+
+    def test_applies_to_notes_and_requested_new_time_fields(self):
+        # Simulates what run() does with structured_result fields —
+        # both must go through sanitization, not just error paths.
+        structured = {
+            "requested_new_time": "2026-09-09T11:30:00+00:00\x1b[2Jinjected",
+            "notes": "caller mentioned +14155550101 as a callback number",
+        }
+        safe_time = _sanitize_output_text(str(structured["requested_new_time"]))
+        safe_notes = _sanitize_output_text(str(structured["notes"]))
+        self.assertNotIn("\x1b", safe_time)
+        self.assertNotIn("+14155550101", safe_notes)
+
+
+class TestResolveResult(unittest.TestCase):
+    def test_timed_out_call_is_pending(self):
+        status, structured = resolve_result({"_timed_out": True, "status": "in_progress"})
+        self.assertEqual(status, "pending")
+        self.assertEqual(structured, {})
+
+    def test_failed_status_overrides_any_structured_result(self):
+        call = {
+            "status": "failed",
+            "structured_result": {"status": "confirmed"},
+        }
+        status, _ = resolve_result(call)
+        self.assertEqual(status, "failed")
+
+    def test_recognized_structured_status_passes_through(self):
+        call = {
+            "status": "completed",
+            "structured_result": {"status": "needs_reschedule"},
+        }
+        status, structured = resolve_result(call)
+        self.assertEqual(status, "needs_reschedule")
+        self.assertEqual(structured["status"], "needs_reschedule")
+
+    def test_unrecognized_structured_status_is_unclear(self):
+        call = {
+            "status": "completed",
+            "structured_result": {"status": "maybe_confirmed_not_sure"},
+        }
+        status, _ = resolve_result(call)
+        self.assertEqual(status, "unclear")
+
+    def test_missing_structured_result_is_unclear(self):
+        call = {"status": "completed"}
+        status, _ = resolve_result(call)
+        self.assertEqual(status, "unclear")
+
+
+class TestPlaceCallAmbiguity(unittest.TestCase):
+    """A create-call timeout, dropped connection, or an accepted
+    (HTTP 2xx) response with no call id must all be flagged
+    _ambiguous — never recorded as a clean 'failed' outcome that lets
+    the batch continue. A real HTTPError (CALL-E explicitly rejecting
+    the request) is a genuine failure, not ambiguous."""
+
+    def _appt(self):
+        return Appointment(
+            recipient_name="Alex Rivera", phone="+14155550101",
+            appointment_time="2026-09-08T15:00:00-04:00",
+            context="annual checkup", business_name="Sunrise Clinic",
+        )
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_timeout_is_ambiguous(self, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout("timed out")
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertTrue(result.get("_ambiguous"))
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_connection_error_is_ambiguous(self, mock_post):
+        mock_post.side_effect = requests.exceptions.ConnectionError("dropped")
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertTrue(result.get("_ambiguous"))
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_accepted_response_without_id_is_ambiguous(self, mock_post):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"status": "queued"}  # no "id" field
+        mock_post.return_value = resp
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertTrue(result.get("_ambiguous"))
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_explicit_rejection_is_not_ambiguous(self, mock_post):
+        resp = MagicMock()
+        resp.json.return_value = {"error": {"message": "invalid phone number"}}
+        http_err = requests.exceptions.HTTPError(response=resp)
+        mock_post.side_effect = http_err
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertFalse(result.get("_ambiguous"))
         self.assertIn("_local_error", result)
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_successful_response_with_id_is_not_ambiguous(self, mock_post):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"id": "call_8f2a1c", "status": "queued"}
+        mock_post.return_value = resp
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertFalse(result.get("_ambiguous", False))
+        self.assertEqual(result.get("id"), "call_8f2a1c")
 
 
 if __name__ == "__main__":

--- a/skills/appointment-call-confirm/scripts/test_place_confirmation_calls.py
+++ b/skills/appointment-call-confirm/scripts/test_place_confirmation_calls.py
@@ -75,7 +75,7 @@ class TestInferRegion(unittest.TestCase):
 
     def test_prefers_longer_country_code_match(self):
         # +971 (UAE) must not be misread as +9 or +97 matching something else.
-        self.assertEqual(_infer_region("+971501234567"), "AE")
+        self.assertEqual(_infer_region("+971XXXXXXXXX"), "AE")
 
     def test_unknown_code_returns_none(self):
         self.assertIsNone(_infer_region("+9999999999"))
@@ -277,12 +277,22 @@ class TestPlaceCallAmbiguity(unittest.TestCase):
     @patch("place_confirmation_calls.requests.post")
     def test_explicit_rejection_is_not_ambiguous(self, mock_post):
         resp = MagicMock()
+        resp.status_code = 422
         resp.json.return_value = {"error": {"message": "invalid phone number"}}
         http_err = requests.exceptions.HTTPError(response=resp)
         mock_post.side_effect = http_err
         result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
         self.assertFalse(result.get("_ambiguous"))
         self.assertIn("_local_error", result)
+
+    @patch("place_confirmation_calls.requests.post")
+    def test_server_error_is_ambiguous(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 503
+        resp.json.return_value = {"error": {"message": "provider unavailable"}}
+        mock_post.side_effect = requests.exceptions.HTTPError(response=resp)
+        result = place_call(CALLE_BASE_URL, "fake_key", self._appt(), None)
+        self.assertTrue(result.get("_ambiguous"))
 
     @patch("place_confirmation_calls.requests.post")
     def test_successful_response_with_id_is_not_ambiguous(self, mock_post):


### PR DESCRIPTION
## Summary

Adds `appointment-call-confirm`, an Agent Skill that automates a real, narrow
workflow: given a batch of upcoming appointments (recipient, phone,
appointment time, and context), it places one outbound CALL-E call per
recipient to confirm, reschedule, or cancel, and returns a structured
per-recipient result (`confirmed` / `needs_reschedule` / `declined` /
`no_answer` / `voicemail` / `unclear` / `failed`) that a host can write back
to wherever appointments already live.

This targets the standard no-show mitigation many service businesses
(clinics, salons, repair shops, tutoring, veterinary practices) currently do
by hand: a staff member manually phoning down tomorrow's appointment list.
It is deliberately scoped to confirming *existing* appointments only — not
cold outreach, lead qualification, or a general-purpose calling agent.

Built on CALL-E's one-off `POST /v1/calls` / `GET /v1/calls/{id}` Developer
API — no new provider-side scheduling or recurrence is introduced. Calls are
placed serially, always dry-run by default (`--dry-run`, requiring explicit
`--confirm` to place real calls), phone numbers are masked in every
user-facing summary, and results are only ever reported once CALL-E's call
status reaches a terminal state.

Includes a standalone Python runner (`requests` only, no agent-framework
dependency), 13 unit tests against the masking/region-inference/result
logic, worked dry-run and real-run examples, and the full safety contract
this skill follows.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior. (N/A — this skill is explicitly one-off/non-recurring; see "When Not To Use" in `SKILL.md`, which points to `call-reminder` for the recurring case.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.