### PR TITLE
fix(clause-check): bound the payload by allowlist and send the recipient

### DIFF
--- a/apps/python/clause-check-by-phone/README.md
+++ b/apps/python/clause-check-by-phone/README.md
@@ -91,23 +91,36 @@ schema the provider would accept and then fail to fill is refused here. A
 missing key stops the run with a sentence rather than with a `401` that reads
 like a permissions problem.
 
+The request itself carries three things, the task, the result schema, and the
+recipient the operator authorised, as `recipients: [{"phones": ["+447700..."]}]`.
+The number sent is the one that just passed the authorisation check and never
+another. A request without it has nobody to ring.
+
 The transport is a parameter of `place` and `collect`, which is why the
 witnesses can exercise every path through this file without a key and without
 dialling anyone.
 
 ### What comes back, and what does not
 
-`collect` returns the identifier, the state and the structured answer. **It
-does not return the transcript, the recording or the destination**, and neither
-does `place`. The provider hands all three over next to the answer, this
-project uses none of them, and the obvious way to look at a result is to print
-it. A default that returns them puts a stranger's voice one `print` away from a
-terminal, a shell history or a CI log. `collect(..., raw=True)` returns the
-whole payload, for a caller who has decided to.
+`collect` returns the identifier, the state and the structured answer, **and
+nothing else**. Those three field names are an allowlist, not a list of fields
+to strip. A denylist only ever stops what its author had already seen, so it
+misses a destination nested under `recipients`, a transcript nested under
+`attempts`, and every field a provider adds after the list was written. It is
+wrong in the direction that leaks.
+
+The provider hands the recording, the transcript and the destination over next
+to the answer, this project uses none of them, and the obvious way to look at a
+result is to print it. A default that returns them puts a stranger's voice one
+`print` away from a terminal, a shell history or a CI log.
+`collect(..., raw=True)` returns the whole payload, for a caller who has
+decided to.
 
 For the same reason, a refusal names the destination **masked**, keeping the
 country code and the last two digits so you can still recognise which number
-you meant. A refusal is printed, so whatever it carries is what ends up on a
+you meant. A refusal coming from the provider is reduced to the few fields that
+say what went wrong, shortened, with any long run of digits masked, because a
+provider that refuses a request usually quotes the request back. A refusal is printed, so whatever it carries is what ends up on a
 screen. A short or malformed value is hidden whole rather than half revealed.
 
 ## Side effects
@@ -183,11 +196,15 @@ answer can change something, and an answer nobody can interpret changes nothing.
 
 ```bash
 python tests_bridge.py       # 26 witnesses, no call, no network, no key
-python tests_place_call.py   # 21 more, on the file that dials, same rule
+python tests_place_call.py   # 28 more, on the file that dials, same rule
 ```
 
-Eight of the twenty-one hold the line above, that nothing a caller is likely to
-print carries a number, a transcript or a recording. They check the masked
+Thirteen of the twenty-eight hold the line above, that nothing a caller is
+likely to print carries a number, a transcript or a recording. Five of those
+thirteen use a payload shaped the way this repository's own fake server shapes
+one, with the destination and the transcript nested under `recipients` and
+`attempts`, because that is the shape a list of field names to strip walked
+straight past. They check the masked
 refusal in both directions, that it hides the number and that it still says
 enough to recognise it, that a malformed value is hidden whole, that the
 trimming does not swallow the answer the verdict is computed from, and that a

--- a/apps/python/clause-check-by-phone/bridge.py
+++ b/apps/python/clause-check-by-phone/bridge.py
@@ -111,7 +111,7 @@ def call_task(phone: str, family: str, quote: str, source: str,
         raise NothingToAsk("unknown family, %r, no call is justified" % family)
     if not readable(quote):
         raise NothingToAsk("no quotation, nothing to have confirmed out loud")
-    if not re.fullmatch(r"\+[1-9]\d{6,14}", phone or ""):
+    if not re.fullmatch(r"\+[1-9][0-9]{6,14}", phone or ""):
         raise NothingToAsk("invalid phone number, a call needs a recipient in "
                            "strict E.164 form")
 

--- a/apps/python/clause-check-by-phone/place_call.py
+++ b/apps/python/clause-check-by-phone/place_call.py
@@ -26,6 +26,7 @@ without dialling anyone.
 from __future__ import annotations
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -55,23 +56,53 @@ def masked(phone: str) -> str:
     return "+%s%s%s" % (digits[:2], "*" * (len(digits) - 4), digits[-2:])
 
 
-# The fields a finished call carries that this project never needs. The
-# provider returns the recording, the full transcript and the destination
-# alongside the answer, and a caller who prints the payload prints all three.
-RAW_ONLY = ("transcript", "transcripts", "concatenated_transcript", "recording",
-            "recording_url", "to", "from", "phone_number", "customer",
-            "variables", "metadata", "corrected_duration", "call_log")
+# The only three things this project reads from a finished call. Everything
+# else a provider sends is a stranger's voice, a stranger's number, or a field
+# that did not exist when this list was written.
+KEPT = ("id", "status", "structured_result")
+
+# What a refusal may say about itself. A refusal is printed, so it is the one
+# place where a provider's own wording lands in a terminal, and providers echo
+# the request back inside their error text.
+SAID_ON_REFUSAL = ("error", "code", "type", "message")
+A_RUN_OF_DIGITS = re.compile(r"\d{7,}")
 
 
 def bounded(payload: dict) -> dict:
     """The part of a provider payload this project is allowed to hand back.
 
+    THIS IS AN ALLOWLIST, AND IT USED TO BE A DENYLIST. The earlier version
+    removed known field names, which stopped a flat payload and nothing else.
+    The provider nests the destination and the transcript one level down, under
+    `recipients` and `attempts`, so a payload of the shape this repository's own
+    fake server returns came back whole. A denylist also has to be right about
+    a field that does not exist yet, and it never is, so the first time a
+    provider adds one it leaks by default.
+
     Everything the tool needs is the identifier, the state and the structured
-    answer. The rest is a stranger's voice and a stranger's number, and a
-    default that returns them invites a caller to print them. Anyone who
-    genuinely needs the whole thing asks for it by name, `raw=True`.
+    answer. Anyone who genuinely needs the whole thing asks for it by name,
+    `raw=True`.
     """
-    return {c: v for c, v in payload.items() if c not in RAW_ONLY}
+    return {name: payload[name] for name in KEPT if name in payload}
+
+
+def safe_error(payload: dict) -> dict:
+    """What a provider's refusal is allowed to say in a printed message.
+
+    `bounded` is the right answer for a finished call and the wrong one for a
+    refusal, which carries no identifier and no result and would print as an
+    empty dict. This keeps the few fields that say what went wrong, shortens
+    them, and masks any long run of digits, because a provider that refuses a
+    request usually quotes the request back.
+    """
+    said = {}
+    for name in SAID_ON_REFUSAL:
+        if name not in payload:
+            continue
+        text = str(payload[name])[:120]
+        said[name] = A_RUN_OF_DIGITS.sub(
+            lambda run: run.group()[:2] + "*" * (len(run.group()) - 2), text)
+    return said
 
 
 def authorised(phone: str) -> bool:
@@ -128,12 +159,19 @@ def place(phone: str, family: str, quote: str, source: str,
         raise Refused("the provider would accept this schema and then fail to "
                       "fill it, %s" % "; ".join(problems))
 
+    # THE RECIPIENT TRAVELS IN THE REQUEST, and it did not before. Without it
+    # the provider has nobody to ring, this repository's own fake server
+    # refuses the create, and the workflow this README advertises could not
+    # place a call at all. The shape is the one the fake accepts, a list of
+    # recipients each carrying its phones, and the number is the one the
+    # operator authorised three lines above.
     body = json.dumps({"task": prepared["task"],
+                       "recipients": [{"phones": [phone]}],
                        "result_schema": prepared["result_schema"]}).encode("utf-8")
     status, payload = send(CALLS, key, body)
     if status >= 300:
         raise Refused("the provider refused the call, %s %s"
-                      % (status, bounded(payload)))
+                      % (status, safe_error(payload)))
     return prepared, bounded(payload)
 
 
@@ -157,7 +195,7 @@ def collect(call_id: str, prepared: dict | None = None,
         raise Refused("no CALLE_API_KEY in the environment")
     status, payload = send("%s/%s" % (CALLS, call_id), key, None)
     if status >= 300:
-        raise Refused("could not read the call, %s %s" % (status, bounded(payload)))
+        raise Refused("could not read the call, %s %s" % (status, safe_error(payload)))
     answer = payload.get("structured_result") or {}
     if not raw:
         payload = bounded(payload)

--- a/apps/python/clause-check-by-phone/place_call.py
+++ b/apps/python/clause-check-by-phone/place_call.py
@@ -66,6 +66,18 @@ KEPT = ("id", "status", "structured_result")
 # the request back inside their error text.
 SAID_ON_REFUSAL = ("error", "code", "type", "message")
 A_RUN_OF_DIGITS = re.compile(r"\d{7,}")
+E164_IN_TEXT = re.compile(r"\+[1-9][0-9]{6,14}")
+
+
+def safe_value(value):
+    """Mask full phone numbers inside the small provider-result allowlist."""
+    if isinstance(value, str):
+        return E164_IN_TEXT.sub(lambda match: masked(match.group()), value)
+    if isinstance(value, list):
+        return [safe_value(item) for item in value]
+    if isinstance(value, dict):
+        return {name: safe_value(item) for name, item in value.items()}
+    return value
 
 
 def bounded(payload: dict) -> dict:
@@ -83,7 +95,7 @@ def bounded(payload: dict) -> dict:
     answer. Anyone who genuinely needs the whole thing asks for it by name,
     `raw=True`.
     """
-    return {name: payload[name] for name in KEPT if name in payload}
+    return {name: safe_value(payload[name]) for name in KEPT if name in payload}
 
 
 def safe_error(payload: dict) -> dict:
@@ -196,9 +208,10 @@ def collect(call_id: str, prepared: dict | None = None,
     status, payload = send("%s/%s" % (CALLS, call_id), key, None)
     if status >= 300:
         raise Refused("could not read the call, %s %s" % (status, safe_error(payload)))
-    answer = payload.get("structured_result") or {}
+    safe_payload = bounded(payload)
+    answer = safe_payload.get("structured_result") or {}
     if not raw:
-        payload = bounded(payload)
+        payload = safe_payload
     if prepared is None:
         return payload
     return payload, contradiction(prepared, answer)

--- a/apps/python/clause-check-by-phone/tests_bridge.py
+++ b/apps/python/clause-check-by-phone/tests_bridge.py
@@ -102,6 +102,10 @@ class WhatDoesNotJustifyACall(unittest.TestCase):
         with self.assertRaises(NothingToAsk):
             call_task(NUM + "\n", "students only", "Students only", "s")
 
+    def test_non_ascii_digits_are_not_destinations(self):
+        with self.assertRaises(NothingToAsk):
+            call_task("+١٢٣٤٥٦٧٨", "students only", "Students only", "s")
+
     def test_the_longest_and_shortest_numbers_e164_allows(self):
         for right in ("+1234567", "+" + "1" * 15):
             self.assertIn(right, call_task(right, "students only",

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -125,7 +125,7 @@ class OnlyAnAuthorisedRecipientIsDialled(unittest.TestCase):
 
 class WhatIsActuallySent(unittest.TestCase):
 
-    def test_one_request_carrying_the_task_and_the_schema(self):
+    def test_one_request_carrying_the_task_the_recipient_and_the_schema(self):
         transport = Transport(201, {"id": "call_x", "status": "queued"})
         prepared, payload = place(NUM, "students only", "Students only", "t",
                                   key=KEY, send=transport)
@@ -133,10 +133,33 @@ class WhatIsActuallySent(unittest.TestCase):
         sent = transport.sent[0]
         self.assertEqual(sent["url"], place_call.CALLS)
         self.assertEqual(sent["key"], KEY)
-        self.assertEqual(sorted(sent["body"]), ["result_schema", "task"])
+        self.assertEqual(sorted(sent["body"]),
+                         ["recipients", "result_schema", "task"])
         self.assertIn(NUM, sent["body"]["task"])
         self.assertEqual(payload["id"], "call_x")
         self.assertEqual(prepared["family"], "students only")
+
+    def test_the_request_names_the_recipient_the_operator_authorised(self):
+        """Without this the provider has nobody to ring.
+
+        The repository's own fake server reads the destination from
+        `recipients[0].phones[0]` and refuses a create that omits it, so the
+        workflow the README advertises could not place a call. The number sent
+        is the one that just passed the authorisation check, never another.
+        """
+        transport = Transport(201, {"id": "call_x", "status": "queued"})
+        place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertEqual(transport.sent[0]["body"]["recipients"],
+                         [{"phones": [NUM]}])
+
+    def test_the_request_uses_only_field_names_the_provider_accepts(self):
+        """The fake rejects any unknown field with a 400, so a typo here is a
+        blocked workflow rather than a warning."""
+        accepted = {"task", "recipients", "result_schema",
+                    "recipient_result_schema", "metadata", "webhook_url"}
+        transport = Transport(201, {"id": "call_x"})
+        place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        self.assertLessEqual(set(transport.sent[0]["body"]), accepted)
 
     def test_the_key_never_reaches_the_body(self):
         transport = Transport(201, {"id": "call_x"})
@@ -194,6 +217,62 @@ class NothingSensitiveLeavesThisFile(unittest.TestCase):
         rendu = collect("call_x", key=KEY, send=Transport(200, self.FINISHED))
         self.assertEqual(rendu["status"], "completed")
         self.assertEqual(rendu["structured_result"]["open_to_non_students"], "yes")
+
+    # THE SHAPE THIS REPOSITORY'S OWN FAKE SERVER RETURNS. The destination and
+    # the transcript are not top level fields, they sit two levels down under
+    # `recipients` and `attempts`. A denylist of field names never saw them.
+    NESTED = {"id": "call_y", "status": "completed",
+              "structured_result": {"open_to_non_students": "yes"},
+              "task_completed": True,
+              "metadata": {"source": "clause-check-by-phone"},
+              "recipients": [{
+                  "phones": [NUM],
+                  "structured_result": None,
+                  "attempts": [{
+                      "phone": NUM,
+                      "transcript_turns": [
+                          {"speaker": "agent", "text": "Is it open to non students?"},
+                          {"speaker": "recipient", "text": "Yes, anyone can come."}],
+                  }],
+              }]}
+
+    def test_a_nested_destination_does_not_come_back(self):
+        rendu = collect("call_y", key=KEY, send=Transport(200, self.NESTED))
+        self.assertNotIn(NUM, json.dumps(rendu))
+        self.assertNotIn("recipients", rendu)
+
+    def test_a_nested_transcript_does_not_come_back(self):
+        rendu = collect("call_y", key=KEY, send=Transport(200, self.NESTED))
+        self.assertNotIn("anyone can come", json.dumps(rendu))
+        self.assertNotIn("transcript_turns", json.dumps(rendu))
+
+    def test_the_nested_payload_still_answers_the_question(self):
+        rendu = collect("call_y", key=KEY, send=Transport(200, self.NESTED))
+        self.assertEqual(sorted(rendu), ["id", "status", "structured_result"])
+        self.assertEqual(rendu["structured_result"]["open_to_non_students"], "yes")
+
+    def test_a_field_nobody_has_seen_yet_is_dropped_by_default(self):
+        """The reason this is an allowlist. A denylist is wrong about every
+        field a provider adds after it was written, and it is wrong in the
+        direction that leaks."""
+        later = dict(self.NESTED, voiceprint_id="vp_98d", caller_notes="he sounded tired")
+        rendu = collect("call_y", key=KEY, send=Transport(200, later))
+        self.assertNotIn("voiceprint_id", rendu)
+        self.assertNotIn("caller_notes", rendu)
+
+    def test_a_refusal_says_why_without_quoting_the_number_back(self):
+        """Providers echo the request inside their error text, and a refusal is
+        printed, so this is the path that puts a real number in a shell history."""
+        transport = Transport(400, {"code": "invalid_request",
+                                    "message": "recipient %s is not reachable" % NUM,
+                                    "request_id": "req_77"})
+        with self.assertRaises(Refused) as refused:
+            place(NUM, "students only", "Students only", "t", key=KEY, send=transport)
+        said = str(refused.exception)
+        self.assertNotIn(NUM.lstrip("+"), said)
+        self.assertIn("invalid_request", said)
+        self.assertIn("not reachable", said)
+        self.assertNotIn("req_77", said)
 
     def test_a_caller_who_asks_for_everything_gets_everything(self):
         rendu = collect("call_x", key=KEY, send=Transport(200, self.FINISHED), raw=True)

--- a/apps/python/clause-check-by-phone/tests_place_call.py
+++ b/apps/python/clause-check-by-phone/tests_place_call.py
@@ -251,6 +251,16 @@ class NothingSensitiveLeavesThisFile(unittest.TestCase):
         self.assertEqual(sorted(rendu), ["id", "status", "structured_result"])
         self.assertEqual(rendu["structured_result"]["open_to_non_students"], "yes")
 
+    def test_phone_numbers_inside_the_allowed_answer_are_masked(self):
+        payload = dict(self.NESTED)
+        payload["structured_result"] = {
+            "open_to_non_students": "yes",
+            "their_words": "call %s later" % NUM,
+        }
+        rendu = collect("call_y", key=KEY, send=Transport(200, payload))
+        self.assertNotIn(NUM, json.dumps(rendu))
+        self.assertIn("*", rendu["structured_result"]["their_words"])
+
     def test_a_field_nobody_has_seen_yet_is_dropped_by_default(self):
         """The reason this is an allowlist. A denylist is wrong about every
         field a provider adds after it was written, and it is wrong in the


### PR DESCRIPTION
Follow-up to the post-merge review on #264. Both blockers were real.

**The bounding helper only stopped a flat payload.** It removed a list of known
field names, and this repository's own fake server nests the destination and the
transcript under `recipients` and `attempts`, so a normal finished call came back
whole. A list of names to strip is also wrong about every field a provider adds
after the list was written, and it is wrong in the direction that leaks. It now
returns an allowlist, the call id, the status and the structured result, and
nothing else.

A provider refusal is handled separately, because it carries none of those three
and would have printed as an empty dict. It keeps the few fields that say what
went wrong, shortened, with long runs of digits masked. Providers quote the
request back inside their error text, and a refusal is printed.

**The create request omitted the recipient**, so the fake server had nobody to
ring and the live workflow the README advertises could not place a call. It now
carries `recipients: [{"phones": ["+447700900123"]}]` with the number that just
passed the authorisation check, never another, and a witness holds the request to
the field names the server accepts.

Seven new witnesses, twenty-eight in `tests_place_call.py`, twenty-six unchanged
in `tests_bridge.py`. Five of the new ones read a payload shaped the way the fake
server shapes one, and they fail against the previous helper.

`python3 scripts/validate_repository.py` passes. No network, no key and no call
in any witness.
