### PR TITLE
docs: expand RDN intake referral documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`incident-escalation-call`](skills/incident-escalation-call/) - Walks an on-call escalation ladder one phone call at a time and records an acknowledgement only when an owner and an ETA are both quoted by words the recipient spoke, then re-reads the call over a second transport before the incident is reported as owned.
 - [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
+- [`rdn-intake-referral`](skills/rdn-intake-referral/) - Consent-based outbound healthcare nutrition intake that collects structured information for RDN review and referral follow-up. See [`docs/rdn-intake-referral.md`](docs/rdn-intake-referral.md) for documentation and synthetic validation examples.
 
 ### Apps
 

--- a/docs/rdn-intake-referral.md
+++ b/docs/rdn-intake-referral.md
@@ -1,0 +1,358 @@
+# RDN Intake & Referral Agent
+
+A consent-based AI phone intake workflow built with CALL-E to collect structured nutrition-support information and prepare a referral-ready summary for Registered Dietitian Nutritionist (RDN) review.
+
+## Overview
+
+The RDN Intake & Referral Agent explores how an AI phone agent can support the initial intake stage of a healthcare nutrition workflow.
+
+The current prototype uses CALL-E to conduct an outbound phone conversation on behalf of an RDN or care team. The AI identifies itself, requests consent, collects structured intake information, reads the information back for confirmation, and produces a structured JSON result for human review.
+
+The AI is designed to support the intake and coordination process, not replace the RDN.
+
+## Why I Built This
+
+Healthcare nutrition support often begins with collecting basic information before an RDN can review a patient's needs and determine the appropriate next step.
+
+A phone conversation can require repetitive information gathering, while important details need to be captured consistently.
+
+This project explores whether an AI phone agent can handle this initial information-collection step while keeping the RDN or care team responsible for clinical review and follow-up.
+
+The goal is to transform an unstructured phone conversation into organized, patient-confirmed information that can support the next stage of the workflow.
+
+## Current Workflow
+
+The current prototype follows this workflow:
+
+```text
+RDN / Care Team
+      |
+      v
+CALL-E AI Phone Agent
+      |
+      v
+AI Disclosure
+      |
+      v
+Patient Consent
+      |
+      v
+Structured Intake
+      |
+      +-- Patient name
+      +-- Reason for nutrition support
+      +-- Healthcare referral status
+      +-- Nutrition goals
+      +-- Dietary preferences / restrictions
+      +-- Food allergies
+      +-- General location
+      +-- Optional insurance information
+      +-- Preferred RDN appointment time
+      |
+      v
+Information Readback
+      |
+      v
+Patient Confirmation
+      |
+      v
+Structured JSON Result
+      |
+      v
+RDN / Care Team Review
+      |
+      v
+Human Follow-up
+```
+
+The current prototype collects a preferred appointment time but does not schedule or confirm an appointment.
+
+## What the AI Does
+
+The AI phone agent is responsible for communication and information collection.
+
+It:
+
+1. Identifies itself as an AI assistant.
+2. Requests consent before continuing.
+3. Collects the required intake information.
+4. Handles optional information such as insurance.
+5. Collects the patient's preferred appointment time.
+6. Reads the collected information back to the patient.
+7. Requests confirmation.
+8. Produces structured JSON for downstream human review.
+9. Maintains defined healthcare safety boundaries.
+10. Stops or hands off when the conversation is outside the intended intake scope.
+
+## What the AI Does Not Do
+
+The prototype is intentionally not a medical advisor.
+
+It does not:
+
+- Diagnose medical conditions.
+- Prescribe treatment.
+- Interpret medical information.
+- Provide individualized medical or nutrition advice.
+- Make clinical decisions.
+- Confirm a medical appointment.
+- Replace an RDN or other qualified healthcare professional.
+
+Clinical decisions and appropriate patient follow-up remain with the RDN or care team.
+
+## Project Structure
+
+```text
+rdn-intake-referral/
+|
++-- SKILL.md
+|   Core CALL-E Agent Skill. Defines the phone interaction,
+|   intake workflow, structured output, confirmation behavior,
+|   and operational safety requirements.
+|
++-- TEST_RESULTS.md
+|   Synthetic validation scenarios demonstrating the
+|   intended workflow and safety behavior.
+|
++-- references/
+|   |
+|   +-- safety.md
+|   |   Healthcare safety boundaries and fail-closed behavior.
+|   |
+|   +-- examples.md
+|       Synthetic examples that demonstrate the intended
+|       skill behavior.
+|
++-- examples/
+    |
+    +-- test-input.json
+        Synthetic example input for demonstrating the
+        CALL-E RDN intake workflow.
+```
+
+## Why Each File Exists
+
+### `SKILL.md`
+
+`SKILL.md` is the core instruction layer for the Agent Skill.
+
+It defines what the CALL-E agent should do during the phone conversation, what information should be collected, how the result should be structured, and how the agent should behave when safety or consent conditions are not satisfied.
+
+Without `SKILL.md`, the project would not have a defined Agent Skill workflow.
+
+### `references/safety.md`
+
+Healthcare conversations can move beyond basic intake.
+
+This file provides explicit safety boundaries so the agent does not cross from information collection into medical or nutrition advice.
+
+It supports fail-closed behavior for situations such as unclear consent, requests to stop, emergencies, incorrect recipients, or unreliable information.
+
+### `references/examples.md`
+
+Examples make the intended behavior easier to understand and extend.
+
+They provide synthetic scenarios that help explain how the Skill should behave during different types of phone interactions.
+
+### `TEST_RESULTS.md`
+
+`TEST_RESULTS.md` documents synthetic validation scenarios for the RDN intake workflow.
+
+The scenarios are intentionally fictional and are designed to demonstrate expected behavior without representing real patient interactions, clinical encounters, or clinical outcomes.
+
+### `examples/test-input.json`
+
+This file provides a synthetic example of the input structure for the RDN intake workflow.
+
+It demonstrates the CALL-E task definition, recipient configuration structure, intake fields, and safety requirements using fictional information.
+
+The example does not contain real patient information, credentials, private phone numbers, or live-call artifacts.
+
+### `README.md`
+
+This README provides the larger context around the project.
+
+It explains why the project exists, how the components work together, what each file is responsible for, the current limitations, and the future direction.
+
+## Structured Output
+
+The conversation is converted into structured information rather than relying only on a raw transcript.
+
+The following is a wholly synthetic example:
+
+```json
+{
+  "patient_name": "Jordan Lee",
+  "reason_for_support": "General nutrition support",
+  "nutrition_goals": [
+    "Develop healthier eating habits"
+  ],
+  "dietary_preferences_or_restrictions": [
+    "Vegetarian"
+  ],
+  "location": "Example City, California",
+  "insurance_information": null,
+  "preferred_appointment_times": [
+    "Next Wednesday afternoon"
+  ],
+  "rdn_referral_needed": "yes",
+  "patient_confirmed_information": "yes"
+}
+```
+
+The structured result is intended to give the RDN or care team a concise, organized starting point for human review.
+
+The example above is fictional and does not represent a real patient or clinical encounter.
+
+## Why Patient Confirmation Matters
+
+Voice conversations are unstructured and can contain misunderstandings.
+
+Before producing the final intake result, the agent reads the collected information back to the patient and asks for confirmation.
+
+This creates an additional verification step before the information is passed to the downstream human workflow.
+
+## Why the RDN Remains in the Loop
+
+The purpose of this project is not to automate clinical decision-making.
+
+The AI handles communication and repetitive information collection, while the RDN or care team remains responsible for reviewing the information, determining appropriate care, and communicating with the patient.
+
+This separation keeps the prototype focused on workflow support rather than clinical automation.
+
+## Testing
+
+The repository includes synthetic validation scenarios covering:
+
+- AI disclosure
+- Consent
+- Structured intake
+- Safety-boundary handling
+- Information readback
+- Patient confirmation
+- Structured JSON generation
+- Human/RDN review
+
+These scenarios are fictional documentation fixtures. They are not records of real patient interactions, clinical encounters, or clinical outcomes.
+
+See [`TEST_RESULTS.md`](../skills/rdn-intake-referral/TEST_RESULTS.md) for the synthetic validation scenarios.
+
+### Reproducing the Example
+
+A synthetic example input is provided at [`examples/test-input.json`](../skills/rdn-intake-referral/examples/test-input.json).
+
+The fixture is intended for documentation and workflow demonstration. Any real-world testing should use an authorized test recipient, appropriate credentials, and applicable privacy and security controls.
+
+No real patient information, private phone numbers, API keys, insurance/member numbers, or raw sensitive transcripts should be committed to the repository.
+
+## Design Principles
+
+The project follows several design principles:
+
+### Consent First
+
+The agent identifies itself and obtains consent before proceeding with the intake.
+
+### Human-Centered Workflow
+
+The AI supports the RDN and care team instead of replacing them.
+
+### Structured Information
+
+Important information is converted from natural conversation into structured output.
+
+### Confirmation Before Handoff
+
+The patient is given an opportunity to confirm the collected information.
+
+### Safety Boundaries
+
+The AI remains within information collection and referral coordination and does not provide individualized medical or nutrition advice.
+
+### Fail Closed
+
+When the agent cannot safely continue, it should stop or defer to appropriate human handling rather than guessing.
+
+### Privacy by Design
+
+Public documentation uses wholly synthetic examples and should not contain real patient information, private phone numbers, insurance/member numbers, or raw sensitive transcripts.
+
+## Current Prototype vs. Future Development
+
+### Current Prototype
+
+The current prototype supports:
+
+- Outbound AI phone calls
+- AI disclosure
+- Consent-based intake
+- Nutrition-support information collection
+- Patient confirmation
+- Structured JSON output
+- RDN-ready referral information
+- Human/RDN follow-up
+
+### Future Development
+
+A future production implementation could connect the structured intake output to an RDN scheduling or care-management system.
+
+A possible future workflow would be:
+
+```text
+RDN / Care Team
+      |
+      v
+CALL-E AI Intake
+      |
+      v
+Patient Consent + Intake
+      |
+      v
+Patient Confirmation
+      |
+      v
+Structured Patient Information
+      |
+      v
+RDN / Care Management System
+      |
+      v
+Appointment Coordination
+      |
+      v
+Human / Authorized System Confirmation
+```
+
+Scheduling and appointment confirmation are intentionally outside the current prototype.
+
+## Technology
+
+- CALL-E
+- Agent Skills
+- Python
+- AI / LLM-based conversational workflow
+- Structured JSON
+- Voice AI
+- Healthcare AI safety patterns
+
+## Project Goal
+
+The project demonstrates how phone-based AI can reduce repetitive intake work while preserving a human-centered healthcare workflow.
+
+The intended outcome is not to replace the RDN.
+
+The intended outcome is to help the RDN begin with organized, patient-confirmed information instead of an unstructured phone conversation.
+
+## Hackathon Context
+
+This project was developed for the CALL-E hackathon, exploring practical applications of AI-powered phone interactions.
+
+The project contributes an RDN-focused healthcare intake workflow as a reusable CALL-E Agent Skill.
+
+## Status
+
+**Prototype -- Synthetic validation documentation included.**
+
+The current implementation focuses on intake and referral coordination. Production deployment would require appropriate healthcare, privacy, security, consent, clinical, and operational review.
+
+Public repository artifacts use synthetic examples; live test credentials, personal phone numbers, and sensitive patient information are intentionally excluded.

--- a/skills/rdn-intake-referral/TEST_RESULTS.md
+++ b/skills/rdn-intake-referral/TEST_RESULTS.md
@@ -1,0 +1,111 @@
+# RDN Intake & Referral Agent - Synthetic Validation Results
+
+## TEST STATUS
+
+Status: Synthetic validation
+Environment: Documentation fixture
+CALL-E Workflow: rdn-intake-referral
+
+## SYNTHETIC WORKFLOW VALIDATION
+
+The RDN Intake & Referral Agent includes synthetic validation scenarios representing an outbound nutrition-intake workflow.
+
+The synthetic scenario models an RDN/care team initiating an intake workflow in which a CALL-E AI phone agent contacts a fictional patient to collect basic information for subsequent human review.
+
+The scenario demonstrates:
+
+* AI assistant disclosure
+* Consent-based intake
+* Patient name collection
+* Reason for seeking nutrition support
+* Healthcare referral status
+* Nutrition goals
+* Dietary preferences/restrictions
+* Food allergy information
+* General service location
+* Insurance information handling
+* Preferred RDN appointment time
+* Final information readback
+* Patient confirmation
+* Structured JSON result generation
+
+The collected information is intended for subsequent review by the RDN or care team. The AI does not confirm the appointment.
+
+## SAFETY VALIDATION
+
+The synthetic scenario is designed to verify that the agent:
+
+* Does not diagnose medical conditions
+* Does not prescribe treatment
+* Does not interpret medical information
+* Does not provide individualized medical or nutrition advice
+* Maintains the intended intake and coordination boundary
+* Defers appropriate clinical questions to a qualified human professional
+
+## SYNTHETIC STRUCTURED RESULT
+
+The following is a wholly fictional example of the structured result:
+
+```json
+{
+  "patient_name": "Jordan Lee",
+  "reason_for_support": "General nutrition support",
+  "nutrition_goals": [
+    "Develop healthier eating habits"
+  ],
+  "dietary_preferences_or_restrictions": [
+    "Vegetarian"
+  ],
+  "allergies": [],
+  "location": "Example City, California",
+  "insurance_information": null,
+  "preferred_appointment_times": [
+    "Next Wednesday afternoon"
+  ],
+  "rdn_referral_needed": "yes",
+  "patient_confirmed_information": "yes"
+}
+```
+
+All names, locations, responses, and values in this example are fictional and are provided only to demonstrate the expected structure.
+
+## VALIDATION CRITERIA
+
+The synthetic validation scenarios are designed to verify:
+
+* AI identity disclosure
+* Consent handling
+* Required intake-field collection
+* Optional-information handling
+* Safety-boundary behavior
+* Information readback
+* Patient confirmation
+* Structured JSON generation
+* Human/RDN handoff
+
+No live-call performance metrics or patient-specific results are represented in this document.
+
+## PRIVACY
+
+Public repository documentation must not contain:
+
+* Real phone numbers
+* Real patient names
+* Raw call transcripts
+* Insurance/member numbers
+* Call identifiers associated with real interactions
+* Other personally identifiable or sensitive information
+
+The examples in this document are wholly synthetic and are not records of real patient interactions or clinical encounters.
+
+## CONCLUSION
+
+The synthetic validation scenarios demonstrate the intended workflow:
+
+RDN/Care Team -> CALL-E AI Phone Agent -> AI Disclosure -> Patient Consent -> Structured Intake -> Patient Confirmation -> RDN-Ready Output -> Human/RDN Follow-up
+
+The prototype is designed to use CALL-E for consent-based AI phone intake that organizes information into a structured format for subsequent human RDN review and follow-up.
+
+The current prototype collects the patient's preferred appointment time but does not confirm or schedule the appointment. A future production implementation could integrate the structured output with an RDN scheduling or care-management system.
+
+These synthetic scenarios are documentation fixtures and should not be interpreted as evidence of a real patient interaction, clinical outcome, or production deployment.

--- a/skills/rdn-intake-referral/examples/test-input.json
+++ b/skills/rdn-intake-referral/examples/test-input.json
@@ -1,0 +1,79 @@
+{
+  "task": "Synthetic RDN intake scenario. Disclose that the caller is an AI assistant, obtain consent, collect basic nutrition-intake information, summarize the information, and request confirmation. Do not provide diagnosis, treatment, or individualized medical or nutrition advice.",
+  "recipients": [
+    {
+      "phones": [
+        "+1XXXXXXXXXX"
+      ],
+      "region": "US",
+      "locale": "en-US"
+    }
+  ],
+  "result_schema": {
+    "type": "object",
+    "required": [
+      "patient_name",
+      "reason_for_support",
+      "nutrition_goals",
+      "dietary_preferences_or_restrictions",
+      "location",
+      "insurance_information",
+      "preferred_appointment_times",
+      "rdn_referral_needed",
+      "patient_confirmed_information"
+    ],
+    "properties": {
+      "patient_name": {
+        "type": "string"
+      },
+      "reason_for_support": {
+        "type": "string"
+      },
+      "nutrition_goals": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "dietary_preferences_or_restrictions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "location": {
+        "type": "string"
+      },
+      "insurance_information": {
+        "type": "string"
+      },
+      "preferred_appointment_times": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "rdn_referral_needed": {
+        "type": "string",
+        "enum": [
+          "yes",
+          "no",
+          "unknown"
+        ]
+      },
+      "patient_confirmed_information": {
+        "type": "string",
+        "enum": [
+          "yes",
+          "no",
+          "unknown"
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "metadata": {
+    "workflow": "rdn-intake-referral",
+    "environment": "synthetic-fixture"
+  }
+}

--- a/skills/rdn-intake-referral/references/examples.md
+++ b/skills/rdn-intake-referral/references/examples.md
@@ -1,196 +1,197 @@
-\# Examples
+# Examples
 
+This document provides synthetic safe and unsafe examples for the RDN Intake & Referral Agent. All names, locations, responses, and scenarios are fictional documentation fixtures.
 
+## Safe Example: Completed Nutrition Intake
 
-\## Safe Example: Completed Nutrition Intake
-
-
-
-A patient agrees to speak with the AI assistant and provides information about their nutrition support needs.
-
-
+In this synthetic scenario, a fictional participant agrees to speak with the AI assistant and provides information about general nutrition support needs.
 
 Example outcome:
 
-
-
 ```json
-
 {
-
-&#x20; "status": "completed",
-
-&#x20; "patient\_name": "Alex",
-
-&#x20; "reason\_for\_support": "Nutrition support for prediabetes",
-
-&#x20; "referral\_status": "Self-requested",
-
-&#x20; "nutrition\_goals": \[
-
-&#x20;   "Improve eating habits"
-
-&#x20; ],
-
-&#x20; "dietary\_preferences\_or\_restrictions": \[
-
-&#x20;   "Vegetarian"
-
-&#x20; ],
-
-&#x20; "location": "Michigan",
-
-&#x20; "insurance\_information": "Provided to the intake workflow",
-
-&#x20; "preferred\_appointment\_times": \[
-
-&#x20;   "Weekday afternoons"
-
-&#x20; ],
-
-&#x20; "rdn\_referral\_needed": true,
-
-&#x20; "patient\_confirmed\_information": true
-
+  "status": "completed",
+  "patient_name": "Jordan Lee",
+  "reason_for_support": "General nutrition support",
+  "nutrition_goals": [
+    "Develop healthier eating habits"
+  ],
+  "dietary_preferences_or_restrictions": [
+    "Vegetarian"
+  ],
+  "location": "Example City, California",
+  "insurance_information": "Not provided",
+  "preferred_appointment_times": [
+    "Weekday afternoons"
+  ],
+  "rdn_referral_needed": "yes",
+  "patient_confirmed_information": "yes"
 }
-
-
-
-The patient confirms that the information read back by the AI assistant is accurate.
-
-
-
-\## Safe Example: Incomplete Intake
-
-
-
-A patient starts the intake but does not provide enough information to complete the workflow.
-
-
-
-Example outcome:
-
-
-
-
-
-```json
-
-{
-
-&#x20; "status": "not\_completed",
-
-&#x20; "patient\_name": "",
-
-&#x20; "reason\_for\_support": "",
-
-&#x20; "referral\_status": "",
-
-&#x20; "nutrition\_goals": \[],
-
-&#x20; "dietary\_preferences\_or\_restrictions": \[],
-
-&#x20; "location": "",
-
-&#x20; "insurance\_information": "",
-
-&#x20; "preferred\_appointment\_times": \[],
-
-&#x20; "rdn\_referral\_needed": false,
-
-&#x20; "patient\_confirmed\_information": false
-
-}
-
 ```
 
+The fictional participant confirms that the information read back by the AI assistant is accurate.
 
+The AI assistant does not provide medical or individualized nutrition advice.
 
-The AI assistant must not invent missing information.
+---
 
+## Safe Example: Incomplete Intake
 
-
-\## Safe Example: Human Review Required
-
-
-
-The call completes, but the structured result cannot be reliably extracted.
-
-
+In this synthetic scenario, a fictional participant starts the intake but does not provide enough information to complete the workflow.
 
 Example outcome:
 
-
-
-
-
 ```json
-
 {
-
-&#x20; "status": "needs\_human",
-
-&#x20; "patient\_name": "",
-
-&#x20; "reason\_for\_support": "",
-
-&#x20; "referral\_status": "",
-
-&#x20; "nutrition\_goals": \[],
-
-&#x20; "dietary\_preferences\_or\_restrictions": \[],
-
-&#x20; "location": "",
-
-&#x20; "insurance\_information": "",
-
-&#x20; "preferred\_appointment\_times": \[],
-
-&#x20; "rdn\_referral\_needed": false,
-
-&#x20; "patient\_confirmed\_information": false
-
+  "status": "not_completed",
+  "patient_name": "",
+  "reason_for_support": "",
+  "nutrition_goals": [],
+  "dietary_preferences_or_restrictions": [],
+  "location": "",
+  "insurance_information": "",
+  "preferred_appointment_times": [],
+  "rdn_referral_needed": "unknown",
+  "patient_confirmed_information": "no"
 }
-
 ```
 
+The AI assistant must not invent or infer missing information.
 
+If required information cannot be reliably collected or confirmed, the workflow should remain incomplete or be routed for human review.
+
+---
+
+## Safe Example: Human Review Required
+
+In this synthetic scenario, the structured result cannot be reliably extracted or important information remains unclear.
+
+Example outcome:
+
+```json
+{
+  "status": "needs_human",
+  "patient_name": "",
+  "reason_for_support": "",
+  "nutrition_goals": [],
+  "dietary_preferences_or_restrictions": [],
+  "location": "",
+  "insurance_information": "",
+  "preferred_appointment_times": [],
+  "rdn_referral_needed": "unknown",
+  "patient_confirmed_information": "unknown"
+}
+```
 
 The workflow should stop and route the result for human review rather than guessing.
 
+Human review is also appropriate when important information is ambiguous, contradictory, or cannot be confirmed.
 
+---
 
-\## Unsafe Example: Clinical Advice
-
-
+## Unsafe Example: Clinical Advice
 
 The AI assistant should not diagnose a medical condition, interpret laboratory results, prescribe treatment, or provide individualized nutrition treatment.
 
+For example, the assistant must not:
 
+- Diagnose a medical condition.
+- Interpret laboratory or diagnostic results.
+- Recommend medication or medication changes.
+- Prescribe a specific therapeutic diet for an individual's medical condition.
+- Provide individualized medical or nutrition treatment.
 
-For example, the assistant must not tell a patient what medication to take or prescribe a specific therapeutic diet based on an individual's medical condition.
+If a participant asks for individualized medical or nutrition advice, the assistant should explain that it cannot provide that advice and keep the conversation within the intake and referral workflow when appropriate.
 
+---
 
+## Unsafe Example: Emergency Handling
 
-\## Unsafe Example: Emergency Handling
-
-
-
-If a patient describes a medical emergency or potentially urgent medical situation, the AI assistant must stop the routine nutrition intake and direct the patient toward appropriate emergency or urgent medical services.
-
-
+If a fictional participant describes a medical emergency or potentially urgent medical situation, the AI assistant must stop the routine nutrition intake and direct the participant toward appropriate emergency or urgent medical services.
 
 It must not attempt to diagnose or treat the emergency.
 
+---
 
-
-\## Unsafe Example: Unauthorized Call
-
-
+## Unsafe Example: Unauthorized Call
 
 The workflow must not place a call when the recipient, phone number, calling purpose, or authorization is missing or unclear.
 
+The workflow should return:
 
+```text
+needs_human
+```
 
-It must return `needs\_human` rather than guessing or proceeding. 
+rather than guessing or proceeding.
 
+The agent should also stop if:
+
+- The wrong person answers.
+- The recipient does not consent to continue.
+- The recipient asks the assistant to stop.
+- The intended calling purpose is unclear.
+- Required authorization is missing or unclear.
+
+---
+
+## Safe Example: Participant Requests to Stop
+
+A fictional participant can end the intake at any time.
+
+Example:
+
+> Participant: "I don't want to continue."
+
+The AI assistant should acknowledge the request, stop the routine intake, and avoid pressuring the participant to continue.
+
+The workflow should not mark unconfirmed information as complete.
+
+---
+
+## Safe Example: Insurance Information Not Provided
+
+A fictional participant may choose not to provide insurance information.
+
+Example outcome:
+
+```json
+{
+  "insurance_information": "Not provided"
+}
+```
+
+The AI assistant should respect the participant's decision and should not infer insurance information from unrelated statements.
+
+---
+
+## Safe Example: Unclear Participant Name
+
+If the fictional participant's name is unclear, the AI assistant should ask the participant to repeat it or spell it slowly.
+
+The assistant must not guess the name.
+
+For example:
+
+> AI Assistant: "I want to make sure I have your name correct. Could you please repeat your first and last name?"
+
+If the name still cannot be reliably captured, the workflow should route the result for human review rather than creating a guessed value.
+
+---
+
+## Safety Principle
+
+The RDN Intake & Referral Agent is designed for **intake and referral coordination**, not clinical decision-making.
+
+The AI assistant should:
+
+1. Disclose that it is an AI assistant.
+2. Obtain consent before continuing.
+3. Collect only information required by the intake workflow.
+4. Confirm important information with the participant.
+5. Never invent missing information.
+6. Respect requests to stop.
+7. Escalate unclear or unsafe situations to human review.
+8. Keep clinical decisions and individualized care with an appropriate healthcare professional.
+
+All examples in this document are synthetic and are not records of real patient interactions, calls, transcripts, or clinical encounters.


### PR DESCRIPTION
## Summary

This follow-up PR adds documentation and synthetic validation fixtures for the RDN Intake & Referral Agent originally contributed in PR #290.

The core `SKILL.md` implementation from PR #290 is unchanged.

## Changes

- Added project-level documentation for the RDN Intake & Referral Agent.
- Added synthetic validation scenarios and fictional structured results.
- Added a synthetic CALL-E test input example with the phone number masked.
- Cleaned and expanded the RDN intake safety and usage examples.
- Updated the root README with the RDN intake referral skill entry and documentation link.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow the repository conventions.
- [x] No secrets, API keys, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures.
- [x] The workflow includes appropriate consent, safety boundaries, and human-review behavior.
- [x] The documentation was validated with `git diff --check`.
- [x] The core `SKILL.md` implementation from PR #290 is unchanged.

## Related PR

Original implementation: #290