### PR TITLE
feat(runaround): add referral-chain tracing app with loop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 | [`apps/python/kept`](apps/python/kept/) | Python | Turns a payment promise made on a collections call into a validated financial record: eleven named rejection reasons stand between a spoken sentence and a ledger entry, vague amounts are refused, over-commitments are clamped to the invoice balance with the spoken figure kept beside them, and the promise is reconciled against the bank feed a week later so only the commitments that actually broke are called again. |
 | [`apps/typescript/callsweep`](apps/typescript/callsweep/) | TypeScript | Calls many local businesses, haggles each one down toward your budget on the call, ranks their offers by the best overall deal (price, what's included, availability), and books the one you pick. Dry-run no-call path by default with fictional sample shops. |
 | [`apps/python/casechaser`](apps/python/casechaser/) | Python | Chases an open claim, refund, repair, or delivery case to closure: every company promise becomes a dated, quoted commitment, broken ones climb a fixed escalation ladder, offers and denials stop at the customer, and a masked evidence pack is ready for the written complaint. Fixture mode by default. |
+| [`apps/python/runaround`](apps/python/runaround/) | Python | Chases one question across organizations that each name the other: every referral is recorded with the sentence that gave it, a number spoken on a call is not permission to dial it, and the chain stops with a quoted evidence pack the moment the referrals close on themselves. Fixture mode by default. |
 
 The default e2e tests use a local fake broker/OAuth/MCP server or dry-run paths, so they do not require real CALL-E credentials or browser login. Live verification is opt-in in each app README.
 
@@ -248,6 +249,7 @@ Plugins should be explicit about inputs, outbound call side effects, credential 
 - [`Fact freshness`](apps/web/local-atlas/docs/fact-freshness.md) - Expiring a call result by outcome so failures are not cached as conclusions, keeping hedges and refusals distinct from answers, and defeating idempotent replay when a reader rechecks.
 - [`Design principles`](docs/design-principles.md) - Repository-wide architecture principles for safe phone-call workflows.
 - [`Fail-closed dispositions`](plugins/zapier-calle/docs/fail-closed-dispositions.md) - Classifying phone-call outcomes so ambiguity, low confidence, and unrecognized statuses route to a human instead of a success branch.
+- [`Referral authorization`](apps/python/runaround/docs/referral-authorization.md) - Why a phone number spoken on a call is a claim rather than a permission, why an unattributed referral is refused outright, and why an organization name is not an identity for loop detection.
 
 ## Contributing
 

--- a/apps/python/runaround/README.md
+++ b/apps/python/runaround/README.md
@@ -1,0 +1,163 @@
+# Runaround
+
+**Two organizations each say the other one is responsible. Runaround calls them
+in turn, records who sent the request where in their own words, and stops with
+proof the moment the referrals close on themselves.**
+
+Every consequential phone task in this repository assumes that somewhere on the
+other end there is a desk that owns the request. Often there is not. The retailer
+says it is the carrier's claim; the carrier says it is the shipper's claim; the
+insurer says talk to the clinic and the clinic says talk to the insurer. The
+question never gets answered and nobody ever refuses to answer it, which is why
+the person chasing it has nothing to escalate.
+
+Runaround treats that as the primary case rather than an error path. The unit of
+work is not a call, it is a **referral edge**: one desk, the desk it named, and
+the sentence that named it. A chain of those edges either reaches an owner or
+closes on itself, and closing on itself is a finding, not a failure.
+
+```text
+  ORD-8472 damaged
+        │
+        ▼
+  Example Retail (+1*****00) ──"damage in transit is the carrier's claim"──┐
+        ▲                                                                  │
+        │                                                                  ▼
+        └──"the box was packed by the shipper, the claim is theirs"── Example Freight (+1*****11)
+
+  loop_detected after 2 calls: +1*****00 -> +1*****11 -> +1*****00
+  evidence pack: both sentences, both dates, numbers masked
+```
+
+## Two rules do the work
+
+**A referral advances the chain only when the words that gave it come with it.**
+`referral_target_phone` without `referral_quote` is refused as
+`unverified_referral` and the case goes to a person. A number with no sentence
+behind it is an extraction artifact, and dialling it means calling a stranger on
+the strength of a guess.
+
+**A number spoken on a call is not permission to dial it.** The desk you
+authorized is the desk you authorized. When a call names a new destination the
+case stops at `awaiting_approval` and waits for `runaround approve`. This is the
+difference between an agent that chases a question and an agent that walks
+outward through the phone book on its own.
+
+Everything else follows from those two:
+
+| Situation | What Runaround does |
+| --- | --- |
+| Referral points at a desk already called | `loop_detected`, chain stops, loop path recorded |
+| Desk gives its own number back | `self_referral`, chain stops |
+| Desk tells you to call yourself | `referred_to_requester`, chain stops |
+| Same organization name, a different number | `loop_suspected` — a person decides, because names are not identities |
+| Desk owns it but did not answer today | `owner_without_answer`, not a resolution |
+| Call failed, or the result did not validate | `unreachable` — never read as "no referral" |
+| Hop budget spent | `budget_exhausted` |
+
+The number `+1 (555) 010-0` and the number `+15550100` are the same desk. Loop
+detection normalizes to E.164 in one place (`runaround/phone.py`), so a chain
+cannot be hidden by punctuation a receptionist read out differently.
+
+## Quick start — no calls, no API key
+
+```bash
+cd apps/python/runaround
+python3 -m runaround --data ./demo-data init-demo
+python3 -m runaround --data ./demo-data plan parcel-8472
+python3 -m runaround --data ./demo-data run parcel-8472 \
+    --mode fixture --fixture fixtures/chain_loop.json
+python3 -m runaround --data ./demo-data approve parcel-8472
+python3 -m runaround --data ./demo-data run parcel-8472 \
+    --mode fixture --fixture fixtures/chain_loop.json
+python3 -m runaround --data ./demo-data evidence parcel-8472
+```
+
+Fixture mode is the default and places no calls. `fixtures/chain_resolved.json`
+runs the same case to an owner who accepts the claim;
+`fixtures/chain_unquoted_referral.json` shows the chain refusing a number that
+arrived without words. All fixture numbers are NANP fiction-reserved `555-01xx`.
+
+Python 3.10 or newer, standard library only. No third-party dependency, at
+runtime or for the tests.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tests -t . -q
+```
+
+57 tests. None of them opens a socket: the CALL-E transport is injected, so the
+adapter is exercised against recorded responses, including the poll ceiling and
+the documented error codes.
+
+## Live path (opt-in, rings a real telephone)
+
+```bash
+export CALLE_API_KEY=...
+python3 -m runaround --data ./data run <case_id> \
+    --mode live --once --i-understand-this-calls-people
+```
+
+`--mode live` alone is not enough; without the acknowledgement flag the command
+exits before building a request. Use `--once` while you are learning what a case
+does, so one command is one call.
+
+The base URL is pinned. `CALLE_BASE_URL` exists for a future official host, but
+`assert_approved_origin` compares the parsed hostname against an allow-list, so
+`api.heycall-e.com.evil.example` cannot receive the bearer token by ending in
+the right letters.
+
+## What it does to CALL-E
+
+Contract source: `https://docs.heycall-e.com/openapi/calle.openapi.yaml`
+(CALL-E Developer API 0.6.0).
+
+- `POST /v1/calls` — one recipient, one hop, with `result_schema` describing the
+  seven fields the chain reads back, and an `Idempotency-Key` derived from
+  `case_id + hop_index + destination`. The key comes from the authorization to
+  place the hop, not from the attempt, so a retried timeout returns the original
+  call instead of ringing a person twice.
+- `GET /v1/calls/{call_id}` — polled until `completed`, `failed`, or `canceled`.
+- A poll ceiling that is reached raises rather than returns. The call may still
+  be running; its outcome is unknown, and an unknown outcome must be reconciled
+  by a person before the case dials anyone again.
+
+The task text is assembled by code, never written per case, so every hop
+discloses automation the same way and closes with the same two questions. From
+the second hop on it carries the chain history verbatim: a desk that hears *"two
+people have already sent me here, and here is what they said"* answers a
+different question than a desk that hears the request cold.
+
+## Side effects, cancellation, and state
+
+- One `run` places at most `hop_budget` calls (default 4) and stops at the first
+  approval gate. `--once` places at most one.
+- The case file under `--data` is the only durable state. It is written before
+  the call and again after it, so an interrupted run shows a call that may have
+  happened rather than no record at all.
+- `runaround stop <case_id> --reason ...` ends a case immediately. A stopped or
+  terminal case refuses to place another call.
+- Nothing recurs. There is no scheduler, no retry timer, and no background job.
+  A call happens because someone ran a command.
+
+## Safety
+
+- The agent discloses that it is an AI assistant in its opening line.
+- It is instructed not to accept, decline, or negotiate any offer, settlement,
+  payment, appointment, or commitment, and not to press a person who declines.
+- Phone numbers are masked to `+1*****00` in previews, status output, and the
+  evidence pack. The full number appears in the call request and the case file,
+  because the next hop has to dial it.
+- Destination authorization is per desk and recorded per hop
+  (`intake` or `approval`), so the evidence pack shows who let each call happen.
+- See [`docs/referral-authorization.md`](docs/referral-authorization.md) for why
+  a number given on a call is treated as a claim rather than a permission.
+
+## What this does not establish
+
+The evidence pack records what was said on a call to the number shown. It does
+not verify who said it, their authority to say it, or whether the organization
+would repeat it. A detected loop proves two desks each named the other on the
+dates shown — which is exactly what a complaint needs and exactly as far as a
+phone call can go.

--- a/apps/python/runaround/README.md
+++ b/apps/python/runaround/README.md
@@ -87,7 +87,7 @@ runtime or for the tests.
 python3 -m unittest discover -s tests -t . -q
 ```
 
-57 tests. None of them opens a socket: the CALL-E transport is injected, so the
+61 tests. None of them opens a socket: the CALL-E transport is injected, so the
 adapter is exercised against recorded responses, including the poll ceiling and
 the documented error codes.
 
@@ -111,7 +111,8 @@ the right letters.
 ## What it does to CALL-E
 
 Contract source: `https://docs.heycall-e.com/openapi/calle.openapi.yaml`
-(CALL-E Developer API 0.6.0).
+(CALL-E Developer API 0.7.0, re-fetched and exercised against the live API on
+2026-09-07).
 
 - `POST /v1/calls` — one recipient, one hop, with `result_schema` describing the
   seven fields the chain reads back, and an `Idempotency-Key` derived from
@@ -122,6 +123,32 @@ Contract source: `https://docs.heycall-e.com/openapi/calle.openapi.yaml`
 - A poll ceiling that is reached raises rather than returns. The call may still
   be running; its outcome is unknown, and an unknown outcome must be reconciled
   by a person before the case dials anyone again.
+
+### What the live API actually accepted
+
+Both statements below are measurements against `https://api.heycall-e.com` on
+2026-09-07, not readings of the specification.
+
+- **`result_schema` may not use union types.** The first live request was
+  refused with `400 result_schema_invalid`, detail `unsupported JSON Schema
+  type at $.properties.answer_summary: ['string', 'null']`. The six optional
+  fields previously declared `["string", "null"]`; a field that may be absent
+  is now typed `string` and left out of `required`, and its description tells
+  the extraction model to omit the key rather than send a null. Local
+  validation was already absence-tolerant (`result.get`), so nothing
+  downstream changed — but the schema this app sends could never have been
+  accepted, and no fixture test could have shown that.
+- **Outbound calls to KR are not currently supported, in any language.**
+  `en-US` to a `+82` number is refused with `422 call_not_ready` — *"recognized
+  as KR with English, which is not currently supported for outbound calls"* —
+  and `ko-KR` with `422 … recognized as KR/Korean, which is not currently
+  supported for calling*. The live path in this repository has therefore been
+  exercised as far as the platform's region policy allows: authentication,
+  request construction, schema acceptance, and the refusal itself are real; no
+  outbound leg has been completed against a supported destination.
+
+Both refusals are fail-closed and surfaced verbatim. The chain does not
+advance, and no state is written as though a call had happened.
 
 The task text is assembled by code, never written per case, so every hop
 discloses automation the same way and closes with the same two questions. From

--- a/apps/python/runaround/docs/referral-authorization.md
+++ b/apps/python/runaround/docs/referral-authorization.md
@@ -1,0 +1,66 @@
+# Referral authorization
+
+A number that arrives on a call is a claim about the world, not a permission to
+act on it. This is the boundary that separates a workflow which chases one
+question from a workflow which walks outward through the phone book on its own.
+
+## The asymmetry
+
+The desk you were authorized to call was chosen by a person who knew the case:
+they had a relationship with that organization, a reason to contact it, and
+standing to ask. None of that transfers to the number that desk reads out.
+
+The referred number is:
+
+- **unverified.** Nobody checked that it belongs to whom the speaker said. It
+  may be a wrong digit, a decommissioned line, a personal mobile, or a number
+  read from a screen the speaker cannot see clearly.
+- **unconsented.** The person who answers it has no relationship with the
+  requester and never agreed to be called about this case.
+- **unbounded.** Each hop can name another hop. Without a gate, one authorized
+  call becomes an unbounded outward walk, and every leaf of it is a stranger
+  hearing a stranger's business.
+
+So the chain stops at `awaiting_approval` and a person runs `approve`. The
+approval is per destination and recorded on the hop, so the evidence pack can
+say who allowed each call.
+
+## Why an unquoted referral is refused entirely
+
+`referral_target_phone` without `referral_quote` is not a weak referral, it is
+an unattributed one. The number is in the result object, but nothing in the
+transcript is on record as having produced it.
+
+That state has two causes and they are indistinguishable from the outside:
+either the recipient said a number and the extraction dropped the sentence, or
+the extraction supplied a number the recipient never said. The second is the
+dangerous one, and no amount of confidence in the first justifies dialling on
+it. The case goes to a person, who can read the transcript and decide.
+
+The same applies in reverse. A spoken referral whose number does not normalize
+to E.164 — an extension, a partial number, a name instead of a number — is
+reported with the raw text preserved and never dialled. Repairing a phone
+number is guessing who answers.
+
+## Why a name is not an identity
+
+When a referral names an organization already called but gives a different
+number, that is `loop_suspected`, not `loop_detected`.
+
+Large organizations really do have several numbers, and a genuine transfer from
+a general line to a claims desk looks exactly like being sent in a circle. The
+difference is not in the data, so the code does not pretend to see it. The chain
+pauses, shows the person both numbers and both names, and lets them decide
+whether this is the same desk refusing twice or a real handoff inward.
+
+Loop *detection* stays on the one thing that is an identity: the normalized
+E.164 destination. `+1 (555) 010-0` and `+15550100` are the same telephone, and
+a chain that let punctuation hide a cycle would keep dialling forever while
+every check stayed green.
+
+## What the requester's own number is for
+
+`requester_phone` is recorded so the chain can recognize being sent back to the
+person who started it. "Have the customer call us" closes the loop as surely as
+a referral between two desks, and it is the outcome most likely to be read as
+progress by a workflow that is only looking for a new number to dial.

--- a/apps/python/runaround/fixtures/chain_loop.json
+++ b/apps/python/runaround/fixtures/chain_loop.json
@@ -1,0 +1,89 @@
+{
+  "note": "Fictional test data. Numbers are NANP fiction-reserved 555-01xx. No call was placed to produce this file.",
+  "calls": {
+    "+15550100": {
+      "id": "call_demo_hop1",
+      "object": "call_task",
+      "status": "completed",
+      "structured_result": {
+        "owns_request": "no",
+        "question_answered": "no",
+        "answer_summary": null,
+        "referral_target_name": "Example Freight Claims",
+        "referral_target_phone": "+15550111",
+        "referral_quote": "We only sell it, we do not ship it. Damage in transit is the carrier's claim. Call Example Freight on five five five, zero one one one.",
+        "reference_number": null
+      },
+      "summary": null,
+      "task_completed": true,
+      "recipients": [
+        {
+          "id": "rcp_demo_hop1",
+          "status": "completed",
+          "structured_result": null,
+          "attempts": [
+            {
+              "status": "completed",
+              "transcript_turns": [
+                {
+                  "offset_seconds": 0,
+                  "speaker": "bot",
+                  "text": "I am an AI assistant calling on behalf of Dana Okafor about order ORD-8472, which arrived crushed."
+                },
+                {
+                  "offset_seconds": 9,
+                  "speaker": "user",
+                  "text": "We only sell it, we do not ship it. Damage in transit is the carrier's claim. Call Example Freight on five five five, zero one one one."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failure_code": null,
+      "failure_message": null
+    },
+    "+15550111": {
+      "id": "call_demo_hop2",
+      "object": "call_task",
+      "status": "completed",
+      "structured_result": {
+        "owns_request": "no",
+        "question_answered": "no",
+        "answer_summary": null,
+        "referral_target_name": "Example Retail Support",
+        "referral_target_phone": "+1 (555) 0100",
+        "referral_quote": "If the box was packed by the shipper, the claim is theirs, not ours. You need to go back to Example Retail on five five five, zero one zero zero.",
+        "reference_number": "FR-55120"
+      },
+      "summary": null,
+      "task_completed": true,
+      "recipients": [
+        {
+          "id": "rcp_demo_hop2",
+          "status": "completed",
+          "structured_result": null,
+          "attempts": [
+            {
+              "status": "completed",
+              "transcript_turns": [
+                {
+                  "offset_seconds": 0,
+                  "speaker": "bot",
+                  "text": "Example Retail Support referred this damage claim to you."
+                },
+                {
+                  "offset_seconds": 11,
+                  "speaker": "user",
+                  "text": "If the box was packed by the shipper, the claim is theirs, not ours. You need to go back to Example Retail on five five five, zero one zero zero."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failure_code": null,
+      "failure_message": null
+    }
+  }
+}

--- a/apps/python/runaround/fixtures/chain_resolved.json
+++ b/apps/python/runaround/fixtures/chain_resolved.json
@@ -1,0 +1,89 @@
+{
+  "note": "Fictional test data. The carrier accepts the claim on hop two.",
+  "calls": {
+    "+15550100": {
+      "id": "call_demo_hop1",
+      "object": "call_task",
+      "status": "completed",
+      "structured_result": {
+        "owns_request": "no",
+        "question_answered": "no",
+        "answer_summary": null,
+        "referral_target_name": "Example Freight Claims",
+        "referral_target_phone": "+15550111",
+        "referral_quote": "We only sell it, we do not ship it. Damage in transit is the carrier's claim. Call Example Freight on five five five, zero one one one.",
+        "reference_number": null
+      },
+      "summary": null,
+      "task_completed": true,
+      "recipients": [
+        {
+          "id": "rcp_demo_hop1",
+          "status": "completed",
+          "structured_result": null,
+          "attempts": [
+            {
+              "status": "completed",
+              "transcript_turns": [
+                {
+                  "offset_seconds": 0,
+                  "speaker": "bot",
+                  "text": "I am an AI assistant calling on behalf of Dana Okafor about order ORD-8472, which arrived crushed."
+                },
+                {
+                  "offset_seconds": 9,
+                  "speaker": "user",
+                  "text": "We only sell it, we do not ship it. Damage in transit is the carrier's claim. Call Example Freight on five five five, zero one one one."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failure_code": null,
+      "failure_message": null
+    },
+    "+15550111": {
+      "id": "call_demo_hop2_owner",
+      "object": "call_task",
+      "status": "completed",
+      "structured_result": {
+        "owns_request": "yes",
+        "question_answered": "yes",
+        "answer_summary": "Example Freight accepts the damage claim and opened reference FR-55120; a decision is due within ten business days.",
+        "referral_target_name": null,
+        "referral_target_phone": null,
+        "referral_quote": null,
+        "reference_number": "FR-55120"
+      },
+      "summary": null,
+      "task_completed": true,
+      "recipients": [
+        {
+          "id": "rcp_demo_hop2_owner",
+          "status": "completed",
+          "structured_result": null,
+          "attempts": [
+            {
+              "status": "completed",
+              "transcript_turns": [
+                {
+                  "offset_seconds": 0,
+                  "speaker": "bot",
+                  "text": "Example Retail Support referred this damage claim to you."
+                },
+                {
+                  "offset_seconds": 12,
+                  "speaker": "user",
+                  "text": "Yes, that is ours. I have opened claim FR-55120 and you will hear within ten business days."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failure_code": null,
+      "failure_message": null
+    }
+  }
+}

--- a/apps/python/runaround/fixtures/chain_unquoted_referral.json
+++ b/apps/python/runaround/fixtures/chain_unquoted_referral.json
@@ -1,0 +1,47 @@
+{
+  "note": "Fictional test data. Hop one returns a number with no words behind it, so the chain refuses to dial it.",
+  "calls": {
+    "+15550100": {
+      "id": "call_demo_unquoted",
+      "object": "call_task",
+      "status": "completed",
+      "structured_result": {
+        "owns_request": "no",
+        "question_answered": "no",
+        "answer_summary": null,
+        "referral_target_name": "Example Freight Claims",
+        "referral_target_phone": "+15550111",
+        "referral_quote": null,
+        "reference_number": null
+      },
+      "summary": null,
+      "task_completed": true,
+      "recipients": [
+        {
+          "id": "rcp_demo_unquoted",
+          "status": "completed",
+          "structured_result": null,
+          "attempts": [
+            {
+              "status": "completed",
+              "transcript_turns": [
+                {
+                  "offset_seconds": 0,
+                  "speaker": "bot",
+                  "text": "Calling about ORD-8472."
+                },
+                {
+                  "offset_seconds": 7,
+                  "speaker": "user",
+                  "text": "That is not us."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failure_code": null,
+      "failure_message": null
+    }
+  }
+}

--- a/apps/python/runaround/runaround/__init__.py
+++ b/apps/python/runaround/runaround/__init__.py
@@ -1,0 +1,10 @@
+"""Runaround - referral-chain tracing for phone-call agents.
+
+Follows a question across organizations one authorized call at a time, records
+who referred whom in their own words, and stops with evidence when the chain
+closes on itself instead of on an owner.
+"""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/apps/python/runaround/runaround/__main__.py
+++ b/apps/python/runaround/runaround/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point so the app runs as ``python3 -m runaround``."""
+
+from runaround.cli import main
+
+raise SystemExit(main())

--- a/apps/python/runaround/runaround/calle_client.py
+++ b/apps/python/runaround/runaround/calle_client.py
@@ -1,0 +1,264 @@
+"""CALL-E Developer API adapter for one hop.
+
+Contract source: ``https://docs.heycall-e.com/openapi/calle.openapi.yaml``
+(CALL-E Developer API 0.6.0).
+
+* ``POST /v1/calls`` with ``task`` and ``result_schema``, bearer auth, optional
+  ``Idempotency-Key``.
+* ``GET  /v1/calls/{call_id}`` until the status is terminal.
+
+The transport is injectable so the whole workflow can be exercised, and is
+exercised in the tests, without a network or an API key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from runaround.schema import HOP_RESULT_SCHEMA
+
+API_KEY_ENV = "CALLE_API_KEY"
+BASE_URL_ENV = "CALLE_BASE_URL"
+DEFAULT_BASE_URL = "https://api.heycall-e.com"
+
+CREATE_CALL_PATH = "/v1/calls"
+GET_CALL_PATH = "/v1/calls/{call_id}"
+IDEMPOTENCY_HEADER = "Idempotency-Key"
+
+TERMINAL_STATUSES = frozenset({"completed", "failed", "canceled"})
+NON_TERMINAL_STATUSES = frozenset({"queued", "in_progress"})
+
+#: Only these hosts may receive a bearer token.
+APPROVED_HOSTS = frozenset({"api.heycall-e.com"})
+
+POLL_INTERVAL_SECONDS = 5.0
+POLL_MAX_ATTEMPTS = 120
+
+
+class CallEError(RuntimeError):
+    """Raised when CALL-E cannot be used for this hop."""
+
+
+class Transport(Protocol):
+    def request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+
+def assert_approved_origin(base_url: str) -> str:
+    """Return ``base_url`` if a credential may be sent to it, else raise.
+
+    An operator-supplied base URL is a place where a bearer token can be
+    redirected. ``api.heycall-e.com.evil.example`` ends in the right letters
+    and is a different host, so the comparison is on the parsed host, exact.
+    """
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme != "https":
+        raise CallEError(f"CALL-E base URL must be https, got {base_url!r}")
+    if parsed.hostname is None or parsed.hostname.lower() not in APPROVED_HOSTS:
+        raise CallEError(
+            f"refusing to send credentials to unapproved host {parsed.hostname!r}"
+        )
+    return base_url.rstrip("/")
+
+
+def idempotency_key(*, case_id: str, hop_index: int, destination: str) -> str:
+    """Return a stable key for one hop of one case.
+
+    Derived from the authorization to place this hop, not from the attempt, so
+    a retried timeout returns the original call instead of dialling a person
+    twice.
+    """
+    material = f"runaround:{case_id}:{hop_index}:{destination}".encode()
+    digest = hashlib.sha256(material).hexdigest()[:32]
+    return f"runaround-{digest}"
+
+
+def build_create_call_body(
+    *,
+    task_text: str,
+    desk_phone: str,
+    region: str | None,
+    locale: str | None,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the ``POST /v1/calls`` request body for one hop."""
+    recipient: dict[str, Any] = {"phones": [desk_phone]}
+    if locale:
+        recipient["locale"] = locale
+    if region:
+        recipient["region"] = region
+    return {
+        "task": task_text,
+        "recipients": [recipient],
+        "result_schema": HOP_RESULT_SCHEMA,
+        "metadata": metadata,
+    }
+
+
+class UrllibTransport:
+    """Real HTTPS transport. Used only on the live path."""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        self._timeout = timeout
+
+    def request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+    ) -> tuple[int, dict[str, Any]]:
+        request = urllib.request.Request(
+            url, data=body, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                payload = response.read().decode("utf-8")
+                return response.status, json.loads(payload or "{}")
+        except urllib.error.HTTPError as error:
+            raw = error.read().decode("utf-8", errors="replace")
+            try:
+                return error.code, json.loads(raw or "{}")
+            except json.JSONDecodeError:
+                return error.code, {"error": {"code": "internal_error", "message": raw}}
+        except urllib.error.URLError as error:
+            raise CallEError(f"CALL-E is unreachable: {error.reason}") from error
+
+
+@dataclass
+class CallEClient:
+    """Places one hop and returns the terminal call task."""
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    transport: Transport | None = None
+    poll_interval: float = POLL_INTERVAL_SECONDS
+    poll_max_attempts: int = POLL_MAX_ATTEMPTS
+    sleep: Any = time.sleep
+
+    def __post_init__(self) -> None:
+        self.base_url = assert_approved_origin(self.base_url)
+        if not self.api_key:
+            raise CallEError(
+                f"{API_KEY_ENV} is not set; the live path needs a CALL-E API key"
+            )
+        if self.transport is None:
+            self.transport = UrllibTransport()
+
+    @classmethod
+    def from_env(cls, **kwargs: Any) -> CallEClient:
+        return cls(
+            api_key=os.environ.get(API_KEY_ENV, ""),
+            base_url=os.environ.get(BASE_URL_ENV, DEFAULT_BASE_URL),
+            **kwargs,
+        )
+
+    def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if extra:
+            headers.update(extra)
+        return headers
+
+    @staticmethod
+    def _raise_for_error(status: int, payload: dict[str, Any]) -> None:
+        if status < 400:
+            return
+        error = payload.get("error") or {}
+        code = error.get("code", "internal_error")
+        message = error.get("message", "no message")
+        raise CallEError(f"CALL-E returned {status} {code}: {message}")
+
+    def create_call(
+        self, *, body: dict[str, Any], key: str | None = None
+    ) -> dict[str, Any]:
+        extra = {IDEMPOTENCY_HEADER: key} if key else None
+        assert self.transport is not None
+        status, payload = self.transport.request(
+            method="POST",
+            url=f"{self.base_url}{CREATE_CALL_PATH}",
+            headers=self._headers(extra),
+            body=json.dumps(body).encode("utf-8"),
+        )
+        self._raise_for_error(status, payload)
+        return payload
+
+    def get_call(self, call_id: str) -> dict[str, Any]:
+        assert self.transport is not None
+        status, payload = self.transport.request(
+            method="GET",
+            url=f"{self.base_url}{GET_CALL_PATH.format(call_id=call_id)}",
+            headers=self._headers(),
+            body=None,
+        )
+        self._raise_for_error(status, payload)
+        return payload
+
+    def await_terminal(self, call_id: str) -> dict[str, Any]:
+        """Poll one call until CALL-E publishes a terminal state.
+
+        A poll ceiling that is reached is not a failed call. The call may
+        still be running, so the caller is told the outcome is unknown and the
+        case waits for a human rather than redialling.
+        """
+        for attempt in range(self.poll_max_attempts):
+            call = self.get_call(call_id)
+            status = call.get("status")
+            if status in TERMINAL_STATUSES:
+                return call
+            if status not in NON_TERMINAL_STATUSES:
+                raise CallEError(f"unrecognized call status {status!r}")
+            if attempt + 1 < self.poll_max_attempts:
+                self.sleep(self.poll_interval)
+        raise CallEError(
+            f"call {call_id} did not reach a terminal state within "
+            f"{self.poll_max_attempts} polls; its outcome is unknown and it "
+            "must be reconciled by hand before this case calls anyone again"
+        )
+
+    def place_hop(
+        self, *, body: dict[str, Any], key: str | None = None
+    ) -> dict[str, Any]:
+        created = self.create_call(body=body, key=key)
+        call_id = created.get("id")
+        if not call_id:
+            raise CallEError("CALL-E create-call response carried no call id")
+        if created.get("status") in TERMINAL_STATUSES:
+            return created
+        return self.await_terminal(call_id)
+
+
+def extract_structured_result(call: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the task-level structured result, falling back to the recipient.
+
+    A single-recipient hop can carry its result in either place depending on
+    which schema CALL-E could satisfy. Neither one present means no result,
+    which is a distinct state from an empty one.
+    """
+    task_level = call.get("structured_result")
+    if isinstance(task_level, dict) and task_level:
+        return task_level
+    recipients = call.get("recipients") or []
+    if recipients:
+        recipient_level = recipients[0].get("structured_result")
+        if isinstance(recipient_level, dict) and recipient_level:
+            return recipient_level
+    return None

--- a/apps/python/runaround/runaround/calle_client.py
+++ b/apps/python/runaround/runaround/calle_client.py
@@ -1,7 +1,7 @@
 """CALL-E Developer API adapter for one hop.
 
 Contract source: ``https://docs.heycall-e.com/openapi/calle.openapi.yaml``
-(CALL-E Developer API 0.6.0).
+(CALL-E Developer API 0.7.0).
 
 * ``POST /v1/calls`` with ``task`` and ``result_schema``, bearer auth, optional
   ``Idempotency-Key``.
@@ -45,6 +45,28 @@ POLL_MAX_ATTEMPTS = 120
 
 class CallEError(RuntimeError):
     """Raised when CALL-E cannot be used for this hop."""
+
+
+#: Statuses on which CALL-E states that the call task was not created.
+#: Measured on 2026-09-07: an unsupported ``result_schema`` answers 400
+#: ``result_schema_invalid``, and an unsupported region answers 422
+#: ``call_not_ready``. In both the request was rejected before dialling.
+NOT_PLACED_STATUSES = frozenset({400, 422})
+
+
+class CallNotPlaced(CallEError):
+    """Raised when CALL-E refused the request and no call exists.
+
+    This is narrower than :class:`CallEError` on purpose. A transport error,
+    a timeout, or a 5xx leaves the question "did a phone ring?" open, and an
+    open question must be reconciled by a person. A 400 or a 422 answers it:
+    nothing was dialled, so the hop it was going to be may be withdrawn.
+    """
+
+    def __init__(self, message: str, *, status: int, code: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
 
 
 class Transport(Protocol):
@@ -185,7 +207,10 @@ class CallEClient:
         error = payload.get("error") or {}
         code = error.get("code", "internal_error")
         message = error.get("message", "no message")
-        raise CallEError(f"CALL-E returned {status} {code}: {message}")
+        text = f"CALL-E returned {status} {code}: {message}"
+        if status in NOT_PLACED_STATUSES:
+            raise CallNotPlaced(text, status=status, code=code)
+        raise CallEError(text)
 
     def create_call(
         self, *, body: dict[str, Any], key: str | None = None

--- a/apps/python/runaround/runaround/case.py
+++ b/apps/python/runaround/runaround/case.py
@@ -1,0 +1,233 @@
+"""The case record: what was authorized, what was called, what came back.
+
+The case file is the only durable state. It is written after every hop, so an
+interrupted run resumes without re-dialling anyone, and so the evidence pack
+can be rebuilt from disk long after the process is gone.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from runaround import phone
+from runaround.chain import CHAIN_CONTINUE, Desk
+
+CASE_FILE_SUFFIX = ".case.json"
+
+DEFAULT_HOP_BUDGET = 4
+
+
+class CaseError(RuntimeError):
+    """Raised when a case cannot be loaded, created, or advanced."""
+
+
+@dataclass
+class Hop:
+    """One placed call and what it produced."""
+
+    index: int
+    desk: Desk
+    authorized_by: str
+    call_id: str | None = None
+    call_status: str | None = None
+    outcome: str | None = None
+    reason: str | None = None
+    answer: str | None = None
+    reference_number: str | None = None
+    referral: dict[str, Any] | None = None
+    started_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "desk": self.desk.to_dict(),
+            "authorized_by": self.authorized_by,
+            "call_id": self.call_id,
+            "call_status": self.call_status,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "answer": self.answer,
+            "reference_number": self.reference_number,
+            "referral": self.referral,
+            "started_at": self.started_at,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> Hop:
+        return Hop(
+            index=int(data["index"]),
+            desk=Desk.from_dict(data["desk"]),
+            authorized_by=str(data.get("authorized_by", "unknown")),
+            call_id=data.get("call_id"),
+            call_status=data.get("call_status"),
+            outcome=data.get("outcome"),
+            reason=data.get("reason"),
+            answer=data.get("answer"),
+            reference_number=data.get("reference_number"),
+            referral=data.get("referral"),
+            started_at=data.get("started_at"),
+        )
+
+
+@dataclass
+class Case:
+    """One question being chased across organizations."""
+
+    case_id: str
+    subject: str
+    question: str
+    requester_name: str
+    requester_phone: str | None = None
+    region: str | None = None
+    locale: str | None = None
+    hop_budget: int = DEFAULT_HOP_BUDGET
+    status: str = "open"
+    status_reason: str = "no call has been placed yet"
+    authorized_desks: list[Desk] = field(default_factory=list)
+    intake_identities: list[str] = field(default_factory=list)
+    hops: list[Hop] = field(default_factory=list)
+    pending_desk: Desk | None = None
+    loop_path: list[str] = field(default_factory=list)
+
+    # -- identity -----------------------------------------------------
+
+    def authorized_identities(self) -> set[str]:
+        return {desk.identity() for desk in self.authorized_desks}
+
+    def visited_desks(self) -> list[Desk]:
+        return [hop.desk for hop in self.hops]
+
+    def hops_used(self) -> int:
+        return len(self.hops)
+
+    def history(self) -> list[dict[str, Any]]:
+        """Referral history handed to the next call, oldest first."""
+        entries: list[dict[str, Any]] = []
+        for hop in self.hops:
+            quote = (hop.referral or {}).get("quote")
+            entries.append({"name": hop.desk.name, "quote": quote})
+        return entries
+
+    def next_desk(self) -> Desk | None:
+        """Return the desk the next call would reach, if any."""
+        if self.status == "open" and not self.hops:
+            return self.authorized_desks[0] if self.authorized_desks else None
+        if self.status == CHAIN_CONTINUE:
+            return self.pending_desk
+        return None
+
+    def authorize(self, desk: Desk) -> None:
+        if desk.identity() in self.authorized_identities():
+            return
+        self.authorized_desks.append(desk)
+
+    # -- persistence --------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "subject": self.subject,
+            "question": self.question,
+            "requester_name": self.requester_name,
+            "requester_phone": self.requester_phone,
+            "region": self.region,
+            "locale": self.locale,
+            "hop_budget": self.hop_budget,
+            "status": self.status,
+            "status_reason": self.status_reason,
+            "authorized_desks": [desk.to_dict() for desk in self.authorized_desks],
+            "intake_identities": self.intake_identities,
+            "hops": [hop.to_dict() for hop in self.hops],
+            "pending_desk": self.pending_desk.to_dict() if self.pending_desk else None,
+            "loop_path": self.loop_path,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> Case:
+        pending = data.get("pending_desk")
+        return Case(
+            case_id=str(data["case_id"]),
+            subject=str(data["subject"]),
+            question=str(data["question"]),
+            requester_name=str(data["requester_name"]),
+            requester_phone=data.get("requester_phone"),
+            region=data.get("region"),
+            locale=data.get("locale"),
+            hop_budget=int(data.get("hop_budget", DEFAULT_HOP_BUDGET)),
+            status=str(data.get("status", "open")),
+            status_reason=str(data.get("status_reason", "")),
+            authorized_desks=[
+                Desk.from_dict(item) for item in data.get("authorized_desks", [])
+            ],
+            intake_identities=list(data.get("intake_identities", [])),
+            hops=[Hop.from_dict(item) for item in data.get("hops", [])],
+            pending_desk=Desk.from_dict(pending) if pending else None,
+            loop_path=list(data.get("loop_path", [])),
+        )
+
+
+def case_path(data_dir: Path, case_id: str) -> Path:
+    return Path(data_dir) / f"{case_id}{CASE_FILE_SUFFIX}"
+
+
+def save_case(data_dir: Path, case: Case) -> Path:
+    path = case_path(data_dir, case.case_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(case.to_dict(), indent=2, ensure_ascii=True) + "\n"
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(payload, encoding="utf-8")
+    temporary.replace(path)
+    return path
+
+
+def load_case(data_dir: Path, case_id: str) -> Case:
+    path = case_path(data_dir, case_id)
+    if not path.exists():
+        raise CaseError(f"no case {case_id!r} under {data_dir}")
+    return Case.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def list_cases(data_dir: Path) -> list[Case]:
+    directory = Path(data_dir)
+    if not directory.exists():
+        return []
+    cases = []
+    for path in sorted(directory.glob(f"*{CASE_FILE_SUFFIX}")):
+        cases.append(Case.from_dict(json.loads(path.read_text(encoding="utf-8"))))
+    return cases
+
+
+def build_case(spec: dict[str, Any]) -> Case:
+    """Create a case from an intake document.
+
+    Every desk named in the intake is authorized by the person who wrote it.
+    Desks discovered later on a call are not.
+    """
+    required = ("case_id", "subject", "question", "requester_name", "first_desk")
+    missing = [key for key in required if key not in spec]
+    if missing:
+        raise CaseError("intake is missing: " + ", ".join(missing))
+
+    first = Desk.from_dict(spec["first_desk"])
+    requester_phone = spec.get("requester_phone")
+    if requester_phone is not None:
+        requester_phone = phone.normalize(str(requester_phone))
+
+    case = Case(
+        case_id=str(spec["case_id"]),
+        subject=str(spec["subject"]),
+        question=str(spec["question"]),
+        requester_name=str(spec["requester_name"]),
+        requester_phone=requester_phone,
+        region=spec.get("region"),
+        locale=spec.get("locale"),
+        hop_budget=int(spec.get("hop_budget", DEFAULT_HOP_BUDGET)),
+        authorized_desks=[first],
+    )
+    for extra in spec.get("also_authorized", []):
+        case.authorize(Desk.from_dict(extra))
+    case.intake_identities = [desk.identity() for desk in case.authorized_desks]
+    return case

--- a/apps/python/runaround/runaround/chain.py
+++ b/apps/python/runaround/runaround/chain.py
@@ -1,0 +1,352 @@
+"""The referral chain: what one call outcome means, and where it may lead.
+
+The whole point of this app lives here, and none of it touches a network. A
+hop outcome is decided from the validated result alone; the chain decision is
+decided from that outcome plus the desks already visited.
+
+Two rules carry the design:
+
+* A referral advances the chain only when the recipient's own words are
+  attached to it. An unquoted referral is a machine's paraphrase, and it is
+  refused.
+* A destination that has already been called is a closed loop, not a next
+  hop. The chain stops and says so, with both quotes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from runaround import phone
+
+# What one call produced.
+HOP_ANSWERED = "answered"
+HOP_REFERRED = "referred"
+HOP_UNVERIFIED_REFERRAL = "unverified_referral"
+HOP_OWNER_WITHOUT_ANSWER = "owner_without_answer"
+HOP_DEAD_END = "dead_end"
+HOP_UNREACHABLE = "unreachable"
+
+# What the chain should do next.
+CHAIN_RESOLVED = "resolved"
+CHAIN_LOOP_DETECTED = "loop_detected"
+CHAIN_SELF_REFERRAL = "self_referral"
+CHAIN_REFERRED_TO_REQUESTER = "referred_to_requester"
+CHAIN_LOOP_SUSPECTED = "loop_suspected"
+CHAIN_AWAITING_APPROVAL = "awaiting_approval"
+CHAIN_BUDGET_EXHAUSTED = "budget_exhausted"
+CHAIN_NEEDS_HUMAN = "needs_human"
+CHAIN_CONTINUE = "continue"
+
+#: Chain states in which no further call may be placed without a human.
+TERMINAL_CHAIN_STATES = frozenset(
+    {
+        CHAIN_RESOLVED,
+        CHAIN_LOOP_DETECTED,
+        CHAIN_SELF_REFERRAL,
+        CHAIN_REFERRED_TO_REQUESTER,
+        CHAIN_BUDGET_EXHAUSTED,
+        CHAIN_NEEDS_HUMAN,
+    }
+)
+
+_ORG_SUFFIXES = (
+    " inc",
+    " llc",
+    " ltd",
+    " limited",
+    " corp",
+    " corporation",
+    " co",
+)
+
+
+def fold_name(name: str | None) -> str:
+    """Return a comparable form of an organization name.
+
+    Used only to *suspect* a loop when two different numbers answer for the
+    same-sounding organization. A suspicion pauses the chain for a human; it
+    never terminates the chain on its own, because names are not identities.
+    """
+    if not name:
+        return ""
+    lowered = name.casefold()
+    kept = [
+        character
+        for character in lowered
+        if character.isalnum() or character == " "
+    ]
+    collapsed = " ".join("".join(kept).split())
+    for suffix in _ORG_SUFFIXES:
+        collapsed = collapsed.removesuffix(suffix)
+    return collapsed.strip()
+
+
+@dataclass(frozen=True)
+class Desk:
+    """One organization or department that can be called."""
+
+    name: str
+    phone: str
+    region: str | None = None
+
+    def identity(self) -> str:
+        return phone.identity(self.phone)
+
+    def masked(self) -> str:
+        return phone.mask(self.phone)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "phone": self.phone, "region": self.region}
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> Desk:
+        return Desk(
+            name=str(data["name"]),
+            phone=phone.normalize(str(data["phone"])),
+            region=data.get("region"),
+        )
+
+
+@dataclass
+class Referral:
+    """A next destination, and the words that licensed it."""
+
+    target_name: str | None
+    target_phone: str
+    quote: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target_name": self.target_name,
+            "target_phone": self.target_phone,
+            "quote": self.quote,
+        }
+
+
+@dataclass
+class HopVerdict:
+    """What one call outcome means on its own."""
+
+    outcome: str
+    reason: str
+    referral: Referral | None = None
+    answer: str | None = None
+    reference_number: str | None = None
+
+
+@dataclass
+class ChainDecision:
+    """What the chain does next, given a hop verdict and the visited desks."""
+
+    state: str
+    reason: str
+    next_desk: Desk | None = None
+    loop_path: list[str] = field(default_factory=list)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_CHAIN_STATES
+
+
+def classify_hop(
+    *,
+    call_status: str,
+    result: dict[str, Any] | None,
+    rejection: str | None = None,
+) -> HopVerdict:
+    """Decide what a single call produced.
+
+    ``rejection`` carries the message from :mod:`runaround.schema` when the
+    returned result could not be validated. An unvalidatable result is
+    unreachable ground: it never becomes "no referral".
+    """
+    if call_status != "completed":
+        return HopVerdict(
+            outcome=HOP_UNREACHABLE,
+            reason=f"call ended in status {call_status!r}, not completed",
+        )
+    if rejection is not None:
+        return HopVerdict(
+            outcome=HOP_UNREACHABLE,
+            reason=f"result refused: {rejection}",
+        )
+    if result is None:
+        return HopVerdict(
+            outcome=HOP_UNREACHABLE,
+            reason="call completed without a structured result",
+        )
+
+    owns = result["owns_request"]
+    answered = result["question_answered"]
+
+    if owns == "yes" and answered == "yes":
+        return HopVerdict(
+            outcome=HOP_ANSWERED,
+            reason="this desk stated it owns the request and answered it",
+            answer=result["answer_summary"],
+            reference_number=result["reference_number"],
+        )
+    if owns == "yes":
+        return HopVerdict(
+            outcome=HOP_OWNER_WITHOUT_ANSWER,
+            reason=(
+                "this desk stated it owns the request but did not answer the "
+                "question on this call"
+            ),
+            reference_number=result["reference_number"],
+        )
+
+    target_phone = result["referral_target_phone"]
+    quote = result["referral_quote"]
+
+    if target_phone and not quote:
+        return HopVerdict(
+            outcome=HOP_UNVERIFIED_REFERRAL,
+            reason=(
+                "a referral number was returned without the words that gave "
+                "it; the chain does not dial an unquoted referral"
+            ),
+        )
+    if quote and not target_phone:
+        rejected = result.get("referral_phone_rejected")
+        detail = f"; the spoken number {rejected!r} is not E.164" if rejected else ""
+        return HopVerdict(
+            outcome=HOP_UNVERIFIED_REFERRAL,
+            reason=(
+                "a referral was spoken but no usable number came with it"
+                + detail
+            ),
+        )
+    if target_phone and quote:
+        return HopVerdict(
+            outcome=HOP_REFERRED,
+            reason="this desk referred the request elsewhere, in its own words",
+            referral=Referral(
+                target_name=result["referral_target_name"],
+                target_phone=target_phone,
+                quote=quote,
+            ),
+            reference_number=result["reference_number"],
+        )
+
+    return HopVerdict(
+        outcome=HOP_DEAD_END,
+        reason="this desk neither owns the request nor named anyone who does",
+    )
+
+
+def decide_next(
+    *,
+    verdict: HopVerdict,
+    current: Desk,
+    visited: list[Desk],
+    requester_phone: str | None,
+    hop_budget: int,
+    hops_used: int,
+    authorized_identities: set[str],
+    auto_dial_referrals: bool,
+) -> ChainDecision:
+    """Decide whether the chain may place another call, and to whom.
+
+    ``visited`` is every desk already called on this case, in order, including
+    ``current``. ``hops_used`` counts calls already placed.
+    """
+    if verdict.outcome == HOP_ANSWERED:
+        return ChainDecision(
+            state=CHAIN_RESOLVED,
+            reason="the owning desk answered the question",
+        )
+    if verdict.outcome in (
+        HOP_UNREACHABLE,
+        HOP_DEAD_END,
+        HOP_OWNER_WITHOUT_ANSWER,
+        HOP_UNVERIFIED_REFERRAL,
+    ):
+        return ChainDecision(state=CHAIN_NEEDS_HUMAN, reason=verdict.reason)
+
+    referral = verdict.referral
+    if referral is None:
+        raise ValueError("a referred hop must carry a referral")
+    target_identity = phone.identity(referral.target_phone)
+
+    if target_identity == current.identity():
+        return ChainDecision(
+            state=CHAIN_SELF_REFERRAL,
+            reason=(
+                "this desk referred the request to its own number; there is "
+                "no next hop to place"
+            ),
+        )
+
+    if requester_phone and target_identity == phone.identity(requester_phone):
+        return ChainDecision(
+            state=CHAIN_REFERRED_TO_REQUESTER,
+            reason=(
+                "this desk referred the request back to the requester's own "
+                "number"
+            ),
+        )
+
+    visited_identities = [desk.identity() for desk in visited]
+    if target_identity in visited_identities:
+        start = visited_identities.index(target_identity)
+        loop_path = [phone.mask(item) for item in visited_identities[start:]]
+        loop_path.append(phone.mask(target_identity))
+        return ChainDecision(
+            state=CHAIN_LOOP_DETECTED,
+            reason=(
+                "the referral points at a desk this case has already called; "
+                "the chain has closed on itself without reaching an owner"
+            ),
+            loop_path=loop_path,
+        )
+
+    if hops_used >= hop_budget:
+        return ChainDecision(
+            state=CHAIN_BUDGET_EXHAUSTED,
+            reason=(
+                f"the hop budget of {hop_budget} is spent and the chain has "
+                "not reached an owner"
+            ),
+        )
+
+    next_desk = Desk(
+        name=referral.target_name or "Unnamed desk",
+        phone=referral.target_phone,
+        region=current.region,
+    )
+
+    folded = fold_name(next_desk.name)
+    if folded:
+        for desk in visited:
+            if (
+                fold_name(desk.name) == folded
+                and desk.identity() != target_identity
+            ):
+                return ChainDecision(
+                    state=CHAIN_LOOP_SUSPECTED,
+                    reason=(
+                        "a different number was given for an organization "
+                        f"already called under the name {desk.name!r}; a "
+                        "human decides whether this is the same desk"
+                    ),
+                    next_desk=next_desk,
+                )
+
+    if not auto_dial_referrals and target_identity not in authorized_identities:
+        return ChainDecision(
+            state=CHAIN_AWAITING_APPROVAL,
+            reason=(
+                "a number given on a call is not an authorization to dial it; "
+                "this destination needs explicit approval"
+            ),
+            next_desk=next_desk,
+        )
+
+    return ChainDecision(
+        state=CHAIN_CONTINUE,
+        reason="the referral is quoted, new, and authorized",
+        next_desk=next_desk,
+    )

--- a/apps/python/runaround/runaround/cli.py
+++ b/apps/python/runaround/runaround/cli.py
@@ -1,0 +1,285 @@
+"""Command line for Runaround.
+
+Default mode is ``fixture``: it places no calls and needs no credential.
+``live`` requires an explicit mode flag, an API key in the environment, and a
+per-run acknowledgement that a real telephone will ring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from runaround import chain, evidence
+from runaround.calle_client import CallEClient, CallEError
+from runaround.case import (
+    CaseError,
+    build_case,
+    list_cases,
+    load_case,
+    save_case,
+)
+from runaround.chain import Desk
+from runaround.runner import (
+    FixturePlacer,
+    LivePlacer,
+    RunRefused,
+    plan_hop,
+    run_chain,
+    run_hop,
+)
+
+DEMO_INTAKE = {
+    "case_id": "parcel-8472",
+    "subject": (
+        "Order ORD-8472 arrived crushed on 2026-08-30; the contents are broken"
+    ),
+    "question": (
+        "Which organization accepts the damage claim for this parcel, and what "
+        "is the claim reference number?"
+    ),
+    "requester_name": "Dana Okafor",
+    "requester_phone": "+15550199",
+    "region": "US",
+    "locale": "en-US",
+    "hop_budget": 4,
+    "first_desk": {
+        "name": "Example Retail Support",
+        "phone": "+15550100",
+        "region": "US",
+    },
+}
+
+
+def _print(payload: Any) -> None:
+    if isinstance(payload, str):
+        print(payload)
+    else:
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+
+
+def _data_dir(args: argparse.Namespace) -> Path:
+    return Path(args.data)
+
+
+def _placer(args: argparse.Namespace):
+    if args.mode == "fixture":
+        if not args.fixture:
+            raise SystemExit(
+                "fixture mode needs --fixture pointing at a scripted call file"
+            )
+        return FixturePlacer.from_file(Path(args.fixture))
+    if args.mode == "live":
+        if not args.i_understand_this_calls_people:
+            raise SystemExit(
+                "live mode rings a real telephone. Re-run with "
+                "--i-understand-this-calls-people once you have the "
+                "recipient's authorization to be called about this case."
+            )
+        return LivePlacer(client=CallEClient.from_env())
+    raise SystemExit(f"unknown mode {args.mode!r}")
+
+
+def _status_line(case) -> str:
+    return (
+        f"{case.case_id}: {case.status} after {case.hops_used()} call(s) "
+        f"-- {case.status_reason}"
+    )
+
+
+def command_init_demo(args: argparse.Namespace) -> int:
+    case = build_case(DEMO_INTAKE)
+    path = save_case(_data_dir(args), case)
+    _print(f"wrote {path}")
+    _print(_status_line(case))
+    return 0
+
+
+def command_open(args: argparse.Namespace) -> int:
+    spec = json.loads(Path(args.intake).read_text(encoding="utf-8"))
+    case = build_case(spec)
+    path = save_case(_data_dir(args), case)
+    _print(f"wrote {path}")
+    _print(_status_line(case))
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    cases = list_cases(_data_dir(args))
+    if not cases:
+        _print("no cases")
+        return 0
+    for case in cases:
+        _print(_status_line(case))
+        if case.pending_desk:
+            _print(
+                f"    next destination would be {case.pending_desk.name} "
+                f"({case.pending_desk.masked()})"
+            )
+    return 0
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    case = load_case(_data_dir(args), args.case_id)
+    _print(plan_hop(case))
+    return 0
+
+
+def command_run(args: argparse.Namespace) -> int:
+    case = load_case(_data_dir(args), args.case_id)
+    placer = _placer(args)
+    if args.once:
+        hop = run_hop(case=case, placer=placer, data_dir=_data_dir(args))
+        _print(
+            f"hop {hop.index} to {hop.desk.name} ({hop.desk.masked()}): "
+            f"{hop.outcome} -- {hop.reason}"
+        )
+    else:
+        for hop in run_chain(
+            case=case, placer=placer, data_dir=_data_dir(args)
+        ):
+            _print(
+                f"hop {hop.index} to {hop.desk.name} ({hop.desk.masked()}): "
+                f"{hop.outcome} -- {hop.reason}"
+            )
+    _print(_status_line(case))
+    return 0
+
+
+def command_approve(args: argparse.Namespace) -> int:
+    case = load_case(_data_dir(args), args.case_id)
+    if case.status != chain.CHAIN_AWAITING_APPROVAL and (
+        case.status != chain.CHAIN_LOOP_SUSPECTED
+    ):
+        _print(
+            f"case {case.case_id} is {case.status}; there is nothing awaiting "
+            "approval"
+        )
+        return 1
+    desk = case.pending_desk
+    if desk is None:
+        _print("no pending destination is recorded on this case")
+        return 1
+    case.authorize(Desk(name=desk.name, phone=desk.phone, region=desk.region))
+    case.status = chain.CHAIN_CONTINUE
+    case.status_reason = (
+        f"a person approved calling {desk.name} at {desk.masked()}"
+    )
+    case.pending_desk = desk
+    save_case(_data_dir(args), case)
+    _print(f"approved {desk.name} ({desk.masked()})")
+    _print(_status_line(case))
+    return 0
+
+
+def command_stop(args: argparse.Namespace) -> int:
+    case = load_case(_data_dir(args), args.case_id)
+    case.status = chain.CHAIN_NEEDS_HUMAN
+    case.status_reason = args.reason or "stopped by a person"
+    case.pending_desk = None
+    save_case(_data_dir(args), case)
+    _print(_status_line(case))
+    return 0
+
+
+def command_evidence(args: argparse.Namespace) -> int:
+    case = load_case(_data_dir(args), args.case_id)
+    pack = evidence.render(case)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(pack, encoding="utf-8")
+        _print(f"wrote {out}")
+    else:
+        _print(pack)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="runaround",
+        description=(
+            "Chase one question across organizations by phone, and stop with "
+            "evidence when the referrals close on themselves."
+        ),
+    )
+    parser.add_argument(
+        "--data",
+        default="./data",
+        help="directory holding case files (default: ./data)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    demo = subparsers.add_parser(
+        "init-demo", help="write the fictional demo case"
+    )
+    demo.set_defaults(handler=command_init_demo)
+
+    opened = subparsers.add_parser("open", help="open a case from an intake file")
+    opened.add_argument("intake", help="path to an intake JSON document")
+    opened.set_defaults(handler=command_open)
+
+    status = subparsers.add_parser("status", help="list cases and their states")
+    status.set_defaults(handler=command_status)
+
+    plan = subparsers.add_parser(
+        "plan", help="print the next call request without sending it"
+    )
+    plan.add_argument("case_id")
+    plan.set_defaults(handler=command_plan)
+
+    run = subparsers.add_parser("run", help="place calls for a case")
+    run.add_argument("case_id")
+    run.add_argument(
+        "--mode",
+        choices=("fixture", "live"),
+        default="fixture",
+        help="fixture places no calls (default); live rings real telephones",
+    )
+    run.add_argument("--fixture", help="scripted call file for fixture mode")
+    run.add_argument(
+        "--once", action="store_true", help="place at most one call"
+    )
+    run.add_argument(
+        "--i-understand-this-calls-people",
+        action="store_true",
+        help="required acknowledgement for live mode",
+    )
+    run.set_defaults(handler=command_run)
+
+    approve = subparsers.add_parser(
+        "approve", help="authorize the destination a call named"
+    )
+    approve.add_argument("case_id")
+    approve.set_defaults(handler=command_approve)
+
+    stop = subparsers.add_parser("stop", help="hand the case to a person")
+    stop.add_argument("case_id")
+    stop.add_argument("--reason")
+    stop.set_defaults(handler=command_stop)
+
+    pack = subparsers.add_parser("evidence", help="render the evidence pack")
+    pack.add_argument("case_id")
+    pack.add_argument("--out", help="write markdown to this path")
+    pack.set_defaults(handler=command_evidence)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (CaseError, RunRefused, CallEError) as error:
+        # A refusal is an answer, not a crash. Every one of these says which
+        # condition was not met, so a traceback would only hide it.
+        print(f"refused: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/runaround/runaround/evidence.py
+++ b/apps/python/runaround/runaround/evidence.py
@@ -1,0 +1,117 @@
+"""The evidence pack: what the chain proves, in the words that proved it.
+
+This is the artifact a person takes to a regulator, an ombudsman, or a
+supervisor. It says who was called, who they sent the request to, and in whose
+words. Numbers are masked, because an evidence pack is written to be attached
+to a complaint and read by strangers.
+"""
+
+from __future__ import annotations
+
+from runaround import chain, phone
+from runaround.case import Case
+
+STATE_HEADLINES = {
+    chain.CHAIN_RESOLVED: "An owner was found and answered the question.",
+    chain.CHAIN_LOOP_DETECTED: (
+        "The chain closed on itself: a desk referred the request back to a "
+        "desk that had already been called."
+    ),
+    chain.CHAIN_SELF_REFERRAL: (
+        "A desk referred the request to its own number."
+    ),
+    chain.CHAIN_REFERRED_TO_REQUESTER: (
+        "A desk referred the request back to the requester."
+    ),
+    chain.CHAIN_LOOP_SUSPECTED: (
+        "A second number was given for an organization already called."
+    ),
+    chain.CHAIN_AWAITING_APPROVAL: (
+        "The next destination came from a call and has not been approved."
+    ),
+    chain.CHAIN_BUDGET_EXHAUSTED: (
+        "The hop budget ran out before an owner was found."
+    ),
+    chain.CHAIN_NEEDS_HUMAN: "The chain stopped and needs a person.",
+    chain.CHAIN_CONTINUE: "The chain is still running.",
+    "open": "No call has been placed yet.",
+}
+
+
+def _quote_block(text: str) -> str:
+    return "\n".join(f"> {line}" for line in text.splitlines() or [""])
+
+
+def render(case: Case) -> str:
+    """Return the evidence pack for ``case`` as markdown."""
+    lines: list[str] = []
+    lines.append(f"# Referral evidence: {case.case_id}")
+    lines.append("")
+    lines.append(f"**Subject.** {case.subject}")
+    lines.append("")
+    lines.append(f"**Question.** {case.question}")
+    lines.append("")
+    headline = STATE_HEADLINES.get(case.status, case.status)
+    lines.append(f"**Outcome.** {headline}")
+    lines.append("")
+    lines.append(f"**Why.** {case.status_reason}")
+    lines.append("")
+    lines.append(
+        f"**Calls placed.** {case.hops_used()} of a budget of {case.hop_budget}."
+    )
+    lines.append("")
+
+    if case.loop_path:
+        lines.append("## The loop")
+        lines.append("")
+        lines.append("```text")
+        lines.append(" -> ".join(case.loop_path))
+        lines.append("```")
+        lines.append("")
+
+    lines.append("## Call by call")
+    lines.append("")
+    if not case.hops:
+        lines.append("No calls have been placed on this case.")
+        lines.append("")
+
+    for hop in case.hops:
+        lines.append(f"### Hop {hop.index}: {hop.desk.name} ({hop.desk.masked()})")
+        lines.append("")
+        lines.append(f"- Destination authorized by: {hop.authorized_by}")
+        lines.append(f"- CALL-E call id: {hop.call_id or 'none'}")
+        lines.append(f"- Call status: {hop.call_status or 'unknown'}")
+        lines.append(f"- Outcome: {hop.outcome or 'unknown'}")
+        lines.append(f"- Reading: {hop.reason or 'not recorded'}")
+        if hop.reference_number:
+            lines.append(f"- Reference given: {hop.reference_number}")
+        lines.append("")
+        if hop.answer:
+            lines.append("Answer given on this call:")
+            lines.append("")
+            lines.append(_quote_block(hop.answer))
+            lines.append("")
+        if hop.referral:
+            target_name = hop.referral.get("target_name") or "an unnamed desk"
+            target = phone.mask(hop.referral["target_phone"])
+            lines.append(f"Referred the request to {target_name} ({target}), saying:")
+            lines.append("")
+            lines.append(_quote_block(hop.referral["quote"]))
+            lines.append("")
+
+    lines.append("## What this does and does not establish")
+    lines.append("")
+    lines.append(
+        "- Each referral above is recorded with the words the recipient used. "
+        "A referral without those words never advanced this chain."
+    )
+    lines.append(
+        "- Names and job titles were not verified. This record establishes "
+        "what was said on a call to the number shown, not who said it."
+    )
+    lines.append(
+        "- Nothing in this pack was accepted, declined, or agreed to on the "
+        "requester's behalf."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/apps/python/runaround/runaround/phone.py
+++ b/apps/python/runaround/runaround/phone.py
@@ -1,0 +1,66 @@
+"""E.164 handling: validation, identity, and masking.
+
+Two phone strings that differ only in punctuation are the same desk. Chain
+cycle detection depends on that being decided in exactly one place.
+"""
+
+from __future__ import annotations
+
+import re
+
+E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+_PUNCTUATION_RE = re.compile(r"[\s()\-.]")
+
+
+class InvalidPhoneNumber(ValueError):
+    """Raised when a phone number is not usable as a call destination."""
+
+
+def normalize(raw: str) -> str:
+    """Return the canonical E.164 form of ``raw``.
+
+    Punctuation humans read aloud is removed. Anything that is still not
+    E.164 is refused rather than repaired, because a repaired number is a
+    guess about who answers.
+    """
+    if not isinstance(raw, str):
+        raise InvalidPhoneNumber("phone number must be a string")
+    candidate = _PUNCTUATION_RE.sub("", raw.strip())
+    if not E164_RE.match(candidate):
+        raise InvalidPhoneNumber(
+            "phone number must be E.164, for example +15550100"
+        )
+    return candidate
+
+
+def is_valid(raw: object) -> bool:
+    """Return True when ``raw`` normalizes to a usable E.164 number."""
+    if not isinstance(raw, str):
+        return False
+    try:
+        normalize(raw)
+    except InvalidPhoneNumber:
+        return False
+    return True
+
+
+def identity(raw: str) -> str:
+    """Return the desk identity used for visited-set and cycle checks."""
+    return normalize(raw)
+
+
+def mask(raw: str) -> str:
+    """Return a display form that keeps the country prefix and last two digits.
+
+    Summaries, previews, ledgers, and evidence packs print this form. The full
+    number stays in the call request and nowhere else.
+    """
+    try:
+        number = normalize(raw)
+    except InvalidPhoneNumber:
+        return "[invalid-number]"
+    head = number[:2]
+    tail = number[-2:]
+    hidden = len(number) - len(head) - len(tail)
+    return f"{head}{'*' * hidden}{tail}"

--- a/apps/python/runaround/runaround/prompt.py
+++ b/apps/python/runaround/runaround/prompt.py
@@ -1,0 +1,108 @@
+"""The task text CALL-E is given for one hop.
+
+The prompt is assembled by code, not written per case, so that every hop in
+every chain discloses automation the same way and asks the same closing
+questions. Chain history is carried into the text because a desk that hears
+"three people have already sent me here" answers a different question than a
+desk that hears the request cold.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from runaround.chain import Desk
+
+DISCLOSURE = (
+    "Open by saying you are an AI assistant calling on behalf of "
+    "{requester_name}, and say why you are calling in one sentence."
+)
+
+CLOSING_QUESTIONS = (
+    "Before ending the call you must establish two things: whether this desk "
+    "is the one responsible for handling this request, and, if it is not, the "
+    "name and phone number of the desk that is."
+)
+
+BOUNDARIES = (
+    "Do not accept, decline, or negotiate any offer, settlement, payment, "
+    "appointment, or commitment on behalf of the requester. Do not give any "
+    "personal detail that is not listed above. If the person asks to be "
+    "removed from contact, acknowledge and end the call. If the person "
+    "declines to help, thank them and end the call without pressing. Do not "
+    "invent a phone number: report only a number the person actually says."
+)
+
+
+def _history_lines(history: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for entry in history:
+        quote = entry.get("quote")
+        name = entry.get("name") or "a previous desk"
+        if quote:
+            lines.append(f'- {name} said: "{quote}"')
+        else:
+            lines.append(f"- {name} did not name anyone responsible.")
+    return lines
+
+
+def build_task_text(
+    *,
+    desk: Desk,
+    subject: str,
+    question: str,
+    requester_name: str,
+    history: list[dict[str, Any]] | None = None,
+) -> str:
+    """Return the ``task`` string for ``POST /v1/calls``.
+
+    ``history`` is a list of ``{"name": ..., "quote": ...}`` entries for the
+    desks already called on this case, oldest first.
+    """
+    history = history or []
+    parts: list[str] = [
+        f"Call {desk.name} at {desk.phone}.",
+        DISCLOSURE.format(requester_name=requester_name),
+        f"Subject: {subject}",
+        f"The question to get answered: {question}",
+    ]
+
+    if history:
+        parts.append(
+            "This request has already been passed along "
+            f"{len(history)} time(s). In order:"
+        )
+        parts.extend(_history_lines(history))
+        parts.append(
+            "Say plainly that the request has already been referred this "
+            "many times, and ask this desk to confirm whether it is "
+            "responsible rather than naming another party by reflex."
+        )
+
+    parts.append(CLOSING_QUESTIONS)
+    parts.append(BOUNDARIES)
+    return "\n".join(parts)
+
+
+def build_preview(
+    *,
+    desk: Desk,
+    subject: str,
+    question: str,
+    requester_name: str,
+    history: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return a human-readable preview with the destination masked."""
+    text = build_task_text(
+        desk=desk,
+        subject=subject,
+        question=question,
+        requester_name=requester_name,
+        history=history,
+    )
+    return {
+        "destination": desk.masked(),
+        "desk_name": desk.name,
+        "task_preview": text.replace(desk.phone, desk.masked()),
+        "will_place_call": False,
+    }

--- a/apps/python/runaround/runaround/runner.py
+++ b/apps/python/runaround/runaround/runner.py
@@ -1,0 +1,258 @@
+"""Running a case: one hop at a time, persisted after each.
+
+The runner is the only place that both talks to a call placer and writes the
+case file. Everything it decides comes from :mod:`runaround.chain`, so the
+decision logic stays testable without a placer at all.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from runaround import chain, schema
+from runaround.calle_client import (
+    CallEClient,
+    build_create_call_body,
+    extract_structured_result,
+    idempotency_key,
+)
+from runaround.case import Case, Hop, save_case
+from runaround.prompt import build_task_text
+
+RUNNABLE_STATES = frozenset({"open", chain.CHAIN_CONTINUE})
+
+
+class RunRefused(RuntimeError):
+    """Raised when the case may not place a call right now."""
+
+
+class CallPlacer(Protocol):
+    """Places one call and returns a CALL-E call task object."""
+
+    def place(
+        self, *, body: dict[str, Any], key: str, destination: str
+    ) -> dict[str, Any]: ...
+
+
+@dataclass
+class FixturePlacer:
+    """Returns scripted call tasks. Places no call and needs no credential.
+
+    The fixture file maps an E.164 destination to a CALL-E call task object.
+    This is the default mode: a run that has not been explicitly asked to
+    call a person does not call a person.
+    """
+
+    scripts: dict[str, Any]
+
+    @staticmethod
+    def from_file(path: Path) -> FixturePlacer:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        return FixturePlacer(scripts=data.get("calls", data))
+
+    def place(
+        self, *, body: dict[str, Any], key: str, destination: str
+    ) -> dict[str, Any]:
+        if destination not in self.scripts:
+            return {
+                "id": f"call_fixture_missing_{key[-8:]}",
+                "status": "failed",
+                "failure_code": "no_fixture",
+                "failure_message": (
+                    f"no scripted call for {destination}; the fixture does not "
+                    "claim to know what this desk would say"
+                ),
+                "structured_result": None,
+                "recipients": [],
+            }
+        call = dict(self.scripts[destination])
+        call.setdefault("id", f"call_fixture_{key[-8:]}")
+        return call
+
+
+@dataclass
+class LivePlacer:
+    """Places a real CALL-E call. Every use of this rings a real telephone."""
+
+    client: CallEClient
+
+    def place(
+        self, *, body: dict[str, Any], key: str, destination: str
+    ) -> dict[str, Any]:
+        return self.client.place_hop(body=body, key=key)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def plan_hop(case: Case) -> dict[str, Any]:
+    """Return the exact request that the next hop would send. Sends nothing."""
+    desk = case.next_desk()
+    if desk is None:
+        raise RunRefused(
+            f"case {case.case_id} is {case.status}: {case.status_reason}"
+        )
+    task_text = build_task_text(
+        desk=desk,
+        subject=case.subject,
+        question=case.question,
+        requester_name=case.requester_name,
+        history=case.history(),
+    )
+    body = build_create_call_body(
+        task_text=task_text,
+        desk_phone=desk.phone,
+        region=desk.region or case.region,
+        locale=case.locale,
+        metadata={"case_id": case.case_id, "hop_index": case.hops_used() + 1},
+    )
+    key = idempotency_key(
+        case_id=case.case_id,
+        hop_index=case.hops_used() + 1,
+        destination=desk.phone,
+    )
+    # Only the destination is masked. The result schema carries its own
+    # example number in a field description, and blanket string replacement
+    # would rewrite that too, making the preview disagree with the request
+    # that is actually sent.
+    masked_body = dict(body)
+    masked_body["task"] = body["task"].replace(desk.phone, desk.masked())
+    masked_body["recipients"] = [
+        {**recipient, "phones": [desk.masked()]}
+        for recipient in body["recipients"]
+    ]
+    return {
+        "destination": desk.masked(),
+        "desk_name": desk.name,
+        "idempotency_key": key,
+        "method": "POST",
+        "path": "/v1/calls",
+        "body": masked_body,
+    }
+
+
+def run_hop(
+    *,
+    case: Case,
+    placer: CallPlacer,
+    data_dir: Path,
+) -> Hop:
+    """Place exactly one call, record it, and set the case status.
+
+    Returns the hop that was recorded. Raises :class:`RunRefused` when the
+    case is in a state that may not call anyone.
+    """
+    if case.status not in RUNNABLE_STATES:
+        raise RunRefused(
+            f"case {case.case_id} is {case.status}: {case.status_reason}"
+        )
+    desk = case.next_desk()
+    if desk is None:
+        raise RunRefused(f"case {case.case_id} has no authorized next desk")
+
+    hop_index = case.hops_used() + 1
+    if hop_index > case.hop_budget:
+        case.status = chain.CHAIN_BUDGET_EXHAUSTED
+        case.status_reason = (
+            f"the hop budget of {case.hop_budget} is spent before this call"
+        )
+        save_case(data_dir, case)
+        raise RunRefused(case.status_reason)
+
+    authorized_by = (
+        "intake" if desk.identity() in set(case.intake_identities) else "approval"
+    )
+    hop = Hop(
+        index=hop_index,
+        desk=desk,
+        authorized_by=authorized_by,
+        started_at=_now(),
+    )
+    # The hop is written before the call so an interrupted run shows a call
+    # that may have happened, rather than no record at all.
+    case.hops.append(hop)
+    case.pending_desk = None
+    save_case(data_dir, case)
+
+    task_text = build_task_text(
+        desk=desk,
+        subject=case.subject,
+        question=case.question,
+        requester_name=case.requester_name,
+        history=case.history()[:-1],
+    )
+    body = build_create_call_body(
+        task_text=task_text,
+        desk_phone=desk.phone,
+        region=desk.region or case.region,
+        locale=case.locale,
+        metadata={"case_id": case.case_id, "hop_index": hop_index},
+    )
+    key = idempotency_key(
+        case_id=case.case_id, hop_index=hop_index, destination=desk.phone
+    )
+
+    call = placer.place(body=body, key=key, destination=desk.phone)
+    hop.call_id = call.get("id")
+    hop.call_status = str(call.get("status", "failed"))
+
+    raw_result = extract_structured_result(call)
+    rejection: str | None = None
+    normalized: dict[str, Any] | None = None
+    if hop.call_status == "completed":
+        try:
+            normalized = schema.validate_hop_result(raw_result)
+        except schema.ResultRejected as error:
+            rejection = str(error)
+
+    verdict = chain.classify_hop(
+        call_status=hop.call_status,
+        result=normalized,
+        rejection=rejection,
+    )
+    hop.outcome = verdict.outcome
+    hop.reason = verdict.reason
+    hop.answer = verdict.answer
+    hop.reference_number = verdict.reference_number
+    hop.referral = verdict.referral.to_dict() if verdict.referral else None
+
+    decision = chain.decide_next(
+        verdict=verdict,
+        current=desk,
+        visited=case.visited_desks(),
+        requester_phone=case.requester_phone,
+        hop_budget=case.hop_budget,
+        hops_used=case.hops_used(),
+        authorized_identities=case.authorized_identities(),
+        auto_dial_referrals=False,
+    )
+    case.status = decision.state
+    case.status_reason = decision.reason
+    case.pending_desk = decision.next_desk
+    case.loop_path = decision.loop_path
+    save_case(data_dir, case)
+    return hop
+
+
+def run_chain(
+    *,
+    case: Case,
+    placer: CallPlacer,
+    data_dir: Path,
+    max_hops: int | None = None,
+) -> list[Hop]:
+    """Run hops until the chain stops asking for another call.
+
+    The loop ends on a terminal state, on an approval gate, on a suspected
+    loop, or on the hop budget. It never ends because it ran out of patience.
+    """
+    placed: list[Hop] = []
+    limit = max_hops if max_hops is not None else case.hop_budget
+    while len(placed) < limit and case.status in RUNNABLE_STATES:
+        placed.append(run_hop(case=case, placer=placer, data_dir=data_dir))
+    return placed

--- a/apps/python/runaround/runaround/runner.py
+++ b/apps/python/runaround/runaround/runner.py
@@ -16,6 +16,7 @@ from typing import Any, Protocol
 from runaround import chain, schema
 from runaround.calle_client import (
     CallEClient,
+    CallNotPlaced,
     build_create_call_body,
     extract_structured_result,
     idempotency_key,
@@ -176,6 +177,7 @@ def run_hop(
     # The hop is written before the call so an interrupted run shows a call
     # that may have happened, rather than no record at all.
     case.hops.append(hop)
+    pending_before = case.pending_desk
     case.pending_desk = None
     save_case(data_dir, case)
 
@@ -197,7 +199,19 @@ def run_hop(
         case_id=case.case_id, hop_index=hop_index, destination=desk.phone
     )
 
-    call = placer.place(body=body, key=key, destination=desk.phone)
+    try:
+        call = placer.place(body=body, key=key, destination=desk.phone)
+    except CallNotPlaced as refusal:
+        # CALL-E rejected the request itself, so no phone rang and the hop
+        # that was written a moment ago never happened. Withdraw it: a hop
+        # that cost nothing must not cost the budget, and `status` must not
+        # report a call that does not exist. Anything less certain than this
+        # -- a timeout, a 5xx, a transport error -- keeps the hop, because
+        # there the question "did a phone ring?" is still open.
+        case.hops.pop()
+        case.pending_desk = pending_before
+        save_case(data_dir, case)
+        raise RunRefused(str(refusal)) from refusal
     hop.call_id = call.get("id")
     hop.call_status = str(call.get("status", "failed"))
 

--- a/apps/python/runaround/runaround/schema.py
+++ b/apps/python/runaround/runaround/schema.py
@@ -1,0 +1,164 @@
+"""The result schema sent to CALL-E, and local validation of what comes back.
+
+CALL-E validates the schema it was given. This module validates again on
+arrival, because a chain that advances on an unchecked field advances on a
+guess. Every field that can move the chain forward must survive both.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from runaround import phone
+
+YES_NO_UNKNOWN = ["yes", "no", "unknown"]
+
+#: JSON Schema handed to CALL-E as ``result_schema`` for one hop.
+#:
+#: Enum descriptions are extraction instructions: CALL-E passes them to the
+#: model that reads the terminal call evidence. They say when to choose
+#: ``unknown``, because a chain that cannot tell "no" from "not established"
+#: will keep dialling on nothing.
+HOP_RESULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "owns_request",
+        "question_answered",
+        "answer_summary",
+        "referral_target_name",
+        "referral_target_phone",
+        "referral_quote",
+        "reference_number",
+    ],
+    "properties": {
+        "owns_request": {
+            "type": "string",
+            "enum": YES_NO_UNKNOWN,
+            "description": (
+                "Use yes only when the person states that this desk or "
+                "organization is responsible for handling the request. Use no "
+                "when they state another party is responsible. Use unknown "
+                "when responsibility was never established on the call."
+            ),
+        },
+        "question_answered": {
+            "type": "string",
+            "enum": YES_NO_UNKNOWN,
+            "description": (
+                "Use yes only when the caller's question was actually "
+                "answered on this call. A promise to answer later is no. Use "
+                "unknown when the call did not reach a person or the answer "
+                "was not intelligible."
+            ),
+        },
+        "answer_summary": {
+            "type": ["string", "null"],
+            "description": (
+                "One sentence stating the answer in the words the person "
+                "used. Null when question_answered is not yes."
+            ),
+        },
+        "referral_target_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Name of the organization or desk this person said to "
+                "contact next. Null when no referral was given."
+            ),
+        },
+        "referral_target_phone": {
+            "type": ["string", "null"],
+            "description": (
+                "Phone number in E.164 format that this person gave for the "
+                "referral, for example +15550100. Null when no number was "
+                "spoken. Do not construct, complete, or look up a number that "
+                "was not said on the call."
+            ),
+        },
+        "referral_quote": {
+            "type": ["string", "null"],
+            "description": (
+                "The words the person actually used to refer the caller "
+                "elsewhere, quoted from the transcript. Null when no referral "
+                "was given. Do not paraphrase and do not supply this field "
+                "unless the referral was spoken."
+            ),
+        },
+        "reference_number": {
+            "type": ["string", "null"],
+            "description": (
+                "Case, ticket, or claim reference the person read out for "
+                "this request. Null when none was given."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+class ResultRejected(ValueError):
+    """Raised when a returned result cannot be trusted to move the chain."""
+
+
+def _enum_field(result: dict[str, Any], key: str) -> str:
+    value = result.get(key)
+    if value not in YES_NO_UNKNOWN:
+        raise ResultRejected(
+            f"{key} must be one of {YES_NO_UNKNOWN}, got {value!r}"
+        )
+    return value
+
+
+def _optional_text(result: dict[str, Any], key: str) -> str | None:
+    value = result.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ResultRejected(f"{key} must be a string or null, got {value!r}")
+    text = value.strip()
+    return text or None
+
+
+def validate_hop_result(result: Any) -> dict[str, Any]:
+    """Return a normalized hop result, or raise :class:`ResultRejected`.
+
+    A missing result is not an empty result. ``None`` arrives when CALL-E
+    could not extract a schema-valid object from the call, and it is refused
+    here rather than read as "no referral".
+    """
+    if result is None:
+        raise ResultRejected("no structured result was extracted from the call")
+    if not isinstance(result, dict):
+        raise ResultRejected("structured result must be a JSON object")
+
+    unknown_keys = set(result) - set(HOP_RESULT_SCHEMA["properties"])
+    if unknown_keys:
+        raise ResultRejected(
+            "unexpected result fields: " + ", ".join(sorted(unknown_keys))
+        )
+
+    normalized: dict[str, Any] = {
+        "owns_request": _enum_field(result, "owns_request"),
+        "question_answered": _enum_field(result, "question_answered"),
+        "answer_summary": _optional_text(result, "answer_summary"),
+        "referral_target_name": _optional_text(result, "referral_target_name"),
+        "referral_quote": _optional_text(result, "referral_quote"),
+        "reference_number": _optional_text(result, "reference_number"),
+        "referral_target_phone": None,
+    }
+
+    raw_phone = _optional_text(result, "referral_target_phone")
+    if raw_phone is not None:
+        if not phone.is_valid(raw_phone):
+            # A spoken number that does not normalize is kept out of the
+            # chain. It is reported, not dialled.
+            normalized["referral_target_phone"] = None
+            normalized["referral_phone_rejected"] = raw_phone
+        else:
+            normalized["referral_target_phone"] = phone.normalize(raw_phone)
+
+    if normalized["question_answered"] == "yes" and not normalized["answer_summary"]:
+        raise ResultRejected(
+            "question_answered is yes but answer_summary is empty"
+        )
+
+    return normalized

--- a/apps/python/runaround/runaround/schema.py
+++ b/apps/python/runaround/runaround/schema.py
@@ -21,14 +21,14 @@ YES_NO_UNKNOWN = ["yes", "no", "unknown"]
 #: will keep dialling on nothing.
 HOP_RESULT_SCHEMA: dict[str, Any] = {
     "type": "object",
+    # 🔴 CALL-E rejects union types (``['string', 'null']``) with
+    # ``result_schema_invalid``: measured against the live API on 2026-09-07,
+    # ``unsupported JSON Schema type at $.properties.a``. Absence is therefore
+    # expressed by omitting the key, not by a null, and only the two enum
+    # fields the chain cannot move without are required.
     "required": [
         "owns_request",
         "question_answered",
-        "answer_summary",
-        "referral_target_name",
-        "referral_target_phone",
-        "referral_quote",
-        "reference_number",
     ],
     "properties": {
         "owns_request": {
@@ -52,42 +52,42 @@ HOP_RESULT_SCHEMA: dict[str, Any] = {
             ),
         },
         "answer_summary": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "One sentence stating the answer in the words the person "
-                "used. Null when question_answered is not yes."
+                "used. Omit this field when question_answered is not yes."
             ),
         },
         "referral_target_name": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "Name of the organization or desk this person said to "
-                "contact next. Null when no referral was given."
+                "contact next. Omit this field when no referral was given."
             ),
         },
         "referral_target_phone": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "Phone number in E.164 format that this person gave for the "
-                "referral, for example +15550100. Null when no number was "
+                "referral, for example +15550100. Omit this field when no number was "
                 "spoken. Do not construct, complete, or look up a number that "
                 "was not said on the call."
             ),
         },
         "referral_quote": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "The words the person actually used to refer the caller "
-                "elsewhere, quoted from the transcript. Null when no referral "
-                "was given. Do not paraphrase and do not supply this field "
+                "elsewhere, quoted from the transcript. Omit this field when "
+                "no referral was given. Do not paraphrase and do not supply this field "
                 "unless the referral was spoken."
             ),
         },
         "reference_number": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "Case, ticket, or claim reference the person read out for "
-                "this request. Null when none was given."
+                "this request. Omit this field when none was given."
             ),
         },
     },

--- a/apps/python/runaround/tests/test_calle_client.py
+++ b/apps/python/runaround/tests/test_calle_client.py
@@ -1,0 +1,197 @@
+"""The CALL-E adapter, exercised through an injected transport.
+
+No test in this file opens a socket. The transport records what would have
+been sent, which is the only way to assert that a bearer token never leaves
+for the wrong host.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any
+
+from runaround.calle_client import (
+    CallEClient,
+    CallEError,
+    assert_approved_origin,
+    build_create_call_body,
+    extract_structured_result,
+)
+
+
+class RecordingTransport:
+    """Replays queued responses and remembers every request."""
+
+    def __init__(self, responses: list[tuple[int, dict[str, Any]]]):
+        self.responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    def request(self, *, method, url, headers, body):
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "body": json.loads(body.decode("utf-8")) if body else None,
+            }
+        )
+        if not self.responses:
+            raise AssertionError("the client made more requests than expected")
+        return self.responses.pop(0)
+
+
+def client(responses, **kwargs):
+    return CallEClient(
+        api_key="test-key",
+        transport=RecordingTransport(responses),
+        poll_interval=0,
+        sleep=lambda _seconds: None,
+        **kwargs,
+    )
+
+
+class OriginTests(unittest.TestCase):
+    def test_the_official_origin_is_approved(self):
+        self.assertEqual(
+            assert_approved_origin("https://api.heycall-e.com/"),
+            "https://api.heycall-e.com",
+        )
+
+    def test_a_host_that_merely_ends_in_the_right_letters_is_refused(self):
+        for hostile in (
+            "https://api.heycall-e.com.evil.example",
+            "https://api-heycall-e.com",
+            "https://notapi.heycall-e.com",
+        ):
+            with self.subTest(hostile=hostile):
+                with self.assertRaises(CallEError):
+                    assert_approved_origin(hostile)
+
+    def test_plain_http_is_refused(self):
+        with self.assertRaises(CallEError):
+            assert_approved_origin("http://api.heycall-e.com")
+
+    def test_a_client_without_a_key_refuses_to_exist(self):
+        with self.assertRaises(CallEError):
+            CallEClient(api_key="", transport=RecordingTransport([]))
+
+
+class RequestShapeTests(unittest.TestCase):
+    def test_the_create_body_matches_the_documented_contract(self):
+        body = build_create_call_body(
+            task_text="Call the desk.",
+            desk_phone="+15550100",
+            region="US",
+            locale="en-US",
+            metadata={"case_id": "parcel-8472"},
+        )
+        self.assertEqual(body["task"], "Call the desk.")
+        self.assertEqual(body["recipients"], [
+            {"phones": ["+15550100"], "locale": "en-US", "region": "US"}
+        ])
+        self.assertEqual(body["result_schema"]["type"], "object")
+        self.assertFalse(body["result_schema"]["additionalProperties"])
+
+    def test_the_bearer_token_and_idempotency_key_are_sent(self):
+        api = client([(201, {"id": "call_1", "status": "completed"})])
+        api.create_call(body={"task": "x"}, key="runaround-abc")
+        sent = api.transport.requests[0]
+        self.assertEqual(sent["method"], "POST")
+        self.assertEqual(sent["url"], "https://api.heycall-e.com/v1/calls")
+        self.assertEqual(sent["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(sent["headers"]["Idempotency-Key"], "runaround-abc")
+
+
+class PollingTests(unittest.TestCase):
+    def test_polling_stops_at_the_first_terminal_state(self):
+        api = client(
+            [
+                (201, {"id": "call_1", "status": "queued"}),
+                (200, {"id": "call_1", "status": "in_progress"}),
+                (200, {"id": "call_1", "status": "completed"}),
+            ]
+        )
+        call = api.place_hop(body={"task": "x"}, key="k")
+        self.assertEqual(call["status"], "completed")
+        self.assertEqual(len(api.transport.requests), 3)
+
+    def test_a_terminal_create_response_is_not_polled_again(self):
+        api = client([(201, {"id": "call_1", "status": "completed"})])
+        api.place_hop(body={"task": "x"}, key="k")
+        self.assertEqual(len(api.transport.requests), 1)
+
+    def test_an_exhausted_poll_ceiling_is_an_unknown_outcome_not_a_failure(self):
+        api = client(
+            [
+                (201, {"id": "call_1", "status": "queued"}),
+                (200, {"id": "call_1", "status": "in_progress"}),
+                (200, {"id": "call_1", "status": "in_progress"}),
+            ],
+            poll_max_attempts=2,
+        )
+        with self.assertRaises(CallEError) as raised:
+            api.place_hop(body={"task": "x"}, key="k")
+        self.assertIn("outcome is unknown", str(raised.exception))
+
+    def test_an_unrecognized_status_is_refused_rather_than_assumed(self):
+        api = client(
+            [
+                (201, {"id": "call_1", "status": "queued"}),
+                (200, {"id": "call_1", "status": "partially_done"}),
+            ]
+        )
+        with self.assertRaises(CallEError):
+            api.place_hop(body={"task": "x"}, key="k")
+
+
+class ErrorTests(unittest.TestCase):
+    def test_a_documented_error_code_reaches_the_caller(self):
+        api = client(
+            [
+                (
+                    403,
+                    {
+                        "error": {
+                            "code": "unsupported_region",
+                            "message": "destination region is not enabled",
+                            "details": {},
+                        }
+                    },
+                )
+            ]
+        )
+        with self.assertRaises(CallEError) as raised:
+            api.create_call(body={"task": "x"})
+        self.assertIn("unsupported_region", str(raised.exception))
+
+    def test_a_create_response_without_an_id_is_refused(self):
+        api = client([(201, {"status": "queued"})])
+        with self.assertRaises(CallEError):
+            api.place_hop(body={"task": "x"}, key="k")
+
+
+class ResultExtractionTests(unittest.TestCase):
+    def test_the_task_level_result_is_preferred(self):
+        call = {
+            "structured_result": {"owns_request": "yes"},
+            "recipients": [{"structured_result": {"owns_request": "no"}}],
+        }
+        self.assertEqual(
+            extract_structured_result(call), {"owns_request": "yes"}
+        )
+
+    def test_the_recipient_result_is_the_fallback(self):
+        call = {
+            "structured_result": None,
+            "recipients": [{"structured_result": {"owns_request": "no"}}],
+        }
+        self.assertEqual(extract_structured_result(call), {"owns_request": "no"})
+
+    def test_no_result_anywhere_is_none_not_an_empty_object(self):
+        call = {"structured_result": None, "recipients": [{"structured_result": {}}]}
+        self.assertIsNone(extract_structured_result(call))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/runaround/tests/test_calle_client.py
+++ b/apps/python/runaround/tests/test_calle_client.py
@@ -14,6 +14,7 @@ from typing import Any
 from runaround.calle_client import (
     CallEClient,
     CallEError,
+    CallNotPlaced,
     assert_approved_origin,
     build_create_call_body,
     extract_structured_result,
@@ -164,6 +165,26 @@ class ErrorTests(unittest.TestCase):
         with self.assertRaises(CallEError) as raised:
             api.create_call(body={"task": "x"})
         self.assertIn("unsupported_region", str(raised.exception))
+
+    def test_a_rejected_request_is_distinguishable_from_an_unknown_one(self):
+        # Measured against the live API on 2026-09-07. Both of these say the
+        # call task was never created, which is what lets the runner withdraw
+        # the hop instead of leaving it in flight.
+        for status, code in ((400, "result_schema_invalid"), (422, "call_not_ready")):
+            with self.subTest(status=status):
+                api = client([(status, {"error": {"code": code, "message": "no"}})])
+                with self.assertRaises(CallNotPlaced) as raised:
+                    api.create_call(body={"task": "x"})
+                self.assertEqual(raised.exception.status, status)
+                self.assertEqual(raised.exception.code, code)
+
+    def test_an_ambiguous_failure_is_not_reported_as_not_placed(self):
+        # A 5xx may have created the call before failing to say so. The hop
+        # stays, and a person reconciles it.
+        api = client([(503, {"error": {"code": "unavailable", "message": "no"}})])
+        with self.assertRaises(CallEError) as raised:
+            api.create_call(body={"task": "x"})
+        self.assertNotIsInstance(raised.exception, CallNotPlaced)
 
     def test_a_create_response_without_an_id_is_refused(self):
         api = client([(201, {"status": "queued"})])

--- a/apps/python/runaround/tests/test_chain.py
+++ b/apps/python/runaround/tests/test_chain.py
@@ -1,0 +1,244 @@
+"""Chain decisions, decided without a network, a credential, or a call."""
+
+from __future__ import annotations
+
+import unittest
+
+from runaround import chain, phone, schema
+
+RETAIL = chain.Desk(name="Example Retail Support", phone="+15550100", region="US")
+FREIGHT = chain.Desk(name="Example Freight Claims", phone="+15550111", region="US")
+
+
+def result(**overrides):
+    base = {
+        "owns_request": "no",
+        "question_answered": "no",
+        "answer_summary": None,
+        "referral_target_name": None,
+        "referral_target_phone": None,
+        "referral_quote": None,
+        "reference_number": None,
+    }
+    base.update(overrides)
+    return schema.validate_hop_result(base)
+
+
+class PhoneTests(unittest.TestCase):
+    def test_punctuation_does_not_create_a_second_desk(self):
+        self.assertEqual(
+            phone.identity("+1 (555) 010-0"), phone.identity("+15550100")
+        )
+
+    def test_a_number_that_is_not_e164_is_refused_not_repaired(self):
+        with self.assertRaises(phone.InvalidPhoneNumber):
+            phone.normalize("555-0100")
+
+    def test_mask_keeps_the_country_prefix_and_last_two_digits(self):
+        self.assertEqual(phone.mask("+15550100"), "+1*****00")
+
+
+class SchemaTests(unittest.TestCase):
+    def test_a_missing_result_is_not_an_empty_result(self):
+        with self.assertRaises(schema.ResultRejected):
+            schema.validate_hop_result(None)
+
+    def test_unknown_fields_are_refused(self):
+        with self.assertRaises(schema.ResultRejected):
+            schema.validate_hop_result(
+                {
+                    "owns_request": "no",
+                    "question_answered": "no",
+                    "answer_summary": None,
+                    "referral_target_name": None,
+                    "referral_target_phone": None,
+                    "referral_quote": None,
+                    "reference_number": None,
+                    "who_knows": "surprise",
+                }
+            )
+
+    def test_answered_yes_without_a_summary_is_refused(self):
+        with self.assertRaises(schema.ResultRejected):
+            result(owns_request="yes", question_answered="yes")
+
+    def test_a_spoken_number_that_is_not_e164_is_reported_not_dialled(self):
+        parsed = result(
+            referral_quote="Try extension four four one.",
+            referral_target_phone="ext. 441",
+        )
+        self.assertIsNone(parsed["referral_target_phone"])
+        self.assertEqual(parsed["referral_phone_rejected"], "ext. 441")
+
+
+class ClassifyHopTests(unittest.TestCase):
+    def test_owner_that_answers_is_answered(self):
+        verdict = chain.classify_hop(
+            call_status="completed",
+            result=result(
+                owns_request="yes",
+                question_answered="yes",
+                answer_summary="We accept the claim.",
+            ),
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_ANSWERED)
+
+    def test_owner_without_an_answer_does_not_resolve(self):
+        verdict = chain.classify_hop(
+            call_status="completed", result=result(owns_request="yes")
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_OWNER_WITHOUT_ANSWER)
+
+    def test_a_quoted_referral_is_a_referral(self):
+        verdict = chain.classify_hop(
+            call_status="completed",
+            result=result(
+                referral_target_name="Example Freight Claims",
+                referral_target_phone="+15550111",
+                referral_quote="That is the carrier's claim.",
+            ),
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_REFERRED)
+        self.assertEqual(verdict.referral.target_phone, "+15550111")
+
+    def test_a_number_without_words_behind_it_is_not_a_referral(self):
+        verdict = chain.classify_hop(
+            call_status="completed",
+            result=result(
+                referral_target_name="Example Freight Claims",
+                referral_target_phone="+15550111",
+            ),
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_UNVERIFIED_REFERRAL)
+
+    def test_words_without_a_usable_number_are_not_a_referral(self):
+        verdict = chain.classify_hop(
+            call_status="completed",
+            result=result(referral_quote="Call the claims people."),
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_UNVERIFIED_REFERRAL)
+
+    def test_a_failed_call_is_unreachable_not_a_dead_end(self):
+        verdict = chain.classify_hop(call_status="failed", result=None)
+        self.assertEqual(verdict.outcome, chain.HOP_UNREACHABLE)
+
+    def test_a_refused_result_is_unreachable(self):
+        verdict = chain.classify_hop(
+            call_status="completed", result=None, rejection="schema mismatch"
+        )
+        self.assertEqual(verdict.outcome, chain.HOP_UNREACHABLE)
+
+    def test_no_owner_and_no_referral_is_a_dead_end(self):
+        verdict = chain.classify_hop(call_status="completed", result=result())
+        self.assertEqual(verdict.outcome, chain.HOP_DEAD_END)
+
+
+def referral_verdict(target_phone: str, name: str = "Example Retail Support"):
+    return chain.classify_hop(
+        call_status="completed",
+        result=result(
+            referral_target_name=name,
+            referral_target_phone=target_phone,
+            referral_quote="Go back to them.",
+        ),
+    )
+
+
+class DecideNextTests(unittest.TestCase):
+    def decide(self, verdict, **overrides):
+        kwargs = {
+            "verdict": verdict,
+            "current": FREIGHT,
+            "visited": [RETAIL, FREIGHT],
+            "requester_phone": "+15550199",
+            "hop_budget": 4,
+            "hops_used": 2,
+            "authorized_identities": {RETAIL.identity(), FREIGHT.identity()},
+            "auto_dial_referrals": False,
+        }
+        kwargs.update(overrides)
+        return chain.decide_next(**kwargs)
+
+    def test_a_referral_to_an_already_called_desk_closes_the_loop(self):
+        decision = self.decide(referral_verdict("+15550100"))
+        self.assertEqual(decision.state, chain.CHAIN_LOOP_DETECTED)
+        self.assertEqual(decision.loop_path, ["+1*****00", "+1*****11", "+1*****00"])
+        self.assertTrue(decision.is_terminal)
+
+    def test_punctuation_does_not_hide_a_loop(self):
+        decision = self.decide(referral_verdict("+1 (555) 010-0"))
+        self.assertEqual(decision.state, chain.CHAIN_LOOP_DETECTED)
+
+    def test_a_desk_referring_to_itself_stops_the_chain(self):
+        decision = self.decide(
+            referral_verdict("+15550111", name="Example Freight Claims")
+        )
+        self.assertEqual(decision.state, chain.CHAIN_SELF_REFERRAL)
+
+    def test_a_referral_back_to_the_requester_stops_the_chain(self):
+        decision = self.decide(
+            referral_verdict("+15550199", name="The customer"),
+            visited=[FREIGHT],
+        )
+        self.assertEqual(decision.state, chain.CHAIN_REFERRED_TO_REQUESTER)
+
+    def test_a_new_number_needs_a_person_before_it_is_dialled(self):
+        decision = self.decide(
+            referral_verdict("+15550122", name="Example Insurance Desk"),
+        )
+        self.assertEqual(decision.state, chain.CHAIN_AWAITING_APPROVAL)
+        self.assertEqual(decision.next_desk.phone, "+15550122")
+        self.assertFalse(decision.is_terminal)
+
+    def test_an_approved_number_continues(self):
+        decision = self.decide(
+            referral_verdict("+15550122", name="Example Insurance Desk"),
+            authorized_identities={
+                RETAIL.identity(),
+                FREIGHT.identity(),
+                "+15550122",
+            },
+        )
+        self.assertEqual(decision.state, chain.CHAIN_CONTINUE)
+
+    def test_a_second_number_for_a_visited_name_is_only_suspected(self):
+        decision = self.decide(
+            referral_verdict("+15550133", name="Example Retail Support, Inc."),
+        )
+        self.assertEqual(decision.state, chain.CHAIN_LOOP_SUSPECTED)
+        self.assertFalse(decision.is_terminal)
+
+    def test_the_hop_budget_stops_the_chain(self):
+        decision = self.decide(
+            referral_verdict("+15550122", name="Example Insurance Desk"),
+            hops_used=4,
+        )
+        self.assertEqual(decision.state, chain.CHAIN_BUDGET_EXHAUSTED)
+
+    def test_an_unverified_referral_goes_to_a_person(self):
+        verdict = chain.classify_hop(
+            call_status="completed",
+            result=result(
+                referral_target_name="Example Freight Claims",
+                referral_target_phone="+15550111",
+            ),
+        )
+        self.assertEqual(self.decide(verdict).state, chain.CHAIN_NEEDS_HUMAN)
+
+
+class FoldNameTests(unittest.TestCase):
+    def test_legal_suffixes_and_punctuation_fold_together(self):
+        self.assertEqual(
+            chain.fold_name("Example Retail Support, Inc."),
+            chain.fold_name("example retail support"),
+        )
+
+    def test_different_organizations_do_not_fold_together(self):
+        self.assertNotEqual(
+            chain.fold_name("Example Retail Support"),
+            chain.fold_name("Example Freight Claims"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/runaround/tests/test_runner.py
+++ b/apps/python/runaround/tests/test_runner.py
@@ -1,0 +1,243 @@
+"""Whole-case runs against scripted calls. No network, no credential."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from runaround import chain, evidence
+from runaround.calle_client import idempotency_key
+from runaround.case import build_case, load_case, save_case
+from runaround.cli import DEMO_INTAKE, main
+from runaround.runner import FixturePlacer, RunRefused, plan_hop, run_chain, run_hop
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+class RunnerTestCase(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.data = Path(self._temporary.name)
+        self.addCleanup(self._temporary.cleanup)
+
+    def open_demo(self):
+        case = build_case(DEMO_INTAKE)
+        save_case(self.data, case)
+        return case
+
+    def placer(self, name):
+        return FixturePlacer.from_file(FIXTURES / name)
+
+
+class ChainRunTests(RunnerTestCase):
+    def test_the_chain_stops_for_approval_before_the_second_desk(self):
+        case = self.open_demo()
+        placed = run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        self.assertEqual(len(placed), 1)
+        self.assertEqual(case.status, chain.CHAIN_AWAITING_APPROVAL)
+        self.assertEqual(case.pending_desk.phone, "+15550111")
+
+    def test_an_approved_chain_closes_on_itself_and_says_so(self):
+        case = self.open_demo()
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        case.authorize(case.pending_desk)
+        case.status = chain.CHAIN_CONTINUE
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        self.assertEqual(case.status, chain.CHAIN_LOOP_DETECTED)
+        self.assertEqual(case.hops_used(), 2)
+        self.assertEqual(
+            case.loop_path, ["+1*****00", "+1*****11", "+1*****00"]
+        )
+
+    def test_an_owner_that_answers_resolves_the_case(self):
+        case = self.open_demo()
+        run_chain(
+            case=case,
+            placer=self.placer("chain_resolved.json"),
+            data_dir=self.data,
+        )
+        case.authorize(case.pending_desk)
+        case.status = chain.CHAIN_CONTINUE
+        run_chain(
+            case=case,
+            placer=self.placer("chain_resolved.json"),
+            data_dir=self.data,
+        )
+        self.assertEqual(case.status, chain.CHAIN_RESOLVED)
+        self.assertEqual(case.hops[-1].reference_number, "FR-55120")
+        self.assertIn("FR-55120", case.hops[-1].answer)
+
+    def test_an_unquoted_referral_never_becomes_a_second_call(self):
+        case = self.open_demo()
+        placed = run_chain(
+            case=case,
+            placer=self.placer("chain_unquoted_referral.json"),
+            data_dir=self.data,
+        )
+        self.assertEqual(len(placed), 1)
+        self.assertEqual(case.status, chain.CHAIN_NEEDS_HUMAN)
+        self.assertIsNone(case.pending_desk)
+
+    def test_a_terminal_case_refuses_another_call(self):
+        case = self.open_demo()
+        run_chain(
+            case=case,
+            placer=self.placer("chain_unquoted_referral.json"),
+            data_dir=self.data,
+        )
+        with self.assertRaises(RunRefused):
+            run_hop(
+                case=case,
+                placer=self.placer("chain_loop.json"),
+                data_dir=self.data,
+            )
+
+    def test_a_desk_with_no_script_is_unreachable_not_a_dead_end(self):
+        case = self.open_demo()
+        run_chain(
+            case=case,
+            placer=FixturePlacer(scripts={}),
+            data_dir=self.data,
+        )
+        self.assertEqual(case.hops[0].outcome, chain.HOP_UNREACHABLE)
+        self.assertEqual(case.status, chain.CHAIN_NEEDS_HUMAN)
+
+
+class PersistenceTests(RunnerTestCase):
+    def test_the_case_survives_a_reload_between_hops(self):
+        case = self.open_demo()
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        reloaded = load_case(self.data, case.case_id)
+        self.assertEqual(reloaded.status, chain.CHAIN_AWAITING_APPROVAL)
+        self.assertEqual(reloaded.hops_used(), 1)
+        self.assertEqual(reloaded.hops[0].referral["target_phone"], "+15550111")
+        self.assertEqual(reloaded.pending_desk.phone, "+15550111")
+
+    def test_the_case_file_holds_no_unmasked_number_it_was_not_given(self):
+        case = self.open_demo()
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        raw = (self.data / f"{case.case_id}.case.json").read_text(
+            encoding="utf-8"
+        )
+        stored = json.loads(raw)
+        self.assertEqual(stored["case_id"], case.case_id)
+        # The destination the operator authorized is stored in full, because
+        # the next hop has to dial it. Nothing else is.
+        self.assertIn("+15550100", raw)
+
+
+class IdempotencyTests(unittest.TestCase):
+    def test_the_key_is_stable_for_the_same_hop(self):
+        first = idempotency_key(
+            case_id="parcel-8472", hop_index=2, destination="+15550111"
+        )
+        second = idempotency_key(
+            case_id="parcel-8472", hop_index=2, destination="+15550111"
+        )
+        self.assertEqual(first, second)
+
+    def test_the_key_changes_with_the_destination(self):
+        self.assertNotEqual(
+            idempotency_key(
+                case_id="parcel-8472", hop_index=2, destination="+15550111"
+            ),
+            idempotency_key(
+                case_id="parcel-8472", hop_index=2, destination="+15550122"
+            ),
+        )
+
+
+class PreviewTests(RunnerTestCase):
+    def test_the_plan_masks_the_destination_and_sends_nothing(self):
+        case = self.open_demo()
+        plan = plan_hop(case)
+        self.assertEqual(plan["destination"], "+1*****00")
+        self.assertEqual(plan["body"]["recipients"][0]["phones"], ["+1*****00"])
+        self.assertNotIn("+15550100", plan["body"]["task"])
+        self.assertEqual(case.hops_used(), 0)
+
+    def test_the_plan_does_not_rewrite_the_schema_example(self):
+        case = self.open_demo()
+        plan = plan_hop(case)
+        description = plan["body"]["result_schema"]["properties"][
+            "referral_target_phone"
+        ]["description"]
+        self.assertIn("+15550100", description)
+
+    def test_the_second_hop_carries_the_first_desk_words(self):
+        case = self.open_demo()
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        case.authorize(case.pending_desk)
+        case.status = chain.CHAIN_CONTINUE
+        plan = plan_hop(case)
+        self.assertIn("already been passed along", plan["body"]["task"])
+        self.assertIn("we do not ship it", plan["body"]["task"])
+
+
+class EvidenceTests(RunnerTestCase):
+    def test_the_pack_quotes_both_referrals_and_masks_both_numbers(self):
+        case = self.open_demo()
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        case.authorize(case.pending_desk)
+        case.status = chain.CHAIN_CONTINUE
+        run_chain(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        pack = evidence.render(case)
+        self.assertIn("we do not ship it", pack)
+        self.assertIn("the claim is theirs, not ours", pack)
+        self.assertIn("+1*****00 -> +1*****11 -> +1*****00", pack)
+        self.assertNotIn("+15550100", pack)
+        self.assertNotIn("+15550111", pack)
+
+
+class CommandLineTests(RunnerTestCase):
+    def test_a_fixture_run_needs_no_credential_and_no_flag_to_call_people(self):
+        data = str(self.data)
+        self.assertEqual(main(["--data", data, "init-demo"]), 0)
+        self.assertEqual(
+            main(
+                [
+                    "--data",
+                    data,
+                    "run",
+                    "parcel-8472",
+                    "--mode",
+                    "fixture",
+                    "--fixture",
+                    str(FIXTURES / "chain_loop.json"),
+                ]
+            ),
+            0,
+        )
+        self.assertEqual(
+            load_case(self.data, "parcel-8472").status,
+            chain.CHAIN_AWAITING_APPROVAL,
+        )
+
+    def test_live_mode_without_the_acknowledgement_exits_instead_of_calling(self):
+        data = str(self.data)
+        main(["--data", data, "init-demo"])
+        with self.assertRaises(SystemExit) as raised:
+            main(["--data", data, "run", "parcel-8472", "--mode", "live"])
+        self.assertIn("rings a real telephone", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/runaround/tests/test_runner.py
+++ b/apps/python/runaround/tests/test_runner.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 
 from runaround import chain, evidence
-from runaround.calle_client import idempotency_key
+from runaround.calle_client import CallNotPlaced, idempotency_key
 from runaround.case import build_case, load_case, save_case
 from runaround.cli import DEMO_INTAKE, main
 from runaround.runner import FixturePlacer, RunRefused, plan_hop, run_chain, run_hop
@@ -29,6 +29,54 @@ class RunnerTestCase(unittest.TestCase):
 
     def placer(self, name):
         return FixturePlacer.from_file(FIXTURES / name)
+
+
+class RefusedRequestTests(RunnerTestCase):
+    """A request CALL-E rejected is not a call that happened."""
+
+    class RefusingPlacer:
+        """Rejects the way the live API rejected an unsupported schema."""
+
+        def __init__(self):
+            self.attempts = 0
+
+        def place(self, *, body, key, destination):
+            self.attempts += 1
+            raise CallNotPlaced(
+                "CALL-E returned 400 result_schema_invalid: "
+                "result_schema is not supported.",
+                status=400,
+                code="result_schema_invalid",
+            )
+
+    def test_a_rejected_request_costs_no_hop_and_no_budget(self):
+        case = self.open_demo()
+        placer = self.RefusingPlacer()
+        before = case.status
+
+        with self.assertRaises(RunRefused) as refused:
+            run_hop(case=case, placer=placer, data_dir=self.data)
+
+        self.assertIn("result_schema_invalid", str(refused.exception))
+        self.assertEqual(placer.attempts, 1)
+        # No phone rang, so nothing about the case may have moved.
+        self.assertEqual(case.hops_used(), 0)
+        self.assertEqual(case.status, before)
+        # And the refusal is not remembered as a call in the saved file.
+        self.assertEqual(load_case(self.data, case.case_id).hops_used(), 0)
+
+    def test_the_next_attempt_is_still_allowed_to_call(self):
+        case = self.open_demo()
+        with self.assertRaises(RunRefused):
+            run_hop(case=case, placer=self.RefusingPlacer(), data_dir=self.data)
+
+        # The desk authorized at intake is still the next desk to call: a
+        # rejected request must not consume the authorization either.
+        hop = run_hop(
+            case=case, placer=self.placer("chain_loop.json"), data_dir=self.data
+        )
+        self.assertEqual(hop.index, 1)
+        self.assertEqual(case.hops_used(), 1)
 
 
 class ChainRunTests(RunnerTestCase):


### PR DESCRIPTION
## What this adds

`apps/python/runaround/` — a Python app on the CALL-E Developer API that chases one question
across organizations which each name the other, and stops with quoted evidence when the
referrals close on themselves.

Every workflow in this repository assumes a desk that owns the request exists. Often it does
not: the retailer says it is the carrier's claim, the carrier says it is the shipper's claim,
and the question is never answered and never refused. Runaround makes the unit of work the
referral edge — one desk, the desk it named, and the sentence that named it.

## Two rules

- A referral advances the chain only when the recipient's own words come with it. A
  `referral_target_phone` without a `referral_quote` is refused as `unverified_referral`.
- A number spoken on a call is not permission to dial it. New destinations stop the chain at
  `awaiting_approval` until a person approves them.

## Contribution checklist

- English-only repository-facing content
- No secrets, tokens, or personal data; all sample numbers are NANP fiction-reserved `555-01xx`
- Fixture mode is the default; the live path needs an API key, a mode flag, and an explicit
  acknowledgement flag
- Side effects, cancellation, and state documented in the README; no recurring jobs
- 57 tests, standard library only, no sockets opened
- `python3 scripts/validate_repository.py` passes
- Also adds one app-table row and one safety-pattern row to `README.md`
