### PR TITLE
fix(redline): clarify static evidence and preserve diagnostic paths

### DIFF
--- a/apps/python/redline/README.md
+++ b/apps/python/redline/README.md
@@ -20,7 +20,7 @@ $ redline verify
 
   benign      10/10 ordinary calls still handled
 
-  Every attack in this run is now closed.
+  All modelled findings are closed in this static run.
 ```
 
 The two numbers are the point. `verify` reruns the attacks and a separate benign
@@ -87,13 +87,14 @@ Or against your own:
 ```console
 $ cd my-calle-agent
 $ redline init          # writes redline.yaml, a scenario, a CI workflow
-$ redline run           # 21 scenarios, 0 calls, exits 1 on a finding
+$ redline run           # starter scenario, 0 calls, exits 1 on a finding
 $ redline explain voice-prompt-injection
 $ redline fix --apply   # writes the hardening into your goal and schema
 $ redline verify        # replays every attack and reports the diff
 ```
 
-Only `--live` needs a CALL-E account. When you have a key:
+Live calls and authenticated planner preflight need a CALL-E account; the
+static path does not. When you have a key:
 
 ```console
 $ cp .env.example .env      # then paste the key after REDLINE_CALLE_API_KEY=
@@ -486,7 +487,7 @@ From this directory:
 
 ```console
 $ pip install -e ".[dev]"
-$ pytest -q                       # 732 tests, no network
+$ pytest -q                       # 746 tests, no network
 $ ruff check . && ruff format --check .
 $ mypy
 ```
@@ -500,21 +501,21 @@ The catalogue is the part of this project other people are meant to extend, and
 [`tests/test_catalogue.py`](tests/test_catalogue.py) enforces its rules so a
 reviewer does not have to.
 
-## After the hackathon
+## Delivery limits and next steps
 
-The three things worth building next, in order:
+The current deliverable is the authored-contract gate. Planner preflight can
+report defense differences, but this package does not implement a blocking
+Plan Firewall, `planned` evidence provenance or `--verify-effective`.
 
-1. **Live-mode validation of the offline model.** Several modelling
-   assumptions — chiefly what `task_completed` reports after a successful
-   defence — are documented as assumptions and need a real call to settle. They
-   remain explicitly labelled as assumptions until an authorised live run
-   settles them.
-2. **A published audit of the CALL-E catalogue.** The repository holds dozens
-   of public agents with visible goals and schemas. Running REDLINE across them
-   would turn "agents fail this way" into a measurement, anonymised, with fixes
-   offered upstream rather than findings published.
-3. **A second platform adapter.** The transport and adapter boundaries already
-   assume one will arrive.
+The wheel contains the runtime and starter template. The full 21-scenario
+catalogue, benign suite and appointment example live in this source directory;
+keep the checkout to reproduce the complete bundled demonstration.
+
+Before extending the product, reconcile the contribution and demonstrate the
+existing CALL-E integration with explicitly authorized runtime evidence.
+Static verification alone does not establish the hackathon's actual-runtime-use
+criterion. A future Plan Firewall needs a separate implementation and proof;
+it is not part of the current product promise.
 
 ## Licence
 

--- a/apps/python/redline/redline/cli.py
+++ b/apps/python/redline/redline/cli.py
@@ -92,7 +92,7 @@ OnlyOption = Annotated[
 
 
 def _fail(message: str) -> None:
-    error_console.print(Text(message, style="bold red"))
+    error_console.print(Text(message, style="bold red"), soft_wrap=True)
     raise typer.Exit(code=2)
 
 
@@ -755,8 +755,11 @@ def verify(
         ),
     ] = None,
 ) -> None:
-    """Generate the fix, replay every attack against it, and report the diff."""
+    """Check the generated patch against the static contract and benign suite."""
     loaded = _load(config)
+    console.print(
+        Text("\n  evidence: static (declared policy model); no real calls", style="dim")
+    )
     scenarios = _load_scenarios(loaded, only)
     transport = MockTransport()
 
@@ -855,7 +858,10 @@ def verify(
         )
     elif verification.fully_closed:
         console.print(
-            Text("  Every attack in this run is now closed.", style="bold green")
+            Text(
+                "  All modelled findings are closed in this static run.",
+                style="bold green",
+            )
         )
     console.print()
 

--- a/apps/python/redline/tests/test_cli.py
+++ b/apps/python/redline/tests/test_cli.py
@@ -325,7 +325,8 @@ class TestVerify:
 
     def test_it_says_when_everything_is_closed(self, project: Path) -> None:
         result = runner.invoke(app, ["verify"])
-        assert "now closed" in result.output
+        assert "All modelled findings are closed" in result.output
+        assert "evidence: static (declared policy model)" in result.output
 
     def test_verification_does_not_modify_the_config(self, project: Path) -> None:
         original = (project / "redline.yaml").read_text("utf-8")

--- a/apps/python/redline/tests/test_doctor.py
+++ b/apps/python/redline/tests/test_doctor.py
@@ -70,9 +70,7 @@ def clean_environment() -> Iterator[None]:
 @pytest.fixture
 def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=False)
-    (tmp_path / ".gitignore").write_text(
-        ".env\nredline.scope.yaml\n", encoding="utf-8"
-    )
+    (tmp_path / ".gitignore").write_text(".env\nredline.scope.yaml\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     return tmp_path
 

--- a/apps/python/redline/tests/test_private_staged.py
+++ b/apps/python/redline/tests/test_private_staged.py
@@ -28,9 +28,16 @@ def test_private_inputs_are_rejected_by_basename() -> None:
 
 def test_public_examples_and_normal_files_are_allowed() -> None:
     scanner = load_scanner()
-    assert scanner.private_staged_paths(
-        ["apps/python/redline/.env.example", "redline.scope.example.yaml", "redline.yaml"]
-    ) == []
+    assert (
+        scanner.private_staged_paths(
+            [
+                "apps/python/redline/.env.example",
+                "redline.scope.example.yaml",
+                "redline.yaml",
+            ]
+        )
+        == []
+    )
 
 
 def test_the_hook_and_scanner_ship_together() -> None:
@@ -45,9 +52,7 @@ def test_a_force_added_scope_file_is_refused_from_the_real_index(
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     (tmp_path / ".gitignore").write_text("redline.scope.yaml\n", encoding="utf-8")
     (tmp_path / "redline.scope.yaml").write_text("private\n", encoding="utf-8")
-    subprocess.run(
-        ["git", "add", "-f", "redline.scope.yaml"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "add", "-f", "redline.scope.yaml"], cwd=tmp_path, check=True)
 
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],

--- a/apps/python/redline/tests/test_scope.py
+++ b/apps/python/redline/tests/test_scope.py
@@ -209,9 +209,7 @@ class TestScopeFilePrivacy:
 
     def test_an_ignored_scope_inside_git_is_allowed(self, tmp_path: Path) -> None:
         subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-        (tmp_path / ".gitignore").write_text(
-            "redline.scope.yaml\n", encoding="utf-8"
-        )
+        (tmp_path / ".gitignore").write_text("redline.scope.yaml\n", encoding="utf-8")
         assert load_scope(write_scope(tmp_path, VALID)).targets
 
 


### PR DESCRIPTION
## Summary

`redline verify` could be read as a claim about real phone behavior, and long
error paths were split inside filenames on narrow terminals. Verification now
labels its static policy model explicitly; diagnostics preserve readable file
paths. The README distinguishes the one-scenario starter, source catalogue,
runtime wheel and deferred Plan Firewall.

This is a focused follow-up to merged PR #304. Existing maintainer safeguards
remain intact. Three existing test files receive formatter-only changes.

## Validation

- Linux Python 3.11 and 3.12: 746 product tests passed on each.
- Standalone repository guards: 104 passed on each, including POSIX hooks.
- Ruff, formatting and mypy passed for product and standalone tooling.
- Official repository validator passed on upstream
  `eb0e5263438de1fb3a5c6cd61e79f323bc6e7793` with this focused overlay.
- Bundled static verification: 21/21 modelled scenarios, 10/10 benign cases,
  zero real calls.

An initial Linux failure exposed the diagnostic wrapping issue; the corrected
product suites pass. No real-call or planner evidence is claimed by these tests.

## Type

- [x] Safety or documentation update
- [x] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch, commit and PR title follow the repository naming conventions.
- [x] No secrets, private phone numbers, recordings or private transcripts are included.
- [x] Existing no-call defaults and side-effect documentation are preserved.
- [x] Examples remain fictional; no recurring workflow is introduced.
- [x] `python3 scripts/validate_repository.py` passes.
