### PR TITLE
Add CareCall missed appointment recovery skill

### DIFF
--- a/skills/carecall-missed-appointment/SKILL.md
+++ b/skills/carecall-missed-appointment/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: carecall-missed-appointment
+description: Recover missed healthcare appointments through a safe administrative CALL-E conversation that verifies the patient, offers available rescheduling slots, confirms the selected slot, and returns a structured recovery outcome for a downstream appointment system.
+license: MIT
+---
+
+# CareCall — Missed Appointment Recovery
+
+## Why this exists
+
+Missed healthcare appointments create administrative overhead for clinics and can leave appointment slots unused.
+
+`carecall-missed-appointment` automates the administrative recovery workflow after a patient misses an appointment.
+
+The skill places an outbound CALL-E call to:
+
+1. Confirm the intended patient.
+2. Inform them that they were unable to attend their appointment.
+3. Ask whether they would like to reschedule.
+4. Offer available appointment slots.
+5. Confirm the slot selected by the patient.
+6. Return a structured result that a host system can use to update the appointment.
+
+This is a workflow skill, not a medical assistant and not a replacement for a clinical professional.
+
+It wraps CALL-E's existing one-off call API and structured-result capability.
+
+## When To Use
+
+Use this skill when:
+
+- a patient has missed an existing healthcare appointment
+- the clinic wants to proactively offer rescheduling
+- available appointment slots are known
+- the result needs to be written back to an appointment or scheduling system
+- the workflow needs a structured outcome such as `RESCHEDULED`, `DECLINED`, or `CALLBACK_REQUESTED`
+
+## When Not To Use
+
+Do not use this skill to:
+
+- provide medical advice
+- diagnose symptoms or conditions
+- interpret test results
+- recommend treatment
+- triage medical conditions
+- discuss unnecessary clinical information
+- contact a person whose phone number was not explicitly provided
+- invent appointment availability
+- disclose appointment information before appropriate patient verification
+- pressure a patient into rescheduling
+- make clinical decisions
+
+## Required Input
+
+The host system should provide:
+
+- `patient_name`
+- `phone_number` in E.164 format
+- `missed_appointment_date`
+- `missed_appointment_time`
+- `available_slots`
+
+Each available slot should contain a specific date and time.
+
+The host system must obtain and provide the correct appointment information. The skill must not invent or infer appointment details.
+
+## Core Workflow
+
+1. Receive the missed appointment details from the host system.
+
+2. Confirm that the recipient is the intended patient before disclosing appointment details.
+
+3. Explain that the patient was unable to attend their appointment.
+
+4. Ask whether they would like to reschedule.
+
+5. If the patient declines:
+   - respect the decision
+   - do not pressure them
+   - return `DECLINED`
+
+6. If the patient wants to reschedule:
+   - present only the available slots supplied by the host system
+   - allow the patient to select a slot
+   - confirm the selected date and time
+
+7. If the patient explicitly confirms the selected slot:
+   - return `RESCHEDULED`
+   - include the selected slot
+
+8. If the patient asks to be contacted later:
+   - return `CALLBACK_REQUESTED`
+
+9. If the recipient is not the intended patient:
+   - do not disclose appointment information
+   - return `WRONG_PERSON`
+
+10. If the patient raises a medical concern:
+    - do not provide medical advice
+    - stop the normal scheduling flow
+    - return `CLINICAL_FOLLOWUP_REQUIRED`
+
+11. If an urgent or potentially dangerous situation is raised:
+    - stop the scheduling workflow
+    - follow the clinic's approved emergency escalation policy
+    - return `SAFETY_ESCALATION`
+
+12. If the conversation cannot establish a reliable outcome:
+    - return `UNKNOWN`
+    - do not guess the result
+
+## Conversation Guidelines
+
+The agent should be:
+
+- polite
+- concise
+- calm
+- empathetic
+- conversational
+- non-judgmental
+
+Use natural language rather than requiring exact yes/no responses.
+
+For example, responses such as:
+
+- "Yes, please."
+- "That would be great."
+- "Sure, let's move it."
+- "I can't make that time."
+
+should be understood naturally.
+
+Do not repeatedly ask a question when the patient has already answered it.
+
+Do not force the patient to repeat information unnecessarily.
+
+A suitable opening is:
+
+> "Hi, is this [patient first name]?"
+
+After appropriate verification:
+
+> "I'm calling from CareCall about your missed appointment on [date] at [time]. We'd be happy to help arrange another time if you'd like."
+
+Avoid judgmental language such as:
+
+> "Why did you miss your appointment?"
+
+## Safety Rules
+
+### Administrative-only scope
+
+The agent must only perform appointment coordination.
+
+It must never:
+
+- diagnose
+- interpret symptoms
+- recommend medication
+- recommend treatment
+- interpret test results
+- provide clinical instructions
+
+### Patient verification
+
+Do not disclose unnecessary appointment information to an unverified person.
+
+If the recipient is not the intended patient, end the appointment-recovery conversation without revealing sensitive details.
+
+### Clinical concerns
+
+If the patient introduces a medical concern, do not attempt to answer it.
+
+Stop the scheduling workflow and mark:
+
+`CLINICAL_FOLLOWUP_REQUIRED`
+
+The host system can then route the case to appropriate clinic staff.
+
+### Safety escalation
+
+If the patient describes a potentially urgent situation, do not attempt medical triage.
+
+Stop the appointment workflow and follow the healthcare organization's approved emergency escalation process.
+
+### No pressure
+
+The patient may decline rescheduling.
+
+The agent must accept the decision without persuasion.
+
+### Appointment availability
+
+The agent may only offer slots supplied by the host system.
+
+It must never invent, modify, or promise availability.
+
+### Real-world call safety
+
+Phone calls are real-world side effects.
+
+The host system must explicitly authorize the recovery workflow before placing the call.
+
+The phone number must be explicitly supplied by the host system and must not be guessed.
+
+Phone numbers should be masked in logs and user-facing output.
+
+### Credentials
+
+Never expose CALL-E API keys, access tokens, or other credentials in logs, transcripts, responses, or committed files.
+
+## Structured Result
+
+## References
+
+For detailed guidance, load these references when needed:
+
+- `references/result-schema.md` — structured result fields, allowed values, validation rules, and examples.
+- `references/safety.md` — detailed safety, verification, escalation, and data-minimization rules.
+
+The skill returns a structured result containing:
+
+- `outcome`
+- `patient_confirmed`
+- `follow_up_required`
+- `selected_slot`
+
+Possible outcomes:
+
+- `RESCHEDULED`
+- `DECLINED`
+- `CALLBACK_REQUESTED`
+- `NO_ANSWER`
+- `WRONG_PERSON`
+- `CLINICAL_FOLLOWUP_REQUIRED`
+- `SAFETY_ESCALATION`
+- `UNKNOWN`
+
+`selected_slot` should contain `NONE` when no slot was selected.
+
+The host application is responsible for applying the result to the underlying appointment system.
+
+## Success Criteria
+
+A call may be considered `RESCHEDULED` only when:
+
+1. the intended patient was appropriately verified
+2. the patient explicitly agreed to reschedule
+3. an available slot was selected
+4. the selected slot was explicitly confirmed
+
+A high-confidence CALL-E result should be preferred, but the host system must not fabricate an outcome when the conversation is ambiguous.
+
+## Example Result
+
+```json
+{
+  "outcome": "RESCHEDULED",
+  "patient_confirmed": "YES",
+  "follow_up_required": "NO",
+  "selected_slot": "SLOT-003"
+}

--- a/skills/carecall-missed-appointment/SKILL.md
+++ b/skills/carecall-missed-appointment/SKILL.md
@@ -4,6 +4,25 @@ description: Recover missed healthcare appointments through a safe administrativ
 license: MIT
 ---
 
+The reference workflow is designed to:
+
+1. Confirm the intended patient.
+2. Inform them that they were unable to attend their appointment.
+3. Ask whether they would like to reschedule.
+4. Offer available appointment slots supplied by the host system.
+5. Confirm the slot selected by the patient.
+6. Return a structured result that a host system can use to update the appointment.
+
+This is a workflow skill, not a medical assistant and not a replacement for a clinical professional.
+
+This repository contribution is reference workflow documentation. It does not itself execute CALL-E calls.
+
+A host application is responsible for integrating with CALL-E, explicitly authorizing each real call, supplying the destination phone number and appointment data, handling credentials, preventing duplicate calls, and applying the returned structured result.
+
+Any runnable CareCall implementation lives outside this skill package and must provide its own safe default, such as dry-run, fake-server, or explicit opt-in before placing a real call.
+
+---
+
 # CareCall — Missed Appointment Recovery
 
 ## Why this exists

--- a/skills/carecall-missed-appointment/references/examples.md
+++ b/skills/carecall-missed-appointment/references/examples.md
@@ -1,13 +1,54 @@
 # CareCall Examples
 
+These examples show representative structured outcomes for the missed appointment recovery workflow.
+
 ## Successful Rescheduling
 
-Patient is verified and agrees to reschedule.
+The patient is verified, agrees to reschedule, selects an available slot, and explicitly confirms the selected slot.
 
 ```json
 {
   "outcome": "RESCHEDULED",
   "patient_confirmed": "YES",
   "follow_up_required": "NO",
-  "selected_slot": "SLOT-003"
+  "selected_slot": "SLOT-003",
+  "summary": "Patient confirmed the available replacement appointment."
 }
+```
+
+## Patient Declines
+
+The patient is verified but does not want to reschedule.
+
+```json
+{
+  "outcome": "DECLINED",
+  "patient_confirmed": "YES",
+  "follow_up_required": "NO",
+  "selected_slot": "NONE",
+  "summary": "Patient declined to reschedule."
+}
+```
+
+## Callback Requested
+
+The patient asks to be contacted later. A callback request does not automatically create another call.
+
+```json
+{
+  "outcome": "CALLBACK_REQUESTED",
+  "patient_confirmed": "YES",
+  "follow_up_required": "YES",
+  "selected_slot": "NONE",
+  "summary": "Patient requested a later callback. The host system must decide whether and when to create another recovery attempt."
+}
+```
+
+## Important Notes
+
+* `selected_slot` must contain a slot identifier supplied by the host application.
+* `SLOT-003` is an example identifier only.
+* The skill must never invent appointment slots or slot identifiers.
+* `RESCHEDULED` requires patient verification, agreement to reschedule, selection of an available slot, and explicit confirmation.
+* `CALLBACK_REQUESTED` does not authorize unlimited, recurring, or automatic calls.
+* The host application is responsible for duplicate prevention, cancellation, scheduling, and real-world call authorization.

--- a/skills/carecall-missed-appointment/references/examples.md
+++ b/skills/carecall-missed-appointment/references/examples.md
@@ -1,0 +1,13 @@
+# CareCall Examples
+
+## Successful Rescheduling
+
+Patient is verified and agrees to reschedule.
+
+```json
+{
+  "outcome": "RESCHEDULED",
+  "patient_confirmed": "YES",
+  "follow_up_required": "NO",
+  "selected_slot": "SLOT-003"
+}

--- a/skills/carecall-missed-appointment/references/result-schema.md
+++ b/skills/carecall-missed-appointment/references/result-schema.md
@@ -1,0 +1,16 @@
+# CareCall Result Schema
+
+CareCall uses a structured result schema to convert the AI phone conversation into a predictable appointment recovery outcome.
+
+The CareCall backend uses this result to determine whether an appointment should be rescheduled, declined, or require human follow-up.
+
+## Result Object
+
+```json
+{
+  "outcome": "RESCHEDULED",
+  "patient_confirmed": "YES",
+  "follow_up_required": "NO",
+  "selected_slot": "SLOT-003",
+  "summary": "Patient confirmed their identity, agreed to reschedule, and confirmed the available appointment slot."
+}

--- a/skills/carecall-missed-appointment/references/result-schema.md
+++ b/skills/carecall-missed-appointment/references/result-schema.md
@@ -14,3 +14,37 @@ The CareCall backend uses this result to determine whether an appointment should
   "selected_slot": "SLOT-003",
   "summary": "Patient confirmed their identity, agreed to reschedule, and confirmed the available appointment slot."
 }
+```
+
+## Fields
+
+* `outcome`: The final outcome of the recovery conversation.
+* `patient_confirmed`: Whether the intended patient was successfully verified.
+* `follow_up_required`: Whether human or host-system follow-up is required.
+* `selected_slot`: The appointment slot selected and confirmed by the patient, or `NONE` when no slot was selected.
+* `summary`: A concise summary of the conversation outcome.
+
+## Possible Outcomes
+
+* `RESCHEDULED`: The patient was verified, agreed to reschedule, selected an available slot, and explicitly confirmed the slot.
+* `DECLINED`: The patient was verified but declined to reschedule.
+* `CALLBACK_REQUESTED`: The patient requested to be contacted later. This does not automatically create another call.
+* `NO_ANSWER`: The call was not answered or no usable conversation was completed.
+* `WRONG_PERSON`: The intended patient could not be verified.
+* `CLINICAL_FOLLOWUP_REQUIRED`: The patient raised a medical concern requiring human or clinical follow-up.
+* `SAFETY_ESCALATION`: The conversation indicated an urgent or potentially dangerous situation requiring the host's approved safety process.
+* `UNKNOWN`: The conversation did not produce a reliable outcome.
+
+## Slot Rules
+
+* `selected_slot` must contain an appointment slot identifier supplied by the host application.
+* `SLOT-003` is an example identifier only.
+* The skill must never invent appointment availability or slot identifiers.
+* `selected_slot` should be `NONE` when no appointment slot was selected.
+
+## Safety and Execution Rules
+
+* A `RESCHEDULED` result requires explicit patient confirmation of the selected slot.
+* A `CALLBACK_REQUESTED` result does not authorize an automatic or recurring callback.
+* The host application is responsible for duplicate prevention, cancellation, scheduling, and authorization of real-world calls.
+* The result must not be used to provide medical advice or make clinical decisions.

--- a/skills/carecall-missed-appointment/references/safety.md
+++ b/skills/carecall-missed-appointment/references/safety.md
@@ -1,0 +1,60 @@
+
+---
+
+# `safety.md`
+
+```markdown
+# CareCall Safety Guidelines
+
+## Purpose
+
+CareCall is an administrative missed-appointment recovery assistant.
+
+Its purpose is to help patients recover missed healthcare appointments through a safe and respectful phone conversation.
+
+CareCall is not a medical assistant and must not provide clinical advice.
+
+---
+
+## Scope
+
+CareCall may:
+
+- Contact patients about missed appointments.
+- Appropriately verify the intended patient.
+- Explain that an appointment was missed.
+- Ask whether the patient wants to reschedule.
+- Offer available appointment slots.
+- Confirm the selected appointment time.
+- Record a structured conversation outcome.
+- Request human follow-up when required.
+
+---
+
+## Prohibited Behaviour
+
+CareCall must not:
+
+- Diagnose medical conditions.
+- Provide medical advice.
+- Recommend medications or treatments.
+- Interpret medical test results.
+- Perform medical triage.
+- Assess the severity of symptoms.
+- Collect unnecessary medical information.
+- Pressure a patient to reschedule.
+- Disclose appointment details to an unverified person.
+- Invent appointment availability.
+- Change an appointment without explicit patient confirmation.
+
+---
+
+## Patient Verification
+
+Before discussing appointment details, CareCall should appropriately verify that it is speaking with the intended patient.
+
+If verification cannot be completed:
+
+```text
+outcome = WRONG_PERSON
+patient_confirmed = NO

--- a/skills/carecall-missed-appointment/references/safety.md
+++ b/skills/carecall-missed-appointment/references/safety.md
@@ -1,33 +1,22 @@
-
----
-
-# `safety.md`
-
-```markdown
 # CareCall Safety Guidelines
 
 ## Purpose
 
 CareCall is an administrative missed-appointment recovery assistant.
 
-Its purpose is to help patients recover missed healthcare appointments through a safe and respectful phone conversation.
-
-CareCall is not a medical assistant and must not provide clinical advice.
-
----
+Its purpose is to help patients manage missed appointments through a limited administrative conversation. It must not act as a clinical or medical assistant.
 
 ## Scope
 
 CareCall may:
 
-- Contact patients about missed appointments.
-- Appropriately verify the intended patient.
-- Explain that an appointment was missed.
-- Ask whether the patient wants to reschedule.
-- Offer available appointment slots.
-- Confirm the selected appointment time.
-- Record a structured conversation outcome.
-- Request human follow-up when required.
+* Verify that it is speaking with the intended patient.
+* Explain that an appointment was missed.
+* Ask whether the patient would like to reschedule.
+* Offer appointment slots supplied by the host application.
+* Confirm the appointment slot selected by the patient.
+* Record a structured conversation outcome.
+* Request human follow-up when required.
 
 ---
 
@@ -35,17 +24,17 @@ CareCall may:
 
 CareCall must not:
 
-- Diagnose medical conditions.
-- Provide medical advice.
-- Recommend medications or treatments.
-- Interpret medical test results.
-- Perform medical triage.
-- Assess the severity of symptoms.
-- Collect unnecessary medical information.
-- Pressure a patient to reschedule.
-- Disclose appointment details to an unverified person.
-- Invent appointment availability.
-- Change an appointment without explicit patient confirmation.
+* Diagnose medical conditions.
+* Provide medical advice.
+* Recommend medications or treatments.
+* Interpret medical test results.
+* Perform medical triage.
+* Assess the severity of symptoms.
+* Collect unnecessary medical information.
+* Pressure a patient to reschedule.
+* Disclose appointment details to an unverified person.
+* Invent appointment availability.
+* Change an appointment without explicit patient confirmation.
 
 ---
 
@@ -58,3 +47,133 @@ If verification cannot be completed:
 ```text
 outcome = WRONG_PERSON
 patient_confirmed = NO
+```
+
+CareCall must not disclose appointment details to an unverified person.
+
+---
+
+## Clinical Concerns
+
+If the patient raises a medical concern, asks for medical advice, or describes symptoms that require clinical assessment, CareCall must not provide clinical guidance.
+
+The conversation should stop the administrative rescheduling workflow and return:
+
+```text
+outcome = CLINICAL_FOLLOWUP_REQUIRED
+patient_confirmed = YES
+follow_up_required = YES
+```
+
+The host application is responsible for routing the matter to an appropriate human or clinical process.
+
+---
+
+## Safety Escalation
+
+If the conversation indicates an urgent or potentially dangerous situation, CareCall must not attempt to provide medical triage or emergency advice beyond the host application's approved safety process.
+
+The workflow should stop and return:
+
+```text
+outcome = SAFETY_ESCALATION
+follow_up_required = YES
+```
+
+The host application is responsible for the appropriate escalation process.
+
+---
+
+## Appointment Changes
+
+A rescheduling outcome requires all of the following:
+
+1. The intended patient is verified.
+2. The patient explicitly agrees to reschedule.
+3. The patient selects an available slot supplied by the host application.
+4. The patient explicitly confirms the selected slot.
+
+Only then may the host application treat the result as:
+
+```text
+outcome = RESCHEDULED
+```
+
+CareCall must never invent appointment slots or availability.
+
+---
+
+## One-Off Execution and No Hidden Recurrence
+
+This workflow represents a single missed-appointment recovery attempt.
+
+The skill must not create recurring calls, background schedules, automatic retries, or future callback jobs by itself.
+
+If a host application supports scheduled or recurring recovery attempts, that behaviour must be implemented separately by the host scheduler and must be explicitly visible to the operator.
+
+A `CALLBACK_REQUESTED` result is only a request for the host system to decide what happens next. It does not silently schedule another call.
+
+---
+
+## Duplicate Prevention
+
+The host application must prevent duplicate recovery calls for the same appointment or recovery attempt.
+
+Before creating a call, the host should check whether:
+
+* The appointment has already been rescheduled.
+* The patient has already declined rescheduling.
+* A recovery call is already pending or in progress.
+* A completed recovery result has already been recorded.
+* The recovery workflow has been cancelled or closed.
+
+The host application should use a stable identifier or idempotency mechanism for each recovery attempt so that retrying a request does not unintentionally create duplicate calls.
+
+If the status of a previous call creation is uncertain, the host should reconcile the existing call state before creating another call.
+
+---
+
+## Cancellation and Stop Conditions
+
+The host application is responsible for cancelling or stopping the recovery workflow.
+
+No new recovery call should be created when:
+
+* The appointment has already been rescheduled.
+* The patient has declined further recovery.
+* The recovery case has been cancelled or closed.
+* A human or clinical follow-up process has taken ownership.
+* The workflow has been disabled by the operator.
+
+If a call has already been created, the host application should use the CALL-E integration's supported cancellation mechanism when available.
+
+If an active call cannot be cancelled, the host must prevent future recovery attempts and ensure that stale results cannot overwrite a newer appointment state.
+
+Cancelling the missed-appointment recovery workflow must not automatically cancel the underlying appointment unless the host application explicitly performs that separate action.
+
+---
+
+## Data Minimization
+
+CareCall should use only the information required to complete the administrative workflow.
+
+The host application should provide:
+
+* The patient's first name or other appropriate identifier.
+* The appointment date and time.
+* Available appointment slots.
+* The explicitly authorized destination phone number.
+
+The skill must not request or expose unnecessary medical information.
+
+---
+
+## Real-World Calls and Credentials
+
+A real outbound call must require explicit authorization from the host application.
+
+The destination phone number must be explicitly supplied by the host application. CareCall must never guess, infer, or construct a phone number.
+
+Credentials, API keys, tokens, and other secrets must be managed by the host application and must never be included in conversation content, structured results, logs, examples, or documentation.
+
+For examples and documentation, use fictional or masked phone numbers only.


### PR DESCRIPTION
## Summary

## Overview

CareCall is a missed-appointment recovery skill for healthcare workflows.

It uses CALL-E to place an outbound administrative phone call to a patient who missed an appointment, offer available rescheduling slots, confirm the selected slot, and return a structured outcome for the host appointment system.

## What it does

- Verifies the intended patient before discussing appointment details
- Explains the missed appointment
- Asks whether the patient wants to reschedule
- Offers only appointment slots supplied by the host system
- Supports natural-language slot selection
- Requires explicit confirmation before returning `RESCHEDULED`
- Returns structured recovery outcomes
- Supports human follow-up for clinical concerns and uncertain outcomes

## Outcomes

- `RESCHEDULED`
- `DECLINED`
- `CALLBACK_REQUESTED`
- `NO_ANSWER`
- `WRONG_PERSON`
- `CLINICAL_FOLLOWUP_REQUIRED`
- `SAFETY_ESCALATION`
- `UNKNOWN`

## Safety

This skill is strictly administrative.

It does not:
- provide medical advice
- diagnose conditions
- interpret symptoms or test results
- recommend treatment
- perform medical triage
- invent appointment availability
- disclose appointment details before appropriate verification
- pressure patients to reschedule

Clinical or potentially urgent concerns are escalated rather than handled by the scheduling agent.

## Files

- `SKILL.md` — core missed-appointment recovery workflow
- `references/result-schema.md` — structured result definition
- `references/safety.md` — safety and escalation guidance

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [ ] Repository-facing content is written in English.
- [ ] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [ ] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [ ] Real-world side effects are clearly described.
- [ ] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior.
- [ ] Runnable code has a dry-run, fake-server, or no-call path by default.
- [ ] `python3 scripts/validate_repository.py` passes.
