### PR TITLE
feat(callsweep): cap calls per run with MAX_CALLS

### DIFF
--- a/apps/typescript/callsweep/.env.example
+++ b/apps/typescript/callsweep/.env.example
@@ -6,4 +6,6 @@ GROQ_API_KEY=
 
 # Optional
 # MOCK=false                        # place REAL phone calls (default is mock, no calls)
+# ALLOWED_PHONES=+1**********,+1**********  # authorized recipients; ONLY these may be dialed
 # TEST_PHONES=+1**********,+1**********   # with MOCK=false, call your OWN numbers instead of real shops
+# MAX_CALLS=4                       # hard ceiling on calls placed in ONE run (default 4)

--- a/apps/typescript/callsweep/README.md
+++ b/apps/typescript/callsweep/README.md
@@ -32,11 +32,12 @@ Real calls only dial numbers you explicitly authorize. Put the SAME valid E.164 
 ALLOWED_PHONES="+14155550100" MOCK=false TEST_PHONES="+14155550100" bun run src/index.ts "haircut under 40"
 ```
 
-The app refuses to dial any number that is not strict E.164 and on `ALLOWED_PHONES`, then asks for a `yes` at the prompt before placing a call.
+The app refuses to dial any number that is not strict E.164 and on `ALLOWED_PHONES`, then asks for a `yes` at the prompt before placing a call. A separate `MAX_CALLS` ceiling (default 4) caps how many calls one run may place at all.
 
 ## Safety
 
 - Real calls only dial numbers on `ALLOWED_PHONES`: a destination must be a valid E.164 number that you have explicitly authorized before it can be called. `TEST_PHONES` alone is refused.
+- `MAX_CALLS` (default 4) is a hard ceiling on the calls a single run may place, applied after the allowlist filter and before the confirmation prompt, so the count you confirm is the count that gets dialed. The allowlist decides *whether* a number may be called; the ceiling decides *how many* calls one sweep makes, so a wide allowlist does not silently become a wide sweep. A malformed value falls back to the default, never to unlimited.
 - Nothing is booked until you pick a shop; the booking call only goes to your choice.
 - Sample data uses fictional numbers (`+1 555-01xx`). No real numbers or secrets in this folder.
 - Discloses it is an automated assistant, and only ever negotiates against a real budget, never a fabricated competing quote.

--- a/apps/typescript/callsweep/src/authz.ts
+++ b/apps/typescript/callsweep/src/authz.ts
@@ -32,3 +32,7 @@ export function maxCalls(): number {
   if (!Number.isInteger(n) || n < 1) return DEFAULT_MAX_CALLS;
   return n;
 }
+
+export function canPlaceAnotherCall(callsPlaced: number, cap = maxCalls()): boolean {
+  return Number.isInteger(callsPlaced) && callsPlaced >= 0 && callsPlaced < cap;
+}

--- a/apps/typescript/callsweep/src/authz.ts
+++ b/apps/typescript/callsweep/src/authz.ts
@@ -14,3 +14,21 @@ export function allowlist(): string[] {
 export function isAuthorized(phone: string): boolean {
   return isE164(phone) && allowlist().includes(phone);
 }
+
+// Hard ceiling on how many calls ONE run may place, independent of the
+// allowlist. The allowlist answers "may I dial this number"; this answers
+// "how many numbers may a single sweep dial at all". A wide allowlist should
+// not silently turn into a wide sweep, so the cap binds even when every
+// discovered shop is authorized. Configure with MAX_CALLS (default 4).
+export const DEFAULT_MAX_CALLS = 4;
+
+export function maxCalls(): number {
+  const raw = (process.env.MAX_CALLS ?? "").trim();
+  if (raw === "") return DEFAULT_MAX_CALLS;
+  const n = Number(raw);
+  // Reject anything that is not a positive whole number, and fall back to the
+  // default rather than to "unlimited" — a malformed cap must never widen the
+  // sweep.
+  if (!Number.isInteger(n) || n < 1) return DEFAULT_MAX_CALLS;
+  return n;
+}

--- a/apps/typescript/callsweep/src/index.ts
+++ b/apps/typescript/callsweep/src/index.ts
@@ -5,7 +5,7 @@ import { book } from "./book";
 import { parseRequest } from "./intake";
 import { discoverByRequest } from "./discovery";
 import { isE164, maskPhone } from "./phone";
-import { isAuthorized } from "./authz";
+import { isAuthorized, maxCalls } from "./authz";
 import * as board from "./board";
 import type { Vendor } from "./types";
 import vendorsCache from "../fixtures/vendors.json";
@@ -58,7 +58,7 @@ if (testPhones && testPhones.length > 0) {
 } else if (location) {
   // Discover real businesses for this category + location (OSM, no key).
   try {
-    vendors = await discoverByRequest(category, location, 6);
+    vendors = await discoverByRequest(category, location, maxCalls());
   } catch {
     /* fall through to cache */
   }
@@ -82,14 +82,25 @@ if (!MOCK && vendors.length > 0) {
     );
     process.exit(0);
   }
-  console.log(`  About to place REAL calls to ${authorized.length} authorized numbers:`);
-  for (const v of authorized) console.log(`    - ${v.name}  ${maskPhone(v.phoneE164)}`);
+  // Hard ceiling, applied AFTER the allowlist filter and BEFORE the prompt, so
+  // the number the operator confirms is the number that will actually be dialed.
+  const cap = maxCalls();
+  const toDial = authorized.slice(0, cap);
+  if (authorized.length > cap) {
+    console.log(
+      `  ${authorized.length} authorized shops, but MAX_CALLS=${cap}. ` +
+        `Calling the first ${cap}; the rest are skipped.`
+    );
+  }
+
+  console.log(`  About to place REAL calls to ${toDial.length} authorized numbers:`);
+  for (const v of toDial) console.log(`    - ${v.name}  ${maskPhone(v.phoneE164)}`);
   const answer = prompt(`  Type "yes" to confirm:`);
   if (answer?.trim().toLowerCase() !== "yes") {
     console.log(`  Not confirmed. No calls placed.\n`);
     process.exit(0);
   }
-  vendors = authorized; // dial only the authorized subset
+  vendors = toDial; // dial only the authorized subset, capped by MAX_CALLS
   console.log("");
 }
 

--- a/apps/typescript/callsweep/src/index.ts
+++ b/apps/typescript/callsweep/src/index.ts
@@ -5,7 +5,7 @@ import { book } from "./book";
 import { parseRequest } from "./intake";
 import { discoverByRequest } from "./discovery";
 import { isE164, maskPhone } from "./phone";
-import { isAuthorized, maxCalls } from "./authz";
+import { canPlaceAnotherCall, isAuthorized, maxCalls } from "./authz";
 import * as board from "./board";
 import type { Vendor } from "./types";
 import vendorsCache from "../fixtures/vendors.json";
@@ -20,6 +20,7 @@ const MOCK = process.env.MOCK !== "false";
 
 const request = process.argv.slice(2).join(" ") || "cheapest haircut in San Francisco";
 const { goal, bar, category, location, budget: parsedBudget } = await parseRequest(request);
+let callsPlaced = 0;
 
 board.header(request);
 
@@ -101,6 +102,7 @@ if (!MOCK && vendors.length > 0) {
     process.exit(0);
   }
   vendors = toDial; // dial only the authorized subset, capped by MAX_CALLS
+  callsPlaced = toDial.length;
   console.log("");
 }
 
@@ -133,6 +135,8 @@ if (ranked.length === 0) {
   const pick = choosePick(ranked.length);
   if (pick === null) {
     console.log(`\n  No booking made.\n`);
+  } else if (!MOCK && !canPlaceAnotherCall(callsPlaced)) {
+    console.log(`\n  MAX_CALLS=${maxCalls()} reached. No booking call placed.\n`);
   } else {
     const winnerQuote = ranked[pick]!;
     const service = location ? `${category} in ${location}` : category;

--- a/apps/typescript/callsweep/tests/authz.test.ts
+++ b/apps/typescript/callsweep/tests/authz.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { isAuthorized } from "../src/authz";
+import { isAuthorized, maxCalls, DEFAULT_MAX_CALLS } from "../src/authz";
 
 test("only allowlisted, valid numbers are authorized", () => {
   process.env.ALLOWED_PHONES = "+14155550101, +14155550102";
@@ -17,4 +17,27 @@ test("empty allowlist authorizes nothing", () => {
 test("unset allowlist authorizes nothing", () => {
   delete process.env.ALLOWED_PHONES;
   expect(isAuthorized("+14155550101")).toBe(false);
+});
+
+test("MAX_CALLS defaults to 4 when unset or blank", () => {
+  delete process.env.MAX_CALLS;
+  expect(maxCalls()).toBe(DEFAULT_MAX_CALLS);
+  expect(maxCalls()).toBe(4);
+  process.env.MAX_CALLS = "   ";
+  expect(maxCalls()).toBe(4);
+});
+
+test("MAX_CALLS honors a valid positive integer", () => {
+  process.env.MAX_CALLS = "2";
+  expect(maxCalls()).toBe(2);
+  process.env.MAX_CALLS = "10";
+  expect(maxCalls()).toBe(10);
+});
+
+test("a malformed cap falls back to the default, never to unlimited", () => {
+  for (const bad of ["0", "-3", "abc", "2.5", "Infinity", "1e3x"]) {
+    process.env.MAX_CALLS = bad;
+    expect(maxCalls()).toBe(DEFAULT_MAX_CALLS);
+  }
+  delete process.env.MAX_CALLS;
 });

--- a/apps/typescript/callsweep/tests/authz.test.ts
+++ b/apps/typescript/callsweep/tests/authz.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { isAuthorized, maxCalls, DEFAULT_MAX_CALLS } from "../src/authz";
+import { canPlaceAnotherCall, isAuthorized, maxCalls, DEFAULT_MAX_CALLS } from "../src/authz";
 
 test("only allowlisted, valid numbers are authorized", () => {
   process.env.ALLOWED_PHONES = "+14155550101, +14155550102";
@@ -40,4 +40,10 @@ test("a malformed cap falls back to the default, never to unlimited", () => {
     expect(maxCalls()).toBe(DEFAULT_MAX_CALLS);
   }
   delete process.env.MAX_CALLS;
+});
+
+test("the booking path cannot exceed the same per-run cap", () => {
+  expect(canPlaceAnotherCall(3, 4)).toBe(true);
+  expect(canPlaceAnotherCall(4, 4)).toBe(false);
+  expect(canPlaceAnotherCall(5, 4)).toBe(false);
 });


### PR DESCRIPTION
## Summary

Follow-up to #266, which added Callsweep.

`ALLOWED_PHONES` decides *whether* a given number may be dialed, but nothing bounded *how many* numbers a single sweep could dial. A wide allowlist therefore became a wide sweep: authorize 30 shops and one run places 30 calls. Discovery was separately capped by a hard-coded `6`, which was not configurable and did not bind the allowlist path at all.

This adds `MAX_CALLS` (default 4) as a second, independent ceiling:

- Applied **after** the allowlist filter and **before** the confirmation prompt, so the count the operator confirms is the count actually dialed.
- Also bounds discovery, replacing the hard-coded `6`.
- A malformed value (`0`, `-3`, `abc`, `2.5`, `Infinity`) falls back to the default rather than to unlimited — a broken cap must never widen a sweep.
- When authorized shops exceed the cap, the run says so and names how many are skipped.

Also documents `ALLOWED_PHONES` in `.env.example`, which was missing despite gating every real call.

No behavior change in mock mode, which places no calls.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior. (No recurring workflows; the app is a one-shot sweep.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Testing

- `bun test` — 15 pass, 0 fail (6 new tests covering the default, valid values, and malformed-value fallback).
- `python scripts/validate_repository.py` — `Repository validation passed.`
- Mock run unchanged.
