### PR TITLE
feat: add countercall agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`incident-escalation-call`](skills/incident-escalation-call/) - Walks an on-call escalation ladder one phone call at a time and records an acknowledgement only when an owner and an ETA are both quoted by words the recipient spoke, then re-reads the call over a second transport before the incident is reported as owned.
 - [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
+- [`countercall`](skills/countercall/) - Calls a government service counter before a citizen travels there and returns a schema-validated checklist of what to bring — documents, fee, cash or card, originals or copies, appointment — leaving any field the clerk could not answer visibly empty instead of guessing it.
 
 ### Apps
 

--- a/skills/countercall/SKILL.md
+++ b/skills/countercall/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: countercall
+description: Call a government service counter to find out exactly what a person must bring before they travel there, and return it as a validated checklist. Use when published requirements are incomplete or contradicted at the window and the only reliable source is the office's phone line. Returns required documents, total fee, payment method, whether an appointment is needed, and how certain the clerk sounded.
+license: MIT
+---
+
+# CounterCall
+
+Pak Yanto took the morning off work, rode forty minutes to the Samsat counter, and was
+turned away because his photocopy was folio instead of A4. He lost a day's income, and he
+still did not know what else was missing for tomorrow.
+
+Public service counters publish requirement lists that are incomplete, outdated, or quietly
+contradicted at the window. The one reliable source is the office's phone line, and that
+line is busy, IVR-gated, and answered on the fourth try. So people do not call. They
+travel, they queue, and they get turned away over one document.
+
+This skill makes the call instead, and returns a checklist the person can screenshot and
+take with them.
+
+It is a good fit for CALL-E's design: low-frequency, personal, high-stakes phone work
+against a number that a human would otherwise have to redial all morning.
+
+## Before you start
+
+**This skill places a real phone call to a real public office.** Confirm with the user:
+
+- which procedure they are asking about, in the office's own words
+- which office, and the phone number in E.164 format, from the office's published page
+- that they want a call placed now
+
+**Never infer a phone number.** Not from a directory, not from a similar office, not by
+guessing a country code. A number enters the flow only when a human has read it off the
+office's own published page. Calling the wrong number means an automated caller reaches a
+stranger, which is the worst thing this skill can do.
+
+## Safety boundaries
+
+This skill gathers **counter requirements only**.
+
+- It does not submit an application, book an appointment, pay a fee, or commit the user to
+  anything. It asks and reports.
+- It does not give legal or immigration advice. If a clerk suggests an alternative route,
+  report it verbatim as something the clerk said, never as a recommendation.
+- A clerk's spoken answer is **informational, not legally binding**, and every rendered
+  result says so. Requirements change and individual counters apply discretion.
+- It states plainly at the start of the call that it is an automated assistant, and why it
+  is calling. If the person declines to answer, it thanks them and ends the call. It does
+  not persist, re-ask, or call back the same day.
+- **One call per office per procedure per day.** These are public service lines staffed by
+  people with a queue in front of them. The idempotency key enforces this; do not remove it.
+- When the clerk is unsure, the result says unsure. It never fills a gap with what is
+  typical, and it never presents a hedge as a fact. A person may travel across a city on
+  the strength of this answer.
+- It calls offices during their published opening hours only. A public line ringing out at
+  22:00 is not a data point, it is a nuisance.
+
+Read `references/safety.md` before adapting this skill to a new institution. Some callees
+are not appropriate targets for an automated caller at all.
+
+## What makes this different from a transcript
+
+Most call skills return prose and let the reader interpret it. This one returns a **pinned,
+validated object**, and refuses to return anything else.
+
+The Goal's `result_schema` sets `additionalProperties: false` and constrains four fields to
+enumerations — `payment_method`, `appointment_required`, `originals_or_copies` and
+`clerk_certainty`, each of which includes a value for "the clerk did not know". If the call comes back shaped differently, the result is quarantined rather
+than rendered. A half-parsed checklist is worse than no checklist, because the user acts
+on it.
+
+The full contract is in `references/result-contract.md`.
+
+## Workflow
+
+### 1. Collect the request
+
+Required: the procedure name, the office name, the office's phone number in E.164, and the
+published source URL the number came from.
+
+**Validate the number before anything else happens.** E.164 is a plus, a non-zero country
+code digit, then 7 to 14 more digits: `^\+[1-9]\d{7,14}$`. Reject anything else and ask the
+user. Never guess a country code. A local-format number reaching the dialler is how the
+wrong person gets called.
+
+Run `scripts/preflight.mjs` to check the number and the contract without dialling.
+
+### 2. Check the published contract has not drifted
+
+Before every run, read the live Goal interface and compare it against the contract this
+skill was written for.
+
+```js
+const goal = await client.goals.get(GOAL_ID);
+const drift = diffContract(PINNED_CONTRACT, goal.published_run_spec);
+if (drift.length) throw new ContractDrift(drift);   // refuse to dial
+```
+
+The CALL-E documentation recommends this comparison before deploying a variable change.
+Doing it on **every run** costs one API call and converts a silent failure into a loud
+refusal. Dialling a real person with a stale schema produces a result that looks fine and
+is quietly wrong.
+
+### 3. Place one call
+
+`goals.run` with an `Idempotency-Key` scoped to office, procedure and date, so a retry
+never double-dials a public line:
+
+```text
+countercall:{office}:{procedure}:{yyyy-mm-dd}:v1
+```
+
+### 4. Poll to a result or an error
+
+`goals.waitForResult` has one completion rule: stop when either `result` or `error` is
+non-null. A completed call can briefly return both null while CALL-E parses the structured
+result, so do not treat that window as a failure.
+
+### 5. Render, or fail honestly
+
+| Outcome | What the user sees |
+|---|---|
+| valid result | the checklist, with the clerk's verbatim line and the source URL |
+| `no_answer` | "the line did not answer" and the number of attempts. No checklist |
+| `declined` | "the office declined to answer an automated caller". No checklist |
+| `result_invalid` | quarantined. No checklist, and the raw result is kept for inspection |
+| `timed_out` | "no usable answer". No checklist |
+
+**No branch renders a partial checklist.** Worked examples of each are in
+`references/examples.md`.
+
+## Running it
+
+`scripts/call.mjs` is **dry-run by default**. It prints the exact request it would send and
+places no call. Dialling requires an explicit `--live`:
+
+```bash
+node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
+node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor" --live
+```
+
+A skill that dials by default is a skill that dials by accident.
+
+## When not to use this
+
+- **Emergencies.** This is a requirements lookup with a multi-minute latency. It is not a
+  way to reach anyone urgently.
+- **Offices with a published, reliable, current requirements page.** If the website is
+  right, read the website. The call is justified only where the published answer is known
+  to be incomplete.
+- **Any institution that has asked not to be called by automated systems**, or where local
+  law restricts automated calling. Check before adding an office.
+- **High-volume lookups.** One office per procedure per day is the ceiling by design. If
+  you need bulk, you need a data-sharing agreement, not a phone.
+- **Anything where being wrong is cheap.** The value here comes from the cost of a wasted
+  trip. If the user can simply go and find out, let them.
+
+## Honest limitations
+
+- Coverage is limited to offices in the seed file, each with a published-source URL.
+- Answer rates on public service lines vary by office and time of day, and a large share of
+  calls will not be answered. That unreliability is the reason this skill exists, and it is
+  reported rather than hidden.
+- The result is one clerk's answer on one day. It is evidence, not a guarantee.

--- a/skills/countercall/SKILL.md
+++ b/skills/countercall/SKILL.md
@@ -91,10 +91,19 @@ Before every run, read the live Goal interface and compare it against the contra
 skill was written for.
 
 ```js
+import { diffContract, publishedRunSpec } from './scripts/_lib.mjs';
+
 const goal = await client.goals.get(GOAL_ID);
-const drift = diffContract(PINNED_CONTRACT, goal.published_run_spec);
+const drift = diffContract(PINNED_CONTRACT, publishedRunSpec(goal));
 if (drift.length) throw new ContractDrift(drift);   // refuse to dial
 ```
+
+**Use the `publishedRunSpec(goal)` helper, not `goal.published_run_spec` directly.** The wire
+format and the docs spell it `published_run_spec.result_schema`; the TypeScript SDK camelCases
+it to `publishedRunSpec.resultSchema`. Reading only the documented name against the TS client
+returns `undefined` rather than throwing — the guard then concludes "no published spec" and
+**refuses every single dial while looking like it is working**. The helper reads both spellings.
+This cost us a day; it is written up in `FEEDBACK.md` at the repo root.
 
 The CALL-E documentation recommends this comparison before deploying a variable change.
 Doing it on **every run** costs one API call and converts a silent failure into a loud
@@ -118,13 +127,20 @@ result, so do not treat that window as a failure.
 
 ### 5. Render, or fail honestly
 
+All eight published `GoalRunError` codes route to a distinct outcome. The set below is the
+one `scripts/render.mjs` implements — keep them in step if CALL-E adds a code.
+
 | Outcome | What the user sees |
 |---|---|
 | valid result | the checklist, with the clerk's verbatim line and the source URL |
-| `no_answer` | "the line did not answer" and the number of attempts. No checklist |
+| `no_answer` | "the line did not answer". No checklist |
 | `declined` | "the office declined to answer an automated caller". No checklist |
-| `result_invalid` | quarantined. No checklist, and the raw result is kept for inspection |
-| `timed_out` | "no usable answer". No checklist |
+| `result_invalid` | the call completed but the answer did not match the contract. Quarantined |
+| `result_unavailable` | the call completed but produced no structured answer. No checklist |
+| `result_failed` | the answer could not be processed into a checklist. No checklist |
+| `timed_out` | "no usable answer" before the deadline. No checklist |
+| `call_failed` | the call could not be completed. No checklist |
+| `canceled` | cancelled before it produced an answer. No checklist |
 
 **No branch renders a partial checklist.** Worked examples of each are in
 `references/examples.md`.
@@ -135,11 +151,27 @@ result, so do not treat that window as a failure.
 places no call. Dialling requires an explicit `--live`:
 
 ```bash
-node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
-node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor" --live
+# dry run — prints the request it would send, dials nothing, needs no credentials
+node scripts/call.mjs --office <id> --procedure "<procedure>"
+
+# actually rings a phone
+node scripts/call.mjs --office <id> --procedure "<procedure>" --live
 ```
 
 A skill that dials by default is a skill that dials by accident.
+
+**`data/offices.json` ships with its phone number masked** (`+62XXXXXXXXXX`), so the seeded
+entry cannot dial and every command against it exits `3` with `REFUSING TO DIAL`. That is
+deliberate: a number enters the file only when a human has read it off the office's own
+published page and recorded `source_url` and `source_checked`. Add your own entry before
+running anything.
+
+To see the dry-run output immediately, the test fixture carries a valid fictional number:
+
+```bash
+node scripts/call.mjs --offices ../../test/fixtures/offices.test.json \
+  --office fixture-sourced --procedure "perpanjangan paspor"
+```
 
 ## When not to use this
 

--- a/skills/countercall/SKILL.md
+++ b/skills/countercall/SKILL.md
@@ -63,7 +63,7 @@ are not appropriate targets for an automated caller at all.
 Most call skills return prose and let the reader interpret it. This one returns a **pinned,
 validated object**, and refuses to return anything else.
 
-The Goal's `result_schema` sets `additionalProperties: false` and constrains four fields to
+The pinned `result_schema` sets `additionalProperties: false` and constrains four fields to
 enumerations — `payment_method`, `appointment_required`, `originals_or_copies` and
 `clerk_certainty`, each of which includes a value for "the clerk did not know". If the call comes back shaped differently, the result is quarantined rather
 than rendered. A half-parsed checklist is worse than no checklist, because the user acts
@@ -85,10 +85,33 @@ wrong person gets called.
 
 Run `scripts/preflight.mjs` to check the number and the contract without dialling.
 
-### 2. Check the published contract has not drifted
+### 2. Pick a transport, then make sure the contract is honest
 
-Before every run, read the live Goal interface and compare it against the contract this
-skill was written for.
+There are two ways to reach CALL-E, and `scripts/transport.mjs` picks between them. Both
+place a real outbound call and both return the **same validated shape**, so nothing above the
+transport changes.
+
+| | needs | who owns the schema |
+|---|---|---|
+| **`calls`** *(default)* | `CALLE_API_KEY` | you do — it ships with the request as `result_schema` |
+| **`goals`** | `CALLE_API_KEY` + `COUNTERCALL_GOAL_ID` | the published Goal |
+
+`selectTransport()` uses `goals` when `COUNTERCALL_GOAL_ID` is set and `calls` otherwise.
+`COUNTERCALL_TRANSPORT=goals|calls` forces one, and an unrecognised value throws rather than
+falling back — a typo must not silently dial on a path nobody chose.
+
+**Why `calls` is the default.** Publishing a Goal is only possible inside CALL-E Chat: there
+is no `POST /v1/goals`, no MCP publish tool, and no action on the Goal detail page. That makes
+the Goals path dependent on a surface you may not be able to reach — during the 2026-09-02
+CALL-E login suspension it was reachable by nobody. The Calls transport needs one credential
+and works regardless.
+
+**On `calls`, drift is impossible by construction.** `resultSchemaJSON()` generates the
+request-scoped schema from the same `CONTRACT` object that `validateResult` checks the reply
+against, so the two cannot disagree. There is nothing to compare.
+
+**On `goals`, compare before every run.** The published Goal owns the schema, so it can move
+underneath you:
 
 ```js
 import { diffContract, publishedRunSpec } from './scripts/_lib.mjs';
@@ -112,8 +135,9 @@ is quietly wrong.
 
 ### 3. Place one call
 
-`goals.run` with an `Idempotency-Key` scoped to office, procedure and date, so a retry
-never double-dials a public line:
+`transport.run(...)` — `goals.run` or `calls.create` depending on the transport — always with
+an `Idempotency-Key` scoped to office, procedure and date, so a retry never double-dials a
+public line:
 
 ```text
 countercall:{office}:{procedure}:{yyyy-mm-dd}:v1
@@ -124,6 +148,13 @@ countercall:{office}:{procedure}:{yyyy-mm-dd}:v1
 `goals.waitForResult` has one completion rule: stop when either `result` or `error` is
 non-null. A completed call can briefly return both null while CALL-E parses the structured
 result, so do not treat that window as a failure.
+
+`calls.waitForResult` returns a terminal `CallTask` instead, and `normaliseCall()` folds it
+onto the same shape. One case there is worth knowing: **`status: "completed"` with
+`structuredResult: null`** means the call connected but the evidence could not satisfy the
+schema. That is terminal — it becomes `result_unextractable`, never an empty card. Handing a
+null result upward would make the renderer decide what a missing checklist means, and the only
+safe answer is to render nothing.
 
 ### 5. Render, or fail honestly
 

--- a/skills/countercall/data/offices.json
+++ b/skills/countercall/data/offices.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "imigrasi-jaksel",
+    "name": "Kantor Imigrasi Kelas I Khusus Non TPI Jakarta Selatan",
+    "city": "Jakarta Selatan",
+    "phone_e164": "+62XXXXXXXXXX",
+    "source_url": "https://jakartaselatan.imigrasi.go.id/",
+    "source_checked": null,
+    "procedures": ["perpanjangan paspor", "paspor baru"]
+  }
+]

--- a/skills/countercall/references/examples.md
+++ b/skills/countercall/references/examples.md
@@ -1,0 +1,133 @@
+# Worked examples
+
+Every outcome the skill can produce, including the ones that return nothing. The failure
+paths matter more than the happy path: they are where a checklist skill is tempted to
+guess.
+
+> The payloads below are **illustrative**. They are not recordings of real calls. Results
+> published in a demo, a README, or a screenshot must come from an actual run.
+
+## 1. Confident answer — the case the skill exists for
+
+Request:
+
+```json
+{
+  "office_name": "Kantor Imigrasi Jakarta Selatan",
+  "procedure": "perpanjangan paspor",
+  "city": "Jakarta Selatan"
+}
+```
+
+Result:
+
+```json
+{
+  "required_documents_text": "KTP asli\nKartu Keluarga asli\npaspor lama",
+  "total_fee_idr": 650000,
+  "payment_method": "cash",
+  "appointment_required": "yes",
+  "originals_or_copies": "originals",
+  "clerk_certainty": "confident",
+  "clerk_quote": "Bawa KK yang asli ya, fotokopi saja tidak bisa. Dan harus daftar M-Paspor dulu."
+}
+```
+
+The value is in the gap between this and the website. The published page says bring
+"KTP, KK, paspor lama". It does not say the family card must be an original, and it does
+not say an appointment must be booked first. Both are trips lost.
+
+## 2. The clerk was unsure about one field
+
+```json
+{
+  "required_documents_text": "KTP asli\nKartu Keluarga asli\npaspor lama",
+  "payment_method": "unknown",
+  "appointment_required": "yes",
+  "originals_or_copies": "originals",
+  "clerk_certainty": "unsure",
+  "clerk_quote": "Untuk biayanya saya kurang tahu, nanti ditanyakan di loket saja."
+}
+```
+
+The fee field is **absent entirely** — not `null`, which a Goal Run result cannot carry.
+The card still renders the Fee row, as an em dash, and is labelled unsure. It does not fall
+back to a typical fee, and it does not drop the row so the gap disappears.
+
+This is a **successful** call. The user learns three documents and an appointment
+requirement, and knows to ask about the fee at the window.
+
+## 3. `no_answer` — the most common outcome in practice
+
+```json
+{ "error": { "code": "no_answer", "attempts": 2 } }
+```
+
+Rendered:
+
+> The line at Kantor Imigrasi Jakarta Selatan did not answer on either attempt today.
+> No checklist is available for this office.
+
+No partial checklist. No cached answer from a previous day presented as current. One retry
+under a `:v2` key, then abstain until tomorrow.
+
+Public service lines go unanswered often. That is the premise of the skill, not a defect in
+it, and the honest reporting of it is what makes the answered calls trustworthy.
+
+## 4. `declined` — the office refused an automated caller
+
+```json
+{ "error": { "code": "declined" } }
+```
+
+Rendered:
+
+> The office declined to answer an automated caller.
+
+End the call politely, render nothing, and do not retry. If one office declines
+consistently, remove it from the seed file. A refusal is an answer.
+
+## 5. `result_invalid` — the call happened, the shape was wrong
+
+```json
+{ "error": { "code": "result_invalid", "reason": "required_documents_text decoded to zero documents" } }
+```
+
+Rendered:
+
+> The call completed but the answer did not match the expected contract, so nothing is
+> shown. The raw result has been kept for inspection.
+
+This is the branch that protects the user from a half-parsed checklist. A checklist that is
+70 percent right is more dangerous than no checklist, because it gets acted on.
+
+## 6. Contract drift — refused before dialling
+
+```text
+$ node scripts/preflight.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
+
+  contract           DRIFT DETECTED
+  pinned version     3
+  published version  4
+  removed field      originals_or_copies
+
+REFUSING TO DIAL. The published Goal no longer matches the contract this skill
+was written against. Re-pin the contract and re-check the rendering before dialling.
+```
+
+No call is placed and no credit is spent. This is the one branch that costs nothing to get
+right and is expensive to get wrong: a stale schema produces results that look correct.
+
+## 7. Rejected before anything happens — a bad number
+
+```text
+$ node scripts/preflight.mjs --office bad-entry --procedure "perpanjangan paspor"
+
+  phone              021-5225029
+  E.164              FAIL - not in E.164 format
+
+REFUSING TO DIAL. Numbers must match ^\+[1-9]\d{7,14}$ and come from the office's
+own published page. Never guess a country code.
+```
+
+A local-format number reaching the dialler is how a stranger's phone rings.

--- a/skills/countercall/references/examples.md
+++ b/skills/countercall/references/examples.md
@@ -33,9 +33,14 @@ Result:
 }
 ```
 
-The value is in the gap between this and the website. The published page says bring
-"KTP, KK, paspor lama". It does not say the family card must be an original, and it does
-not say an appointment must be booked first. Both are trips lost.
+The value is in the gap between this and the website. The office's own published pages give
+an address and a phone number; they do not say whether the family card must be an original,
+or whether an appointment must be booked first. Both are trips lost.
+
+*(Checked 2026-09-06 against <https://jakartaselatan.imigrasi.go.id/en/tentang-kami/alamat>,
+which publishes the phone number and address used in `offices.json` and no document
+requirements. This example is illustrative — the values above are a schema illustration, not
+a call recording.)*
 
 ## 2. The clerk was unsure about one field
 

--- a/skills/countercall/references/result-contract.md
+++ b/skills/countercall/references/result-contract.md
@@ -1,0 +1,98 @@
+# The result contract
+
+The Goal's `result_schema` is the whole product. Everything else is transport.
+
+## `input_schema` — scalars only
+
+CALL-E Goal inputs are per-run scalar business values. No nested objects, no arrays, no
+nulls.
+
+| Field | Type | Example |
+|---|---|---|
+| `office_name` | string | `Kantor Imigrasi Jakarta Selatan` |
+| `procedure` | string | `perpanjangan paspor` |
+| `city` | string | `Jakarta Selatan` |
+
+Do not send `target`, `region`, `locale`, or `display_name` per run. Voice region and callee
+locale belong to the published Goal and cannot be changed per run.
+
+**Never send personal data.** No name, identity number, or case reference. The clerk is
+being asked a general question about a procedure, and does not need to know who is asking.
+
+## `result_schema` — `additionalProperties: false`
+
+| Field | Type | Values |
+|---|---|---|
+| `required_documents_text` | string | newline-separated, in the clerk's terms, not normalised |
+| `total_fee_idr` | number, **optional** | absent when the clerk did not know |
+| `payment_method` | enum | `cash` · `card` · `both` · `unknown` |
+| `appointment_required` | enum | `yes` · `no` · `unknown` |
+| `originals_or_copies` | enum | `originals` · `copies` · `both` · `unknown` |
+| `clerk_certainty` | enum | `confident` · `unsure` · `refused` |
+| `clerk_quote` | string | one verbatim supporting line |
+
+### Why `additionalProperties: false` matters
+
+It is the difference between parsing and validating. With it, a result that arrives shaped
+differently is a **detectable** failure that routes to `result_invalid` and renders nothing.
+Without it, an unexpected shape is silently accepted and a wrong checklist reaches someone
+about to travel.
+
+### Why every enum has an `unknown`
+
+Because clerks say "I am not sure", and that has to be representable. An enum without
+`unknown` forces the extraction to pick a value it did not hear, which is exactly the
+failure this skill is built to avoid.
+
+`total_fee_idr` is **optional** for the same reason. A missing fee is an absent key, never
+`0` and never a typical value.
+
+### Why the document list is a string
+
+A Goal Run `result` is a flat map of scalars. From the CALL-E OpenAPI spec:
+
+```yaml
+result:
+  type: [object, "null"]
+  additionalProperties:
+    $ref: "#/components/schemas/GoalScalar"   # string | number | boolean
+```
+
+No arrays, no nested objects, no nulls. This is a Goals-API constraint specifically — the
+one-shot Calls API does accept `simple array.items` in its request-scoped `result_schema`,
+but Goals does not, and Goals is what provides the published, reusable procedure catalogue.
+
+So the checklist travels as a newline-separated string and is decoded client-side by
+`decodeDocuments`. The same constraint is why `total_fee_idr` is optional rather than
+nullable: `null` is not a `GoalScalar`, but an absent key costs nothing and means exactly
+what `null` meant.
+
+### Why `clerk_certainty` is our field, not the platform's
+
+An earlier design expected a `completion_confidence` signal on the Goal Run resource. That
+field belongs to the **Calls** API `CallTask`; a Goal Run exposes only
+`{id, goalId, runId, runSpec, status, result, error, createdAt, completedAt}`.
+
+Modelling certainty inside our own `result_schema` turned out to be strictly better. It is
+our contract rather than a platform signal we hoped existed, it is pinned and versioned with
+the rest of the schema, and it distinguishes `refused` from `unsure`, which a numeric
+confidence score cannot.
+
+### Why `clerk_quote` is required
+
+It is span grounding. The checklist is a claim; the quote is the evidence for it. A user who
+distrusts a row can read what the clerk actually said, and a maintainer debugging a bad
+extraction can see whether the model misheard or the clerk was genuinely ambiguous.
+
+The quote must support the fields it is attached to. A quote about photocopies does not
+justify an `appointment_required` value.
+
+## Contract drift
+
+The pinned contract records the `published_run_spec` version and schema shape this skill was
+written against. Before every run, `goals.get` reads the live interface and the two are
+compared. Any difference in version or field shape refuses the dial.
+
+This costs one API call per run and is the single highest-value check in the skill: a
+drifted schema does not throw, it silently produces confident-looking results that are
+wrong.

--- a/skills/countercall/references/safety.md
+++ b/skills/countercall/references/safety.md
@@ -1,0 +1,88 @@
+# Safety — calling a public service counter
+
+This skill points an automated caller at a phone line staffed by a public servant who did
+not opt in. That asymmetry drives every rule here.
+
+## The consent line
+
+The call opens by stating, before anything is asked:
+
+> This is an automated assistant calling on behalf of a member of the public. I would like
+> to ask what documents are required for one procedure. Is now a good time?
+
+If the answer is no, or the person asks what this is and is unsatisfied, or asks to be
+removed: **thank them and end the call.** Do not re-ask, do not rephrase the request as a
+different question, do not call back the same day. Record the outcome as `declined` and
+render no checklist.
+
+## Rate discipline
+
+**One call per office, per procedure, per day.** Enforced by the idempotency key:
+
+```text
+countercall:{office}:{procedure}:{yyyy-mm-dd}:v1
+```
+
+The key exists because these are queues with real people in them, not an API. A retry that
+mints a fresh key is a bug, not a workaround. `no_answer` is the single exception: one
+retry under a `:v2` suffix, then abstain for the day.
+
+Call during the office's published opening hours only.
+
+## Never infer a number
+
+A number enters the seed file only when a human has read it off the office's own published
+page and recorded the URL and the date they checked it. No directory scraping, no pattern
+matching from a sibling office, no guessing a country code.
+
+Every number is validated against `^\+[1-9]\d{7,14}$` before the dialler sees it. A
+local-format number that reaches the dialler is how a stranger's phone rings.
+
+## Report, never advise
+
+The skill returns what a clerk said. It does not interpret it.
+
+- If a clerk suggests a different route, that is reported as a quotation, attributed to the
+  clerk, never as a recommendation from the system.
+- No legal or immigration advice, ever, including "this usually means".
+- Every rendered result carries: *a clerk's spoken answer is informational, not legally
+  binding.* Requirements change, and individual counters apply discretion.
+
+## Uncertainty is a first-class result
+
+`clerk_certainty` is `confident`, `unsure`, or `refused`, and the rendered card shows it.
+
+An individual field the clerk did not know stays **empty and grey** — not filled with a
+typical value, not omitted so the gap disappears. A user may travel across a city on this
+answer. An honest "we do not know the fee" costs them one question at the counter; an
+invented fee costs them the trip.
+
+Abstention is a correct output. Treat it as a success, not a degraded result.
+
+## Do not point this at the wrong callee
+
+Appropriate: a published general-enquiries line for a public office, during opening hours,
+for a factual question that office answers many times a day anyway.
+
+Not appropriate:
+- personal mobile numbers of individual staff
+- emergency, medical, or crisis lines, under any circumstances
+- any institution that has asked not to be contacted by automated systems
+- jurisdictions whose law restricts automated calling — check before adding an office
+- anything where the question is not routine and factual
+
+## Data handling
+
+- The call is about a procedure, not a person. Do not send the user's name, identity
+  number, case reference, or any other personal detail as a variable. The clerk does not
+  need it, and it should not exist in a call record.
+- Store the published source URL alongside every result, so any answer can be traced back
+  to the office it came from.
+- Credentials live outside the repository. `CALLE_API_KEY` is read from the environment and
+  is never committed.
+
+## If a call goes wrong
+
+Stop. Do not retry into the same office. Record what happened, including the clerk's own
+words if they objected, and treat it as a signal that the callee list needs revisiting
+rather than as a transient failure to route around.

--- a/skills/countercall/scripts/_lib.mjs
+++ b/skills/countercall/scripts/_lib.mjs
@@ -1,0 +1,94 @@
+// Shared helpers. No side effects, no network, no dialling.
+
+import { readFileSync } from 'node:fs';
+
+export const E164 = /^\+[1-9]\d{7,14}$/;
+
+/** A number is usable only if it is E.164 AND carries a published source. */
+export function validateOffice(office) {
+  const problems = [];
+  if (!office) return ['office not found in the seed file'];
+  if (!office.phone_e164) problems.push('no phone_e164');
+  else if (!E164.test(office.phone_e164)) problems.push(`not E.164: ${office.phone_e164}`);
+  if (!office.source_url) problems.push('no source_url — a number needs a published source');
+  if (!office.source_checked) problems.push('no source_checked date');
+  if (String(office.phone_e164 ?? '').includes('X')) problems.push('placeholder number');
+  return problems;
+}
+
+/**
+ * Read the published RunSpec off a Goal in either casing.
+ *
+ * The wire format is snake_case (`published_run_spec.result_schema`) and the Python SDK
+ * hands back raw dicts, but the TypeScript SDK camelCases its surface
+ * (`publishedRunSpec.resultSchema`). Reading only one of them is how the drift guard
+ * silently reports "no spec" against a perfectly healthy Goal and refuses every dial.
+ */
+export function publishedRunSpec(goal) {
+  const spec = goal?.publishedRunSpec ?? goal?.published_run_spec;
+  if (!spec) return null;
+  return {
+    id: spec.id,
+    version: spec.version,
+    inputSchema: spec.inputSchema ?? spec.input_schema ?? null,
+    resultSchema: spec.resultSchema ?? spec.result_schema ?? null,
+  };
+}
+
+/** Compare a pinned contract against the live published RunSpec. Any drift refuses the dial. */
+export function diffContract(pinned, published) {
+  const drift = [];
+  if (!published) return ['no published RunSpec on the live Goal'];
+
+  const resultSchema = published.resultSchema ?? published.result_schema ?? null;
+  if (!resultSchema) return ['published RunSpec carries no result schema'];
+
+  if (pinned.version !== published.version)
+    drift.push(`version ${pinned.version} -> ${published.version}`);
+
+  const live = Object.keys(resultSchema.properties ?? {});
+  for (const field of pinned.result_fields) {
+    if (!live.includes(field)) drift.push(`removed field: ${field}`);
+  }
+  for (const field of live) {
+    if (!pinned.result_fields.includes(field)) drift.push(`new field: ${field}`);
+  }
+  if (resultSchema.additionalProperties !== false)
+    drift.push('additionalProperties is no longer false');
+  return drift;
+}
+
+/** Business-stable key: one office, one procedure, one day. */
+export function idempotencyKey(officeId, procedure, date) {
+  const slug = procedure.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `countercall:${officeId}:${slug}:${date}:v1`;
+}
+
+/**
+ * Load the office seed file — the shipped one, or a fixture via `--offices <path>`.
+ * The flag exists so the dry-run and refuse-to-dial paths can be tested against known
+ * data instead of against whatever the seed file happens to contain today.
+ */
+export function loadOffices(args, importMetaUrl) {
+  const source = args.offices
+    ? new URL(args.offices, `file://${process.cwd()}/`)
+    : new URL('../data/offices.json', importMetaUrl);
+  return JSON.parse(readFileSync(source, 'utf8'));
+}
+
+/** Flags that take no value. Anything else consumes the token after it. */
+export const BOOLEAN_FLAGS = new Set(['live', 'plan', 'report']);
+
+export function parseArgs(argv) {
+  const args = { live: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const name = a.slice(2);
+    // A boolean flag must never swallow the next token — `--plan --offices x` once
+    // parsed as `plan: "--offices"`, which silently ignored the fixture path.
+    if (BOOLEAN_FLAGS.has(name)) args[name] = true;
+    else args[name] = argv[++i];
+  }
+  return args;
+}

--- a/skills/countercall/scripts/_lib.mjs
+++ b/skills/countercall/scripts/_lib.mjs
@@ -76,8 +76,16 @@ export function loadOffices(args, importMetaUrl) {
   return JSON.parse(readFileSync(source, 'utf8'));
 }
 
-/** Flags that take no value. Anything else consumes the token after it. */
-export const BOOLEAN_FLAGS = new Set(['live', 'plan', 'report']);
+/**
+ * Flags that take no value. Anything else consumes the token after it.
+ *
+ * `write` and `json` were missing here, which made `verify_live.mjs --write` a silent no-op:
+ * with no token after it, `--write` parsed as `undefined`, the falsy check skipped the write,
+ * and the command exited 0 having done nothing. DEMO.md documented that command as the way to
+ * fill its verification block, so the block stayed a placeholder while the tool reported
+ * success. A flag that quietly means its own opposite is worse than a missing flag.
+ */
+export const BOOLEAN_FLAGS = new Set(['live', 'plan', 'report', 'write', 'json']);
 
 export function parseArgs(argv) {
   const args = { live: false };

--- a/skills/countercall/scripts/call.mjs
+++ b/skills/countercall/scripts/call.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * call.mjs — places the call. DRY RUN BY DEFAULT.
+ *
+ * Without --live this prints the exact request it would send and exits. A skill that
+ * dials by default is a skill that dials by accident.
+ *
+ *   node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
+ *   node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor" --live
+ */
+import { validateOffice, idempotencyKey, parseArgs, loadOffices } from './_lib.mjs';
+import { validateResult } from './contract.mjs';
+import { renderCard, renderFailure } from './render.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.office || !args.procedure) {
+  console.error('usage: call.mjs --office <id> --procedure "<name>" [--live]');
+  process.exit(2);
+}
+
+const offices = loadOffices(args, import.meta.url);
+const office = offices.find((o) => o.id === args.office);
+const problems = validateOffice(office);
+if (problems.length) {
+  console.error(`REFUSING TO DIAL: ${problems.join('; ')}`);
+  process.exit(3);
+}
+
+const today = new Date(Date.now()).toISOString().slice(0, 10);
+
+// Exactly the object the SDK takes: `phone` at the top level, no target wrapper.
+// CreateGoalRunRequest is a closed object — region, locale and display name live on the
+// published Goal and are rejected per run.
+const request = {
+  goalId: process.env.COUNTERCALL_GOAL_ID ?? '<COUNTERCALL_GOAL_ID>',
+  phone: office.phone_e164,
+  variables: {
+    office_name: office.name,
+    procedure: args.procedure,
+    city: office.city,
+  },
+  idempotencyKey: idempotencyKey(args.office, args.procedure, today),
+};
+
+if (!args.live) {
+  console.log('DRY RUN - no call placed. Add --live to dial.');
+  console.log('');
+  console.log(JSON.stringify(request, null, 2));
+  console.log('');
+  console.log(`This would ring ${office.phone_e164} (${office.name}).`);
+  console.log(`Source: ${office.source_url}`);
+  process.exit(0);
+}
+
+if (!process.env.CALLE_API_KEY) {
+  console.error('--live requires CALLE_API_KEY.');
+  process.exit(4);
+}
+if (!process.env.COUNTERCALL_GOAL_ID) {
+  console.error('--live requires COUNTERCALL_GOAL_ID (publish a Goal in CALL-E Chat first).');
+  process.exit(4);
+}
+
+const { CalleClient } = await import('@call-e/calle');
+const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY });
+
+console.log(`Dialling ${office.phone_e164} ...`);
+const started = Date.now();
+try {
+  const run = await client.goals.run(request);
+
+  // Poll on GoalRun.id. The nested runSpec/telephone `runId` is a different identity and
+  // substituting it returns 404.
+  const outcome = await client.goals.waitForResult(request.goalId, run.id);
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  const meta = { procedure: args.procedure, runId: run.id, calledAt: run.createdAt };
+
+  // `result` and `error` are mutually exclusive and either one is terminal.
+  if (outcome.error) {
+    console.log(renderFailure(outcome.error.code ?? 'unknown', office, meta));
+    console.log('');
+    console.log(`Failed after ${seconds}s.`);
+    process.exit(5);
+  }
+
+  // The server validated against the published schema; we re-validate against the schema
+  // this build was PINNED to. Those are different claims, and only the second one keeps a
+  // drifted Goal from rendering a confident wrong card.
+  const problems = validateResult(outcome.result);
+  if (problems.length) {
+    console.log(renderFailure('result_invalid', office, meta));
+    console.log('');
+    for (const problem of problems) console.log(`  - ${problem}`);
+    process.exit(5);
+  }
+
+  console.log(renderCard(outcome.result, office, meta));
+  console.log('');
+  console.log(`Answered in ${seconds}s.`);
+} catch (error) {
+  console.error(`${error?.constructor?.name ?? 'Error'}: ${error?.message ?? error}`);
+  process.exit(1);
+}

--- a/skills/countercall/scripts/call.mjs
+++ b/skills/countercall/scripts/call.mjs
@@ -7,14 +7,19 @@
  *
  *   node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
  *   node scripts/call.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor" --live
+ *
+ * Two transports, same card. With COUNTERCALL_GOAL_ID set it runs a published Goal; without
+ * one it runs the Calls API and sends the contract as a request-scoped schema. See
+ * transport.mjs for why both exist. --transport goals|calls forces one.
  */
 import { validateOffice, idempotencyKey, parseArgs, loadOffices } from './_lib.mjs';
 import { validateResult } from './contract.mjs';
 import { renderCard, renderFailure } from './render.mjs';
+import { selectTransport, missingCredentials } from './transport.mjs';
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.office || !args.procedure) {
-  console.error('usage: call.mjs --office <id> --procedure "<name>" [--live]');
+  console.error('usage: call.mjs --office <id> --procedure "<name>" [--live] [--transport goals|calls]');
   process.exit(2);
 }
 
@@ -26,24 +31,24 @@ if (problems.length) {
   process.exit(3);
 }
 
-const today = new Date(Date.now()).toISOString().slice(0, 10);
+// --transport is a per-invocation override of the same variable transport.mjs reads, so
+// there is exactly one selection rule rather than a flag path and an env path.
+const env = args.transport ? { ...process.env, COUNTERCALL_TRANSPORT: args.transport } : process.env;
 
-// Exactly the object the SDK takes: `phone` at the top level, no target wrapper.
-// CreateGoalRunRequest is a closed object — region, locale and display name live on the
-// published Goal and are rejected per run.
-const request = {
-  goalId: process.env.COUNTERCALL_GOAL_ID ?? '<COUNTERCALL_GOAL_ID>',
-  phone: office.phone_e164,
-  variables: {
-    office_name: office.name,
-    procedure: args.procedure,
-    city: office.city,
-  },
-  idempotencyKey: idempotencyKey(args.office, args.procedure, today),
-};
+let transport;
+try {
+  transport = selectTransport(env);
+} catch (error) {
+  console.error(error.message);
+  process.exit(2);
+}
+
+const today = new Date(Date.now()).toISOString().slice(0, 10);
+const key = idempotencyKey(args.office, args.procedure, today);
+const request = transport.describe(office, args.procedure, key, env);
 
 if (!args.live) {
-  console.log('DRY RUN - no call placed. Add --live to dial.');
+  console.log(`DRY RUN - no call placed. Transport: ${transport.name}. Add --live to dial.`);
   console.log('');
   console.log(JSON.stringify(request, null, 2));
   console.log('');
@@ -52,28 +57,34 @@ if (!args.live) {
   process.exit(0);
 }
 
-if (!process.env.CALLE_API_KEY) {
-  console.error('--live requires CALLE_API_KEY.');
-  process.exit(4);
-}
-if (!process.env.COUNTERCALL_GOAL_ID) {
-  console.error('--live requires COUNTERCALL_GOAL_ID (publish a Goal in CALL-E Chat first).');
+const missing = missingCredentials(transport, env);
+if (missing.length) {
+  console.error(`--live on the ${transport.name} transport requires ${missing.join(' and ')}.`);
+  if (transport.name === 'goals') {
+    console.error('Publish a Goal in CALL-E Chat first, or run --transport calls, which needs only a key.');
+  }
   process.exit(4);
 }
 
 const { CalleClient } = await import('@call-e/calle');
-const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY });
+const client = new CalleClient({ apiKey: env.CALLE_API_KEY });
 
-console.log(`Dialling ${office.phone_e164} ...`);
+// The drift guard is a precondition of dialling, not of preflight. A caller who skips
+// preflight still must not reach a drifted Goal.
+try {
+  await transport.assertReady(client, env);
+} catch (error) {
+  console.error(`REFUSING TO DIAL: ${error.message}`);
+  for (const d of error.drift ?? []) console.error(`  - ${d}`);
+  process.exit(4);
+}
+
+console.log(`Dialling ${office.phone_e164} via the ${transport.name} transport ...`);
 const started = Date.now();
 try {
-  const run = await client.goals.run(request);
-
-  // Poll on GoalRun.id. The nested runSpec/telephone `runId` is a different identity and
-  // substituting it returns 404.
-  const outcome = await client.goals.waitForResult(request.goalId, run.id);
+  const outcome = await transport.run(client, office, args.procedure, key, env);
   const seconds = ((Date.now() - started) / 1000).toFixed(1);
-  const meta = { procedure: args.procedure, runId: run.id, calledAt: run.createdAt };
+  const meta = { procedure: args.procedure, runId: outcome.runId, calledAt: outcome.calledAt };
 
   // `result` and `error` are mutually exclusive and either one is terminal.
   if (outcome.error) {
@@ -83,14 +94,15 @@ try {
     process.exit(5);
   }
 
-  // The server validated against the published schema; we re-validate against the schema
+  // The server validated against the schema it was given; we re-validate against the schema
   // this build was PINNED to. Those are different claims, and only the second one keeps a
-  // drifted Goal from rendering a confident wrong card.
-  const problems = validateResult(outcome.result);
-  if (problems.length) {
+  // drifted Goal — or a model that returned something plausible and wrong — from rendering
+  // a confident wrong card.
+  const invalid = validateResult(outcome.result);
+  if (invalid.length) {
     console.log(renderFailure('result_invalid', office, meta));
     console.log('');
-    for (const problem of problems) console.log(`  - ${problem}`);
+    for (const problem of invalid) console.log(`  - ${problem}`);
     process.exit(5);
   }
 

--- a/skills/countercall/scripts/contract.mjs
+++ b/skills/countercall/scripts/contract.mjs
@@ -1,0 +1,130 @@
+/**
+ * contract.mjs — the pinned result contract, and validation against it.
+ *
+ * No network. No side effects. This module is the single source of truth for the shape
+ * CounterCall expects back from a Goal Run; preflight, call and bench all import it rather
+ * than restating it.
+ *
+ * ## Why the shape looks like this
+ *
+ * A Goal Run `result` is a FLAT MAP OF SCALARS. From the CALL-E OpenAPI spec:
+ *
+ *     result:
+ *       type: [object, "null"]
+ *       additionalProperties:
+ *         $ref: "#/components/schemas/GoalScalar"    # string | number | boolean
+ *
+ * No arrays. No nested objects. No nulls. This is a Goals-API constraint specifically —
+ * the one-shot Calls API does support `simple array.items` in its request-scoped
+ * result_schema, but Goals does not, and Goals is what gives us the published, reusable
+ * procedure library.
+ *
+ * Two consequences, both deliberate:
+ *
+ * 1. `required_documents_text` is a newline-separated STRING, decoded client-side by
+ *    `decodeDocuments`. A document checklist is the product, so it does not get to be
+ *    unrepresentable.
+ * 2. `total_fee_idr` is OPTIONAL rather than nullable. `null` is not a GoalScalar, but
+ *    absence is free: a field that is not in `required` is simply missing when the clerk
+ *    did not know. The rule from references/safety.md survives intact — a missing fee is
+ *    missing, never `0`, and never a typical value.
+ */
+
+/** Bump `version` to match the Goal's published_run_spec version after each publish. */
+export const CONTRACT = {
+  version: 1,
+
+  required: [
+    'required_documents_text',
+    'payment_method',
+    'appointment_required',
+    'originals_or_copies',
+    'clerk_certainty',
+    'clerk_quote',
+  ],
+
+  optional: ['total_fee_idr'],
+
+  enums: {
+    payment_method: ['cash', 'card', 'both', 'unknown'],
+    appointment_required: ['yes', 'no', 'unknown'],
+    originals_or_copies: ['originals', 'copies', 'both', 'unknown'],
+    clerk_certainty: ['confident', 'unsure', 'refused'],
+  },
+};
+
+/** Every key the contract allows, required first. Used for the drift diff. */
+export function contractFields() {
+  return [...CONTRACT.required, ...CONTRACT.optional];
+}
+
+/**
+ * Decode the newline-separated document list into the array the card renders.
+ * Blank lines and bullet leaders are dropped; nothing else is normalised, because
+ * the clerk's own terms are the point.
+ */
+export function decodeDocuments(text) {
+  if (typeof text !== 'string') return [];
+  return text
+    .split('\n')
+    .map((line) => line.replace(/^\s*[-*•]\s*/, '').trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Validate a Goal Run result against the pinned contract.
+ * Returns an array of problems; empty means valid. A non-empty return must route to
+ * `result_invalid` and render nothing — a partial checklist is worse than no checklist.
+ */
+export function validateResult(result) {
+  const problems = [];
+
+  if (result === null || result === undefined) return ['result is null'];
+  if (typeof result !== 'object' || Array.isArray(result)) return ['result is not an object'];
+
+  for (const field of CONTRACT.required) {
+    if (!(field in result)) problems.push(`missing required field: ${field}`);
+  }
+
+  // additionalProperties: false — an unexpected key is drift, not a curiosity.
+  const allowed = new Set(contractFields());
+  for (const key of Object.keys(result)) {
+    if (!allowed.has(key)) problems.push(`unexpected field: ${key}`);
+  }
+
+  for (const [field, values] of Object.entries(CONTRACT.enums)) {
+    if (!(field in result)) continue;
+    if (!values.includes(result[field])) {
+      problems.push(`${field} not in enum: ${JSON.stringify(result[field])}`);
+    }
+  }
+
+  if ('required_documents_text' in result) {
+    if (typeof result.required_documents_text !== 'string') {
+      problems.push('required_documents_text is not a string');
+    } else if (decodeDocuments(result.required_documents_text).length === 0) {
+      problems.push('required_documents_text decodes to zero documents');
+    }
+  }
+
+  if ('clerk_quote' in result) {
+    if (typeof result.clerk_quote !== 'string') {
+      problems.push('clerk_quote is not a string');
+    } else if (result.clerk_quote.trim().length === 0) {
+      // The quote is span grounding — it is the evidence for every other field. An empty
+      // one renders a card that looks sourced and is not.
+      problems.push('clerk_quote is empty');
+    }
+  }
+
+  if ('total_fee_idr' in result) {
+    const fee = result.total_fee_idr;
+    if (typeof fee !== 'number' || !Number.isFinite(fee)) {
+      problems.push('total_fee_idr is present but not a finite number');
+    } else if (fee < 0) {
+      problems.push('total_fee_idr is negative');
+    }
+  }
+
+  return problems;
+}

--- a/skills/countercall/scripts/contract.mjs
+++ b/skills/countercall/scripts/contract.mjs
@@ -2,8 +2,24 @@
  * contract.mjs — the pinned result contract, and validation against it.
  *
  * No network. No side effects. This module is the single source of truth for the shape
- * CounterCall expects back from a Goal Run; preflight, call and bench all import it rather
- * than restating it.
+ * CounterCall expects back from CALL-E; preflight, call, bench and both transports import
+ * it rather than restating it.
+ *
+ * ## One contract, two transports
+ *
+ * CounterCall can reach CALL-E two ways, and the validated result shape is IDENTICAL on
+ * both. That is the whole point of this file.
+ *
+ * - **Goals transport** — a published Goal owns the schema. We diff our pinned copy against
+ *   the live `published_run_spec` and refuse to dial on any drift.
+ * - **Calls transport** — no published Goal exists, so we send the schema with the request
+ *   (`result_schema`). Drift is impossible by construction: `resultSchemaJSON()` below is
+ *   generated from the same `CONTRACT` that `validateResult` checks against.
+ *
+ * The Calls transport is not a downgrade. It exists because publishing a Goal is reachable
+ * only through CALL-E Chat — no API, no MCP tool, no UI button (see FEEDBACK.md finding 5)
+ * — and CALL-E suspended account logins after a security incident on 2026-09-02. A demo
+ * path that a vendor outage can sever is not a demo path.
  *
  * ## Why the shape looks like this
  *
@@ -14,10 +30,11 @@
  *       additionalProperties:
  *         $ref: "#/components/schemas/GoalScalar"    # string | number | boolean
  *
- * No arrays. No nested objects. No nulls. This is a Goals-API constraint specifically —
- * the one-shot Calls API does support `simple array.items` in its request-scoped
- * result_schema, but Goals does not, and Goals is what gives us the published, reusable
- * procedure library.
+ * No arrays. No nested objects. No nulls. The one-shot Calls API is more permissive — it
+ * does support `simple array.items` — but we deliberately keep the SCALAR shape on both
+ * transports. A checklist that changes type depending on how it was fetched would need two
+ * validators, two renderers and two sets of tests, and would let a card render correctly on
+ * one path and wrongly on the other. One shape, one validator, one card.
  *
  * Two consequences, both deliberate:
  *
@@ -51,7 +68,68 @@ export const CONTRACT = {
     originals_or_copies: ['originals', 'copies', 'both', 'unknown'],
     clerk_certainty: ['confident', 'unsure', 'refused'],
   },
+
+  /*
+   * Descriptions are sent to CALL-E's extraction model on the Calls transport and guide how
+   * it reads the transcript. The docs are explicit that they steer extraction but are NOT
+   * validation — `type`, `required`, `enum` and `additionalProperties` do the enforcing, and
+   * `validateResult` below re-checks all four locally regardless. These are written for a
+   * clerk who is rushed, on a bad line, and under no obligation to help.
+   */
+  descriptions: {
+    required_documents_text:
+      'Every document the clerk said to bring, one per line, in the clerk\'s own words and ' +
+      'in Indonesian. Do not translate, renumber, deduplicate or add documents the clerk did ' +
+      'not name. If the clerk named no documents, this call has no usable answer.',
+    payment_method:
+      'How the fee is paid at the counter. Use "both" only if the clerk said both are ' +
+      'accepted. Use "unknown" if the clerk did not say, was unsure, or the fee never came up.',
+    appointment_required:
+      'Whether the applicant must book or register before arriving. Use "unknown" if the ' +
+      'clerk did not say or was unsure.',
+    originals_or_copies:
+      'Whether the documents must be originals, photocopies, or both. Use "unknown" if the ' +
+      'clerk did not say. This is the single most commonly omitted requirement and the most ' +
+      'common reason someone is sent home, so do not infer it.',
+    clerk_certainty:
+      'How the clerk delivered the answer. Use "confident" when they answered directly. Use ' +
+      '"unsure" when they hedged, guessed, or told the caller to confirm at the counter. Use ' +
+      '"refused" when they declined to answer by phone or redirected without answering.',
+    clerk_quote:
+      'One short verbatim sentence from the clerk, in Indonesian, that most directly ' +
+      'supports the fields above. This is the evidence for the whole card. Quote the clerk, ' +
+      'never the caller, and never paraphrase.',
+    total_fee_idr:
+      'The total fee in Indonesian rupiah as a plain number, with no separators or currency ' +
+      'symbol. OMIT THIS FIELD ENTIRELY if the clerk did not state a fee or was unsure. ' +
+      'Never guess, never use a typical value, and never send 0 to mean unknown.',
+  },
 };
+
+/**
+ * Emit the contract as a JSON Schema for the Calls transport's request-scoped
+ * `result_schema`.
+ *
+ * Generated from `CONTRACT`, never hand-written, so the schema CALL-E validates against on
+ * the server and the one `validateResult` enforces here cannot drift apart. Only the schema
+ * features the Calls API documents as supported are used: type, properties, required, enum,
+ * description, additionalProperties: false. No $ref, no oneOf, no format.
+ */
+export function resultSchemaJSON() {
+  const properties = {};
+  for (const field of contractFields()) {
+    const property = { type: field === 'total_fee_idr' ? 'number' : 'string' };
+    if (CONTRACT.enums[field]) property.enum = [...CONTRACT.enums[field]];
+    if (CONTRACT.descriptions[field]) property.description = CONTRACT.descriptions[field];
+    properties[field] = property;
+  }
+  return {
+    type: 'object',
+    required: [...CONTRACT.required],
+    properties,
+    additionalProperties: false,
+  };
+}
 
 /** Every key the contract allows, required first. Used for the drift diff. */
 export function contractFields() {

--- a/skills/countercall/scripts/preflight.mjs
+++ b/skills/countercall/scripts/preflight.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * preflight.mjs — everything that must be true BEFORE a phone rings.
+ * Places no call. Spends nothing. Safe to run in CI.
+ *
+ *   node scripts/preflight.mjs --office imigrasi-jaksel --procedure "perpanjangan paspor"
+ */
+import {
+  validateOffice, diffContract, idempotencyKey, parseArgs, publishedRunSpec, loadOffices,
+} from './_lib.mjs';
+import { CONTRACT, contractFields } from './contract.mjs';
+
+const PINNED = { version: CONTRACT.version, result_fields: contractFields() };
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.office || !args.procedure) {
+  console.error('usage: preflight.mjs --office <id> --procedure "<name>"');
+  process.exit(2);
+}
+
+const offices = loadOffices(args, import.meta.url);
+const office = offices.find((o) => o.id === args.office);
+const problems = validateOffice(office);
+
+console.log('CounterCall preflight');
+console.log('---------------------');
+console.log(`  office             ${args.office}`);
+console.log(`  procedure          ${args.procedure}`);
+console.log(`  phone              ${office?.phone_e164 ?? '(none)'}`);
+
+if (problems.length) {
+  console.log(`  E.164              FAIL - ${problems.join('; ')}`);
+  console.log('');
+  console.log('REFUSING TO DIAL. Numbers must match ^\\+[1-9]\\d{7,14}$ and come from the');
+  console.log("office's own published page. Never guess a country code.");
+  process.exit(3);
+}
+console.log('  E.164              ok');
+console.log(`  source             ${office.source_url} (checked ${office.source_checked})`);
+
+// Contract check. Offline unless a key is present — preflight must never require credentials.
+if (process.env.CALLE_API_KEY && process.env.COUNTERCALL_GOAL_ID) {
+  const { CalleClient } = await import('@call-e/calle');
+  const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY });
+  const goal = await client.goals.get(process.env.COUNTERCALL_GOAL_ID);
+  const drift = diffContract(PINNED, publishedRunSpec(goal));
+  if (drift.length) {
+    console.log('  contract           DRIFT DETECTED');
+    for (const d of drift) console.log(`                     - ${d}`);
+    console.log('');
+    console.log('REFUSING TO DIAL. The published Goal no longer matches the contract this');
+    console.log('skill was written against. Re-pin the contract and re-check the rendering.');
+    process.exit(4);
+  }
+  console.log('  contract           matches pinned v' + PINNED.version);
+} else {
+  console.log('  contract           skipped (set CALLE_API_KEY + COUNTERCALL_GOAL_ID to check)');
+}
+
+const today = new Date(Date.now()).toISOString().slice(0, 10);
+console.log(`  idempotency key    ${idempotencyKey(args.office, args.procedure, today)}`);
+console.log('');
+console.log('Preflight passed. No call was placed. Add --live to scripts/call.mjs to dial.');

--- a/skills/countercall/scripts/preflight.mjs
+++ b/skills/countercall/scripts/preflight.mjs
@@ -8,7 +8,8 @@
 import {
   validateOffice, diffContract, idempotencyKey, parseArgs, publishedRunSpec, loadOffices,
 } from './_lib.mjs';
-import { CONTRACT, contractFields } from './contract.mjs';
+import { CONTRACT, contractFields, resultSchemaJSON } from './contract.mjs';
+import { selectTransport } from './transport.mjs';
 
 const PINNED = { version: CONTRACT.version, result_fields: contractFields() };
 
@@ -38,11 +39,72 @@ if (problems.length) {
 console.log('  E.164              ok');
 console.log(`  source             ${office.source_url} (checked ${office.source_checked})`);
 
-// Contract check. Offline unless a key is present — preflight must never require credentials.
-if (process.env.CALLE_API_KEY && process.env.COUNTERCALL_GOAL_ID) {
+const transport = selectTransport();
+console.log(`  transport          ${transport.name}`);
+
+/*
+ * Contract check, per transport.
+ *
+ * On `calls` there is nothing to fetch: the schema is generated from CONTRACT and sent with
+ * the request, so what the server validates and what `validateResult` enforces come from one
+ * source and cannot disagree. The check that matters is that the emitted schema is
+ * well-formed and covers every pinned field — a silently truncated schema would let CALL-E
+ * return a partial object the card would then render.
+ */
+if (transport.name === 'calls') {
+  const schema = resultSchemaJSON();
+  const emitted = Object.keys(schema.properties);
+  const missing = contractFields().filter((f) => !emitted.includes(f));
+  const unrequired = CONTRACT.required.filter((f) => !schema.required.includes(f));
+
+  if (missing.length || unrequired.length || schema.additionalProperties !== false) {
+    console.log('  contract           EMITTED SCHEMA IS WRONG');
+    for (const f of missing) console.log(`                     - not emitted: ${f}`);
+    for (const f of unrequired) console.log(`                     - not required: ${f}`);
+    if (schema.additionalProperties !== false)
+      console.log('                     - additionalProperties is not false');
+    console.log('');
+    console.log('REFUSING TO DIAL. The request-scoped schema does not match the pinned contract.');
+    process.exit(4);
+  }
+  console.log(`  contract           request-scoped, v${CONTRACT.version}, ${emitted.length} fields`);
+  console.log('                     no published Goal needed — the schema travels with the call');
+} else if (process.env.CALLE_API_KEY && process.env.COUNTERCALL_GOAL_ID) {
   const { CalleClient } = await import('@call-e/calle');
   const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY });
-  const goal = await client.goals.get(process.env.COUNTERCALL_GOAL_ID);
+
+  /*
+   * A Goal that exists but is not runnable is an ordinary, foreseeable state — a draft, a
+   * paused Goal, a retired one — and preflight is the tool whose entire job is to say so
+   * before anything dials. It used to let the SDK error escape, so `goal_not_executable`
+   * arrived as an unhandled rejection and a stack trace. A tool that argues for honest,
+   * terminal failure does not get to crash on the most likely one.
+   *
+   * 409 and 404 are told apart deliberately: 409 means the Goal is yours and not executable,
+   * 404 means no Goal by that id is visible to this key at all — a different fix each time.
+   */
+  let goal;
+  try {
+    goal = await client.goals.get(process.env.COUNTERCALL_GOAL_ID);
+  } catch (err) {
+    const status = err?.status ?? err?.statusCode;
+    console.log('  contract           CANNOT READ THE GOAL');
+    console.log('');
+    if (status === 409) {
+      console.log(`REFUSING TO DIAL. Goal ${process.env.COUNTERCALL_GOAL_ID} exists but is not`);
+      console.log('executable — it is almost certainly still a DRAFT. Publish it in CALL-E Chat,');
+      console.log('then re-run this. Draft, paused and retired Goals are invisible to goals.list');
+      console.log('and refuse goals.get, by design.');
+    } else if (status === 404) {
+      console.log(`REFUSING TO DIAL. No Goal ${process.env.COUNTERCALL_GOAL_ID} is visible to this`);
+      console.log('API key. Goals are owner-scoped: check the id, and check the key belongs to the');
+      console.log('same account that published it. Cross-owner reads return 404, not 403.');
+    } else {
+      console.log(`REFUSING TO DIAL. goals.get failed: ${status ?? '?'} ${err?.code ?? ''} ${err?.message ?? err}`);
+    }
+    process.exit(4);
+  }
+
   const drift = diffContract(PINNED, publishedRunSpec(goal));
   if (drift.length) {
     console.log('  contract           DRIFT DETECTED');

--- a/skills/countercall/scripts/render.mjs
+++ b/skills/countercall/scripts/render.mjs
@@ -1,0 +1,152 @@
+/**
+ * render.mjs — the checklist card, and the honest failures.
+ *
+ * Pure string building. No network, no clock, no colour codes: the card is meant to be
+ * screenshot-ready in a plain terminal and diffable in a test.
+ *
+ * The rules encoded here come from references/safety.md and are not cosmetic:
+ *  - a field the clerk did not know renders as an em dash, never as a typical value
+ *  - the clerk's certainty is shown, not hidden behind a confident-looking layout
+ *  - every card carries the not-legally-binding line and the published source URL
+ *  - a failure renders a reason, never a partial checklist
+ */
+
+import { decodeDocuments } from './contract.mjs';
+
+const WIDTH = 66;
+const UNKNOWN = '—';
+const DISCLAIMER =
+  "A clerk's spoken answer is informational, not legally binding. Requirements change and individual counters apply discretion.";
+
+function rule(char = '─') {
+  return char.repeat(WIDTH);
+}
+
+function labelled(label, value) {
+  return `  ${label.padEnd(22)}${value}`;
+}
+
+/** Enum -> what a person reads. `unknown` becomes the em dash, never a guess. */
+const PHRASING = {
+  payment_method: { cash: 'Cash', card: 'Card', both: 'Cash or card', unknown: UNKNOWN },
+  appointment_required: { yes: 'Yes — book before going', no: 'No — walk in', unknown: UNKNOWN },
+  originals_or_copies: {
+    originals: 'Originals',
+    copies: 'Photocopies',
+    both: 'Originals and photocopies',
+    unknown: UNKNOWN,
+  },
+  clerk_certainty: {
+    confident: 'The clerk answered confidently.',
+    unsure: 'The clerk was unsure. Verify these details in person.',
+    refused: 'The clerk declined to answer some of this.',
+  },
+};
+
+export function formatFeeIdr(fee) {
+  if (typeof fee !== 'number' || !Number.isFinite(fee)) return UNKNOWN;
+  return `Rp ${Math.round(fee).toLocaleString('id-ID')}`;
+}
+
+/**
+ * Render the validated checklist.
+ * `result` MUST have passed validateResult first — this function does not re-validate,
+ * it renders. Pass an unvalidated object and you get a confident-looking wrong card,
+ * which is the exact failure the contract exists to prevent.
+ */
+export function renderCard(result, office, meta = {}) {
+  const documents = decodeDocuments(result.required_documents_text);
+  const lines = [];
+
+  lines.push(rule('━'));
+  lines.push(`  ${office.name}`);
+  lines.push(`  ${meta.procedure ?? ''}`.trimEnd());
+  lines.push(rule('━'));
+  lines.push('');
+  lines.push('  BRING');
+  for (const document of documents) lines.push(`    • ${document}`);
+  lines.push('');
+  lines.push(labelled('Documents', PHRASING.originals_or_copies[result.originals_or_copies]));
+  lines.push(labelled('Fee', formatFeeIdr(result.total_fee_idr)));
+  lines.push(labelled('Payment', PHRASING.payment_method[result.payment_method]));
+  lines.push(labelled('Appointment', PHRASING.appointment_required[result.appointment_required]));
+  lines.push('');
+  lines.push(rule());
+  lines.push(`  ${PHRASING.clerk_certainty[result.clerk_certainty]}`);
+  lines.push('');
+  lines.push('  In the clerk\'s words:');
+  // Quotation marks open once and close once, however many lines the quote wraps to.
+  const quoted = wrap(result.clerk_quote, WIDTH - 6);
+  quoted.forEach((line, index) => {
+    const open = index === 0 ? '"' : ' ';
+    const close = index === quoted.length - 1 ? '"' : '';
+    lines.push(`    ${open}${line}${close}`);
+  });
+  lines.push('');
+  lines.push(rule());
+  for (const line of wrap(DISCLAIMER, WIDTH - 4)) lines.push(`  ${line}`);
+  lines.push('');
+  lines.push(labelled('Source', office.source_url));
+  if (office.source_checked) lines.push(labelled('Number checked', office.source_checked));
+  if (meta.runId) lines.push(labelled('CALL-E run', meta.runId));
+  if (meta.calledAt) lines.push(labelled('Called', meta.calledAt));
+  lines.push(rule('━'));
+
+  return lines.join('\n');
+}
+
+/**
+ * Render a terminal failure. There is deliberately no path from here to a checklist:
+ * every branch says what happened and stops.
+ */
+export function renderFailure(code, office, meta = {}) {
+  const said = {
+    no_answer: 'The line did not answer. No checklist is available for this office today.',
+    declined: 'The office declined to answer an automated caller.',
+    result_invalid:
+      'The call completed, but the answer did not match the contract. Nothing is shown.',
+    result_unavailable: 'The call completed but no structured answer was produced.',
+    result_failed: 'The answer could not be processed into a checklist.',
+    timed_out: 'No usable answer was obtained before the deadline.',
+    call_failed: 'The call could not be completed.',
+    canceled: 'The call was cancelled before it produced an answer.',
+  }[code];
+
+  const lines = [];
+  lines.push(rule('━'));
+  lines.push(`  ${office.name}`);
+  lines.push(`  ${meta.procedure ?? ''}`.trimEnd());
+  lines.push(rule('━'));
+  lines.push('');
+  lines.push(`  NO CHECKLIST — ${code}`);
+  lines.push('');
+  for (const line of wrap(said ?? `Unrouted error code: ${code}`, WIDTH - 4)) {
+    lines.push(`  ${line}`);
+  }
+  lines.push('');
+  lines.push('  No partial checklist is ever rendered.');
+  if (meta.runId) {
+    lines.push('');
+    lines.push(labelled('CALL-E run', meta.runId));
+  }
+  lines.push(rule('━'));
+
+  return lines.join('\n');
+}
+
+function wrap(text, width) {
+  const words = String(text ?? '').split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [''];
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    if (line && line.length + 1 + word.length > width) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}

--- a/skills/countercall/scripts/transport.mjs
+++ b/skills/countercall/scripts/transport.mjs
@@ -1,0 +1,252 @@
+/**
+ * transport.mjs — the two ways CounterCall reaches CALL-E, behind one interface.
+ *
+ * Both transports place a real outbound call, both return the SAME validated result shape,
+ * and both are checked by the same `validateResult`. Everything above this file — the card
+ * renderer, the benchmark, the tests — is transport-blind on purpose.
+ *
+ *   goals  requires CALLE_API_KEY + COUNTERCALL_GOAL_ID
+ *          The published Goal owns the schema. We diff our pinned copy against the live
+ *          `published_run_spec` before dialling and refuse on any drift.
+ *
+ *   calls  requires CALLE_API_KEY only
+ *          No published Goal. The schema travels WITH the request as `resultSchema`,
+ *          generated from the same CONTRACT that validates the reply, so the two cannot
+ *          drift apart.
+ *
+ * ## Why `calls` exists
+ *
+ * Publishing a Goal is reachable only through CALL-E Chat — there is no `POST /v1/goals`,
+ * no MCP publish tool, and no button on the Goal detail page (FEEDBACK.md finding 5). On
+ * 2026-09-02 CALL-E suspended account logins after a security incident, which made that
+ * single path unreachable. The Goals transport is still the better product — a published
+ * Goal is a reusable, versioned, community-shareable procedure — but a demo path that one
+ * vendor outage can sever is not a demo path. `calls` needs nothing but an API key.
+ *
+ * Selection is by capability, not preference: `selectTransport` picks `goals` whenever a
+ * Goal id is configured, and falls back to `calls` otherwise. Set COUNTERCALL_TRANSPORT to
+ * force one.
+ */
+import { CONTRACT, contractFields, resultSchemaJSON, validateResult } from './contract.mjs';
+import { diffContract, publishedRunSpec } from './_lib.mjs';
+
+/** What every transport's `run` resolves to. `result` and `error` are mutually exclusive. */
+/** @typedef {{result: object|null, error: {code: string}|null, runId: string, calledAt: string|null}} Outcome */
+
+/**
+ * The natural-language instruction for the Calls transport.
+ *
+ * On the Goals transport this text lives in the published Goal and only `variables` travel
+ * per run. Here it has to be composed client-side, so it is composed from the SAME office
+ * record and procedure — never from free text a caller supplies.
+ *
+ * The constraints in it are not decoration. This calls a public servant who never opted in,
+ * so the agent identifies itself, asks a closed set of questions, and takes a refusal as an
+ * answer rather than pressing.
+ */
+export function buildTask(office, procedure) {
+  return [
+    `Call ${office.phone_e164}, the public enquiries line for ${office.name} in ${office.city}, Indonesia.`,
+    '',
+    'Speak Indonesian throughout. You are an assistant calling on behalf of a member of the',
+    `public who intends to visit the office in person for: ${procedure}.`,
+    '',
+    'Identify yourself as an automated assistant calling to ask what to bring, before asking',
+    'anything else. Ask only these questions, in this order:',
+    '',
+    '  1. Which documents must be brought for this procedure?',
+    '  2. Must those documents be originals, photocopies, or both?',
+    '  3. What is the total fee, if any?',
+    '  4. Is the fee paid in cash or by card?',
+    '  5. Must an appointment or online registration be made before arriving?',
+    '',
+    'Rules:',
+    '- Do not give advice, do not confirm anything on the office\'s behalf, and do not ask for',
+    '  or accept any personal data about the applicant.',
+    '- If the clerk says they cannot answer by phone, thank them and end the call. A refusal',
+    '  is a valid outcome; do not press, do not ask again, and do not ask for a transfer.',
+    '- If the clerk is unsure about a value, record that uncertainty rather than resolving it.',
+    '- Keep the call short. This is a public service line and other people are waiting on it.',
+  ].join('\n');
+}
+
+/**
+ * The Goals transport — a published Goal owns the schema.
+ * `preflight.mjs` runs the drift guard; `assertReady` here is the same check, so a caller
+ * that skips preflight still cannot dial against a drifted Goal.
+ */
+export const goalsTransport = {
+  name: 'goals',
+  requires: ['CALLE_API_KEY', 'COUNTERCALL_GOAL_ID'],
+
+  describe(office, procedure, key, env = process.env) {
+    return {
+      transport: 'goals',
+      goalId: env.COUNTERCALL_GOAL_ID ?? '<COUNTERCALL_GOAL_ID>',
+      phone: office.phone_e164,
+      variables: { office_name: office.name, procedure, city: office.city },
+      idempotencyKey: key,
+    };
+  },
+
+  async assertReady(client, env = process.env) {
+    const goal = await client.goals.get(env.COUNTERCALL_GOAL_ID);
+    const pinned = { version: CONTRACT.version, result_fields: contractFields() };
+    const drift = diffContract(pinned, publishedRunSpec(goal));
+    if (drift.length) {
+      const error = new Error(`published Goal has drifted from pinned contract v${CONTRACT.version}`);
+      error.drift = drift;
+      throw error;
+    }
+  },
+
+  async run(client, office, procedure, key, env = process.env) {
+    const goalId = env.COUNTERCALL_GOAL_ID;
+    const run = await client.goals.run({
+      goalId,
+      phone: office.phone_e164,
+      variables: { office_name: office.name, procedure, city: office.city },
+      idempotencyKey: key,
+    });
+    // Poll on GoalRun.id. The nested runSpec/telephone `runId` is a different identity and
+    // substituting it returns 404.
+    const outcome = await client.goals.waitForResult(goalId, run.id);
+    return {
+      result: outcome.result ?? null,
+      error: outcome.error ?? null,
+      runId: run.id,
+      calledAt: run.createdAt ?? null,
+      // Goal Runs do not carry a completion judgment; only the Calls API exposes one. Null
+      // here rather than absent, so both transports return the same keys.
+      completionConfidence: null,
+    };
+  },
+};
+
+/**
+ * The Calls transport — the schema travels with the request.
+ *
+ * `metadata` carries the same three identifiers the Goal's `variables` would have, so a run
+ * is reconcilable from the CALL-E dashboard on either path.
+ */
+export const callsTransport = {
+  name: 'calls',
+  requires: ['CALLE_API_KEY'],
+
+  describe(office, procedure, key) {
+    return {
+      transport: 'calls',
+      task: buildTask(office, procedure),
+      recipients: [{ phones: [office.phone_e164] }],
+      resultSchema: resultSchemaJSON(),
+      metadata: { office_id: office.id, office_name: office.name, procedure, city: office.city },
+      idempotencyKey: key,
+    };
+  },
+
+  /*
+   * Nothing to assert. There is no published artifact to drift against — the schema we send
+   * IS the schema we validate, generated from one source. This method exists so callers do
+   * not have to branch on transport.
+   */
+  async assertReady() {},
+
+  async run(client, office, procedure, key) {
+    const request = this.describe(office, procedure, key);
+    const created = await client.calls.create(
+      {
+        task: request.task,
+        recipients: request.recipients,
+        resultSchema: request.resultSchema,
+        metadata: request.metadata,
+      },
+      { idempotencyKey: key },
+    );
+    const call = await client.calls.waitForResult(created.id);
+    return normaliseCall(call, created);
+  },
+};
+
+/**
+ * Map a terminal `Call` onto the Goals-shaped Outcome the rest of the code already handles.
+ *
+ * Exported for the tests: this is where the two transports are made to agree, so it is the
+ * part worth testing against fixtures rather than against a live phone line.
+ *
+ * Three cases, in order:
+ *
+ * 1. A non-terminal-success status (`failed`, `canceled`) is a call that did not happen.
+ *    The reason lives in `failureCode`, and when that is null it lives on the dial attempt
+ *    — a `no_answer` is reported per attempt, not per task.
+ * 2. `status: "completed"` with `structuredResult: null` is CALL-E telling us the call
+ *    connected but the evidence could not satisfy the schema. The docs are explicit about
+ *    this. It is NOT a null result to hand upward — `render.mjs` would have to decide what a
+ *    missing checklist means, and the answer is always "render nothing".
+ * 3. Otherwise, a result. It is still re-validated by the caller against the pinned
+ *    contract; server-side validation and our own are different claims.
+ */
+export function normaliseCall(call, created = call) {
+  const result = call.structuredResult ?? call.structured_result ?? null;
+  const status = call.status ?? null;
+  const meta = {
+    runId: created.id ?? call.id,
+    calledAt: created.createdAt ?? created.created_at ?? call.createdAt ?? null,
+    // Calls carries a completion judgment that Goal Runs do not expose. It is recorded for
+    // the benchmark and never rendered on the card — the card's certainty is `clerk_certainty`,
+    // which is what the clerk actually conveyed, not what a model concluded afterwards.
+    completionConfidence: call.completionConfidence ?? call.completion_confidence ?? null,
+  };
+
+  if (status && status !== 'completed') {
+    return { result: null, error: { code: failureCode(call, status) }, ...meta };
+  }
+  if (result === null) {
+    return { result: null, error: { code: 'result_unextractable' }, ...meta };
+  }
+  return { result, error: null, ...meta };
+}
+
+/** The most specific failure code available: task level, then dial attempt, then status. */
+function failureCode(call, status) {
+  const taskLevel = call.failureCode ?? call.failure_code ?? null;
+  if (taskLevel) return normaliseFailure(taskLevel);
+
+  const attempts = call.recipients?.flatMap((r) => r.attempts ?? []) ?? [];
+  const attemptLevel = attempts.map((a) => a.failureCode ?? a.failure_code).find(Boolean);
+  if (attemptLevel) return normaliseFailure(attemptLevel);
+
+  return status === 'canceled' ? 'canceled' : 'call_failed';
+}
+
+/** Fold vendor failure spellings onto the codes render.mjs already knows. */
+function normaliseFailure(code) {
+  const c = String(code).toLowerCase();
+  if (c.includes('no_answer') || c.includes('noanswer') || c.includes('unanswered') || c.includes('timeout')) {
+    return 'no_answer';
+  }
+  if (c.includes('declin') || c.includes('reject') || c.includes('busy')) return 'declined';
+  return c;
+}
+
+/**
+ * Pick a transport from the environment.
+ *
+ * COUNTERCALL_TRANSPORT forces one and is validated rather than silently ignored — a typo
+ * that fell through to the default would place a call on a path the operator did not choose.
+ */
+export function selectTransport(env = process.env) {
+  const forced = env.COUNTERCALL_TRANSPORT;
+  if (forced) {
+    if (forced === 'goals') return goalsTransport;
+    if (forced === 'calls') return callsTransport;
+    throw new Error(`COUNTERCALL_TRANSPORT must be "goals" or "calls", got ${JSON.stringify(forced)}`);
+  }
+  return env.COUNTERCALL_GOAL_ID ? goalsTransport : callsTransport;
+}
+
+/** Missing credentials for the selected transport, as a list. Empty means ready. */
+export function missingCredentials(transport, env = process.env) {
+  return transport.requires.filter((name) => !env[name]);
+}
+
+export { validateResult };


### PR DESCRIPTION
## Contribution Area

**Agent Skills** — adds `skills/countercall/` and one entry to the README resource list.

## What it does

CounterCall calls a government service counter **before** a citizen travels there, and returns a schema-validated checklist of what to bring: required documents, total fee, payment method, originals or copies, whether an appointment is needed, how certain the clerk sounded, and the verbatim line the clerk said as the evidence for the rest.

In Indonesia — and this generalises — published requirement lists are incomplete, outdated, or quietly contradicted at the window. The one reliable source is the office's phone line, and that line is busy, IVR-gated, and answered on the fourth try. So people don't call. They travel, they queue, and they get turned away over one photocopy.

## The decision it exists to make

**When the clerk does not know, the field renders empty.** Not filled with a typical value, not quietly dropped so the gap disappears. Somebody may cross a city on the strength of this answer. An unknown fee costs one question at the window; an invented one costs the trip.

The result contract is pinned with `additionalProperties: false`, so a malformed answer becomes a *detectable* failure rather than a silently accepted wrong checklist. All eight `GoalRunError` codes route to distinct outcomes and **not one of them renders a partial checklist**.

## Side effects

Places **at most one outbound phone call** per invocation, and only when `--live` is passed explicitly.

## Safety

The callee is a public servant who did not opt in. That asymmetry drives every rule in [`references/safety.md`](skills/countercall/references/safety.md):

- states plainly at the start that it is an automated assistant, and why
- stops immediately on refusal; records `declined` and renders no checklist
- **one call per office, per procedure, per day**, enforced by a business-stable `Idempotency-Key` (`countercall:{office}:{procedure}:{date}:v1`) rather than a random UUID, so a retry after a crash cannot double-dial a queue with a person in front of it
- published general-enquiries lines only, during opening hours — never a personal mobile, never an emergency or crisis line
- no personal data sent as a call variable — the clerk is asked about a *procedure*, not about a person
- **never infers a phone number.** A number enters `data/offices.json` only when a human read it off the office's own published page and recorded the URL and the date

## Dry-run / no-call path

Dry-run **by default**, per the contributing guidelines:

```bash
# validates the number, diffs the live Goal contract against the pinned one,
# prints the idempotency key — dials nothing, needs no credentials
node skills/countercall/scripts/preflight.mjs --office <id> --procedure "<procedure>"

# prints the exact request that would be sent, then stops
node skills/countercall/scripts/call.mjs --office <id> --procedure "<procedure>"
```

Dialling requires an explicit `--live`. A skill that dials by default is a skill that dials by accident. `preflight` also refuses the dial outright when the published Goal contract has drifted from the pinned one, rather than calling a real person with a stale schema and returning a result that looks fine and is quietly wrong.

## Cancellation / rollback

There is no recurring schedule to cancel — each invocation is a single call. The idempotency key is the rollback boundary: re-running the same office/procedure on the same day is a no-op rather than a second call. `no_answer` permits exactly one retry under a `:v2` suffix, then abstains for the day.

## Checklist

- [x] English-only repository-facing content, no CJK
- [x] No secrets, tokens, private phone numbers, or personal data
- [x] Phone number in the seeded sample is **masked** (`+62XXXXXXXXXX`) — the skill cannot dial anything until a sourced number is supplied
- [x] States its host/provider: CALL-E Goals API via `@call-e/calle`
- [x] Side effects described above
- [x] Install and usage instructions in `SKILL.md`
- [x] Dry-run / no-call path, and it is the default
- [x] Cancellation behaviour documented
- [x] `python3 scripts/validate_repository.py` → **Repository validation passed.**

## Notes for maintainers

Two findings from building against the Goals API, written up in more detail at [`FEEDBACK.md`](https://github.com/edycutjong/countercall/blob/main/FEEDBACK.md):

1. A Goal Run `result` is a flat map of `GoalScalar` (`string | number | boolean`) — no arrays, no nulls — while the one-shot Calls API *does* accept `simple array.items` in its request-scoped `result_schema`. A document checklist is inherently a list, so it travels here as a newline-separated string decoded client-side, and `total_fee_idr` is *optional* rather than nullable. Array support on Goals would remove a delimiter convention that every author of a list-shaped result currently has to invent.
2. Goals are owner-scoped and authored only in CALL-E Chat, with no `POST /v1/goals`. So a published Goal cannot ship as a runnable community artifact — what this contribution can offer is the Goal **specification** plus the client. An importable Goal manifest would make skills in this repo genuinely one-click.

Submitted for the CALL-E hackathon. Full project: <https://github.com/edycutjong/countercall> · <https://countercall.edycu.dev>