### PR TITLE
docs(apps): add audition-agent callback app guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Apps
 
+- [Audition Agent](apps/python/audition-agent/) - Producer-reviewed CALL-E role-disclosure calls that collect performer interest, callback availability, and unanswered questions, with a no-call verification path.
 - [CallParity](https://github.com/ruddro-roy/callparity) - Two-call ops workbench for Party A claims, a Party B falsification CALL-E task, and a merged claim graph. Preview and fixture mode by default.
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.
 - [GridGuard Voice Escalation Agent](https://github.com/draculess99/gridguard-voice-escalation-agent) - Approval-gated grid-risk escalation app using CALL-E with disclosed calls, two human confirmations, structured escalation packets, and a dry-run/no-call default. [Demo](https://gridguard-voice-escalation-agent-production.up.railway.app/)

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`python/audition-agent`](python/audition-agent/) | Python / React | Catalog and setup guide for producer-reviewed CALL-E role-disclosure callbacks, with upstream source and no-call verification. |
 | [`typescript/asyncfounders`](typescript/asyncfounders/) | TypeScript | Callback-first persistent team memory: consented CALL-E interviews capture updates, brief unseen company deltas, and resolve open questions into evidence-linked typed memory. |
 | [`web/fieldclose`](web/fieldclose/) | TypeScript / Next.js | Human-approved commercial HVAC closeout workflow with a fake-only public path, durable recipient suppression, one-attempt duplicate protection, structured CALL-E results, and explicit human disposition. |
 | [`typescript/kincall`](typescript/kincall/) | TypeScript | Consent-first check-in and trusted-circle coordination: a stated request for help overrides the agent's own judgement, contacts are called one at a time until somebody commits, and the monitored person is called back with the outcome. |

--- a/apps/python/audition-agent/README.md
+++ b/apps/python/audition-agent/README.md
@@ -1,0 +1,160 @@
+# Audition Agent
+
+Audition Agent helps independent filmmakers turn a film into an audition, review
+self-tapes, and follow up with shortlisted performers. Its CALL-E workflow explains
+an AI-generated role in the producer's own words, asks whether the performer wants
+to continue, collects a callback time, and returns unanswered questions to the producer.
+
+**Contribution area: User-facing Apps.** This directory is a catalog and setup guide
+for the runnable [Audition Agent application](https://github.com/michi883/audition-agent).
+The application source and tests are maintained there under the MIT license.
+The instructions below target revision
+[`64d5d72`](https://github.com/michi883/audition-agent/tree/64d5d72694d1dd48bd1a0379d215aea3e5050a61).
+
+- [Project description](https://devpost.com/software/audition-agent)
+- [Demo video](https://www.youtube.com/watch?v=zGYd7K8DeAA)
+- [Full setup and architecture](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/README.md)
+- [Demo walkthrough](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/docs/DEMO.md)
+
+## Supported host and CALL-E integration
+
+The app runs locally as a Python 3.12 FastAPI server with a React/TypeScript frontend.
+The Strands Producer Agent uses Amazon Bedrock and prepares callback plans through
+application tools. CALL-E integration uses the REST API through Python `httpx`:
+
+1. The producer selects a performer and supplies a day, time range, and duration.
+2. `plan_callback` persists the exact disclosure, offered windows, masked destination,
+   timezone, and a per-intent idempotency key. Planning makes no provider request.
+3. The producer reviews the plan and presses **Call**. Agent tools can redisplay or
+   cancel a plan, but cannot execute it. Live execution posts one task to `/v1/calls`
+   with `recipient_result_schema` and the saved idempotency key.
+4. The server polls `GET /v1/calls/{id}`. The structured result includes disclosure
+   delivery, continued interest, the chosen window, confidence, evidence, and questions.
+5. A callback is marked confirmed only when the result reports disclosure delivery,
+   continued interest, an offered window, medium/high confidence, and nonempty evidence,
+   without a contradictory disposition. Unanswered questions stay visible for a human.
+
+The evidence check tests presence; it does not independently prove transcript entailment.
+Casting choices and production commitments remain with the producer. No calendar event
+is created and no performance ranking is performed by the callback workflow.
+
+Relevant source:
+
+| File | Responsibility |
+| --- | --- |
+| [calle.py](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/backend/app/services/calle.py) | Task text, result schema, REST execution, polling, verification, and simulated results |
+| [callback.py](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/backend/app/agent/tools/callback.py) | Saved plans, producer-confirmed execution, cancellation, and workspace updates |
+| [test_regressions.py](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/tests/test_regressions.py) | Isolated no-call checks |
+
+## Setup and no-call verification
+
+Use Python 3.12 on macOS or Linux. Clone into a new directory:
+
+```bash
+git clone https://github.com/michi883/audition-agent.git
+cd audition-agent
+git checkout --detach 64d5d72694d1dd48bd1a0379d215aea3e5050a61
+python3.12 -m venv .venv
+.venv/bin/python -m pip install -r requirements.txt
+```
+
+Installing dependencies needs internet access. After installation, these focused
+checks use temporary database state and committed fixtures, without AWS credentials,
+CALL-E credentials, private media, a frontend build, or live calls:
+
+```bash
+PYTHONPATH=backend:tests .venv/bin/python -m unittest -v \
+  test_regressions.Regressions.test_agent_confirmation_only_redisplays_plan \
+  test_regressions.Regressions.test_callback_requires_evidence_and_an_offered_window \
+  test_regressions.Regressions.test_call_mode_defaults_to_mock_even_with_credentials
+```
+
+Expected: three tests pass. They check that agent confirmation only shows a plan,
+incomplete or contradictory results cannot confirm a callback, and credentials alone
+do not enable live calling. The tests force mock mode and replace network connection
+attempts with failures. They do not verify a live CALL-E account or carrier connection.
+
+## Run the application in mock mode
+
+The web app additionally requires Node.js 20.19+ or 22+ and npm. From the new clone:
+
+```bash
+cp .env.example .env
+make seed-offline
+AA_CALLE_MODE=mock ./start.sh
+```
+
+Open `http://localhost:8000`. The seed command creates nine fictional demo profiles
+and handwritten responses; use a dedicated demo database because reseeding replaces
+applicants. The launcher installs dependencies and builds the frontend.
+
+Mock mode simulates the phone call and its result without contacting CALL-E. The full
+application is not offline: agent chat needs Bedrock, media playback needs accessible
+S3 assets, and live ingestion uses cloud services. Configure your AWS region, private
+S3 bucket, and credentials as described in the upstream README before exercising those
+features. Original films and self-tapes are not distributed; supply permitted media
+for playback and tape analysis. The focused checks above work without them.
+
+With AWS configured, open Carla's profile, record the producer's shortlist decision,
+then ask: "Call Carla and tell her where Vivi stands. 15 minutes tomorrow between
+2:30 and 5 if she's still in." Review the disclosure and windows. Pressing **Call** in
+mock mode runs the simulated workflow and updates her profile with a mock result.
+
+For the full upstream regression suite and frontend type-check/build, run `make check`
+after the launcher has installed frontend dependencies.
+
+## Opt-in live verification and credentials
+
+1. Obtain your own CALL-E API access using the
+   [official integration guide](https://github.com/CALLE-AI/call-e-integrations).
+2. In your local, ignored `.env`, set `CALLE_API_KEY` and `DEMO_PHONE_E164` to your own
+   phone number in E.164 format. Never commit credentials or a private phone number.
+3. Set `AA_TIMEZONE` explicitly and review the producer-written disclosure in
+   `backend/app/seed/audition_focus.json`. The supplied disclosure describes the Vivi
+   demo role; another production needs its own reviewed terms.
+4. Stop the server, then start it with `AA_CALLE_MODE=live ./start.sh`. The mode defaults
+   to mock; `AA_CALLE_MODE` overrides `DEMO_MODE`. Live mode requires both the CALL-E
+   key and demo destination. Inspect the plan's masked destination and demo label.
+5. Prepare a new plan, review it, and press **Call** only when ready to receive the call
+   on your own phone. Answer as the fictional performer. The AI identifies itself,
+   reads the disclosure, asks about continued interest and an offered time, and takes
+   questions for the producer.
+6. Inspect the returned result in the profile. Report incomplete or failed results as
+   such; a mock run is not evidence of a live call. Return to
+   `AA_CALLE_MODE=mock ./start.sh` for rehearsals.
+
+CALL-E credentials remain on the server. AWS credentials use the standard boto3
+credential chain. A Gemini key is optional for video analysis. Live cloud use can incur
+charges; no live call is needed for the default verification path.
+
+## Side effects, cancellation, and boundaries
+
+- Planning writes local database and event state. Producer-confirmed live execution
+  sends the task, destination, and schema to CALL-E and places a real outbound call.
+  Returned call information is stored locally. Keep real performer data private.
+- Use the supplied demo with your own phone. For real performers, obtain permission
+  to contact them for this purpose; producer approval alone does not establish that
+  permission. Plan summaries mask the destination.
+- Cancel an unexecuted plan using the plan card's cancel action or ask the agent to
+  cancel it. Plans expire after 15 minutes by default. There are no recurring jobs.
+- Stop the local app with **Ctrl+C** or `./stop.sh`. Once submitted, this app has no
+  active-call cancellation API. Stopping the server or reaching the polling timeout
+  does not cancel a provider call; the recipient can end the call. Inspect CALL-E's
+  call state before retrying an interrupted or ambiguous submission.
+- Execution uses the saved intent's idempotency key and state checks to avoid repeat
+  submissions of that intent. Creating a new plan is a distinct intent; reconcile an
+  uncertain call before creating another. Ambiguous submissions are not auto-redialed.
+- Calls convey the producer's reviewed terms and route unresolved questions back to
+  a human. They do not negotiate contracts or provide medical, legal, financial, or
+  emergency advice. They do not make hiring or casting decisions.
+- This is a local, single-producer prototype without authentication or tenant
+  isolation. Bind to localhost. Public hosting requires access controls for producer,
+  upload, reset, and call endpoints. Background jobs and polling are in-process;
+  interrupted calls may need manual reconciliation.
+
+## License and assets
+
+The [source license](https://github.com/michi883/audition-agent/blob/64d5d72694d1dd48bd1a0379d215aea3e5050a61/LICENSE)
+is MIT. Demo profiles and portraits are illustrative fixtures. Private films, self-tapes,
+real call recordings, and transcripts are not included in this contribution. The source
+license does not grant rights to third-party media.


### PR DESCRIPTION
## Summary

Independent filmmakers need to explain a role's AI-related production terms to shortlisted performers and bring their questions back to the producer before arranging a callback. Audition Agent prepares a producer-reviewed CALL-E call that reads the disclosure, asks about continued interest, collects an offered time, and returns a structured result to the casting workspace.

This contributes Audition Agent under **User-facing Apps** at `apps/python/audition-agent/`, with entries in the root and app indexes. The app guide links to the public MIT-licensed implementation at a pinned revision and documents installation, three no-call verification checks, mock rehearsal, opt-in live execution, credentials, cancellation, and current limitations. Application source remains maintained in its existing public repository; this PR contributes the catalog and integration guide.

Audition Agent is a new project submitted for CALL-E: Your Code Is Calling.

- Source: https://github.com/michi883/audition-agent
- Project: https://devpost.com/software/audition-agent
- Demo video (2:44): https://www.youtube.com/watch?v=zGYd7K8DeAA
- Verified source revision: `64d5d72694d1dd48bd1a0379d215aea3e5050a61`

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

The listed resource is a runnable app maintained upstream; no app implementation is copied into this PR.

## Validation

- `python3 scripts/validate_repository.py` — passed.
- `python3 scripts/check_branch_name.py` — passed.
- `git diff --check` — passed.
- The documented upstream callback checks — 3 passed: agent confirmation only redisplays a plan, incomplete/contradictory results cannot confirm a callback, and credentials alone do not enable live calling.

Verification used local fixtures and temporary state. No live calls were placed for this contribution. The complete web workflow needs AWS access and permitted media; the focused callback checks need neither. The guide documents the lack of active-call cancellation, independent transcript entailment checking, and public-deployment authentication.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. (No recurring jobs; plan cancellation and active-call limitations are documented.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default. (The linked app defaults to mock mode and includes isolated verification.)
- [x] `python3 scripts/validate_repository.py` passes.
