### PR TITLE
feat(fieldline): add lone-worker safety app

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Apps
 
+- [FieldLine](https://github.com/xiehuanyi/fieldline) - Lone-worker safety net that schedules check-in calls, detects a silent duress phrase, and runs an escalation call cascade ending in a structured incident brief.
 - [CallParity](https://github.com/ruddro-roy/callparity) - Two-call ops workbench for Party A claims, a Party B falsification CALL-E task, and a merged claim graph. Preview and fixture mode by default.
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
 - [GridGuard Voice Escalation Agent](https://github.com/draculess99/gridguard-voice-escalation-agent) - Approval-gated grid-risk escalation app using CALL-E with disclosed calls, two human confirmations, structured escalation packets, and a dry-run/no-call default. [Demo](https://gridguard-voice-escalation-agent-production.up.railway.app/)
@@ -179,6 +180,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/typescript/call-on-behalf`](apps/typescript/call-on-behalf/) | TypeScript | Delegated errand caller with a disclosure budget: says only the details the person authorized, commits only inside authorized windows, and returns the answers plus the transcript. |
 | [`apps/typescript/lost-line-coordinator`](apps/typescript/lost-line-coordinator/) | TypeScript | Consent-first lost-property route coordinator with inspectable calls, locally validated feature evidence, adaptive early stopping, and privacy-minimized results. |
 | [`apps/typescript/surplus-signal`](apps/typescript/surplus-signal/) | TypeScript | Consent-first surplus-food pickup confirmations with strict structured results and a redacted candidate manifest that still requires human dispatch approval. |
+| [`apps/python/fieldline`](apps/python/fieldline/) | Python | Demo-first lone-worker check-ins with silent duress detection, an escalation ladder, masked phone output, and human-owned emergency response. |
 | [`apps/python/accessline`](apps/python/accessline/) | Python | Consent-first venue accessibility verification with disclosed automation, three fixed factual questions, CALL-E REST polling, schema-valid structured results, uncertainty preservation, and a no-call mock CLI by default. |
 | [`apps/python/appointment-confirm`](apps/python/appointment-confirm/) | Python | Consent-first appointment confirmation with a no-call preview, fixture mock, and one-shot CALL-E execute path that returns yes/no + time as fail-closed JSON. |
 | [`apps/python/blood-bank-dispatch`](apps/python/blood-bank-dispatch/) | Python | Parallel blood-stock enquiry that dials every blood bank at once on CALL-E, extracts a strict availability schema with `unknown` preserved as an answer, and returns a shortlist for a human to act on. |

--- a/apps/python/fieldline/.env.example
+++ b/apps/python/fieldline/.env.example
@@ -1,0 +1,15 @@
+# ---- CALL-E credentials (live mode) ----------------------------------
+# Create an account at https://www.heycall-e.com/ (20 free calls),
+# then create a key at https://dashboard.heycall-e.com/account/api-keys
+CALLE_API_KEY=
+
+# Optional: override the API base URL (defaults to the public API).
+# CALLE_BASE_URL=https://api.heycall-e.com
+
+# ---- FieldLine switches ----------------------------------------------
+# 1 = force DEMO mode (scripted calls, no network) even if a key is set.
+# When CALLE_API_KEY is empty, demo mode is on automatically.
+FIELDLINE_DEMO=
+
+# 1 = skip demo pacing delays (used by tests/CI).
+FIELDLINE_FAST=

--- a/apps/python/fieldline/.gitignore
+++ b/apps/python/fieldline/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.fieldline/
+dist/
+.pytest_cache/
+uv.lock
+docs/event.md
+docs/plan.md
+docs/submit-checklist.md
+docs/video-script.md
+docs/video*.mp4
+docs/video-notes.md
+docs/video-narration.md

--- a/apps/python/fieldline/LICENSE
+++ b/apps/python/fieldline/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Huanyi Xie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/python/fieldline/README.md
+++ b/apps/python/fieldline/README.md
@@ -1,0 +1,127 @@
+# FieldLine
+
+**A lone-worker safety net that phones the field.** Scheduled check-in
+calls, a silent duress phrase, and an automatic escalation call cascade —
+one agent watching every trip plan, built on the
+[CALL-E](https://docs.heycall-e.com/) phone-call platform.
+
+> I do marine fieldwork on the Red Sea coast. Our field-safety plan is a
+> PDF and a promise that someone will notice if we don't come back. At
+> 18:05, nobody is watching the clock. FieldLine is the thing that
+> watches the clock — and it has a phone.
+
+## What it does
+
+1. **You file a trip plan** (`examples/trip.yaml`): who, where, check-in
+   times, an escalation ladder (buddy → safety officer), and a
+   pre-agreed **duress phrase**.
+2. **FieldLine calls you at each check-in.** CALL-E holds the
+   conversation and returns a structured result (`safe` /
+   `needs_assistance` / duress flag / location / plan changes).
+3. **Miss a check-in?** Retry after 5 minutes → declared OVERDUE →
+   FieldLine climbs the ladder call by call, briefing each contact with
+   accumulated facts (last confirmed contact, vehicle, what the previous
+   contact said) until a human explicitly assumes coordination.
+4. **Say the duress phrase mid-call?** The agent doesn't flinch — ends
+   the call normally — and silently escalates straight to the top rung,
+   with instructions not to call your phone back.
+5. Every incident produces a **written brief**: timeline, transcripts,
+   structured results, evidence, recommended actions.
+
+FieldLine **never auto-dials emergency services** — the last rung is
+always a human who does.
+
+## Quickstart (demo mode — no account, no keys)
+
+Requires Python ≥3.12 and [uv](https://docs.astral.sh/uv/).
+
+```bash
+uv sync
+uv run fieldline demo                      # golden path: safe check-in → missed → cascade
+uv run fieldline demo --scenario duress    # the silent-duress beat
+uv run fieldline report                    # re-read the latest incident brief
+uv run pytest -q                           # 32 unit tests
+```
+
+Demo mode replays scripted calls with realistic transcripts (marked
+`// DEMO` in the source; all people and +1-555-01xx numbers are
+fictional). The dicts it returns follow CALL-E's real `call_task` schema
+(from the [OpenAPI spec](https://docs.heycall-e.com/openapi/calle.openapi.yaml)),
+so everything above the transport layer is exercised for real.
+
+## Going live (real phone calls)
+
+```bash
+uv sync --extra live                # installs the calle-ai SDK
+cp .env.example .env                # put your CALLE_API_KEY inside
+# edit examples/trip.yaml → your own numbers, in E.164
+uv run fieldline checkin-now examples/trip.yaml   # ONE real test call to yourself
+uv run fieldline start examples/trip.yaml         # monitor the whole trip
+uv run fieldline end                              # cancel: stops all future calls
+```
+
+Get a key: create an account at <https://www.heycall-e.com/> (20 free
+calls), then <https://dashboard.heycall-e.com/account/api-keys>.
+
+The only difference between demo and live is the transport
+(`src/fieldline/calle_client.py`): live mode calls
+`client.calls.create_and_wait(...)` from the official `calle-ai` SDK
+with the same task prompts, the same `result_schema`s, and idempotency
+keys so a retried request can never double-dial anyone. Live calls
+require typing `LIVE` at a consent gate (or `--yes`).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Y[trip.yaml<br/>plan + ladder + duress phrase] --> E[TripEngine<br/>schedule · retries · cascade]
+  E -->|task + result_schema| D{dispatcher}
+  D -->|live| C[CALL-E API<br/>calle-ai SDK]
+  D -->|demo| S[scripted call_tasks<br/>// DEMO]
+  C --> P[protocol.py<br/>classify + decide<br/>pure state machine]
+  S --> P
+  P -->|safe| E
+  P -->|overdue / duress| L[escalation ladder<br/>buddy → safety officer]
+  L --> R[incident brief<br/>timeline · transcripts · evidence]
+```
+
+- **CALL-E does the talking.** Each call is one `POST /v1/calls` with a
+  natural-language `task` and a JSON `result_schema`; the platform
+  plans, dials, converses, and returns `structured_result`,
+  `task_completed`, `completion_confidence`, and `evidence`.
+- **FieldLine does the policy.** `protocol.py` is a deterministic,
+  unit-tested state machine — no LLM in the loop, so safety decisions
+  are reproducible. Duress overrides a stated "safe"; an unreachable
+  API degrades to the no-answer path (fail-soft) instead of crashing
+  the safety loop.
+- **The silent-duress trick** is pure prompt + schema: the `task` tells
+  the agent to never react to the phrase, and
+  `duress_phrase_detected: boolean` rides back in the structured result.
+
+## Safety design
+
+- Consent gate before any live call; `fieldline end` cancels a trip
+  (cancellation is honored between calls).
+- Duress protocol never re-contacts the worker.
+- Emergency services are never auto-dialed; the brief tells the human
+  coordinator who to call.
+- Phone numbers are masked in all output and reports.
+
+## Repo map
+
+```
+src/fieldline/     engine, protocol (state machine), dispatchers, prompts, rendering
+examples/trip.yaml sample trip plan (fictional numbers)
+tests/             32 tests: protocol policy, dispatcher shape-conformance, full scenarios
+scripts/demo-reset one-command reset to a clean demo state
+```
+
+## AI tools used
+
+Built with AI coding assistance (Claude) during the hackathon window;
+design, review, and verification by the author. Demo transcripts are
+hand-written simulation data and marked as such.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/apps/python/fieldline/examples/trip.yaml
+++ b/apps/python/fieldline/examples/trip.yaml
@@ -1,0 +1,42 @@
+# FieldLine trip plan.
+# Phone numbers below are FICTIONAL (+1-555-01xx reserved range).
+# For a live test, replace them with your own numbers in E.164 format.
+
+worker:
+  name: "Huanyi"
+  role: "marine field researcher"
+  phone: "+15555550100"
+  locale: "en-US"
+
+trip:
+  label: "Reef Station 3 sampling dive"
+  site: "Reef Station 3, Thuwal coast (Red Sea)"
+  vehicle: "White pickup, KAUST plate 7-3421, parked at South Pier"
+  date: "2026-09-05"
+  start: "08:00"
+  end: "18:00"
+  checkins: ["14:00", "18:00"]
+  grace_minutes: 15        # missed check-in becomes OVERDUE after this
+  retry_after_minutes: 5   # gap between dial attempts to the worker
+  max_retries: 1           # extra dials before escalating
+
+# Said verbatim on a call, this quietly triggers escalation without the
+# agent reacting. Pick something natural; at least 3 words.
+duress_phrase: "the weather has been lovely all week"
+
+# Called in order when the worker is overdue. Duress skips straight to
+# the last (highest-authority) rung.
+escalation:
+  - name: "Marco"
+    relation: "dive buddy coordinator"
+    phone: "+15555550101"
+  - name: "Dr. Rivera"
+    relation: "PI / field safety officer"
+    phone: "+15555550102"
+
+# Surfaced in the incident brief. FieldLine NEVER auto-dials emergency
+# services — a human makes that call.
+emergency_note: >-
+  If the worker cannot be located, notify KAUST Security control room
+  (number in the safety plan). FieldLine never auto-dials emergency
+  services.

--- a/apps/python/fieldline/pyproject.toml
+++ b/apps/python/fieldline/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "fieldline"
+version = "0.1.0"
+description = "A lone-worker safety net that phones the field: scheduled check-in calls, silent duress detection, and an automatic escalation call cascade — built on CALL-E."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Huanyi Xie" }]
+dependencies = [
+    "rich>=13.7",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+# Live mode: real phone calls through the CALL-E platform.
+live = ["calle-ai>=0.7.0"]
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+fieldline = "fieldline.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/fieldline"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/apps/python/fieldline/scripts/demo-reset
+++ b/apps/python/fieldline/scripts/demo-reset
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Reset FieldLine to a clean demo starting state (one command, per
+# demo-hardening doctrine): clears state dir incl. old incident briefs.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+rm -rf .fieldline
+echo "FieldLine demo state cleared. Run: uv run fieldline demo"

--- a/apps/python/fieldline/src/fieldline/__init__.py
+++ b/apps/python/fieldline/src/fieldline/__init__.py
@@ -1,0 +1,9 @@
+"""FieldLine — a lone-worker safety net that phones the field.
+
+Built on the CALL-E platform (https://docs.heycall-e.com/): every call is
+a CALL-E call task with a natural-language instruction and a JSON
+`result_schema`, and every decision FieldLine makes is driven by the
+structured result CALL-E extracts from the live conversation.
+"""
+
+__version__ = "0.1.0"

--- a/apps/python/fieldline/src/fieldline/calle_client.py
+++ b/apps/python/fieldline/src/fieldline/calle_client.py
@@ -1,0 +1,211 @@
+"""Call dispatchers: one interface, two transports.
+
+`LiveCalleDispatcher` places real phone calls through the CALL-E Python
+SDK (`calle-ai`), mirroring `client.calls.create_and_wait(**kwargs)`
+exactly. `DemoCalleDispatcher` replays scripted calls shaped like real
+terminal `call_task` objects (per the CALL-E OpenAPI spec), so the whole
+product runs end-to-end with zero accounts or keys.
+
+Going live is a transport swap only: set CALLE_API_KEY in .env, install
+the `live` extra (`uv sync --extra live`), and the engine code above this
+layer does not change.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+Call = dict[str, Any]
+TurnCallback = Callable[[str, str], None]  # (speaker, text)
+
+
+class CallDispatcher(Protocol):
+    streams_transcript: bool
+
+    def create_and_wait(self, **kwargs: Any) -> Call: ...
+
+
+# ---------------------------------------------------------------------
+# Live transport — the real CALL-E SDK
+# ---------------------------------------------------------------------
+class LiveCalleDispatcher:
+    """Real calls via `calle-ai`, with timeout + one safe retry + fail-soft.
+
+    Retries reuse the caller's `idempotency_key`, so a retried create can
+    never double-dial a worker or a contact. If the platform stays
+    unreachable, a synthetic `failed` call_task is returned: the protocol
+    layer treats that as "could not reach" and keeps the safety cascade
+    moving instead of crashing the monitor loop.
+    """
+
+    streams_transcript = False  # transcript arrives with the terminal result
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.heycall-e.com",
+        call_timeout_seconds: float = 420.0,
+        client: Any | None = None,  # injectable for tests
+    ) -> None:
+        if client is not None:
+            self._client = client
+            self._errors: tuple[type[Exception], ...] = (Exception,)
+            return
+        try:
+            from calle import (  # lazy: only needed in live mode
+                CalleClient,
+                CalleConnectionError,
+                CalleRateLimitError,
+                CalleTimeoutError,
+            )
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "Live mode needs the CALL-E SDK. Install it with: uv sync --extra live"
+            ) from exc
+        self._client = CalleClient(api_key=api_key, base_url=base_url)
+        self._errors = (CalleConnectionError, CalleTimeoutError, CalleRateLimitError)
+        self._call_timeout = call_timeout_seconds
+
+    def create_and_wait(self, **kwargs: Any) -> Call:
+        kwargs.setdefault("timeout_seconds", getattr(self, "_call_timeout", 420.0))
+        last_error: Exception | None = None
+        for attempt in (1, 2):  # one retry, made safe by the idempotency key
+            try:
+                return self._client.calls.create_and_wait(**kwargs)
+            except self._errors as exc:
+                last_error = exc
+                if attempt == 1:
+                    time.sleep(2.0)
+        return _synthetic_failure(kwargs, last_error)
+
+
+def _synthetic_failure(kwargs: dict[str, Any], error: Exception | None) -> Call:
+    """Fail-soft terminal state when CALL-E is unreachable."""
+    return {
+        "object": "call_task",
+        "id": "call_unavailable",
+        "status": "failed",
+        "task": kwargs.get("task", ""),
+        "recipients": [],
+        "structured_result": None,
+        "summary": "CALL-E platform unreachable; call was not completed.",
+        "task_completed": False,
+        "completion_confidence": None,
+        "evidence": [],
+        "metadata": kwargs.get("metadata") or {},
+        "failure_code": "client_unreachable",
+        "failure_message": f"{type(error).__name__}: {error}" if error else "unknown error",
+    }
+
+
+# ---------------------------------------------------------------------
+# DEMO transport — scripted calls, zero network
+# ---------------------------------------------------------------------
+# DEMO: everything below simulates the CALL-E platform for the offline
+# demo. The dicts it returns follow the real `call_task` schema from
+# https://docs.heycall-e.com/openapi/calle.openapi.yaml so the rest of
+# FieldLine cannot tell the difference.
+@dataclass
+class DemoCallScript:
+    kind: str  # "checkin" | "escalation"
+    at: str  # display clock label, e.g. "14:00"
+    answered: bool
+    turns: list[tuple[str, str]] = field(default_factory=list)  # (speaker, text)
+    structured_result: dict | None = None
+    summary: str = ""
+    task_completed: bool | None = None
+    confidence: float | None = None
+    confidence_label: str = ""
+    evidence: list[str] = field(default_factory=list)
+
+
+class ScriptExhaustedError(RuntimeError):
+    pass
+
+
+class DemoCalleDispatcher:
+    """DEMO: replays scripted calls in order, streaming transcript turns."""
+
+    streams_transcript = True
+
+    def __init__(
+        self,
+        scripts: list[DemoCallScript],
+        on_turn: TurnCallback | None = None,
+        turn_delay: float = 1.15,
+        date: str = "2026-09-05",
+    ) -> None:
+        self._scripts = list(scripts)
+        self._cursor = 0
+        self._on_turn = on_turn
+        self._delay = turn_delay
+        self._date = date
+
+    def create_and_wait(self, **kwargs: Any) -> Call:
+        if self._cursor >= len(self._scripts):
+            raise ScriptExhaustedError("DEMO scenario has no script for this call.")
+        script = self._scripts[self._cursor]
+        self._cursor += 1
+
+        # DEMO: stream the conversation for the live-demo feel.
+        for speaker, text in script.turns:
+            if self._on_turn:
+                self._on_turn(speaker, text)
+            if self._delay:
+                time.sleep(self._delay)
+
+        return self._build_call(script, kwargs)
+
+    def _build_call(self, script: DemoCallScript, kwargs: dict[str, Any]) -> Call:
+        recipient_req = kwargs.get("recipient") or {}
+        phone = recipient_req.get("phone") or (recipient_req.get("phones") or ["+00000000000"])[0]
+        started = f"{self._date}T{script.at}:04+03:00"
+        attempt: dict[str, Any] = {
+            "id": f"attempt_demo_{self._cursor:02d}",
+            "phone": phone,
+            "status": "completed" if script.answered else "no_answer",
+            "started_at": started,
+            "completed_at": f"{self._date}T{script.at}:59+03:00",
+            "summary": script.summary or None,
+            "transcript_turns": [
+                {"offset_seconds": i * 7, "speaker": ("bot" if s == "bot" else "user"), "text": t}
+                for i, (s, t) in enumerate(script.turns)
+            ],
+            "provider_call_id": f"demo_provider_{self._cursor:02d}",
+            "failure_code": None if script.answered else "no_answer",
+            "failure_message": None if script.answered else "Recipient did not answer before ring-out.",
+        }
+        return {
+            "object": "call_task",
+            "id": f"call_demo_{self._cursor:02d}",
+            "status": "completed",
+            "task": kwargs.get("task", ""),
+            "recipients": [
+                {
+                    "id": f"rcpt_demo_{self._cursor:02d}",
+                    "phones": [phone],
+                    "locale": recipient_req.get("locale"),
+                    "region": recipient_req.get("region"),
+                    "status": "completed" if script.answered else "no_answer",
+                    "structured_result": script.structured_result,
+                    "summary": script.summary or None,
+                    "attempts": [attempt],
+                }
+            ],
+            "structured_result": script.structured_result,
+            "summary": script.summary or None,
+            "task_completed": script.task_completed,
+            "completion_confidence": (
+                {"score": script.confidence, "label": script.confidence_label or "high"}
+                if script.confidence is not None
+                else None
+            ),
+            "evidence": list(script.evidence),
+            "metadata": kwargs.get("metadata") or {},
+            "failure_code": None,
+            "failure_message": None,
+            "created_at": started,
+            "completed_at": f"{self._date}T{script.at}:59+03:00",
+        }

--- a/apps/python/fieldline/src/fieldline/cli.py
+++ b/apps/python/fieldline/src/fieldline/cli.py
@@ -1,0 +1,142 @@
+"""FieldLine CLI.
+
+    fieldline demo [--scenario full|safe|duress] [--fast]   zero-key demo
+    fieldline start examples/trip.yaml                      live monitoring
+    fieldline checkin-now examples/trip.yaml                one live test call
+    fieldline end                                           cancel the active trip
+    fieldline report                                        show the latest incident brief
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.markdown import Markdown
+
+from .calle_client import DemoCalleDispatcher, LiveCalleDispatcher
+from .config import Settings, get_settings
+from .demo_data import SCENARIOS, demo_trip_plan
+from .engine import DemoWaiter, LiveWaiter, TripEngine
+from .render import RichRenderer
+from .schemas import TripPlanError, load_trip_plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="fieldline", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_demo = sub.add_parser("demo", help="run the scripted offline demo (no account, no keys)")
+    p_demo.add_argument("--scenario", choices=sorted(SCENARIOS), default="full")
+    p_demo.add_argument("--fast", action="store_true", help="skip pacing delays")
+
+    p_start = sub.add_parser("start", help="LIVE: monitor a trip plan (places real calls)")
+    p_start.add_argument("plan", help="path to a trip plan YAML")
+    p_start.add_argument("--yes", action="store_true", help="skip the live-call confirmation")
+
+    p_now = sub.add_parser("checkin-now", help="LIVE: place one check-in call immediately")
+    p_now.add_argument("plan", help="path to a trip plan YAML")
+    p_now.add_argument("--yes", action="store_true", help="skip the live-call confirmation")
+
+    sub.add_parser("end", help="cancel the active trip (stops future calls)")
+    sub.add_parser("report", help="print the most recent incident brief")
+
+    args = parser.parse_args(argv)
+    settings = get_settings()
+
+    if args.command == "demo":
+        return cmd_demo(settings, args.scenario, fast=args.fast or settings.fast)
+    if args.command == "start":
+        return cmd_live(settings, args.plan, args.yes, single=False)
+    if args.command == "checkin-now":
+        return cmd_live(settings, args.plan, args.yes, single=True)
+    if args.command == "end":
+        return cmd_end(settings)
+    if args.command == "report":
+        return cmd_report(settings)
+    return 2
+
+
+def cmd_demo(settings: Settings, scenario: str, fast: bool) -> int:
+    renderer = RichRenderer()
+    dispatcher = DemoCalleDispatcher(
+        SCENARIOS[scenario],
+        on_turn=renderer.turn,
+        turn_delay=0.0 if fast else 1.15,
+    )
+    engine = TripEngine(
+        plan=demo_trip_plan(),
+        dispatcher=dispatcher,
+        renderer=renderer,
+        home=settings.home,
+        demo=True,
+        waiter=DemoWaiter(fast=fast),
+    )
+    engine.run()
+    return 0
+
+
+def cmd_live(settings: Settings, plan_path: str, yes: bool, single: bool) -> int:
+    console = Console()
+    if settings.demo or not settings.api_key:
+        console.print(
+            "[yellow3]Live mode needs a CALL-E API key.[/]\n"
+            "1. Create an account: https://www.heycall-e.com/ (20 free calls)\n"
+            "2. Create a key:      https://dashboard.heycall-e.com/account/api-keys\n"
+            "3. Put it in .env:    CALLE_API_KEY=... (and leave FIELDLINE_DEMO unset)\n"
+            "Meanwhile, try the offline demo:  uv run fieldline demo"
+        )
+        return 2
+    try:
+        plan = load_trip_plan(plan_path)
+    except TripPlanError as exc:
+        console.print(f"[red]Invalid trip plan:[/] {exc}")
+        return 2
+
+    # Consent gate: never place real calls without an explicit go-ahead.
+    if not yes:
+        console.print("[bold red]LIVE MODE[/] — real phone calls will be placed to the numbers in the plan.")
+        if input("Type LIVE to continue: ").strip() != "LIVE":
+            console.print("Aborted; no calls placed.")
+            return 1
+
+    cancel_file = settings.home / "cancel"
+    cancel_file.unlink(missing_ok=True)
+    engine = TripEngine(
+        plan=plan,
+        dispatcher=LiveCalleDispatcher(api_key=settings.api_key, base_url=settings.base_url),
+        renderer=RichRenderer(),
+        home=settings.home,
+        demo=False,
+        waiter=LiveWaiter(cancel_file),
+    )
+    if single:
+        engine.run_single_checkin()
+    else:
+        engine.run()
+    return 0
+
+
+def cmd_end(settings: Settings) -> int:
+    settings.home.mkdir(parents=True, exist_ok=True)
+    (settings.home / "cancel").touch()
+    Console().print("Cancel signal set — the active trip will stop before its next call.")
+    return 0
+
+
+def cmd_report(settings: Settings) -> int:
+    console = Console()
+    reports = sorted((settings.home / "reports").glob("incident-*.md"))
+    if not reports:
+        console.print("No incident briefs yet. Run: uv run fieldline demo")
+        return 1
+    latest = reports[-1]
+    console.print(f"[dim]{latest}[/]\n")
+    console.print(Markdown(latest.read_text(encoding="utf-8")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/fieldline/src/fieldline/config.py
+++ b/apps/python/fieldline/src/fieldline/config.py
@@ -1,0 +1,57 @@
+"""Environment/settings handling. Zero-key demo mode by default."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _load_dotenv(path: Path) -> None:
+    """Tiny .env loader (KEY=VALUE lines); never overrides real env vars."""
+    if not path.is_file():
+        return
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key, value = key.strip(), value.strip().strip("'\"")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _flag(name: str) -> bool | None:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return None
+    return raw.strip().lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class Settings:
+    demo: bool
+    fast: bool
+    api_key: str | None
+    base_url: str
+    home: Path  # state dir for trip state + incident reports
+
+
+def get_settings(cwd: Path | None = None) -> Settings:
+    root = Path(cwd) if cwd else Path.cwd()
+    _load_dotenv(root / ".env")
+
+    api_key = os.environ.get("CALLE_API_KEY", "").strip() or None
+    demo_flag = _flag("FIELDLINE_DEMO")
+    # Demo mode when explicitly requested, or when there is no API key.
+    demo = demo_flag if demo_flag is not None else api_key is None
+
+    return Settings(
+        demo=demo,
+        fast=_flag("FIELDLINE_FAST") or False,
+        api_key=api_key,
+        base_url=os.environ.get("CALLE_BASE_URL", "https://api.heycall-e.com"),
+        home=Path(os.environ.get("FIELDLINE_HOME", root / ".fieldline")),
+    )

--- a/apps/python/fieldline/src/fieldline/demo_data.py
+++ b/apps/python/fieldline/src/fieldline/demo_data.py
@@ -1,0 +1,263 @@
+"""DEMO: scripted scenarios for offline demo mode.
+
+Every transcript and structured result in this file is hand-written
+simulation data — no real people, and the +1-555-01xx numbers are the
+reserved fictional range. The dict shapes match real CALL-E terminal
+call_task objects (see calle_client.DemoCalleDispatcher), so swapping in
+live credentials changes the transport, not the code above it.
+"""
+
+from __future__ import annotations
+
+from .calle_client import DemoCallScript
+from .schemas import Contact, TripPlan, Worker
+
+DEMO_DATE = "2026-09-05"
+
+
+def demo_trip_plan() -> TripPlan:
+    """DEMO: mirrors examples/trip.yaml (kept in sync by a unit test)."""
+    return TripPlan(
+        label="Reef Station 3 sampling dive",
+        site="Reef Station 3, Thuwal coast (Red Sea)",
+        vehicle="White pickup, KAUST plate 7-3421, parked at South Pier",
+        date=DEMO_DATE,
+        start="08:00",
+        end="18:00",
+        checkins=["14:00", "18:00"],
+        grace_minutes=15,
+        retry_after_minutes=5,
+        max_retries=1,
+        worker=Worker(
+            name="Huanyi",
+            role="marine field researcher",
+            phone="+15555550100",
+            locale="en-US",
+        ),
+        duress_phrase="the weather has been lovely all week",
+        escalation=[
+            Contact(name="Marco", relation="dive buddy coordinator", phone="+15555550101"),
+            Contact(name="Dr. Rivera", relation="PI / field safety officer", phone="+15555550102"),
+        ],
+        emergency_note=(
+            "If the worker cannot be located, notify KAUST Security control room "
+            "(number in the safety plan). FieldLine never auto-dials emergency services."
+        ),
+    )
+
+
+# --------------------------- scripts ---------------------------------
+
+_CHECKIN_1400_SAFE = DemoCallScript(
+    kind="checkin",
+    at="14:00",
+    answered=True,
+    turns=[
+        ("bot", "Hi Huanyi, this is FieldLine — your 2 p.m. safety check-in for the Reef Station 3 dive. Is everything okay out there?"),
+        ("user", "Hey, yes — all good. We just finished the second transect and everyone's back on the boat."),
+        ("bot", "Great to hear. Are you still at Reef Station 3, and is anything changing versus your filed plan?"),
+        ("user", "Still at station 3. We might head back around 5:30 instead of 6, but otherwise same plan."),
+        ("bot", "Noted — possible earlier departure at 5:30. Your next check-in is at 6 p.m. Stay safe and enjoy the rest of the dive."),
+        ("user", "Thanks, will do."),
+    ],
+    structured_result={
+        "checkin_status": "safe",
+        "duress_phrase_detected": False,
+        "current_location": "Reef Station 3, on the boat",
+        "plan_change": "May depart site ~17:30 instead of 18:00",
+        "notes": "Second transect complete; all divers back aboard.",
+    },
+    summary="Huanyi confirmed safe at Reef Station 3; may depart ~30 minutes early; next check-in 18:00.",
+    task_completed=True,
+    confidence=0.96,
+    confidence_label="high",
+    evidence=[
+        "Worker explicitly confirmed being safe and on the boat",
+        "Worker stated location and a minor plan change unprompted",
+    ],
+)
+
+_CHECKIN_1800_NO_ANSWER = DemoCallScript(
+    kind="checkin",
+    at="18:00",
+    answered=False,
+    turns=[],
+    structured_result=None,
+    summary="No answer before ring-out.",
+    task_completed=False,
+)
+
+_CHECKIN_1805_NO_ANSWER = DemoCallScript(
+    kind="checkin",
+    at="18:05",
+    answered=False,
+    turns=[],
+    structured_result=None,
+    summary="No answer on retry before ring-out.",
+    task_completed=False,
+)
+
+_ESCALATION_MARCO = DemoCallScript(
+    kind="escalation",
+    at="18:16",
+    answered=True,
+    turns=[
+        ("bot", "Hello, is this Marco? This is FieldLine, the automated safety service covering Huanyi's field trip today."),
+        ("user", "Yes, this is Marco. What's going on?"),
+        ("bot", "Huanyi missed the 6 p.m. safety check-in at Reef Station 3, and two follow-up calls went unanswered. When did you last hear from them?"),
+        ("user", "Uh — around 1:30, they radioed that transect two was done. Nothing since. Their truck was still at the South Pier when I passed an hour ago."),
+        ("bot", "Thank you. To confirm: last contact around 13:30 by radio, and the vehicle was still at the South Pier at roughly 5:15 p.m. Are you able to physically check the pier or the boat channel now?"),
+        ("user", "Yes, I'm five minutes away. I'll drive over and try them on VHF channel 72."),
+        ("bot", "Please do. FieldLine is now notifying Dr. Rivera, the field safety officer. If you reach Huanyi, ask them to call the check-in line back immediately."),
+        ("user", "Understood, heading there now."),
+    ],
+    structured_result={
+        "contact_reached": True,
+        "heard_from_worker_since_checkin": False,
+        "last_contact_time": "~13:30, by radio",
+        "will_check_in_person": True,
+        "assuming_coordination": False,
+        "notes": "Vehicle still at South Pier ~17:15. Marco driving to the pier; will hail on VHF 72.",
+    },
+    summary="Marco reached: no contact since ~13:30; truck still at South Pier; he is checking in person now.",
+    task_completed=True,
+    confidence=0.93,
+    confidence_label="high",
+    evidence=[
+        "Contact confirmed identity and last radio contact at ~13:30",
+        "Contact committed to physically checking the pier",
+    ],
+)
+
+_ESCALATION_RIVERA = DemoCallScript(
+    kind="escalation",
+    at="18:23",
+    answered=True,
+    turns=[
+        ("bot", "Dr. Rivera, this is FieldLine, the automated field-safety service. This is a safety escalation for Huanyi, marine field researcher on today's Reef Station 3 sampling dive."),
+        ("user", "Go ahead."),
+        ("bot", "Huanyi missed the 18:00 check-in and two retry calls went unanswered. Last confirmed contact was 13:30 by radio. Marco, the dive buddy coordinator, reports the vehicle still at the South Pier and is checking the pier now. Planned departure was between 17:30 and 18:00."),
+        ("user", "Understood. I'm taking over. I'll call the marina office, and KAUST Security if Marco finds nothing in the next fifteen minutes."),
+        ("bot", "Confirmed — you are assuming coordination as of 18:24. The full timeline and transcripts are in the FieldLine incident brief. Per the safety plan, KAUST Security is the emergency contact; FieldLine does not dial emergency services itself."),
+        ("user", "Got it. Keep the line clear."),
+    ],
+    structured_result={
+        "contact_reached": True,
+        "heard_from_worker_since_checkin": False,
+        "last_contact_time": "not since morning briefing",
+        "will_check_in_person": False,
+        "assuming_coordination": True,
+        "notes": "Calling marina office; will involve KAUST Security if no news within 15 minutes.",
+    },
+    summary="Dr. Rivera acknowledged the incident and assumed coordination at 18:24.",
+    task_completed=True,
+    confidence=0.97,
+    confidence_label="high",
+    evidence=[
+        "Contact explicitly said 'I'm taking over'",
+        "Contact named concrete next actions and a 15-minute decision point",
+    ],
+)
+
+_CHECKIN_1800_DURESS = DemoCallScript(
+    kind="checkin",
+    at="18:00",
+    answered=True,
+    turns=[
+        ("bot", "Hi Huanyi, this is FieldLine — your 6 p.m. safety check-in. How's everything at Reef Station 3?"),
+        ("user", "Oh — hi. Yes. We're fine. Um... the weather has been lovely all week."),
+        ("bot", "Good to hear. Are you back at the pier, or still out at the site?"),
+        ("user", "Still at the site. We'll pack up soon."),
+        ("bot", "Understood. Your next check-in is at 8 p.m. Talk to you then — take care."),
+        ("user", "...yes. Bye."),
+    ],
+    structured_result={
+        "checkin_status": "safe",
+        "duress_phrase_detected": True,
+        "current_location": "states still at the site",
+        "plan_change": "",
+        "notes": "Worker used the configured duress phrase verbatim; speech hesitant. Call ended normally per protocol.",
+    },
+    summary="Worker verbally reported safe but used the exact duress phrase; silent-duress protocol applies.",
+    task_completed=True,
+    confidence=0.91,
+    confidence_label="high",
+    evidence=[
+        "Duress phrase matched the configured phrase verbatim",
+        "Hesitations and flat affect inconsistent with the 14:00 call",
+    ],
+)
+
+_ESCALATION_RIVERA_DURESS = DemoCallScript(
+    kind="escalation",
+    at="18:03",
+    answered=True,
+    turns=[
+        ("bot", "Dr. Rivera, this is FieldLine with an urgent, confidential safety escalation for Huanyi."),
+        ("user", "What happened?"),
+        ("bot", "On the 18:00 check-in call, Huanyi used the pre-agreed duress phrase. Per protocol, the call was ended normally and no reaction was shown. Their stated location was Reef Station 3. Please do not call or message their phone directly."),
+        ("user", "Understood. I'm calling KAUST Security right now."),
+        ("bot", "Confirmed — you are taking over coordination. The incident brief with the transcript is ready for security. FieldLine will not contact the worker again."),
+        ("user", "Good. Ending the call."),
+    ],
+    structured_result={
+        "contact_reached": True,
+        "heard_from_worker_since_checkin": False,
+        "last_contact_time": "18:00 check-in call (duress)",
+        "will_check_in_person": False,
+        "assuming_coordination": True,
+        "notes": "Contacting KAUST Security immediately; will not contact the worker's phone.",
+    },
+    summary="Dr. Rivera acknowledged the duress escalation and is engaging security directly.",
+    task_completed=True,
+    confidence=0.97,
+    confidence_label="high",
+    evidence=[
+        "Contact explicitly acknowledged the duress protocol",
+        "Contact committed to engaging security without contacting the worker",
+    ],
+)
+
+
+SCENARIOS: dict[str, list[DemoCallScript]] = {
+    # Golden path: one green check-in, then the missed-check-in cascade.
+    "full": [
+        _CHECKIN_1400_SAFE,
+        _CHECKIN_1800_NO_ANSWER,
+        _CHECKIN_1805_NO_ANSWER,
+        _ESCALATION_MARCO,
+        _ESCALATION_RIVERA,
+    ],
+    # A quiet day: both check-ins green, trip closes normally.
+    "safe": [
+        _CHECKIN_1400_SAFE,
+        DemoCallScript(
+            kind="checkin",
+            at="18:00",
+            answered=True,
+            turns=[
+                ("bot", "Hi Huanyi, FieldLine again — 6 p.m. check-in. All good?"),
+                ("user", "All good — we're loading the boat at the pier. Heading home."),
+                ("bot", "Perfect. That was your last check-in; FieldLine is closing your trip. Safe drive back."),
+            ],
+            structured_result={
+                "checkin_status": "safe",
+                "duress_phrase_detected": False,
+                "current_location": "South Pier, loading the boat",
+                "plan_change": "",
+                "notes": "Trip wrapping up on schedule.",
+            },
+            summary="Huanyi safe at the pier; trip complete.",
+            task_completed=True,
+            confidence=0.97,
+            confidence_label="high",
+            evidence=["Worker confirmed safe and off the water"],
+        ),
+    ],
+    # The wow beat: answered check-in hiding a duress phrase.
+    "duress": [
+        _CHECKIN_1400_SAFE,
+        _CHECKIN_1800_DURESS,
+        _ESCALATION_RIVERA_DURESS,
+    ],
+}

--- a/apps/python/fieldline/src/fieldline/engine.py
+++ b/apps/python/fieldline/src/fieldline/engine.py
@@ -1,0 +1,321 @@
+"""Trip engine: runs the check-in schedule and the escalation cascade.
+
+The same engine drives DEMO and LIVE modes — only the dispatcher (real
+CALL-E SDK vs scripted transport) and the waiter (wall clock vs
+demo time-warp) differ.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from .calle_client import CallDispatcher
+from .prompts import checkin_task, escalation_task
+from .protocol import (
+    CheckinOutcome,
+    EscalationOutcome,
+    NextStep,
+    classify_checkin,
+    classify_escalation,
+    decide,
+)
+from .render import RichRenderer
+from .report import CallRecord, build_incident_brief, write_incident_brief
+from .schemas import CHECKIN_RESULT_SCHEMA, ESCALATION_RESULT_SCHEMA, TripPlan, add_minutes
+
+Call = dict[str, Any]
+
+
+class Waiter(Protocol):
+    def wait_until(self, hhmm: str, reason: str) -> bool:
+        """Block until the given local time. False = canceled by the user."""
+        ...
+
+
+class DemoWaiter:
+    """DEMO: time-warps to the next scheduled moment instead of waiting."""
+
+    def __init__(self, fast: bool = False) -> None:
+        self.fast = fast
+
+    def wait_until(self, hhmm: str, reason: str) -> bool:
+        if not self.fast:
+            time.sleep(0.9)  # DEMO: a beat, for pacing on screen
+        return True
+
+
+class LiveWaiter:
+    """Waits on the real wall clock; a cancel file stops the trip cleanly."""
+
+    def __init__(self, cancel_file: Path, poll_seconds: float = 5.0) -> None:
+        self.cancel_file = cancel_file
+        self.poll = poll_seconds
+
+    def wait_until(self, hhmm: str, reason: str) -> bool:
+        hour, minute = (int(x) for x in hhmm.split(":"))
+        while True:
+            if self.cancel_file.exists():
+                return False
+            now = datetime.now()
+            if (now.hour, now.minute) >= (hour, minute):
+                return True
+            time.sleep(self.poll)
+
+
+@dataclass
+class TripResult:
+    status: str  # closed_safe | handed_off | notified | unreachable_ladder | canceled
+    report_path: Path | None
+    timeline: list[tuple[str, str, str]]
+    records: list[CallRecord] = field(default_factory=list)
+
+
+class TripEngine:
+    def __init__(
+        self,
+        plan: TripPlan,
+        dispatcher: CallDispatcher,
+        renderer: RichRenderer,
+        home: Path,
+        demo: bool = True,
+        waiter: Waiter | None = None,
+    ) -> None:
+        self.plan = plan
+        self.dispatcher = dispatcher
+        self.renderer = renderer
+        self.home = home
+        self.demo = demo
+        self.waiter = waiter or DemoWaiter()
+        self.timeline: list[tuple[str, str, str]] = []
+        self.records: list[CallRecord] = []
+        self._last_confirmed = f"{plan.start} — trip start briefing"
+        self._coordinator: str | None = None
+
+    # -- public --------------------------------------------------------
+    def run(self) -> TripResult:
+        plan, r = self.plan, self.renderer
+        r.banner(plan, self.demo)
+        self._log(plan.start, f"Trip opened: {plan.label}", "info")
+
+        for at in plan.checkins:
+            if not self.waiter.wait_until(at, "next scheduled check-in"):
+                return self._canceled()
+            r.section(at, f"scheduled check-in — {plan.worker.name}")
+            outcome, step, last_dial_at = self._checkin_cycle(at)
+
+            if step.kind == "schedule_next":
+                continue
+
+            # step.kind == "escalate"
+            duress = step.silent
+            if duress:
+                r.duress_alert()
+            elif outcome is CheckinOutcome.NEEDS_HELP:
+                r.section(at, f"ASSISTANCE REQUESTED — engaging escalation ladder for {plan.worker.name}", "crit")
+                self._log(at, "Worker requested assistance; escalation ladder engaged", "crit")
+            else:
+                overdue_at = add_minutes(at, plan.grace_minutes)
+                r.section(overdue_at, f"OVERDUE — {plan.worker.name} unreachable, engaging escalation ladder", "crit")
+                self._log(overdue_at, "Worker declared OVERDUE; escalation ladder engaged", "crit")
+
+            esc_outcome = self._run_ladder(missed_at=at, last_dial_at=last_dial_at, duress=duress, outcome=outcome)
+            if esc_outcome is EscalationOutcome.STAND_DOWN:
+                r.notice("Stand-down confirmed — resuming the check-in schedule.", "ok")
+                continue
+            return self._finish_incident(esc_outcome, duress)
+
+        r.closing("Trip closed — all check-ins green. FieldLine standing down.", True)
+        self._log(plan.end, "Trip closed; all check-ins green", "ok")
+        return TripResult("closed_safe", None, self.timeline, self.records)
+
+    def run_single_checkin(self) -> CheckinOutcome:
+        """One immediate check-in call, no cascade — live-mode verification."""
+        plan, r = self.plan, self.renderer
+        r.banner(plan, self.demo)
+        now = datetime.now().strftime("%H:%M")
+        r.section(now, f"on-demand check-in — {plan.worker.name}")
+        call = self._place_checkin(now, dials=1)
+        outcome = classify_checkin(call)
+        self._render_checkin(outcome, call, now)
+        step = decide(outcome, dials_made=1, max_retries=0)
+        r.notice(f"In a monitored trip, FieldLine would now: {step.kind} ({step.reason}).", "info")
+        return outcome
+
+    # -- check-ins -----------------------------------------------------
+    def _checkin_cycle(self, at: str) -> tuple[CheckinOutcome, NextStep, str]:
+        plan, r = self.plan, self.renderer
+        dial_at, dials = at, 0
+        while True:
+            dials += 1
+            call = self._place_checkin(at, dials, dial_at=dial_at)
+            outcome = classify_checkin(call)
+            step = decide(outcome, dials_made=dials, max_retries=plan.max_retries)
+            self._render_checkin(outcome, call, dial_at)
+            if step.kind != "retry":
+                return outcome, step, dial_at
+            next_dial = add_minutes(dial_at, plan.retry_after_minutes)
+            r.notice(f"Retrying at {next_dial} (retry interval {plan.retry_after_minutes} min)…", "warn")
+            if not self.waiter.wait_until(next_dial, "retry"):
+                return outcome, NextStep("schedule_next", reason="canceled"), dial_at
+            dial_at = next_dial
+
+    def _place_checkin(self, at: str, dials: int, dial_at: str | None = None) -> Call:
+        plan = self.plan
+        self.renderer.dialing(
+            plan.worker.name, plan.worker.phone, note="" if dials == 1 else f"retry {dials - 1}"
+        )
+        call = self.dispatcher.create_and_wait(
+            task=checkin_task(plan, at),
+            recipient={"phone": plan.worker.phone, "locale": plan.worker.locale},
+            result_schema=CHECKIN_RESULT_SCHEMA,
+            metadata={"app": "fieldline", "kind": "checkin", "scheduled_at": at, "dial": dials},
+            idempotency_key=f"fieldline-checkin-{plan.date}-{at}-{dials}",
+        )
+        self._replay_transcript_if_needed(call, plan.worker.name)
+        self.records.append(
+            CallRecord(dial_at or at, "check-in call", plan.worker.name, plan.worker.phone, call)
+        )
+        return call
+
+    def _render_checkin(self, outcome: CheckinOutcome, call: Call, at: str) -> None:
+        r = self.renderer
+        if outcome is CheckinOutcome.SAFE:
+            r.call_result("SAFE — check-in confirmed", call, True)
+            summary = call.get("summary") or "worker confirmed safe"
+            self._last_confirmed = f"{at} check-in call — {summary}"
+            self._log(at, f"Check-in OK: {summary}", "ok")
+        elif outcome is CheckinOutcome.DURESS:
+            r.call_result("Check-in completed — worker states safe", call, True)
+            self._log(at, "Duress phrase detected on check-in call; silent protocol engaged", "crit")
+        elif outcome is CheckinOutcome.NEEDS_HELP:
+            r.call_result("WORKER REQUESTS ASSISTANCE", call, False)
+            self._log(at, "Worker requested assistance on check-in call", "crit")
+        else:  # NO_ANSWER / UNCLEAR
+            detail = call.get("summary") or call.get("failure_message") or outcome.value
+            r.notice(f"✗ {detail}", "warn")
+            self._log(at, f"Check-in call: {detail}", "warn")
+
+    # -- escalation ----------------------------------------------------
+    def _run_ladder(
+        self, missed_at: str, last_dial_at: str, duress: bool, outcome: CheckinOutcome
+    ) -> EscalationOutcome:
+        plan, r = self.plan, self.renderer
+        facts = self._initial_facts(missed_at, last_dial_at, duress, outcome)
+        ladder = [plan.escalation[-1]] if duress else plan.escalation
+        base_at = add_minutes(missed_at, 3 if duress else plan.grace_minutes + 1)
+        informed = False
+
+        for rung, contact in enumerate(ladder):
+            at_label = add_minutes(base_at, rung * 7)
+            r.section(
+                at_label,
+                f"escalation call {rung + 1}/{len(ladder)} — {contact.name} ({contact.relation})",
+                "crit" if duress else "warn",
+            )
+            r.dialing(contact.name, contact.phone)
+            call = self.dispatcher.create_and_wait(
+                task=escalation_task(plan, contact, facts, duress=duress),
+                recipient={"phone": contact.phone},
+                result_schema=ESCALATION_RESULT_SCHEMA,
+                metadata={"app": "fieldline", "kind": "escalation", "rung": rung, "duress": duress},
+                idempotency_key=f"fieldline-esc-{plan.date}-{missed_at}-{rung}",
+            )
+            self._replay_transcript_if_needed(call, contact.name)
+            self.records.append(CallRecord(at_label, "escalation call", contact.name, contact.phone, call))
+            outcome = classify_escalation(call)
+
+            if outcome is EscalationOutcome.NOT_REACHED:
+                r.notice(f"✗ could not reach {contact.name} — climbing the ladder.", "warn")
+                self._log(at_label, f"Escalation call to {contact.name}: not reached", "warn")
+                continue
+            informed = True
+            if outcome is EscalationOutcome.STAND_DOWN:
+                r.call_result(f"STAND-DOWN — {contact.name} has heard from {plan.worker.name}", call, True)
+                self._log(at_label, f"{contact.name} reports contact with worker; stand-down", "ok")
+                return outcome
+            if outcome is EscalationOutcome.HANDED_OFF:
+                r.call_result(f"HANDED OFF — {contact.name} assumed coordination", call, True)
+                self._log(at_label, f"{contact.name} acknowledged and assumed coordination", "ok")
+                self._coordinator = contact.name
+                return outcome
+            # WILL_CHECK: informed, but nobody owns the incident yet
+            r.call_result(f"{contact.name} informed — checking in person", call, True)
+            self._log(at_label, f"{contact.name} informed; checking site/route", "warn")
+            notes = (call.get("structured_result") or {}).get("notes", "")
+            facts.append(f"{contact.name} ({contact.relation}) reported: {notes or 'informed, checking now'}")
+
+        if not informed:
+            r.notice(f"LADDER EXHAUSTED. {plan.emergency_note}", "crit")
+            self._log(add_minutes(base_at, len(ladder) * 7), "Escalation ladder exhausted — nobody reached", "crit")
+            return EscalationOutcome.NOT_REACHED
+        return EscalationOutcome.WILL_CHECK
+
+    def _initial_facts(
+        self, missed_at: str, last_dial_at: str, duress: bool, outcome: CheckinOutcome
+    ) -> list[str]:
+        plan = self.plan
+        facts: list[str] = []
+        last_sr = self.records[-1].call.get("structured_result") if self.records else None
+        if duress:
+            facts.append(f"The duress phrase was used on the {missed_at} check-in call.")
+            if isinstance(last_sr, dict) and last_sr.get("current_location"):
+                facts.append(f"Worker's stated location: {last_sr['current_location']}.")
+        elif outcome is CheckinOutcome.NEEDS_HELP:
+            facts.append(f"Worker answered the {missed_at} check-in and requested assistance.")
+            if isinstance(last_sr, dict):
+                for key in ("current_location", "notes"):
+                    if last_sr.get(key):
+                        facts.append(f"Worker's {key.replace('_', ' ')}: {last_sr[key]}.")
+        else:
+            facts.append(f"Missed the scheduled {missed_at} safety check-in at {plan.site}.")
+            facts.append(f"Retry calls unanswered (last attempt {last_dial_at}).")
+        facts.append(f"Last confirmed contact: {self._last_confirmed}.")
+        if plan.vehicle:
+            facts.append(f"Vehicle on file: {plan.vehicle}.")
+        facts.append(f"Planned site departure: {plan.end}.")
+        return facts
+
+    # -- wrap-up -------------------------------------------------------
+    def _finish_incident(self, esc: EscalationOutcome, duress: bool) -> TripResult:
+        plan, r = self.plan, self.renderer
+        if esc is EscalationOutcome.HANDED_OFF:
+            what = "silent duress escalation" if duress else "missed check-in escalation"
+            status_line = f"{self._coordinator} has assumed coordination ({what})."
+            status, good = "handed_off", True
+        elif esc is EscalationOutcome.WILL_CHECK:
+            status_line = "Contacts informed and checking — no one has assumed coordination yet."
+            status, good = "notified", False
+        else:
+            status_line = f"ESCALATION LADDER EXHAUSTED — manual action required. {plan.emergency_note}"
+            status, good = "unreachable_ladder", False
+
+        brief = build_incident_brief(plan, self.timeline, self.records, status_line, self.demo)
+        path = write_incident_brief(brief, self.home)
+        r.section("", "incident summary", "warn")
+        r.timeline(self.timeline)
+        r.report_written(str(path))
+        r.closing(status_line, good)
+        return TripResult(status, path, self.timeline, self.records)
+
+    def _canceled(self) -> TripResult:
+        self.renderer.closing("Trip canceled — FieldLine monitoring stopped. No further calls will be placed.", True)
+        self._log(datetime.now().strftime("%H:%M"), "Trip canceled by user", "info")
+        return TripResult("canceled", None, self.timeline, self.records)
+
+    # -- helpers -------------------------------------------------------
+    def _replay_transcript_if_needed(self, call: Call, party: str) -> None:
+        """Live mode: transcript arrives with the result, render it then."""
+        if self.dispatcher.streams_transcript:
+            return
+        self.renderer._party = party
+        for recipient in call.get("recipients") or []:
+            for attempt in recipient.get("attempts") or []:
+                for turn in attempt.get("transcript_turns") or []:
+                    self.renderer.turn(turn.get("speaker", "unknown"), turn.get("text", ""))
+
+    def _log(self, at: str, label: str, level: str) -> None:
+        self.timeline.append((at, label, level))

--- a/apps/python/fieldline/src/fieldline/prompts.py
+++ b/apps/python/fieldline/src/fieldline/prompts.py
@@ -1,0 +1,60 @@
+"""Builders for the natural-language `task` sent to CALL-E per call.
+
+CALL-E plans and holds the conversation from this instruction and fills
+the matching `result_schema`; FieldLine never scripts the exact wording
+of live calls, only the goal, tone, and the silent-duress protocol.
+"""
+
+from __future__ import annotations
+
+from .schemas import Contact, TripPlan
+
+
+def checkin_task(plan: TripPlan, at: str) -> str:
+    w = plan.worker
+    return (
+        f"You are FieldLine, an automated field-safety check-in service. "
+        f"Call {w.name}, a {w.role}, who is on the field trip "
+        f"'{plan.label}' at {plan.site}. This is the scheduled {at} "
+        f"safety check-in. Confirm they are safe, ask for their current "
+        f"location, and ask whether anything changed versus the filed "
+        f"plan (planned site departure {plan.end}). Keep the call warm, "
+        f"calm, and under 90 seconds. "
+        f"SILENT-DURESS PROTOCOL (critical): if the worker says the "
+        f"exact phrase \"{plan.duress_phrase}\" at any point, they may "
+        f"be speaking under duress. Do NOT react to it, do NOT repeat "
+        f"it, do NOT change your tone; end the call normally, and set "
+        f"duress_phrase_detected to true in the structured result. "
+        f"Never mention that a duress phrase exists."
+    )
+
+
+def escalation_task(plan: TripPlan, contact: Contact, facts: list[str], *, duress: bool) -> str:
+    w = plan.worker
+    fact_lines = " ".join(f"- {f}" for f in facts)
+    if duress:
+        return (
+            f"You are FieldLine, an automated field-safety service. Call "
+            f"{contact.name} ({contact.relation} for {w.name}). This is "
+            f"an URGENT and CONFIDENTIAL duress escalation: on the last "
+            f"check-in call, {w.name} used the pre-agreed duress phrase. "
+            f"Per protocol that call was ended normally with no visible "
+            f"reaction. Known facts: {fact_lines} "
+            f"Instruct the contact NOT to call or message the worker's "
+            f"phone directly. Ask them to engage the appropriate security "
+            f"or emergency channel themselves — FieldLine never dials "
+            f"emergency services. Confirm they understand and whether "
+            f"they are taking over coordination. Be calm, precise, brief."
+        )
+    return (
+        f"You are FieldLine, an automated field-safety service. Call "
+        f"{contact.name} ({contact.relation} for {w.name}, a {w.role}). "
+        f"This is a safety escalation for the trip '{plan.label}' at "
+        f"{plan.site}. Known facts: {fact_lines} "
+        f"Do not cause panic; be factual and calm. Ask: when they last "
+        f"heard from {w.name}; whether there is a benign explanation; "
+        f"whether they can physically check the site or route now; and "
+        f"whether they will take over coordination. If they reach "
+        f"{w.name}, {w.name} should call back the check-in line "
+        f"immediately."
+    )

--- a/apps/python/fieldline/src/fieldline/protocol.py
+++ b/apps/python/fieldline/src/fieldline/protocol.py
@@ -1,0 +1,98 @@
+"""FieldLine's safety protocol: pure decision logic over CALL-E results.
+
+Deliberately deterministic (no LLM here): given a terminal `call_task`
+dict from CALL-E, classify what happened and decide the next step. All
+conversational intelligence lives on the CALL-E side; all safety policy
+lives here, where it is unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Literal
+
+Call = dict[str, Any]
+
+
+class CheckinOutcome(StrEnum):
+    SAFE = "safe"
+    NEEDS_HELP = "needs_help"
+    DURESS = "duress"
+    NO_ANSWER = "no_answer"
+    UNCLEAR = "unclear"
+
+
+class EscalationOutcome(StrEnum):
+    STAND_DOWN = "stand_down"  # contact heard from worker after the missed check-in
+    HANDED_OFF = "handed_off"  # contact explicitly assumed coordination
+    WILL_CHECK = "will_check"  # reached + informed, but nobody owns it yet
+    NOT_REACHED = "not_reached"
+
+
+@dataclass(frozen=True)
+class NextStep:
+    kind: Literal["schedule_next", "retry", "escalate"]
+    silent: bool = False  # duress: escalate without recontacting the worker
+    reason: str = ""
+
+
+def _has_transcript(call: Call) -> bool:
+    for recipient in call.get("recipients") or []:
+        for attempt in recipient.get("attempts") or []:
+            if attempt.get("transcript_turns"):
+                return True
+    return False
+
+
+def classify_checkin(call: Call) -> CheckinOutcome:
+    """Map a terminal CALL-E call_task dict onto a check-in outcome."""
+    if call.get("status") in ("failed", "canceled"):
+        # Includes FieldLine's fail-soft synthetic result when the API is
+        # unreachable: an unplaceable call is treated as an unanswered one
+        # so the safety cascade keeps moving instead of crashing.
+        return CheckinOutcome.NO_ANSWER
+
+    result = call.get("structured_result")
+    if not isinstance(result, dict):
+        # Completed but nothing extracted: if we spoke to someone, it is
+        # ambiguous (UNCLEAR -> retry); if nobody answered, NO_ANSWER.
+        return CheckinOutcome.UNCLEAR if _has_transcript(call) else CheckinOutcome.NO_ANSWER
+
+    if result.get("duress_phrase_detected"):
+        return CheckinOutcome.DURESS  # overrides any stated "safe"
+
+    status = result.get("checkin_status")
+    if status == "safe":
+        return CheckinOutcome.SAFE
+    if status in ("needs_assistance", "emergency"):
+        return CheckinOutcome.NEEDS_HELP
+    return CheckinOutcome.UNCLEAR
+
+
+def decide(outcome: CheckinOutcome, *, dials_made: int, max_retries: int) -> NextStep:
+    """Safety policy for what happens after a check-in call."""
+    if outcome is CheckinOutcome.DURESS:
+        return NextStep("escalate", silent=True, reason="duress phrase detected on call")
+    if outcome is CheckinOutcome.NEEDS_HELP:
+        return NextStep("escalate", reason="worker requested assistance")
+    if outcome is CheckinOutcome.SAFE:
+        return NextStep("schedule_next", reason="worker confirmed safe")
+    # NO_ANSWER / UNCLEAR
+    if dials_made <= max_retries:
+        return NextStep("retry", reason=f"{outcome.value} (dial {dials_made} of {max_retries + 1})")
+    return NextStep("escalate", reason=f"{outcome.value} after {dials_made} dials")
+
+
+def classify_escalation(call: Call) -> EscalationOutcome:
+    """Map a terminal escalation-call dict onto a ladder outcome."""
+    if call.get("status") in ("failed", "canceled"):
+        return EscalationOutcome.NOT_REACHED
+    result = call.get("structured_result")
+    if not isinstance(result, dict) or not result.get("contact_reached"):
+        return EscalationOutcome.NOT_REACHED
+    if result.get("heard_from_worker_since_checkin"):
+        return EscalationOutcome.STAND_DOWN
+    if result.get("assuming_coordination"):
+        return EscalationOutcome.HANDED_OFF
+    return EscalationOutcome.WILL_CHECK

--- a/apps/python/fieldline/src/fieldline/render.py
+++ b/apps/python/fieldline/src/fieldline/render.py
@@ -1,0 +1,118 @@
+"""Terminal rendering (Rich). The product experience of the CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+
+from .schemas import TripPlan, mask_phone
+
+Call = dict[str, Any]
+
+_LEVEL_STYLE = {"info": "dim", "ok": "green", "warn": "yellow3", "crit": "bold red"}
+
+
+class RichRenderer:
+    def __init__(self, console: Console | None = None) -> None:
+        self.console = console or Console(highlight=False)
+        self._party = "Recipient"
+
+    # -- structure -----------------------------------------------------
+    def banner(self, plan: TripPlan, demo: bool) -> None:
+        c = self.console
+        mode = (
+            "[black on yellow3] DEMO MODE [/] [yellow3]simulated calls — set CALLE_API_KEY to go live[/]"
+            if demo
+            else "[black on red] LIVE [/] [red]real phone calls will be placed[/]"
+        )
+        body = (
+            f"[bold cyan]FieldLine[/] — a safety net that phones the field\n"
+            f"{mode}\n\n"
+            f"[bold]{plan.label}[/]\n"
+            f"Site      {plan.site}\n"
+            f"Worker    {plan.worker.name} ({plan.worker.role}) · {mask_phone(plan.worker.phone)}\n"
+            f"Window    {plan.date} {plan.start}–{plan.end} · check-ins at {', '.join(plan.checkins)}\n"
+            f"Ladder    " + "  →  ".join(f"{x.name} ({x.relation})" for x in plan.escalation) + "\n"
+            f"Duress    phrase armed · silent protocol"
+        )
+        c.print(Panel(body, box=box.ROUNDED, border_style="cyan", padding=(1, 2)))
+
+    def section(self, at: str, title: str, level: str = "info") -> None:
+        style = {"info": "cyan", "warn": "yellow3", "crit": "red"}.get(level, "cyan")
+        label = f"[bold]{at}[/]  {title}" if at else title
+        self.console.print()
+        self.console.print(Rule(label, style=style))
+
+    # -- calls ---------------------------------------------------------
+    def dialing(self, name: str, phone: str, note: str = "") -> None:
+        self._party = name
+        extra = f"  [dim]{note}[/]" if note else ""
+        self.console.print(f"[cyan]📞 CALL-E dialing[/] [bold]{name}[/] [dim]{mask_phone(phone)}[/]{extra}")
+
+    def turn(self, speaker: str, text: str) -> None:
+        if speaker == "bot":
+            self.console.print(f"   [cyan]agent[/] [cyan]▏[/]{text}")
+        else:
+            self.console.print(f"   [bold]{self._party.lower()}[/] [white]▏[/][bold]{text}[/]")
+
+    def call_result(self, label: str, call: Call, good: bool) -> None:
+        style = "green" if good else "red"
+        lines: list[str] = [f"[bold {style}]{label}[/]"]
+        if call.get("summary"):
+            lines.append(str(call["summary"]))
+        sr = call.get("structured_result")
+        if isinstance(sr, dict):
+            compact = {k: v for k, v in sr.items() if v not in (None, "")}
+            lines.append(f"[dim]structured_result[/] [white]{json.dumps(compact, ensure_ascii=False)}[/]")
+        cc = call.get("completion_confidence")
+        if isinstance(cc, dict) and cc.get("score") is not None:
+            lines.append(f"[dim]task_completed={call.get('task_completed')} · confidence {cc['score']:.2f} ({cc.get('label', '')})[/]")
+        for ev in call.get("evidence") or []:
+            lines.append(f"[dim]· {ev}[/]")
+        self.console.print(Panel("\n".join(lines), box=box.ROUNDED, border_style=style, padding=(0, 2)))
+
+    # -- notices -------------------------------------------------------
+    def notice(self, text: str, level: str = "info") -> None:
+        self.console.print(f"[{_LEVEL_STYLE.get(level, 'dim')}]{text}[/]")
+
+    def duress_alert(self) -> None:
+        self.console.print(
+            Panel(
+                "[bold red]DURESS PHRASE DETECTED[/]\n"
+                "Call was ended normally — no reaction shown on the line.\n"
+                "Engaging [bold]silent escalation[/]: the worker will not be re-contacted.",
+                border_style="red",
+                box=box.HEAVY,
+                padding=(0, 2),
+            )
+        )
+
+    def report_written(self, path: str) -> None:
+        self.console.print(f"\n[bold]Incident brief written:[/] [cyan]{path}[/]")
+
+    def closing(self, text: str, good: bool) -> None:
+        style = "green" if good else "red"
+        self.console.print()
+        self.console.print(Panel(f"[bold {style}]{text}[/]", box=box.ROUNDED, border_style=style, padding=(0, 2)))
+
+    def timeline(self, events: list[tuple[str, str, str]]) -> None:
+        table = Table(box=box.SIMPLE, show_header=True, header_style="dim")
+        table.add_column("time", style="bold", no_wrap=True)
+        table.add_column("event")
+        for at, label, level in events:
+            table.add_row(at, Text(label, style=_LEVEL_STYLE.get(level, "")))
+        self.console.print(table)
+
+
+class QuietRenderer(RichRenderer):
+    """Renderer that swallows output (tests / machine runs)."""
+
+    def __init__(self) -> None:
+        super().__init__(console=Console(quiet=True))

--- a/apps/python/fieldline/src/fieldline/report.py
+++ b/apps/python/fieldline/src/fieldline/report.py
@@ -1,0 +1,106 @@
+"""Incident brief generation — the artifact a human responder receives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .schemas import TripPlan, mask_phone
+
+Call = dict[str, Any]
+
+
+@dataclass
+class CallRecord:
+    at: str  # HH:MM display label
+    kind: str  # "checkin" | "escalation"
+    party: str  # who was called
+    phone: str
+    call: Call
+
+
+def build_incident_brief(
+    plan: TripPlan,
+    timeline: list[tuple[str, str, str]],  # (at, label, level)
+    records: list[CallRecord],
+    status_line: str,
+    demo: bool,
+) -> str:
+    lines: list[str] = []
+    add = lines.append
+    add(f"# FieldLine incident brief — {plan.label}")
+    add("")
+    stamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    mode = "DEMO (simulated calls)" if demo else "LIVE"
+    add(f"Generated {stamp} · mode: {mode}")
+    add("")
+    add(f"**Status:** {status_line}")
+    add("")
+    add("## Situation")
+    add("")
+    add(f"- Worker: **{plan.worker.name}** ({plan.worker.role}), {mask_phone(plan.worker.phone)}")
+    add(f"- Trip: {plan.label} — {plan.site}")
+    add(f"- Window: {plan.date} {plan.start}–{plan.end}; check-ins at {', '.join(plan.checkins)}")
+    if plan.vehicle:
+        add(f"- Vehicle: {plan.vehicle}")
+    add(
+        "- Escalation ladder: "
+        + " → ".join(f"{c.name} ({c.relation}, {mask_phone(c.phone)})" for c in plan.escalation)
+    )
+    add("")
+    add("## Timeline")
+    add("")
+    add("| Time | Event |")
+    add("|---|---|")
+    for at, label, _level in timeline:
+        add(f"| {at} | {label} |")
+    add("")
+    add("## Calls")
+    for rec in records:
+        add("")
+        add(f"### {rec.at} — {rec.kind}: {rec.party} ({mask_phone(rec.phone)})")
+        add("")
+        call = rec.call
+        if call.get("summary"):
+            add(f"*{call['summary']}*")
+            add("")
+        turns = [
+            turn
+            for recipient in call.get("recipients") or []
+            for attempt in recipient.get("attempts") or []
+            for turn in attempt.get("transcript_turns") or []
+        ]
+        if turns:
+            for turn in turns:
+                who = "agent" if turn.get("speaker") == "bot" else rec.party.lower()
+                add(f"> **{who}:** {turn.get('text', '')}")
+            add("")
+        sr = call.get("structured_result")
+        if isinstance(sr, dict):
+            add("Structured result:")
+            add("")
+            for key, value in sr.items():
+                if value not in (None, ""):
+                    add(f"- `{key}`: {value}")
+            add("")
+        for ev in call.get("evidence") or []:
+            add(f"- evidence: {ev}")
+    add("")
+    add("## Recommended actions")
+    add("")
+    if plan.emergency_note:
+        add(f"- {plan.emergency_note}")
+    add("- If the worker makes contact, have them call the FieldLine check-in line to stand the incident down.")
+    add("- FieldLine never dials emergency services; a human must make that call.")
+    add("")
+    return "\n".join(lines)
+
+
+def write_incident_brief(text: str, home: Path) -> Path:
+    reports_dir = home / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / f"incident-{datetime.now().strftime('%Y%m%d-%H%M%S')}.md"
+    path.write_text(text, encoding="utf-8")
+    return path

--- a/apps/python/fieldline/src/fieldline/schemas.py
+++ b/apps/python/fieldline/src/fieldline/schemas.py
@@ -1,0 +1,175 @@
+"""Trip plans and the JSON Schemas FieldLine sends to CALL-E.
+
+The schemas below ride on `result_schema` in `POST /v1/calls`, so the
+CALL-E platform extracts a machine-readable outcome from each live
+conversation. FieldLine's protocol decisions consume only these fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# --- Result schema for a worker check-in call -------------------------
+CHECKIN_RESULT_SCHEMA: dict = {
+    "type": "object",
+    "required": ["checkin_status", "duress_phrase_detected"],
+    "properties": {
+        "checkin_status": {
+            "type": "string",
+            "enum": ["safe", "needs_assistance", "emergency", "unclear"],
+            "description": "The worker's safety status as stated on the call.",
+        },
+        "duress_phrase_detected": {
+            "type": "boolean",
+            "description": (
+                "True if the worker said the configured duress phrase "
+                "verbatim at any point during the call."
+            ),
+        },
+        "current_location": {
+            "type": "string",
+            "description": "Location as stated by the worker, if any.",
+        },
+        "plan_change": {
+            "type": "string",
+            "description": "Any change to the filed trip plan, if mentioned.",
+        },
+        "notes": {"type": "string"},
+    },
+}
+
+# --- Result schema for an escalation-ladder call ----------------------
+ESCALATION_RESULT_SCHEMA: dict = {
+    "type": "object",
+    "required": ["contact_reached"],
+    "properties": {
+        "contact_reached": {
+            "type": "boolean",
+            "description": "True if the intended contact was reached and understood the situation.",
+        },
+        "heard_from_worker_since_checkin": {
+            "type": "boolean",
+            "description": "True if the contact reports contact with the worker after the missed check-in.",
+        },
+        "last_contact_time": {
+            "type": "string",
+            "description": "When the contact last heard from the worker, as stated.",
+        },
+        "will_check_in_person": {
+            "type": "boolean",
+            "description": "True if the contact will physically check the site/route.",
+        },
+        "assuming_coordination": {
+            "type": "boolean",
+            "description": "True if the contact explicitly takes over incident coordination.",
+        },
+        "notes": {"type": "string"},
+    },
+}
+
+
+@dataclass(frozen=True)
+class Worker:
+    name: str
+    role: str
+    phone: str  # E.164
+    locale: str = "en-US"
+
+
+@dataclass(frozen=True)
+class Contact:
+    name: str
+    relation: str
+    phone: str  # E.164
+
+
+@dataclass(frozen=True)
+class TripPlan:
+    label: str
+    site: str
+    date: str  # YYYY-MM-DD
+    start: str  # HH:MM local
+    end: str  # HH:MM local
+    checkins: list[str]  # HH:MM labels
+    worker: Worker
+    escalation: list[Contact]
+    duress_phrase: str
+    vehicle: str = ""
+    grace_minutes: int = 15
+    retry_after_minutes: int = 5
+    max_retries: int = 1
+    emergency_note: str = ""
+    extra: dict = field(default_factory=dict)
+
+
+class TripPlanError(ValueError):
+    """Raised when a trip plan file is invalid."""
+
+
+def load_trip_plan(path: str | Path) -> TripPlan:
+    p = Path(path)
+    if not p.is_file():
+        raise TripPlanError(f"Trip plan not found: {p}")
+    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TripPlanError(f"Trip plan must be a YAML mapping: {p}")
+    try:
+        w = data["worker"]
+        t = data["trip"]
+        plan = TripPlan(
+            label=str(t["label"]),
+            site=str(t["site"]),
+            vehicle=str(t.get("vehicle", "")),
+            date=str(t["date"]),
+            start=str(t["start"]),
+            end=str(t["end"]),
+            checkins=[str(c) for c in t["checkins"]],
+            grace_minutes=int(t.get("grace_minutes", 15)),
+            retry_after_minutes=int(t.get("retry_after_minutes", 5)),
+            max_retries=int(t.get("max_retries", 1)),
+            worker=Worker(
+                name=str(w["name"]),
+                role=str(w.get("role", "field worker")),
+                phone=str(w["phone"]),
+                locale=str(w.get("locale", "en-US")),
+            ),
+            duress_phrase=str(data["duress_phrase"]),
+            escalation=[
+                Contact(name=str(c["name"]), relation=str(c.get("relation", "contact")), phone=str(c["phone"]))
+                for c in data["escalation"]
+            ],
+            emergency_note=str(data.get("emergency_note", "")),
+        )
+    except KeyError as exc:
+        raise TripPlanError(f"Trip plan missing required field: {exc}") from exc
+    _validate(plan)
+    return plan
+
+
+def _validate(plan: TripPlan) -> None:
+    if not plan.checkins:
+        raise TripPlanError("Trip plan needs at least one check-in time.")
+    if not plan.escalation:
+        raise TripPlanError("Trip plan needs at least one escalation contact.")
+    if len(plan.duress_phrase.split()) < 3:
+        raise TripPlanError("Duress phrase must be at least 3 words (avoid accidental triggers).")
+    for phone in [plan.worker.phone, *[c.phone for c in plan.escalation]]:
+        if not phone.startswith("+") or not phone[1:].isdigit() or len(phone) < 8:
+            raise TripPlanError(f"Phone numbers must be E.164 (e.g. +15555550100), got: {mask_phone(phone)}")
+
+
+def mask_phone(phone: str) -> str:
+    """Mask a phone number for display/logs: +15555550100 -> +1•••0100."""
+    if len(phone) < 6:
+        return "•••"
+    return f"{phone[:2]}•••{phone[-4:]}"
+
+
+def add_minutes(hhmm: str, minutes: int) -> str:
+    """'18:00' + 5 -> '18:05' (wraps at midnight)."""
+    h, m = (int(x) for x in hhmm.split(":"))
+    total = (h * 60 + m + minutes) % (24 * 60)
+    return f"{total // 60:02d}:{total % 60:02d}"

--- a/apps/python/fieldline/tests/conftest.py
+++ b/apps/python/fieldline/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Shared test helpers: synthetic CALL-E call_task dicts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def make_call(
+    status: str = "completed",
+    structured_result: dict | None = None,
+    task_completed: bool | None = None,
+    turns: list[tuple[str, str]] | None = None,
+    summary: str | None = None,
+) -> dict:
+    return {
+        "object": "call_task",
+        "id": "call_test",
+        "status": status,
+        "task": "test task",
+        "recipients": [
+            {
+                "id": "rcpt_test",
+                "phones": ["+15555550100"],
+                "status": "completed",
+                "structured_result": structured_result,
+                "summary": summary,
+                "attempts": [
+                    {
+                        "id": "attempt_test",
+                        "phone": "+15555550100",
+                        "status": "completed" if turns else "no_answer",
+                        "transcript_turns": [
+                            {"offset_seconds": i * 5, "speaker": s, "text": t}
+                            for i, (s, t) in enumerate(turns or [])
+                        ],
+                    }
+                ],
+            }
+        ],
+        "structured_result": structured_result,
+        "summary": summary,
+        "task_completed": task_completed,
+        "completion_confidence": None,
+        "evidence": [],
+        "metadata": {},
+        "failure_code": None,
+        "failure_message": None,
+    }

--- a/apps/python/fieldline/tests/test_dispatchers.py
+++ b/apps/python/fieldline/tests/test_dispatchers.py
@@ -1,0 +1,93 @@
+import pytest
+
+import fieldline.calle_client as cc
+from fieldline.calle_client import (
+    DemoCalleDispatcher,
+    LiveCalleDispatcher,
+    ScriptExhaustedError,
+)
+from fieldline.demo_data import SCENARIOS
+
+CALL_STATUSES = {"queued", "in_progress", "completed", "failed", "canceled"}
+
+
+def _dispatch_all(scenario):
+    d = DemoCalleDispatcher(SCENARIOS[scenario], turn_delay=0.0)
+    return [
+        d.create_and_wait(
+            task="t",
+            recipient={"phone": "+15555550100"},
+            result_schema={},
+            metadata={"i": i},
+            idempotency_key=f"k{i}",
+        )
+        for i in range(len(SCENARIOS[scenario]))
+    ]
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIOS))
+def test_demo_calls_match_call_task_shape(scenario):
+    """DEMO dicts must be indistinguishable from real terminal call_tasks."""
+    for call in _dispatch_all(scenario):
+        assert call["object"] == "call_task"
+        assert call["status"] in CALL_STATUSES
+        assert isinstance(call["recipients"], list) and call["recipients"]
+        for recipient in call["recipients"]:
+            assert recipient["phones"]
+            for attempt in recipient["attempts"]:
+                for turn in attempt["transcript_turns"]:
+                    assert turn["speaker"] in {"bot", "user", "unknown"}
+                    assert isinstance(turn["text"], str)
+        assert "structured_result" in call
+        assert "task_completed" in call
+        assert "evidence" in call
+        assert call["metadata"] is not None  # request metadata echoed
+
+
+def test_demo_checkin_results_match_result_schema_enum():
+    for call in _dispatch_all("full"):
+        sr = call["structured_result"]
+        if sr and "checkin_status" in sr:
+            assert sr["checkin_status"] in {"safe", "needs_assistance", "emergency", "unclear"}
+            assert isinstance(sr["duress_phrase_detected"], bool)
+
+
+def test_demo_scripts_pop_in_order_and_exhaust():
+    d = DemoCalleDispatcher(SCENARIOS["duress"], turn_delay=0.0)
+    for _ in SCENARIOS["duress"]:
+        d.create_and_wait(task="t", recipient={"phone": "+15555550100"})
+    with pytest.raises(ScriptExhaustedError):
+        d.create_and_wait(task="t", recipient={"phone": "+15555550100"})
+
+
+def test_demo_streams_turns():
+    seen = []
+    d = DemoCalleDispatcher(SCENARIOS["safe"], on_turn=lambda s, t: seen.append((s, t)), turn_delay=0.0)
+    d.create_and_wait(task="t", recipient={"phone": "+15555550100"})
+    assert seen and seen[0][0] == "bot"
+
+
+# --- live dispatcher fail-soft ---------------------------------------
+class _ExplodingCalls:
+    def __init__(self):
+        self.attempts = 0
+
+    def create_and_wait(self, **kwargs):
+        self.attempts += 1
+        raise ConnectionError("provider down")
+
+
+class _ExplodingClient:
+    def __init__(self):
+        self.calls = _ExplodingCalls()
+
+
+def test_live_dispatcher_fails_soft(monkeypatch):
+    monkeypatch.setattr(cc.time, "sleep", lambda s: None)
+    client = _ExplodingClient()
+    d = LiveCalleDispatcher(api_key="k", client=client)
+    call = d.create_and_wait(task="t", recipient={"phone": "+15555550100"}, metadata={"kind": "checkin"})
+    assert client.calls.attempts == 2  # one retry, idempotency-key safe
+    assert call["status"] == "failed"
+    assert call["failure_code"] == "client_unreachable"
+    assert call["metadata"] == {"kind": "checkin"}

--- a/apps/python/fieldline/tests/test_engine.py
+++ b/apps/python/fieldline/tests/test_engine.py
@@ -1,0 +1,78 @@
+from fieldline.calle_client import DemoCallScript, DemoCalleDispatcher
+from fieldline.demo_data import SCENARIOS, demo_trip_plan
+from fieldline.engine import DemoWaiter, TripEngine
+from fieldline.render import QuietRenderer
+
+
+def run_scenario(scripts, tmp_path):
+    engine = TripEngine(
+        plan=demo_trip_plan(),
+        dispatcher=DemoCalleDispatcher(scripts, turn_delay=0.0),
+        renderer=QuietRenderer(),
+        home=tmp_path,
+        demo=True,
+        waiter=DemoWaiter(fast=True),
+    )
+    return engine.run()
+
+
+def test_full_scenario_hands_off_and_writes_brief(tmp_path):
+    result = run_scenario(SCENARIOS["full"], tmp_path)
+    assert result.status == "handed_off"
+    assert len(result.records) == 5  # safe + 2 unanswered dials + 2 escalation calls
+    assert result.report_path and result.report_path.exists()
+    brief = result.report_path.read_text()
+    assert "Dr. Rivera" in brief and "Timeline" in brief
+    assert "+15555550100" not in brief  # phones masked in the brief
+
+
+def test_safe_scenario_closes_without_incident(tmp_path):
+    result = run_scenario(SCENARIOS["safe"], tmp_path)
+    assert result.status == "closed_safe"
+    assert result.report_path is None
+    assert len(result.records) == 2
+
+
+def test_duress_skips_ladder_to_top_rung(tmp_path):
+    result = run_scenario(SCENARIOS["duress"], tmp_path)
+    assert result.status == "handed_off"
+    # 2 check-ins + exactly ONE escalation call (silent: straight to the top)
+    assert len(result.records) == 3
+    assert result.records[-1].party == "Dr. Rivera"
+    assert result.report_path and "duress" in result.report_path.read_text().lower()
+
+
+def _no_answer(at):
+    return DemoCallScript(kind="checkin", at=at, answered=False, summary="No answer.", task_completed=False)
+
+
+def test_stand_down_resumes_schedule(tmp_path):
+    scripts = [
+        _no_answer("14:00"),
+        _no_answer("14:05"),
+        DemoCallScript(
+            kind="escalation",
+            at="14:16",
+            answered=True,
+            turns=[("bot", "…"), ("user", "They just texted me, all fine — flat battery.")],
+            structured_result={"contact_reached": True, "heard_from_worker_since_checkin": True},
+            summary="Contact heard from worker minutes ago.",
+            task_completed=True,
+        ),
+        SCENARIOS["safe"][1],  # 18:00 check-in green
+    ]
+    result = run_scenario(scripts, tmp_path)
+    assert result.status == "closed_safe"
+    assert result.report_path is None
+
+
+def test_exhausted_ladder_flags_manual_action(tmp_path):
+    scripts = [
+        _no_answer("14:00"),
+        _no_answer("14:05"),
+        DemoCallScript(kind="escalation", at="14:16", answered=False, task_completed=False),
+        DemoCallScript(kind="escalation", at="14:23", answered=False, task_completed=False),
+    ]
+    result = run_scenario(scripts, tmp_path)
+    assert result.status == "unreachable_ladder"
+    assert result.report_path and "manual action" in result.report_path.read_text().lower()

--- a/apps/python/fieldline/tests/test_protocol.py
+++ b/apps/python/fieldline/tests/test_protocol.py
@@ -1,0 +1,83 @@
+from conftest import make_call
+from fieldline.protocol import (
+    CheckinOutcome,
+    EscalationOutcome,
+    classify_checkin,
+    classify_escalation,
+    decide,
+)
+
+
+# --- classify_checkin -------------------------------------------------
+def test_safe_checkin():
+    call = make_call(structured_result={"checkin_status": "safe", "duress_phrase_detected": False})
+    assert classify_checkin(call) is CheckinOutcome.SAFE
+
+
+def test_duress_overrides_stated_safe():
+    call = make_call(structured_result={"checkin_status": "safe", "duress_phrase_detected": True})
+    assert classify_checkin(call) is CheckinOutcome.DURESS
+
+
+def test_needs_assistance():
+    for status in ("needs_assistance", "emergency"):
+        call = make_call(structured_result={"checkin_status": status, "duress_phrase_detected": False})
+        assert classify_checkin(call) is CheckinOutcome.NEEDS_HELP
+
+
+def test_no_answer_when_no_result_and_no_transcript():
+    assert classify_checkin(make_call(structured_result=None)) is CheckinOutcome.NO_ANSWER
+
+
+def test_unclear_when_conversation_but_no_result():
+    call = make_call(structured_result=None, turns=[("bot", "hi"), ("user", "…")])
+    assert classify_checkin(call) is CheckinOutcome.UNCLEAR
+
+
+def test_api_failure_degrades_to_no_answer():
+    # Fail-soft: an unplaceable call keeps the cascade moving.
+    assert classify_checkin(make_call(status="failed")) is CheckinOutcome.NO_ANSWER
+
+
+# --- decide -----------------------------------------------------------
+def test_safe_schedules_next():
+    assert decide(CheckinOutcome.SAFE, dials_made=1, max_retries=1).kind == "schedule_next"
+
+
+def test_no_answer_retries_then_escalates():
+    assert decide(CheckinOutcome.NO_ANSWER, dials_made=1, max_retries=1).kind == "retry"
+    step = decide(CheckinOutcome.NO_ANSWER, dials_made=2, max_retries=1)
+    assert step.kind == "escalate" and not step.silent
+
+
+def test_duress_escalates_silently_and_immediately():
+    step = decide(CheckinOutcome.DURESS, dials_made=1, max_retries=5)
+    assert step.kind == "escalate" and step.silent
+
+
+def test_needs_help_escalates_loudly():
+    step = decide(CheckinOutcome.NEEDS_HELP, dials_made=1, max_retries=5)
+    assert step.kind == "escalate" and not step.silent
+
+
+# --- classify_escalation ---------------------------------------------
+def test_escalation_stand_down():
+    call = make_call(structured_result={"contact_reached": True, "heard_from_worker_since_checkin": True})
+    assert classify_escalation(call) is EscalationOutcome.STAND_DOWN
+
+
+def test_escalation_handed_off():
+    call = make_call(structured_result={"contact_reached": True, "assuming_coordination": True})
+    assert classify_escalation(call) is EscalationOutcome.HANDED_OFF
+
+
+def test_escalation_will_check():
+    call = make_call(structured_result={"contact_reached": True, "will_check_in_person": True})
+    assert classify_escalation(call) is EscalationOutcome.WILL_CHECK
+
+
+def test_escalation_not_reached():
+    assert classify_escalation(make_call(structured_result=None)) is EscalationOutcome.NOT_REACHED
+    assert classify_escalation(make_call(status="failed")) is EscalationOutcome.NOT_REACHED
+    call = make_call(structured_result={"contact_reached": False})
+    assert classify_escalation(call) is EscalationOutcome.NOT_REACHED

--- a/apps/python/fieldline/tests/test_schemas.py
+++ b/apps/python/fieldline/tests/test_schemas.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+from fieldline.demo_data import demo_trip_plan
+from fieldline.schemas import (
+    CHECKIN_RESULT_SCHEMA,
+    ESCALATION_RESULT_SCHEMA,
+    TripPlanError,
+    add_minutes,
+    load_trip_plan,
+    mask_phone,
+)
+
+EXAMPLE = Path(__file__).resolve().parents[1] / "examples" / "trip.yaml"
+
+
+def test_example_plan_loads_and_matches_demo_plan():
+    plan = load_trip_plan(EXAMPLE)
+    demo = demo_trip_plan()
+    assert plan.label == demo.label
+    assert plan.checkins == demo.checkins
+    assert plan.duress_phrase == demo.duress_phrase
+    assert [c.name for c in plan.escalation] == [c.name for c in demo.escalation]
+    assert plan.worker.phone == demo.worker.phone
+
+
+def test_result_schemas_are_wellformed():
+    for schema in (CHECKIN_RESULT_SCHEMA, ESCALATION_RESULT_SCHEMA):
+        assert schema["type"] == "object"
+        assert set(schema["required"]) <= set(schema["properties"])
+
+
+def test_short_duress_phrase_rejected(tmp_path):
+    bad = EXAMPLE.read_text().replace("the weather has been lovely all week", "ok")
+    p = tmp_path / "bad.yaml"
+    p.write_text(bad)
+    with pytest.raises(TripPlanError, match="Duress phrase"):
+        load_trip_plan(p)
+
+
+def test_non_e164_phone_rejected(tmp_path):
+    bad = EXAMPLE.read_text().replace("+15555550100", "0555-01-00")
+    p = tmp_path / "bad.yaml"
+    p.write_text(bad)
+    with pytest.raises(TripPlanError, match="E.164"):
+        load_trip_plan(p)
+
+
+def test_mask_phone():
+    assert mask_phone("+15555550100") == "+1•••0100"
+    assert "5555501" not in mask_phone("+15555550100")
+    assert "*" not in mask_phone("+15555550100")  # '*' breaks markdown rendering
+
+
+def test_add_minutes():
+    assert add_minutes("18:00", 5) == "18:05"
+    assert add_minutes("18:58", 5) == "19:03"
+    assert add_minutes("23:58", 5) == "00:03"


### PR DESCRIPTION
## Summary

Adds **FieldLine**, a user-facing Python app for lone-worker safety check-ins. It schedules CALL-E calls from a YAML trip plan, detects a silent duress phrase through structured extraction, and escalates missed or unsafe check-ins through a human-owned contact ladder. Demo mode is the default and places no calls; live mode requires credentials, explicit consent, and a `LIVE` confirmation.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Verification

- `uv run pytest -q` — 32 passed
- `python3 scripts/validate_repository.py` — passed

Built for the CALL-E: Your Code Is Calling hackathon.