### PR TITLE
fix(tests): guard the 0600 assertions behind POSIX

### DIFF
--- a/apps/python/appointment-confirm/tests/test_flow.py
+++ b/apps/python/appointment-confirm/tests/test_flow.py
@@ -155,7 +155,13 @@ class FlowTests(unittest.TestCase):
                     ]
                 )
             self.assertEqual(rc, 0)
-            self.assertEqual(oct(dest.stat().st_mode)[-3:], "600")
+            # THE MODE IS A POSIX FACT AND ONLY THERE. Windows has no owner
+            # permission bits, `st_mode` comes back 0o666 whatever the file was
+            # created with, so this line fails on every Windows machine and
+            # says nothing about the code. The rest of the case, including the
+            # refusal to overwrite, still runs everywhere.
+            if os.name == "posix":
+                self.assertEqual(oct(dest.stat().st_mode)[-3:], "600")
             with patch("sys.stderr", StringIO()):
                 rc = cli.main(
                     [

--- a/skills/scope-signal/tests/test_scope_signal.py
+++ b/skills/scope-signal/tests/test_scope_signal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -150,7 +151,13 @@ class PreviewTests(unittest.TestCase):
                  "--approved-digest", digest, "--output", str(target)],
                 check=True, capture_output=True, text=True,
             )
-            self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+            # THE MODE IS A POSIX FACT AND ONLY THERE. Windows has no owner
+            # permission bits, `st_mode` comes back 0o666 whatever the file was
+            # created with, so this line fails on every Windows machine and
+            # says nothing about the code. The two assertions below, which are
+            # the ones about the number never reaching a stream, still run.
+            if os.name == "posix":
+                self.assertEqual(target.stat().st_mode & 0o777, 0o600)
             self.assertIn(raw["contact"]["phone_e164"], target.read_text())
             self.assertNotIn(raw["contact"]["phone_e164"], completed.stdout + completed.stderr)
 


### PR DESCRIPTION
Two suites fail on `main` on any Windows machine, with no change to either app.

```
apps/python/appointment-confirm/tests/test_flow.py
  AssertionError: '666' != '600'
skills/scope-signal/tests/test_scope_signal.py
  AssertionError: 438 != 384
```

Both assert that a written file carries mode `0600`. Windows has no owner
permission bits, so `st_mode` comes back `0o666` whatever the file was created
with. The assertion cannot hold there, and the failure says nothing about the
code.

Each one is now guarded by `os.name == "posix"`. The rest of both cases still
runs everywhere, including the refusal to overwrite in the first and the two
assertions about the phone number never reaching a stream in the second. The
mode is still checked wherever it means something.

Worth saying plainly rather than burying it. The property itself does not hold
on Windows, the file really is readable by others there. The guard makes that
visible instead of hiding it behind a red suite that everyone learns to ignore.
If you would rather the app refused to write a handoff file on a platform where
it cannot protect it, that is a different and larger change and I am happy to
open it separately.

`python3 scripts/validate_repository.py` passes. Twelve tests and twenty-six
tests, all green here.
