### PR TITLE
docs(skills): add groundtruth-verification skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`incident-escalation-call`](skills/incident-escalation-call/) - Walks an on-call escalation ladder one phone call at a time and records an acknowledgement only when an owner and an ETA are both quoted by words the recipient spoke, then re-reads the call over a second transport before the incident is reported as owned.
 - [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
+- [`groundtruth-verification`](skills/groundtruth-verification/) - Verify a goal's hard requirements across several suppliers with CALL-E, keeping hedged answers UNKNOWN, and refuse to run a published Goal whose result schema cannot answer a constraint.
 
 ### Apps
 

--- a/skills/groundtruth-verification/SKILL.md
+++ b/skills/groundtruth-verification/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: groundtruth-verification
+description: Run evidence-backed real-world verification by phone. Turn a fuzzy operational goal ("find a compatible part available today, held until 5 PM, under budget") into hard constraints, verify them with CALL-E phone calls that adapt to what each supplier actually says, and return claims with call-linked evidence — never promoting "probably" to verified. Use when an agent must confirm a real-world fact that only a human answering a phone knows (stock, compatibility, price, availability, holds, delivery windows), when a purchase or payment must NOT be made, and when the answer needs auditable evidence rather than a guess.
+license: MIT
+---
+
+# GroundTruth Verification
+
+An evidence-backed real-world verification protocol for phone-work agents.
+CALL-E is the phone execution layer; this skill is the orchestration,
+verification, and safety discipline around it.
+
+## When to use this skill
+
+Use it when ALL of these hold:
+
+1. **The fact lives with a human, not a database.** Stock counts, exact-part
+   compatibility, "can you actually come tomorrow", "is the quoted lead time
+   real". Web search cannot settle it; calling can.
+2. **The goal has checkable requirements.** You can name what counts as done:
+   "compatible AND in stock AND ≤ ₹25,000 AND held until 5 PM".
+3. **No commitment is needed.** GroundTruth verification is question-only.
+   It may request a temporary hold when explicitly authorized. It never
+   purchases, pays, accepts quotes, or reveals credentials.
+4. **The answer must be auditable.** Every verified claim links to the CALL-E
+   call that produced it, the supplier's own words, and a confidence score.
+
+Do NOT use it for: appointment booking (use a scheduling skill), lead
+qualification, surveys, emergencies, medical/legal/financial advice, or any
+task whose success requires a transaction on the call.
+
+## How to formulate a verification goal
+
+Write the goal as: objective + item + hard constraints + soft preferences +
+authorization.
+
+- **Hard constraints** are gates: a candidate either passes or is rejected.
+  Each one must be verifiable by asking a question on a phone call, and each
+  maps to one structured-result field. Kinds: `availability`, `compatibility`,
+  `price_max`, `quantity_min`, `distance_max`, `pickup_today`, `hold_until`,
+  `deadline`, `custom`.
+- **Soft preferences** only rank passing candidates (closer is better, cheaper
+  is better). They never reject anyone.
+- **Authorization** is explicit and structural: allowed actions
+  (`ask_question`, `request_availability`, `request_pricing`,
+  `request_delivery_estimate`, `request_pickup_window`, and only if the user
+  said so, `request_hold`) and the mandatory prohibition list (`purchase`,
+  `payment`, `contract_acceptance`, `legally_binding_commitment`,
+  `disclose_credentials`, `disclose_payment_info`).
+
+Example goal (the flagship):
+
+```
+Find a genuine XZ-420 compressor for an ACME HVAC-200 within 25 km.
+Hard: compatible with HVAC-200; in stock; pickup today; price ≤ ₹25,000;
+      supplier holds one unit until 5 PM; distance ≤ 25 km.
+Soft: prefer lower price; prefer closer.
+Authorization: questions + hold request allowed; purchases prohibited.
+```
+
+Read `references/verification-protocol.md` before your first run. It defines
+the plan → call → adapt → extract → verify → decide loop step by step.
+
+## Setup
+
+No credentials are needed to read this skill or to run its scripts against a
+saved Goal document. To execute verifications you need one of:
+
+- **The GroundTruth app** (recommended). `pnpm install`, then
+  `MOCK_CALL_E=true pnpm dev` — deterministic mock CALL-E, no keys.
+- **Direct CALL-E access.** `pnpm add @call-e/calle`, then set
+  `CALLE_API_KEY` (server-side only; never in browser code) and optionally
+  `CALLE_BASE_URL`. Keys are issued from the CALL-E dashboard.
+
+The scripts in `scripts/` have no dependencies and run on plain Node:
+
+```bash
+node scripts/build-call-task.mjs goal.json
+node scripts/check-goal-compatibility.mjs goal.json --spec published-goal.json
+```
+
+## Side effects and cancellation
+
+**This skill places real phone calls to real people.** That is the whole
+point of it, and it is the thing to be careful about.
+
+| Effect | When | Reversible? |
+| --- | --- | --- |
+| An outbound phone call to a business | once per candidate, per attempt | No — a person's phone rings |
+| A follow-up call to the same business | at most once more, when a constraint is resolvably unknown | No |
+| A temporary hold requested on an item | only when `request_hold` is explicitly authorised | Yes — by calling back, which this skill does not do for you |
+| Rows written to your own store | every call | Yes |
+
+Nothing else. No purchase, payment, contract acceptance, or credential
+disclosure is ever performed, and the prohibited-phrase gate blocks such
+language from reaching a call task in the first place.
+
+**Before running in real mode**, make sure the candidate list contains only
+numbers you intend to dial. Demo or sample personas must never be dialled:
+their numbers are fictional but well-formed, so a real run reaches a
+stranger. Gate this structurally rather than by care — refuse to start unless
+the pending candidate set is exactly what you nominated.
+
+**Cancellation.** Stopping between calls is safe and immediate: the loop is
+driven by discrete ticks, all state is persisted, and abandoning a run leaves
+verified claims and their evidence intact. A call already in flight cannot be
+recalled — the person has answered — and the correct response to an aborted
+run is to let that call finish and ignore its result, not to redial.
+Idempotency keys mean a retried create never produces a second call.
+
+**Budgets.** `maxCalls` (default 8) and `maxCallsPerCandidate` (default 2)
+bound how many times anyone can be dialled in one run. Lower them before you
+raise them.
+
+## Running a verification
+
+### Option A — through the GroundTruth app (recommended)
+
+```bash
+# Start the app (demo mode, no credentials needed)
+MOCK_CALL_E=true pnpm dev        # or pnpm build && pnpm start
+
+# 1. Submit the goal
+curl -s localhost:3000/api/tasks -H 'content-type: application/json' \
+  -d '{"input":"Find a genuine XZ-420 compressor for an ACME HVAC-200 within 25 km. It must be compatible, available today, under ₹25,000, and the supplier must hold it until 5 PM. You may request a hold, but do not purchase anything."}'
+# -> { "task": { "id": "...", "goal": { ... hardConstraints, authorization ... } } }
+
+# 2. Start the run, then poll the tick endpoint until task.status = completed
+curl -s -X POST localhost:3000/api/tasks/$TASK_ID/start
+curl -s -X POST localhost:3000/api/tasks/$TASK_ID/tick   # repeat
+# -> { "task", "candidates", "calls", "claims", "evidence", "decision", "audit" }
+```
+
+The final `decision` object contains `status` (`success` | `partial` |
+`no_match`), the winning candidate, per-candidate reasons, and confidence.
+Every verified claim carries `evidenceIds` pointing into the `evidence` array
+(call ID, transcript excerpt, completion confidence).
+
+### Option B — through a published CALL-E Goal
+
+When a published Goal already encodes the verification questions, run that
+instead of composing a call task. The Goal owns its `inputSchema` and
+`resultSchema`; each run supplies a phone number, variables, and an
+idempotency key.
+
+```bash
+MOCK_CALL_E=false CALLE_API_KEY=... CALLE_GOAL_ID=goal_... pnpm start
+```
+
+**Check the Goal before you dial.** A Goal can be healthy and still be
+structurally unable to answer a hard constraint, because its result schema
+declares no field for it. Running it anyway spends a real call on a human and
+returns a constraint that can only ever be UNKNOWN.
+
+```ts
+const goal = await client.goals.get(goalId);
+const fields = Object.keys(goal.publishedRunSpec.resultSchema.properties ?? {});
+// Every phone-derived hard constraint must bind to one of `fields`.
+// Every required input variable must be suppliable.
+// Otherwise: refuse, and say which constraint the Goal cannot answer.
+```
+
+Two properties of the Goal path to carry into your own implementation:
+
+1. **No transcript.** A Goal run returns a validated flat result, a `callId`,
+   and a typed `error` — no turns. Claims from this path carry
+   structured-result evidence and the call id. Do not imply a quote exists.
+2. **Typed errors.** Branch on `error.code`: `no_answer`, `call_failed`,
+   `declined`, `timed_out`, `canceled` mean the call did not happen (the
+   candidate is unreachable); `result_invalid`, `result_unavailable`,
+   `result_failed` mean it happened but produced nothing usable.
+
+A `completed` run can briefly carry neither `result` nor `error` while CALL-E
+parses. Keep polling — do not read it as an empty success.
+
+### Option C — direct CALL-E calls following the protocol
+
+If you cannot run the app, follow `references/verification-protocol.md`
+against the official `@call-e/calle` SDK directly:
+
+- Compose one call task per candidate with the opening disclosure, the
+  per-constraint questions (plus fallback questions for hedged answers), and
+  the safety footer. Run the text through the prohibited-phrase check BEFORE
+  creating the call.
+- Always pass a `resultSchema` (see `references/evidence-model.md`) and an
+  idempotency key per logical call.
+- Treat `uncertain` as an answer. Re-ask once with the fallback question; if
+  the supplier still cannot confirm, the constraint stays UNKNOWN — that is a
+  result, not a failure of the process.
+
+## Non-negotiable rules
+
+1. **UNKNOWN never becomes VERIFIED.** "Probably", "I think", "we usually
+   have it" are `uncertain`, and an uncertain answer is an unresolved
+   constraint. One polite follow-up ("could you check for me?") is allowed;
+   after that, move on.
+2. **No evidence, no verified claim.** A claim is verified only when the
+   structured result supports it AND provenance is stored alongside it. On
+   the call path that provenance includes the supplier's own words — store
+   both. On the Goal path no transcript exists, so store the run id, the
+   pinned RunSpec version and the correlated call id, and say plainly that no
+   quote is available. Never synthesise a quote to fill the gap.
+3. **Purchase language never enters a call task.** The side-effect scanner
+   blocks purchase/payment/commitment/credential phrases at the orchestration
+   layer. The structural prohibition ("we will not purchase") is fine;
+   affirmative side-effect language is not.
+4. **Never dial a question the contract cannot answer.** Whether the result
+   shape is your own `resultSchema` or a published Goal's, check that every
+   hard constraint maps to a declared field *before* the call is created. A
+   constraint with nowhere to land is a configuration error, not a supplier
+   outcome — refuse it loudly rather than spending someone's time on it.
+5. **Stop when done.** Stop early when one candidate satisfies every hard
+   constraint (with a follow-up for a pending hold). Stop when no candidate
+   remains. Report failure honestly with per-candidate reasons — the failure
+   report IS a result.
+6. **Mask phone numbers and redact PII** in anything shown or stored beyond
+   the working state. Never log API keys, codes, or card-like digit strings.
+
+Read `references/safety.md` before composing your first call task. It is
+short, and violating it is the difference between a verification agent and a
+prank caller with a budget.
+
+## Verification states
+
+| State        | Meaning                                                        |
+| ------------ | -------------------------------------------------------------- |
+| `unknown`    | Not asked yet, or the answer was hedged/refused                |
+| `pending`    | On a call now, or awaiting a scheduled follow-up               |
+| `verified`   | Concrete answer + attached evidence + sufficient confidence    |
+| `contradicted` | A later call contradicted an earlier verified claim (recorded, never deleted) |
+| `failed`     | Explicitly negative (out of stock, not compatible, cannot hold) |
+| `expired`    | Was verified, but past its validity horizon (stock and holds go stale) |
+
+## Stopping rules
+
+Stop when ANY of: a candidate fully verified (preferred), all candidates
+exhausted, the call budget (`maxCalls`, default 8; `maxCallsPerCandidate`,
+default 2) is spent, or the only remaining unknowns are provably
+unresolvable by phone. Continue when: a hard constraint is still unknown AND
+a follow-up or another candidate could resolve it. Prefer candidates by
+distance to the geography constraint, then by expected match.
+
+## Failure handling
+
+- **No answer / voicemail / hangup**: mark the candidate `unreachable`, move
+  to the next candidate. Do not redial the same number in the same run.
+- **API failure or timeout**: retry the CALL-E create with the SAME
+  idempotency key (never double-dial); after repeated failures, mark the
+  candidate unknown and continue.
+- **Duplicate webhook deliveries**: deduplicate by webhook event id.
+- **Ambiguous final state** (a hold was requested but not confirmed): report
+  the candidate as partial with the specific unresolved constraint. Offer the
+  operator the honest options: relax a constraint, expand the search, or stop.
+
+## Further reading
+
+- `references/verification-protocol.md` — the full plan → call → adapt →
+  extract → verify → decide loop with pseudo-code.
+- `references/evidence-model.md` — claims, evidence, confidence, schemas.
+- `references/safety.md` — authorization boundaries and prohibited actions.
+- `scripts/build-call-task.mjs` — compose a protocol-compliant CALL-E call
+  task + result schema from a goal JSON (no dependencies).
+- `scripts/check-goal-compatibility.mjs` — decide whether a published CALL-E
+  Goal can answer a verification goal, before you run it. Works offline
+  against a saved Goal document, or live via `goals.get` (read-only; places
+  no call). Exit code 2 means "do not run this Goal".
+
+```bash
+# Offline, against a saved Goal document
+node scripts/check-goal-compatibility.mjs goal.json --spec published-goal.json
+
+# Live (read-only)
+CALLE_API_KEY=... node scripts/check-goal-compatibility.mjs goal.json --goal-id goal_abc
+```

--- a/skills/groundtruth-verification/SKILL.md
+++ b/skills/groundtruth-verification/SKILL.md
@@ -244,6 +244,16 @@ distance to the geography constraint, then by expected match.
 
 - **No answer / voicemail / hangup**: mark the candidate `unreachable`, move
   to the next candidate. Do not redial the same number in the same run.
+- **Zero-duration provider failures**: a call that starts and ends in the same
+  second, with no transcript, never reached the person. Observed codes are
+  opaque and inconsistent — `500`, `404`, SIP `480` — and carry no actionable
+  reason, so do not branch on them. Treat the candidate as unreachable and
+  move on. Repeated zero-duration failures to one number after several
+  successful calls usually mean carrier-side filtering of automated traffic,
+  not a fault in your code: stop dialling that number rather than retrying.
+- **Before a follow-up**: leave a deliberate gap after the first call ends.
+  Redialling someone seconds after asking them to check with a manager is
+  both unrealistic and, in practice, unreliable.
 - **API failure or timeout**: retry the CALL-E create with the SAME
   idempotency key (never double-dial); after repeated failures, mark the
   candidate unknown and continue.
@@ -254,6 +264,8 @@ distance to the geography constraint, then by expected match.
 
 ## Further reading
 
+- `references/examples.md` — runnable examples: composing a call task, the
+  Goal compatibility refusal, a full offline run, and the honest-failure path.
 - `references/verification-protocol.md` — the full plan → call → adapt →
   extract → verify → decide loop with pseudo-code.
 - `references/evidence-model.md` — claims, evidence, confidence, schemas.

--- a/skills/groundtruth-verification/references/evidence-model.md
+++ b/skills/groundtruth-verification/references/evidence-model.md
@@ -1,0 +1,101 @@
+# Evidence Model
+
+Claims and evidence are first-class objects. A phone call that "went well" is
+not a result; typed claims with attached evidence are.
+
+## Claim
+
+```json
+{
+  "id": "uuid",
+  "taskId": "uuid",
+  "candidateId": "uuid",
+  "callId": "uuid",
+  "type": "availability | compatibility | price | quantity | pickup | hold | deadline | service_area | other",
+  "statement": "Metro Components availability of the requested item",
+  "value": 2,
+  "unit": null,
+  "status": "unknown | pending | verified | contradicted | failed | expired",
+  "confidence": 0.93,
+  "evidenceIds": ["uuid"],
+  "statusHistory": [
+    { "from": "unknown", "to": "verified", "at": "ISO-8601", "reason": "Call mock_gt_... terminal result" }
+  ],
+  "createdAt": "ISO-8601",
+  "updatedAt": "ISO-8601"
+}
+```
+
+Lifecycle rules:
+
+- `unknown -> verified` requires evidence + sufficient completion confidence.
+- `verified -> contradicted` is allowed and RECORDED (history is never
+  rewritten). `verified -> verified` is a no-op.
+- `failed` means an explicit negative from the supplier.
+- Claims are immutable once evidence is attached; corrections are new
+  transitions, not edits.
+
+## Evidence
+
+```json
+{
+  "id": "uuid",
+  "claimId": "uuid",
+  "callId": "uuid",
+  "candidateId": "uuid",
+  "source": "calle_call | calle_transcript | structured_result",
+  "excerpt": "Supplier said: \"Yes, we have two units right now.\"",
+  "confidence": 0.93,
+  "capturedAt": "ISO-8601"
+}
+```
+
+Every verified claim carries at least one `structured_result` evidence (the
+schema-validated CALL-E result) and, when the transcript supports it, one
+`calle_transcript` evidence quoting the supplier's own words. Transcript
+excerpts are PII-redacted before storage.
+
+## Structured result contract (CALL-E resultSchema)
+
+```json
+{
+  "type": "object",
+  "required": ["availability"],
+  "properties": {
+    "availability":   { "type": "string", "enum": ["confirmed", "not_available", "uncertain"] },
+    "quantity":       { "type": "integer", "minimum": 0 },
+    "compatibility":  { "type": "string", "enum": ["confirmed", "not_compatible", "uncertain"] },
+    "price":          { "type": "number", "minimum": 0 },
+    "currency":       { "type": "string", "enum": ["INR", "USD", "EUR"] },
+    "pickup_available": { "type": "boolean" },
+    "pickup_time":    { "type": "string" },
+    "hold_available": { "type": "boolean" },
+    "hold_confirmed": { "type": "boolean" },
+    "hold_until":     { "type": "string" },
+    "notes":          { "type": "string" }
+  }
+}
+```
+
+Design rules:
+
+- `uncertain` is a first-class enum value — hedged answers survive
+  end-to-end and keep constraints UNKNOWN.
+- Missing optional fields are null-filled after validation so evaluators see
+  explicit gaps instead of undefined.
+- Adjust the schema per task when needed (e.g. a service-area check may swap
+  `compatibility` for a `service_area` enum), but keep the pattern: enums for
+  judgments, numbers for quantities/prices, booleans for yes/no facts, and a
+  free-text `notes` field that never substitutes for a structured field.
+
+## Confidence
+
+- Claim confidence = the CALL-E `completionConfidence.score` of the call that
+  produced it (mock mode reports a scripted value; the default floor is 0.8
+  when CALL-E omits it).
+- Claims below a 0.5 completion confidence cannot become verified even when
+  the structured result looks positive.
+- Decision confidence = the MINIMUM confidence across the winner's verified
+  hard constraints — one weak leg lowers the whole verdict.
+- Confidence never overrides a deterministic `fail`, and an ambiguous answer
+  stays UNKNOWN even at high model confidence.

--- a/skills/groundtruth-verification/references/examples.md
+++ b/skills/groundtruth-verification/references/examples.md
@@ -1,0 +1,163 @@
+# Examples
+
+All phone numbers below are reserved fictional numbers. Every example runs
+with no credentials, no network, and places no call.
+
+## Example 1: compose a verification call task from a goal
+
+`goal.json`:
+
+```json
+{
+  "item": "XZ-420 compressor",
+  "targetEquipment": "ACME HVAC-200",
+  "constraints": [
+    { "kind": "availability" },
+    { "kind": "compatibility" },
+    { "kind": "price_max", "params": { "max": 25000, "currency": "INR" } },
+    { "kind": "pickup_today" },
+    { "kind": "hold_until", "params": { "until": "5 PM" } }
+  ],
+  "authorizedActions": [
+    "ask_question", "request_availability", "request_pricing",
+    "request_pickup_window", "request_hold"
+  ],
+  "candidate": { "name": "Example Components", "phone": "+15550101234" }
+}
+```
+
+```bash
+node scripts/build-call-task.mjs goal.json
+```
+
+Emits the composed task text and the strict `resultSchema`. The task opens
+with the disclosure, carries one question per hard constraint plus a fallback
+question for the hedge-prone ones, and ends with the safety footer. Nothing
+is dialled.
+
+Exit codes: `0` ok, `1` invalid goal, `2` authorization violation,
+`3` prohibited side-effect phrase. Remove `request_hold` from
+`authorizedActions` and the hold question disappears rather than being asked
+without permission:
+
+```bash
+# authorizedActions without "request_hold" -> exit 2
+node scripts/build-call-task.mjs goal-no-hold.json
+```
+
+## Example 2: refuse a published Goal that cannot answer the question
+
+A published CALL-E Goal owns its own version-pinned `resultSchema`. It can be
+healthy and still be structurally unable to settle a hard constraint, because
+no declared field can carry the answer. Running it anyway spends a real call
+on a real person and returns a constraint that can only ever be UNKNOWN.
+
+`published-goal.json` — a stock-check Goal with no hold or compatibility
+field:
+
+```json
+{
+  "id": "goal_example_stock_check",
+  "title": "Example stock check",
+  "publishedRunSpec": {
+    "id": "runspec_1",
+    "version": 2,
+    "inputSchema": {
+      "type": "object",
+      "required": ["item"],
+      "properties": { "item": { "type": "string" } }
+    },
+    "resultSchema": {
+      "type": "object",
+      "properties": {
+        "in_stock": { "type": "string" },
+        "quoted_price": { "type": "number" }
+      }
+    }
+  }
+}
+```
+
+```bash
+node scripts/check-goal-compatibility.mjs goal.json --spec published-goal.json
+```
+
+```json
+{
+  "goal": "Example stock check",
+  "runSpecVersion": 2,
+  "compatible": false,
+  "bindings": [
+    { "kind": "availability", "resultField": "in_stock" },
+    { "kind": "price_max", "resultField": "quoted_price" }
+  ],
+  "unanswerable": [
+    { "kind": "compatibility", "lookedFor": ["compatibility", "compatible", "fits"] },
+    { "kind": "pickup_today", "lookedFor": ["pickup_available", "pickup_today", "can_pickup"] },
+    { "kind": "hold_until", "lookedFor": ["hold_confirmed", "hold_available", "will_hold"] }
+  ],
+  "missingVariables": [],
+  "declaredResultFields": ["in_stock", "quoted_price"]
+}
+```
+
+Exit code `2`, with a message naming the constraints that have nowhere to
+land. **Do not run that Goal**: the call would happen and the answer would
+still be missing.
+
+Note that `availability` bound to `in_stock` and `price_max` to
+`quoted_price` — binding is family-based, so a Goal may name its fields its
+own way.
+
+Give it a Goal that also declares `compatibility`, `pickup_available` and
+`hold_confirmed`, and the same command exits `0`:
+
+```
+COMPATIBLE — "Example supplier verification" v4 can answer all 4 phone-derived constraint(s).
+```
+
+Check a live Goal instead of a saved document with
+`--goal-id goal_abc123` and `CALLE_API_KEY` set. That path is read-only
+(`goals.get`); it places no call and spends no credit.
+
+## Example 3: a full run, offline
+
+```bash
+MOCK_CALL_E=true pnpm dev     # deterministic mock CALL-E, no credentials
+```
+
+```bash
+curl -s localhost:3000/api/tasks -H 'content-type: application/json' \
+  -d '{"input":"Find a genuine XZ-420 compressor for an ACME HVAC-200 within 25 km. It must be compatible, available today, under 25000, and the supplier must hold it until 5 PM. You may request a hold, but do not purchase anything."}'
+
+curl -s -X POST localhost:3000/api/tasks/$TASK_ID/start
+curl -s -X POST localhost:3000/api/tasks/$TASK_ID/tick   # repeat until completed
+```
+
+Six fictional suppliers are contacted in priority order. Watch for the three
+behaviours that matter:
+
+- one supplier hedges ("I think we have it") and the constraint stays
+  `unknown` — it never becomes verified;
+- one has the hold pending a manager, so a **follow-up call is generated from
+  state**, not from a script, and the hold resolves on the second call;
+- two suppliers are never called at all, because a candidate satisfied every
+  hard requirement and the run stopped early.
+
+The final `decision` is `success`, `partial`, or `no_match`, and every
+verified claim carries `evidenceIds` into the `evidence` array with the
+CALL-E call id, the supplier's own words, and a confidence score.
+
+## Example 4: the honest failure
+
+Same request, different morning — the winning supplier sold out:
+
+```bash
+curl -s localhost:3000/api/tasks -H 'content-type: application/json' \
+  -d '{"input":"...","scenarioId":"compressor_failure"}'
+```
+
+Every candidate fails a hard requirement or stays unknown, and the run ends
+`NO FULLY VERIFIED MATCH` with a per-candidate reason. That report is the
+result. A verification agent that cannot return "no" is not a verification
+agent.

--- a/skills/groundtruth-verification/references/safety.md
+++ b/skills/groundtruth-verification/references/safety.md
@@ -1,0 +1,79 @@
+# Safety
+
+GroundTruth verification is question-only. These rules are enforced at the
+orchestration layer — not in a prompt the model can drift from.
+
+## Authorization boundaries
+
+Every verification task carries an explicit authorization block:
+
+- **Allowed** (subset, always question-only): `ask_question`,
+  `request_availability`, `request_pricing`, `request_delivery_estimate`,
+  `request_pickup_window`, `request_hold`.
+- **Prohibited** (mandatory, constant): `purchase`, `payment`,
+  `contract_acceptance`, `legally_binding_commitment`,
+  `disclose_credentials`, `disclose_payment_info`.
+
+Enforcement points, in order:
+
+1. **Goal validation** — a goal whose authorization list is missing any
+   prohibition is rejected at creation.
+2. **Plan-time action check** — every constraint's phone question maps to an
+   allowed action; asking about a hold without `request_hold` in the allowed
+   set throws before any call exists.
+3. **Composition-time phrase gate** — the composed call task text is scanned
+   for affirmative side-effect language (purchase/buy, pay/card, order
+   confirmation, terms acceptance, credential sharing). Negations
+   ("do NOT purchase") are stripped before scanning so the safety footer and
+   disclosures never trip the gate. Affirmative phrases abort the call.
+4. **Action ledger** — every created call and every blocked action is
+   recorded (`actions` table) with the task, candidate, and call ids.
+
+## Never send on a call
+
+- Payment card numbers, CVVs, or any card-like digit string
+- Passwords, one-time codes, API keys, tokens, any secret
+- National identifiers, full addresses of the requester, or any personal data
+  beyond what the question strictly requires
+
+The standard disclosure states who is calling, that it is automated, on whose
+behalf, and that no commitment will be made. Questions disclose nothing about
+the requester beyond the item being verified.
+
+## PII handling
+
+- Phone numbers are masked in the UI (`+91 •••• ••01`); full E.164 numbers
+  live only in the working state and the CALL-E call.
+- Before persistence and display, free text (transcripts, notes, evidence
+  excerpts) is redacted for: emails, card-like digit sequences, OTP-like
+  codes, and secret-shaped strings.
+- Human (callee) transcript turns are redacted; bot turns are safe by
+  construction.
+- Transcripts and evidence excerpts are the minimum necessary quote — not the
+  full recording.
+
+## Auditability
+
+- Every significant action is in the audit log: task created, goal analyzed,
+  CALL-E call created/completed/failed, claim verified/recorded, blocked
+  action, decision reached — each with actor (`user` | `system` | `calle`)
+  and timestamp.
+- Webhook deliveries are deduplicated by event id and the raw payload is
+  retained for dispute resolution.
+- No secrets in logs: CALL-E keys and tokens are redacted in structured
+  logging; phone numbers are masked.
+
+## Failure behavior
+
+- A candidate that cannot be reached is marked `unreachable` — never retried
+  in the same run, never counted as a failure of its answers.
+- A call that ends in ambiguity leaves claims UNKNOWN; the final decision is
+  `partial`/`no_match`, never a soft success.
+- Side-effect gate violations fail LOUDLY (the call is not silently rewritten).
+
+## What this skill will never do
+
+- Purchase, pay, reserve beyond a temporary hold, or accept any offer.
+- Reveal, read back, or request codes or credentials on a call.
+- Present an unverified or low-confidence answer as verified.
+- Place calls without an explicit operator-initiated task.

--- a/skills/groundtruth-verification/references/verification-protocol.md
+++ b/skills/groundtruth-verification/references/verification-protocol.md
@@ -1,0 +1,154 @@
+# Verification Protocol
+
+The GroundTruth loop:
+
+```
+PLAN -> CALL -> ADAPT -> EXTRACT -> VERIFY -> DECIDE
+```
+
+## 0. Inputs
+
+- A natural-language goal (from an operator or an agent).
+- A candidate list (demo provider, manual list, or a discovery provider).
+- Explicit authorization (allowed + prohibited actions).
+
+## 1. PLAN
+
+Produce a `VerificationGoal` and a `VerificationPlan`.
+
+Goal extraction rules:
+
+- **Item** — the thing to verify, with its exact identity (model code, revision).
+  "A compressor" is not verifiable; "XZ-420 compressor, genuine/OEM" is.
+- **Hard constraints** — each has: kind, human label, parameters
+  (e.g. `{max: 25000}`), the exact phone question, and the structured-result
+  field it maps to.
+- **Soft preferences** — ranking only.
+- **Authorization** — validate BEFORE planning calls. The prohibition list is
+  mandatory and constant. If the user's request implies a purchase, reject the
+  goal or downgrade it to verification.
+
+Plan rules:
+
+- One primary question per hard constraint. Constraints whose answers are
+  likely to be hedged (compatibility checks, holds needing approval) get a
+  **fallback question** ("could you check the model compatibility for me?").
+- Candidate order: within the geography constraint first (nearest first),
+  then the rest.
+- Stopping rules: `stopOnFirstFullyVerified: true`, `maxCalls: 8`,
+  `maxCallsPerCandidate: 2` (the second call is a targeted follow-up, not a
+  repeat).
+
+## 2. CALL
+
+For each candidate (in priority order):
+
+1. Compose the call task text:
+   - Opening disclosure: who is calling (automated assistant), on whose
+     behalf, and that no commitment will be made.
+   - The questions, in order. If a prior call to this candidate left context
+     (e.g. "you were going to check with your manager"), reference it.
+   - The safety footer (verification-only; decline commitments; never reveal
+     codes or credentials).
+2. Run the composed text through the side-effect gate. Violations abort the
+   call BEFORE creation.
+3. Create the CALL-E call with:
+   - `task` — the composed text.
+   - `recipient` — `{ phone, region, locale }` in E.164.
+   - `resultSchema` — the structured result contract (see
+     `references/evidence-model.md`).
+   - `metadata` — `{ taskId, candidateId, purpose, attempt }` for tracing.
+   - `idempotencyKey` — derived from `(taskId, candidateId, purpose, attempt)`.
+     Retries reuse the same key; CALL-E will not double-dial.
+   - `webhookUrl` — registered terminal-result receiver, when available.
+4. Track status. On terminal state, go to EXTRACT.
+
+## 3. ADAPT
+
+After each terminal call, inspect the state and choose exactly one action:
+
+- **follow_up** — a hard constraint is UNKNOWN and resolvable with one more
+  question:
+  - hold requested and possible but pending approval (`hold_available: true`,
+    `hold_confirmed: false`);
+  - compatibility answered as `uncertain` but the supplier engaged.
+  The follow-up call must be shorter than the first (one focused question)
+  and must state that it is a follow-up.
+- **next_candidate** — the candidate failed a hard requirement, or its
+  remaining unknowns are not resolvable by phone (the supplier cannot check,
+  "call back tomorrow", no answer), or the per-candidate call budget is spent.
+- **stop** — one candidate fully verified; or no candidates remain; or the
+  global call budget is spent.
+
+Never follow up on: explicit failures, refusals, unreachable lines. Never
+follow up twice for the same constraint.
+
+## 4. EXTRACT
+
+From the terminal CALL-E call, build claims:
+
+- Validate `structuredResult` against the strict schema; missing optional
+  fields are null-filled so evaluation sees explicit gaps.
+- Merge results across attempts for the same candidate: a later call's
+  non-null fields override earlier ones (the follow-up's `hold_confirmed: true`
+  lands on top of the first call's availability/price).
+- One claim per phone-derived constraint type: availability, compatibility,
+  price, quantity, pickup, hold.
+
+## 5. VERIFY
+
+For each hard constraint, evaluate deterministically:
+
+- `pass` — the structured field says exactly the required thing (confirmed /
+  not_compatible / number ≤ max / hold_confirmed true ...).
+- `fail` — the field explicitly negates it.
+- `unknown` — null, hedged (`uncertain`), or unevaluatable. UNKNOWN IS A
+  RESULT. It is never rounded up to pass and never counted as failure
+  without an explicit negative.
+
+Promotion to `verified` requires ALL of:
+
+1. The deterministic evaluation is `pass`.
+2. The CALL-E call's `completionConfidence` is ≥ 0.5.
+3. Evidence is attached (structured result + the supplier's words from the
+   transcript).
+
+Anything else keeps the claim `unknown` — regardless of how good the overall
+call felt. A verified claim is immutable; a later call can only confirm it
+(no-op) or contradict it (recorded in status history, never erased).
+
+## 6. DECIDE
+
+- Rank candidates: every hard constraint satisfied ⇒ viable. Failures and
+  unknowns make a candidate non-viable. Soft preferences break ties.
+- One viable candidate ⇒ `success` with that candidate, confidence = the
+  minimum confidence across its verified hard constraints (the weakest leg).
+- Some constraints verified but no fully viable candidate ⇒ `partial`, with
+  per-candidate reasons and the unresolved constraint list.
+- Nothing verified ⇒ `no_match` with the full breakdown.
+
+Report the decision with: the winner (if any), the alternatives, the rejected
+candidates WITH reasons, the unresolved constraints, and the confidence. The
+honest failure report is a first-class output — "6 suppliers contacted, 2 out
+of stock, 1 incompatible, 2 over budget, 1 availability uncertain" is a
+usable operational answer, and it is more valuable than a soft success.
+
+## Pseudo-code
+
+```
+task   = analyze(goalText)          # + authorization validation
+plan   = buildPlan(task.goal)       # throws on authorization violation
+cands  = discover(goal, plan.limit) # ranked
+for cand in cands:
+    call = createCall(composeCallTask(cand, plan.questions), schema, idemKey)
+    result = awaitTerminal(call)    # poll or webhook
+    mergeResults(cand, result)
+    extractClaims(cand, result)     # + evidence + confidence
+    evaluateConstraints(cand)       # deterministic
+    if fullyVerified(cand): break
+    elif resolvableUnknown(cand) and budgetRemaining(cand):
+        followUp(cand)              # targeted second call
+    else: continue                  # next candidate
+decision = decide(cands)            # success | partial | no_match
+auditLog.append(decision)
+```

--- a/skills/groundtruth-verification/references/verification-protocol.md
+++ b/skills/groundtruth-verification/references/verification-protocol.md
@@ -69,11 +69,26 @@ After each terminal call, inspect the state and choose exactly one action:
 
 - **follow_up** — a hard constraint is UNKNOWN and resolvable with one more
   question:
-  - hold requested and possible but pending approval (`hold_available: true`,
-    `hold_confirmed: false`);
+  - a hold was requested and the supplier did not refuse it — typically
+    "I can hold it, but I need to check with my manager first";
   - compatibility answered as `uncertain` but the supplier engaged.
   The follow-up call must be shorter than the first (one focused question)
   and must state that it is a follow-up.
+
+  **Key the trigger on refusal, not on a positive flag.** It is tempting to
+  require something like `hold_available: true` before following up. Do not:
+  on a live call that sentence came back as `hold_available: null,
+  hold_confirmed: false`, and only a deterministic mock ever produced the
+  positive flag — so the follow-up silently never fired against real
+  conversations while passing every test. An explicit refusal closes the
+  door; anything short of it is unresolved, and unresolved is what a
+  follow-up is for.
+
+  **Leave a gap before redialling.** The supplier was just asked to go and
+  check with someone. Calling back within seconds is both socially wrong and
+  technically fragile — a live redial ~90s after hang-up failed with a
+  zero-duration provider error. Wait, and make the wait configurable. A mock
+  has no wall clock, so this failure mode cannot surface in a demo.
 - **next_candidate** — the candidate failed a hard requirement, or its
   remaining unknowns are not resolvable by phone (the supplier cannot check,
   "call back tomorrow", no answer), or the per-candidate call budget is spent.

--- a/skills/groundtruth-verification/scripts/build-call-task.mjs
+++ b/skills/groundtruth-verification/scripts/build-call-task.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * build-call-task.mjs — compose a protocol-compliant CALL-E call task and
+ * structured-result schema from a verification goal JSON.
+ *
+ * Usage:
+ *   node build-call-task.mjs goal.json > call-task.json
+ *
+ * Goal JSON shape (only `item` and `constraints` are required):
+ * {
+ *   "item": "XZ-420 compressor",
+ *   "targetEquipment": "ACME HVAC-200",
+ *   "constraints": [
+ *     { "kind": "availability" },
+ *     { "kind": "compatibility" },
+ *     { "kind": "price_max", "params": { "max": 25000 } },
+ *     { "kind": "pickup_today" },
+ *     { "kind": "hold_until", "params": { "until": "5 PM" } }
+ *   ],
+ *   "authorizedActions": ["ask_question", "request_availability", "request_pricing", "request_pickup_window", "request_hold"],
+ *   "candidate": { "name": "Metro Components", "phone": "+91XXXXXXXXXX" },
+ *   "priorContext": "You were going to check with your manager."
+ * }
+ *
+ * Exit codes: 0 ok, 1 invalid goal, 2 authorization violation,
+ * 3 side-effect phrase violation.
+ */
+import { readFileSync } from "node:fs";
+
+const QUESTIONS = {
+  availability: "Do you currently have a genuine {item} in stock right now?",
+  compatibility:
+    "Can you confirm the {item} is compatible with the {equipment}? Please check the model compatibility if you are unsure.",
+  price_max: "What is your best price for the {item}, including taxes?",
+  quantity_min: "How many {item} units do you have in stock right now?",
+  pickup_today: "Could I pick it up today if it suits?",
+  hold_until:
+    "Could you hold one {item} until {until} for pickup? To be clear, we will not purchase during this call — I am only asking you to reserve it.",
+  deadline: "By what time could the {item} be ready for pickup?",
+  distance_max: "Are you located within {max} km of the city centre?",
+  custom: "Could you confirm {claimKey} for the {item}?",
+};
+const FALLBACKS = {
+  availability:
+    "To be clear: is the {item} physically in stock right now, or not?",
+  compatibility:
+    "Could you check the model compatibility for me before we finish? I want to be sure the {item} fits the {equipment}.",
+};
+const ACTION_FOR_KIND = {
+  availability: "request_availability",
+  compatibility: "ask_question",
+  price_max: "request_pricing",
+  quantity_min: "ask_question",
+  pickup_today: "request_pickup_window",
+  hold_until: "request_hold",
+  deadline: "request_delivery_estimate",
+  distance_max: "ask_question",
+  custom: "ask_question",
+};
+const MANDATORY_PROHIBITED = [
+  "purchase",
+  "payment",
+  "contract_acceptance",
+  "legally_binding_commitment",
+  "disclose_credentials",
+  "disclose_payment_info",
+];
+const FOOTER =
+  "You are placing a VERIFICATION call only. Every question above is information-gathering. Your job ends at collecting answers and, when listed, asking to reserve an item for pickup. If the supplier asks for any commitment or authorization beyond that, politely decline and end the call. If the supplier offers a deal, say the buyer will decide separately. Do not go beyond the listed questions even if the supplier invites you to.";
+
+function fail(code, message) {
+  console.error(message);
+  process.exit(code);
+}
+
+const goal = JSON.parse(readFileSync(process.argv[2], "utf8"));
+if (!goal.item || !Array.isArray(goal.constraints) || goal.constraints.length === 0) {
+  fail(1, "goal.json must have `item` and a non-empty `constraints` array");
+}
+if (!goal.candidate?.name || !goal.candidate?.phone) {
+  fail(1, "goal.candidate must include name and phone (E.164)");
+}
+
+// Authorization check (structural, not prompt-level).
+const allowed = new Set(
+  goal.authorizedActions ?? [
+    "ask_question",
+    "request_availability",
+    "request_pricing",
+    "request_pickup_window",
+  ],
+);
+for (const p of MANDATORY_PROHIBITED) {
+  if (allowed.has(p)) {
+    fail(2, `authorization violation: "${p}" can never be an allowed action`);
+  }
+}
+const unauthorized = goal.constraints
+  .map((c) => ACTION_FOR_KIND[c.kind] ?? "ask_question")
+  .filter((a) => !allowed.has(a));
+if (unauthorized.length > 0) {
+  fail(
+    2,
+    `authorization violation: constraints require actions not in the allowed set: ${[...new Set(unauthorized)].join(", ")}`,
+  );
+}
+
+// Compose the task text.
+const fill = (tpl) =>
+  tpl
+    .replaceAll("{item}", goal.item)
+    .replaceAll("{equipment}", goal.targetEquipment ?? "target equipment")
+    .replaceAll("{until}", goal.constraints.find((c) => c.kind === "hold_until")?.params?.until ?? "the deadline")
+    .replaceAll("{max}", goal.constraints.find((c) => c.kind === "distance_max")?.params?.max ?? "")
+    .replaceAll("{claimKey}", goal.constraints.find((c) => c.kind === "custom")?.claimKey ?? "the detail");
+
+const lines = [
+  `Call ${goal.candidate.name} (${goal.candidate.phone}) and verify a ${goal.item}.`,
+  'Start exactly with: "Hi, this is GroundTruth, an automated verification assistant calling on behalf of a buyer. I have a few quick factual questions — no purchase is being made on this call."',
+];
+if (goal.priorContext) lines.push(`Context from our previous call with this supplier: ${goal.priorContext}`);
+for (const c of goal.constraints) {
+  lines.push(`- ${fill(QUESTIONS[c.kind] ?? QUESTIONS.custom)}`);
+  if (FALLBACKS[c.kind]) lines.push(`  If the answer is hedged or uncertain, ask: "${fill(FALLBACKS[c.kind])}"`);
+}
+lines.push(
+  "Ask ONLY the listed questions. If the supplier raises a concern, politely acknowledge it and move to the next question.",
+  "If the supplier offers to transfer you to someone who can answer better, accept the transfer politely.",
+  FOOTER,
+);
+const task = lines.join("\n");
+
+// Side-effect phrase gate (negation-aware, mirrors lib/safety/authorization).
+const stripNegations = (t) =>
+  t.replace(
+    /\b(?:do|does|did|must|should|will|would|can|could|shall)\s+not\s+(?:\w+\s+){0,3}|\bdon'?t\s+(?:\w+\s+){0,3}|\bnever\s+(?:\w+\s+){0,3}|\bno\s+(?:\w+\s+){0,3}/gi,
+    " ",
+  );
+const VIOLATIONS = {
+  purchase: /\bpurchase\b|\bbuy(ing)?\b/i,
+  payment: /\bpay(ment)?\b|\bcard\b|\bCVV\b/i,
+  contract_acceptance: /\bconfirm (the )?order\b|\bplace (the )?order\b/i,
+  legally_binding_commitment: /\b(agree|accept) (to )?(the )?(terms|contract|quote)\b/i,
+  disclose_credentials: /\b(password|OTP|one[- ]time (code|password)|API key|secret)\b/i,
+};
+const scan = stripNegations(task);
+const violations = Object.entries(VIOLATIONS)
+  .filter(([, re]) => re.test(scan))
+  .map(([name]) => name);
+if (violations.length > 0) {
+  fail(3, `side-effect gate violation in composed task: ${violations.join(", ")}`);
+}
+
+// Structured result schema (see references/evidence-model.md).
+const resultSchema = {
+  type: "object",
+  required: ["availability"],
+  properties: {
+    availability: { type: "string", enum: ["confirmed", "not_available", "uncertain"] },
+    quantity: { type: "integer", minimum: 0 },
+    compatibility: { type: "string", enum: ["confirmed", "not_compatible", "uncertain"] },
+    price: { type: "number", minimum: 0 },
+    currency: { type: "string", enum: ["INR", "USD", "EUR"] },
+    pickup_available: { type: "boolean" },
+    pickup_time: { type: "string" },
+    hold_available: { type: "boolean" },
+    hold_confirmed: { type: "boolean" },
+    hold_until: { type: "string" },
+    notes: { type: "string" },
+  },
+};
+
+console.log(
+  JSON.stringify(
+    {
+      task,
+      resultSchema,
+      recipient: { phone: goal.candidate.phone, region: goal.candidate.region ?? "IN", locale: goal.candidate.locale ?? "en-IN" },
+      idempotencyKeySeed: `${goal.candidate.phone}:${goal.constraints.map((c) => c.kind).join("+")}`,
+      metadata: { goalItem: goal.item, constraints: goal.constraints.map((c) => c.kind) },
+    },
+    null,
+    2,
+  ),
+);

--- a/skills/groundtruth-verification/scripts/check-goal-compatibility.mjs
+++ b/skills/groundtruth-verification/scripts/check-goal-compatibility.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * check-goal-compatibility.mjs — can this published CALL-E Goal actually
+ * answer this verification goal?
+ *
+ * A published Goal owns its own result schema. It can be perfectly healthy
+ * and still be structurally unable to settle one of your hard constraints,
+ * because no declared field can carry the answer. Running it anyway spends a
+ * real phone call on a real person and returns a constraint that can only
+ * ever be UNKNOWN.
+ *
+ * Run this BEFORE the first goals.run of a new pairing, and in CI whenever a
+ * Goal's published version changes.
+ *
+ * Usage:
+ *   # Against a live Goal (needs CALLE_API_KEY; read-only, places no call):
+ *   CALLE_API_KEY=... node check-goal-compatibility.mjs goal.json --goal-id goal_abc
+ *
+ *   # Fully offline, against a saved Goal document:
+ *   node check-goal-compatibility.mjs goal.json --spec published-goal.json
+ *
+ * goal.json is the same verification-goal shape build-call-task.mjs takes:
+ * {
+ *   "item": "XZ-420 compressor",
+ *   "targetEquipment": "ACME HVAC-200",
+ *   "constraints": [
+ *     { "kind": "availability" },
+ *     { "kind": "compatibility" },
+ *     { "kind": "price_max", "params": { "max": 25000, "currency": "INR" } },
+ *     { "kind": "hold_until", "params": { "until": "5 PM" } }
+ *   ]
+ * }
+ *
+ * published-goal.json is a CALL-E Goal document (what goals.get returns), or
+ * just its `publishedRunSpec`.
+ *
+ * Exit codes: 0 compatible, 1 invalid input, 2 INCOMPATIBLE, 3 fetch failed.
+ */
+import { readFileSync } from "node:fs";
+
+// Result-field families. A Goal may name things its own way; the first
+// declared field in a family wins.
+const RESULT_FIELDS = {
+  availability: ["availability", "in_stock", "stock_status"],
+  compatibility: ["compatibility", "compatible", "fits"],
+  price_max: ["price", "quoted_price", "total_price"],
+  quantity_min: ["quantity", "units_available", "stock_count"],
+  pickup_today: ["pickup_available", "pickup_today", "can_pickup"],
+  hold_until: ["hold_confirmed", "hold_available", "will_hold"],
+  deadline: ["pickup_time", "ready_time", "lead_time"],
+};
+
+// Settled from candidate data, never from the call — a Goal is never
+// required to answer these.
+const NON_PHONE_KINDS = new Set(["distance_max"]);
+
+function die(code, message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function readJson(path, code) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    die(code, `Cannot read JSON from ${path}: ${error.message}`);
+  }
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+/** Variables GroundTruth can supply, from the goal itself. */
+function availableVariables(goal) {
+  const vars = { item: goal.item, supplier_name: "<per candidate>" };
+  if (goal.targetEquipment) vars.target_equipment = goal.targetEquipment;
+  for (const c of goal.constraints ?? []) {
+    const p = c.params ?? {};
+    if (c.kind === "price_max" && p.max !== undefined) {
+      vars.max_price = p.max;
+      if (p.currency) vars.currency = p.currency;
+    }
+    if (c.kind === "quantity_min" && p.min !== undefined) vars.min_quantity = p.min;
+    if (c.kind === "hold_until" && p.until !== undefined) vars.hold_until = String(p.until);
+    if (c.kind === "deadline" && p.by !== undefined) vars.deadline = String(p.by);
+  }
+  vars.distance_km = 0; // always suppliable from candidate data
+  return vars;
+}
+
+function props(schema) {
+  return schema && typeof schema.properties === "object" ? schema.properties : {};
+}
+
+function check(runSpec, goal) {
+  const resultFields = new Set(Object.keys(props(runSpec.resultSchema)));
+  const required = Array.isArray(runSpec.inputSchema?.required) ? runSpec.inputSchema.required : [];
+  const vars = availableVariables(goal);
+
+  const bindings = [];
+  const unanswerable = [];
+  for (const c of goal.constraints ?? []) {
+    if (NON_PHONE_KINDS.has(c.kind)) continue;
+    const family = RESULT_FIELDS[c.kind] ?? [c.claimKey ?? c.kind];
+    const match = family.find((f) => resultFields.has(f));
+    if (match) bindings.push({ kind: c.kind, resultField: match });
+    else unanswerable.push({ kind: c.kind, lookedFor: family });
+  }
+  const missingVariables = required.filter((v) => vars[v] === undefined);
+
+  return {
+    compatible: unanswerable.length === 0 && missingVariables.length === 0,
+    bindings,
+    unanswerable,
+    missingVariables,
+    declaredResultFields: [...resultFields],
+  };
+}
+
+async function fetchGoal(goalId) {
+  const apiKey = process.env.CALLE_API_KEY;
+  if (!apiKey) die(1, "CALLE_API_KEY is required to fetch a live Goal (or pass --spec).");
+  let CalleClient;
+  try {
+    ({ CalleClient } = await import("@call-e/calle"));
+  } catch {
+    die(1, "@call-e/calle is not installed. Install it, or pass --spec with a saved Goal document.");
+  }
+  const client = new CalleClient({
+    apiKey,
+    baseUrl: process.env.CALLE_BASE_URL ?? "https://api.heycall-e.com",
+  });
+  try {
+    // Read-only. This places no call.
+    return await client.goals.get(goalId);
+  } catch (error) {
+    die(3, `Could not fetch Goal ${goalId}: ${error.message}`);
+  }
+}
+
+const goalPath = process.argv[2];
+if (!goalPath || goalPath.startsWith("--")) {
+  die(1, "Usage: check-goal-compatibility.mjs goal.json (--goal-id <id> | --spec <published-goal.json>)");
+}
+
+const goal = readJson(goalPath, 1);
+if (!goal.item || !Array.isArray(goal.constraints) || goal.constraints.length === 0) {
+  die(1, "goal.json needs `item` and a non-empty `constraints` array.");
+}
+
+const specPath = arg("--spec");
+const goalId = arg("--goal-id");
+
+let goalDoc;
+if (specPath) goalDoc = readJson(specPath, 1);
+else if (goalId) goalDoc = await fetchGoal(goalId);
+else die(1, "Pass either --goal-id <id> (live) or --spec <published-goal.json> (offline).");
+
+// Accept either a full Goal document or a bare publishedRunSpec.
+const runSpec = goalDoc.publishedRunSpec ?? goalDoc;
+if (!runSpec.resultSchema) {
+  die(1, "The Goal document has no publishedRunSpec.resultSchema.");
+}
+
+const report = check(runSpec, goal);
+const name = goalDoc.title ?? goalDoc.id ?? goalId ?? "goal";
+const version = runSpec.version ?? "?";
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      goal: name,
+      runSpecVersion: version,
+      compatible: report.compatible,
+      bindings: report.bindings,
+      unanswerable: report.unanswerable,
+      missingVariables: report.missingVariables,
+      declaredResultFields: report.declaredResultFields,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+if (!report.compatible) {
+  const reasons = [];
+  if (report.unanswerable.length > 0) {
+    reasons.push(
+      `no declared result field for: ${report.unanswerable.map((u) => u.kind).join(", ")}`,
+    );
+  }
+  if (report.missingVariables.length > 0) {
+    reasons.push(`required input variable(s) unavailable: ${report.missingVariables.join(", ")}`);
+  }
+  die(
+    2,
+    `INCOMPATIBLE — "${name}" v${version} cannot verify this goal (${reasons.join("; ")}). Do not run it: the constraint would stay UNKNOWN after a real call.`,
+  );
+}
+
+process.stderr.write(
+  `COMPATIBLE — "${name}" v${version} can answer all ${report.bindings.length} phone-derived constraint(s).\n`,
+);


### PR DESCRIPTION
## Summary

`groundtruth-verification` turns an operational goal into hard constraints, verifies them across several suppliers with CALL-E, and returns claims that each carry the call id, the supplier's own words, and a confidence score. A hedged answer stays UNKNOWN; an honest "no fully verified match" is a first-class result.

Three things it adds that the existing verification skills do not cover:

- **A solver across candidates, not a single call.** Per-candidate call budgets, priority ordering, and early stopping once one candidate satisfies every hard requirement — so the remaining suppliers are never dialled.
- **Follow-up calls generated from state, not from a script.** A constraint left UNKNOWN by a hedged answer earns exactly one more question ("could you check for me?"); after that the run moves on and says so.
- **A pre-dial contract check for published Goals.** A Goal can be perfectly healthy and still be structurally unable to answer a hard constraint, because its version-pinned `resultSchema` declares no field for it. Running it anyway spends a real call on a real person and returns a constraint that can only ever be UNKNOWN. `scripts/check-goal-compatibility.mjs` binds each constraint to a declared result field and exits `2` when one has nowhere to land. No other skill in this repository currently touches the Goals API.

Both scripts are dependency-free and place no call. `check-goal-compatibility.mjs` works fully offline against a saved Goal document, or read-only against a live Goal via `goals.get`.

## Type

- [x] New skill
- [x] README awesome-list entry

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Notes on side effects and cancellation

`SKILL.md` carries a **Side effects and cancellation** section with a table of what the skill causes in the world and whether each effect is reversible. The short version: it places outbound calls, at most two per candidate (`maxCallsPerCandidate`, default 2) and eight per run (`maxCalls`, default 8); it may request a temporary hold when `request_hold` is explicitly authorised; it never purchases, pays, accepts contracts, or discloses credentials, and a prohibited-phrase gate blocks such language from reaching a call task.

Stopping between calls is safe and immediate — the loop runs on discrete ticks and all state is persisted. A call already in flight cannot be recalled, and the documented response to an aborted run is to let it finish and ignore the result rather than redial. Idempotency keys mean a retried create never produces a second call.

The skill also states the rule that sample personas must never be dialled: fictional numbers are only safe while nothing can dial them, so gate it structurally rather than by care.

## Reference implementation

The skill is extracted from a working app: <https://github.com/TusharTechs/groundtruth> (live demo: <https://groundtruth-calle.vercel.app>). One real CALL-E call has been placed through it end to end; that run returned `no_match` with three constraints left UNKNOWN and none invented, which is the behaviour this skill is trying to make portable.
