### PR TITLE
feat(outcome-completion-agent): add a skill for goals that need more than one call

### DIFF
--- a/skills/outcome-completion-agent/SKILL.md
+++ b/skills/outcome-completion-agent/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: outcome-completion-agent
+description: Own one goal across as many CALL-E calls as it takes, when who to call next depends on what the last call said — read every call as structured evidence, reject offers that break the user's stated limits, follow referrals to parties the user never supplied, and gate the single call that commits the user.
+license: MIT
+---
+
+# Outcome Completion Agent
+
+Use this skill when the user states an **outcome** rather than a call, the route to that
+outcome runs through more than one organisation, and the next organisation is usually
+named *on* a call rather than known in advance.
+
+> "Get a replacement pallet for the crushed delivery on order BK-7741, before Friday,
+> under $500."
+
+The user has one phone number: the supplier who sent the broken pallet. The supplier is
+out of stock and names a distributor. The distributor quotes over the limit and names its
+own depot. The depot can do it. Three organisations, two of which did not exist as far as
+the agent was concerned when the run began.
+
+`outcome-completion-agent` is a **calling-pattern skill**. It adds no backend, no queue and
+no daemon. It turns one authorized "make this happen" request into a bounded loop of
+one-off CALL-E calls whose order is decided by what earlier calls established.
+
+## When To Use
+
+- a problem whose owner is unknown: "find out who can actually fix this and get it fixed"
+- a chain of custody: supplier to distributor to depot, carrier to facility to counter,
+  insurer to provider to adjuster
+- a goal with a hard limit attached — a price ceiling, a date, a required reference — where
+  a cheerful "yes" that breaks the limit is a failed outcome
+- any request where the honest answer to "who should we call?" is "ask the first person"
+
+## When Not To Use
+
+- **one call, one structured answer.** Use a single-call skill; this loop is overhead.
+- **a known, priority-ordered candidate list for one opening.** Read
+  `skills/priority-call-waterfall/SKILL.md` instead — one opening, call in order, stop at
+  the first yes.
+- **comparison shopping over an enumerable set of same-service vendors** (every barber
+  within 4km). If the candidate list is a database or map query, the frontier does not
+  need to grow and this skill's machinery buys nothing.
+- anything email, a web form, or an API can do. A phone call is a real-world side effect
+  and the most expensive way to ask a question.
+- goals with no completion test. If nobody can say what "done" looks like, the loop cannot
+  stop, and a loop that cannot stop must not be given a phone.
+
+## Core Workflow
+
+1. Confirm the user wants this pursued by phone, now, and that they accept calls may go to
+   organisations they did not name.
+2. Collect the outcome fields (see Required Fields). Ask for anything missing. Never infer
+   a phone number, a price ceiling, or a deadline.
+3. Show a masked preview: the goal, the constraints as the agent understood them, the
+   starting phone book, and the call budget. Get explicit confirmation before call one.
+   **Always show the parsed constraints back.** A price ceiling that failed to parse is a
+   ceiling that will never block anything, and the user is the only one who can catch it.
+4. Loop, one call at a time:
+
+   ```text
+   plan -> (approval, if it commits) -> one call -> evidence -> constraints -> plan
+   ```
+
+   - **plan** — pick the next party from the frontier: a party never called, else a party
+     that did not answer and is under its retry cap. Prefer a party named by the call that
+     just happened over one the user listed but nobody has reached.
+   - **call** — exactly one CALL-E call, with a structured result schema. Wait for a
+     terminal status. Read `references/evidence-schema.md` for the schema every call fills.
+   - **evidence** — record what was established: verdict, facts, blockers, referrals, and
+     any concrete offer. Add referrals with a valid E.164 number to the frontier. Drop
+     referrals without one.
+   - **constraints** — evaluate any offer against the user's limits. Read
+     `references/constraint-evaluation.md`. A call that completed happily and breaks a hard
+     limit is a **failed outcome**: keep working.
+5. Stop conditions, checked before every dial:
+   - an acceptable offer has been confirmed by the other party → resolved
+   - the call budget or the per-party cap is reached → stop and report
+   - every lead is exhausted with nothing acceptable → stop and report
+6. Exactly one call in the run may commit the user, and only after they approve it. Read
+   `references/approval-gate.md`.
+7. Report using the Output Format below, whether or not the goal was reached.
+
+## Required Fields
+
+- `goal` — one sentence, imperative, with the constraints taken out of it
+- `constraints[]` — each with `kind`, `description`, `value`, and `hard`
+  (`budget` · `deadline` · `required_fact` · `preference` · `forbidden`).
+  `hard: true` disqualifies an offer. `hard: false` only ranks it.
+- `organizations[]` — the starting phone book: `name`, `phone` (E.164), `role`.
+  One entry is enough; that is the point of the skill.
+- `budget` — `max_calls` for the whole outcome and `max_calls_per_org`.
+  Both are required. A goal-seeking agent with an unbounded phone budget is not a
+  product, and CALL-E accounts are metered.
+
+Phone numbers must be E.164, and must be masked in every summary, preview and report.
+
+## Following A Referral
+
+This is the part that distinguishes this pattern, so it has its own rules.
+
+- A referral counts only when the person on the call **named a number**. "Try their head
+  office" without a number is a fact, not a lead.
+- Validate it as E.164 before adding it. A number that cannot be dialled is not a lead,
+  and keeping it puts an entry in front of the planner that can never be actioned.
+- De-duplicate on the number. Two calls naming the same depot must not produce two entries,
+  or the depot gets called twice.
+- Carry the provenance: which call produced this lead, and the reason given. The report has
+  to be able to say *"the agent found this one"*, and the next call should be able to open
+  with "Halden Packaging suggested I call you".
+- A referral is a lead, not an instruction. It still costs a call from the budget, it still
+  goes through the same constraint checks, and it never bypasses the approval gate.
+
+## Budgets
+
+Check the budget **immediately before dialling**, never when planning. An approval can sit
+overnight; the credit it would spend may be gone by the time it comes back.
+
+Sensible defaults for a metered account: 6 calls per outcome, 2 per organisation. The
+per-organisation cap is what stops a no-answer loop from consuming the whole budget on one
+unanswered line.
+
+Never widen a budget mid-run to finish a goal. Stop, report, and let the user decide
+whether it is worth more calls.
+
+## Output Format
+
+Report every run, resolved or not:
+
+- the goal, restated, and the constraints as they were evaluated
+- every organisation touched, in order: masked number, calls used, final verdict, whether
+  the agent found it or the user supplied it
+- every offer received, with a per-constraint verdict and, for the ones turned down, which
+  constraint they broke
+- the outcome: what was secured, from whom, at what price, by when, and any reference
+  number — or why the run stopped
+- calls used against the budget
+
+Never report an outcome as resolved unless the other party confirmed it on a call the user
+approved. An offer is not a resolution.
+
+## Safety Rules
+
+Read `references/safety.md` for the full contract. Always:
+
+- Disclose that the caller is an AI assistant, at the start of every call, before asking
+  anything. If the person asks for a human or asks you to stop: apologise, end the call,
+  record it, and do not call that number again in this run.
+- Gathering calls have no authority. Their script must say so explicitly.
+- One call per run may commit the user, only with prior approval, and only to the exact
+  terms approved.
+- Mask every phone number in output. Never read a credential aloud.
+- Medical, legal, financial and emergency matters are logistics only: ask about times,
+  availability and reference numbers, and give no advice.
+- This skill creates no recurring schedule. Every call is one-shot. To stop a run, stop
+  approving; nothing is committed without an approval, and nothing is queued for later.
+
+## Worked Examples
+
+Read `references/examples.md` for a full run, a run that stops on budget, and the two
+failure modes that most often get this pattern wrong.
+
+## Validating A Result
+
+`scripts/check_evidence_schema.py` checks one `structured_result` against the schema and
+reports what a planner would actually be able to use from it — no network, no credentials,
+no calls:
+
+```bash
+python3 scripts/check_evidence_schema.py path/to/result.json
+```
+
+It reports errors (the result is malformed) separately from notes (the result parses, but
+something in it will be discarded). The notes matter more than they look: a referral whose
+number is unusable is the difference between an agent that finds the depot and one that
+stops at the supplier, and nothing else in the run will tell you it was dropped.
+
+Check the checker with `python3 scripts/test_check_evidence_schema.py`.

--- a/skills/outcome-completion-agent/references/approval-gate.md
+++ b/skills/outcome-completion-agent/references/approval-gate.md
@@ -1,0 +1,86 @@
+# The approval gate
+
+The rule is not "ask before every call". Asking before every call makes an autonomous agent
+pointless, and users stop reading a prompt they see six times in one run.
+
+The rule is about **commitment**. Asking a question costs nothing and can be undone by
+hanging up. Agreeing to a price, cancelling a booking, or placing an order binds the user to
+something they cannot take back by hanging up.
+
+So: **information gathering runs unattended. Anything that would bind the user stops and
+waits.**
+
+## Two kinds of call
+
+### Gathering — may ask, may not agree
+
+Runs without asking the user anything. Its script must say so explicitly, in the script
+itself, not merely in the planner's intent:
+
+> You are NOT authorised to agree to anything, accept any price, place any order, or cancel
+> anything on this call. If they offer something, record it as an offer and say you will
+> confirm shortly. Saying yes is not your decision to make.
+
+Without that paragraph, a helpful caller offered a good deal will take it.
+
+### Commit — the one call that may say yes
+
+Exactly one call per run, after the user approves, and its script names the exact terms:
+
+> YOU ARE AUTHORISED TO ACCEPT EXACTLY THIS AND NOTHING ELSE:
+>   500 insulated shipping boxes, local van delivery
+>   Price: USD 438.00
+>   Delivery: 2026-09-10
+>
+> If the terms have changed in any way — a different price, a later date, an added fee, a
+> different item — do NOT accept. Record the new terms as an offer, set verdict to 'offer',
+> and end the call politely. The customer will decide again.
+
+The authorisation is an **envelope**, not a permission. The user approved *that* offer, not
+a renegotiated version of it. A caller told to "use its judgement" on changed terms is a
+caller that can spend more than the user agreed to, and the user will not find out until the
+invoice.
+
+## The backstop, and its trap
+
+Flag committing actions explicitly in the planner. Underneath that, keep a keyword net over
+the call script for the case where the planner forgets — `accept`, `confirm the order`,
+`place an order`, `purchase`, `pay`, `cancel`, `agree to`, `sign`, `authorise`, `commit`.
+
+**The net must be negation-aware, and this is not a detail.**
+
+Every gathering script above ends with "you are NOT authorised to *agree to* anything,
+*accept* any price, or *cancel* anything" — three committing verbs, in the one paragraph
+whose whole purpose is to forbid them. A naive keyword net flags every call in the run. The
+user approves six times, learns that approval means nothing, and clicks through the seventh
+without reading it. A safety net that fires constantly is worse than no net: it trains the
+behaviour it exists to prevent.
+
+Exclude lines carrying a negation cue — `not authorised`, `do not`, `never`, `must not`,
+`cannot`, `without approval` — before matching. Match line by line, not on the whole script:
+these are bulleted rules, and a bullet is the unit that carries one instruction.
+
+## What the approval screen must show
+
+- the question, in plain language: what is being accepted, from whom, for how much, by when
+- every constraint, with its verdict, hard and soft marked differently
+- **what was turned down, and on which constraint**
+
+The last one is not decoration. An approval screen showing only the winner asks the user to
+trust a search they cannot see. Showing the $612 offer that was rejected for being $112 over
+the limit is what turns a one-tap approval into an informed one.
+
+## Declining
+
+Record the declined offer so the planner cannot re-propose it, and send the agent back out.
+Do not treat a decline as an abandonment: the user rejected an option, not the goal.
+
+## Never
+
+- Never let a gathering call commit, however good the offer.
+- Never widen the approved envelope because the terms improved. A cheaper price is still a
+  different offer; take it back to the user.
+- Never hold a thread or a timer waiting for approval. It may take a day. Park the run as a
+  value and resume it when the answer arrives.
+- Never re-check the budget only at planning time. Check it again immediately before the
+  approved call is dialled — the approval may have sat overnight.

--- a/skills/outcome-completion-agent/references/constraint-evaluation.md
+++ b/skills/outcome-completion-agent/references/constraint-evaluation.md
@@ -1,0 +1,73 @@
+# Constraints: deciding whether an answer is good enough
+
+A call that ends with a cheerful "yes, we can do that" is a **success** to the telephony
+layer and can still be a **failure** to the user, because it costs sixty dollars over their
+limit or lands two days after they needed it.
+
+This is the single most important idea in the pattern. The loop replans on the constraint
+verdict, not on the call status.
+
+## Keep it deterministic
+
+A model decides what was said. A comparison operator decides whether it is good enough.
+
+Putting the money and the deadline behind a rule rather than a prompt is what makes the
+approval screen trustworthy. "Do not accept anything over $500" in a system prompt is a
+suggestion; `offer.price > limit` is not.
+
+## Kinds
+
+| Kind | `value` | Test |
+|---|---|---|
+| `budget` | a bare number | `offer.price <= value` |
+| `deadline` | ISO date | `offer.eta <= value`, compared as dates, never as strings |
+| `required_fact` | a field name | that field is present and non-empty |
+| `forbidden` | a term | the term does not appear in the offer summary |
+| `preference` | a term | the term appears in the offer summary |
+
+## Four judgements, not two
+
+| Judgement | Meaning | Blocks? |
+|---|---|---|
+| `satisfied` | Checked and met | no |
+| `violated` | Checked and not met | **only if the constraint is hard** |
+| `unknown` | Not enough information — no price was quoted | no |
+| `not_applicable` | Constraint not configured | no |
+
+`unknown` deliberately does not block. Refusing every offer that failed to mention a detail
+nobody asked about on the call would strand every run behind a missing field. Surface it at
+the approval step instead, where a human can weigh it.
+
+Distinguishing `unknown` from `violated` is the whole reason a missing price must parse to
+`null` rather than `0`.
+
+## Hard and soft
+
+- **Hard** — a violation disqualifies the offer. The agent keeps working.
+- **Soft** — a violation only ranks the offer lower. The agent may still take it, and shows
+  the violation at the approval step.
+
+Among acceptable offers, rank by: fewest soft violations, then cheapest, then earliest. An
+unquoted price sorts **last**, not free.
+
+## Show soft and hard differently
+
+On any screen a human uses to approve something, a soft violation must not look like a hard
+one. Rendering "no reference number was given" with the same red cross as "$112 over your
+limit" teaches the user that the crosses mean nothing — on the one screen where they must.
+Use a distinct mark and colour.
+
+## Stop at the first acceptable offer
+
+Default to taking the first offer that satisfies every hard constraint, rather than
+canvassing every remaining lead for a better one. With a metered account, exhaustive search
+is not a neutral default: it spends the user's credits to improve an answer they already
+said they would accept.
+
+Make it a flag, not an assumption, so a caller with cheap credits can opt in.
+
+## Declining must not loop
+
+When the user declines an offer at the approval step, record that offer as declined. The
+next planning pass must not propose it again. Without that, "no" is an infinite loop, and
+the user's only escape is to abandon the run.

--- a/skills/outcome-completion-agent/references/evidence-schema.md
+++ b/skills/outcome-completion-agent/references/evidence-schema.md
@@ -1,0 +1,149 @@
+# The evidence schema
+
+Every call in an outcome run fills in the same structure. That is what makes calls
+composable: the planner reads a uniform record rather than a transcript, so a call to a
+supplier and a call to a depot are the same kind of input.
+
+Pass it as `recipient_result_schema` on `POST /v1/calls`.
+
+```json
+{
+  "type": "object",
+  "required": ["verdict"],
+  "properties": {
+    "reached": {
+      "type": "string",
+      "enum": ["yes", "no", "unknown"],
+      "description": "yes only if a person actually spoke with you. no if nobody did. unknown if you cannot tell."
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["no_answer", "refused", "blocked", "partial", "offer", "confirmed"],
+      "description": "no_answer if nobody picked up. refused if they declined to help. blocked if they cannot do it and named an obstacle. partial if you learned something but the objective is unmet. offer if they proposed something concrete. confirmed if the objective is now met and they committed to it."
+    },
+    "facts": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Short statements of what the person actually said. Do not infer, summarise or add anything they did not say. Empty if nothing was said."
+    },
+    "blockers": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Reasons given for why the objective cannot be met here. Empty if none."
+    },
+    "referrals": {
+      "type": "array",
+      "description": "Other organisations or departments they told you to contact, with the number they gave. Empty if none were offered. Never invent a number.",
+      "items": {
+        "type": "object",
+        "required": ["org_name"],
+        "properties": {
+          "org_name": {"type": "string", "description": "Who they told you to call."},
+          "phone": {"type": "string", "description": "The number they read out, in E.164 such as +447700900123. Empty string if they did not give one."},
+          "role": {"type": "string", "description": "What that organisation does."},
+          "reason": {"type": "string", "description": "Why they sent you there."}
+        },
+        "additionalProperties": false
+      }
+    },
+    "offer": {
+      "type": "object",
+      "description": "A concrete proposal, if one was made. Leave every field empty if none was.",
+      "properties": {
+        "what_is_offered": {"type": "string", "description": "What they proposed, in a few words. Empty string if they proposed nothing."},
+        "price": {"type": "string", "description": "The total amount only, digits and decimal point, such as 438.00. No currency symbol. Empty string if no price was quoted."},
+        "currency": {"type": "string", "description": "Three-letter code such as USD. Empty string if not stated."},
+        "eta": {"type": "string", "description": "The date they committed to, as YYYY-MM-DD. Empty string if no date was given."},
+        "reference": {"type": "string", "description": "Any reference, order or booking number they gave. Empty string if none."}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## Three CALL-E schema rules
+
+These rules come from CALL-E's calls guide and are worth checking before you write your
+own schema.
+
+**1. A `type` is one value.** `{"type": ["object", "null"]}` is the natural way to say
+"this field is optional" and it is legal JSON Schema, but CALL-E accepts only one
+supported type per field.
+
+The supported list is `object`, `string`, `number`, `integer`, `boolean`, `array` — one
+of them, not a union. `oneOf`, `anyOf` and `allOf` are also unsupported, and a union type
+is those in shorthand. **Express absence with an empty string or an empty array**, never
+with `null`.
+
+**2. Some field names are reserved.** `summary`, `status`, `transcript`, `call_id` and
+timing fields are reserved recipient response names. This schema says `what_is_offered`
+because `summary` is not available.
+
+**3. The result is all or nothing.** From the guide: "If CALL-E cannot produce a
+schema-valid result from the evidence, the public `structured_result` is `null`." Not
+partially filled — absent. So every field you mark `required` is a field that can throw
+away the whole call.
+
+That is why `required` here holds one entry. A caller who comes back with a clear verdict
+and nothing quotable should still give you the verdict; requiring `facts` as well would
+trade a partial answer for no answer at all.
+
+For the same reason, **prices and dates are strings**. A number has no way to say "they
+never quoted one", and `0` is a lie that a budget check would happily accept.
+
+## The six verdicts
+
+The enum is small on purpose. Each value maps to a different next move, and a verdict that
+does not change what the planner does next does not deserve to exist.
+
+| Verdict | What it means | What the planner does |
+|---|---|---|
+| `no_answer` | Nobody picked up | Retry once, under the per-party cap, then move on |
+| `refused` | They declined to engage | Do not call back. Take any referral and move on |
+| `blocked` | They would help but cannot, and said why | Record the blocker, take the referral, move on |
+| `partial` | Something learned, objective unmet | Record it; usually move on |
+| `offer` | A concrete proposal | Evaluate against constraints |
+| `confirmed` | Objective met and committed to | Resolved, if this was an approved commit call |
+
+## Parse it defensively
+
+This is the least trustworthy input in the system: a model's reading of a phone
+conversation, filled in under time pressure by a caller who may have been talked over. The
+loop must not crash on it, and — more importantly — must not quietly invent the missing
+half.
+
+- **A price you cannot read is unknown, never zero.** Accept `"438"`, `"438.00"`,
+  `"$438.00"`, `"USD 1,438"` and a bare number if one arrives anyway. Anything else is
+  absent. Guessing `0` sails a quote straight past a budget ceiling.
+- **A referral without a valid E.164 number is dropped.** See the Following A Referral
+  section of `SKILL.md`.
+- **A call the provider did not complete is never testimony.** If the CALL-E call status is
+  `failed` or `canceled`, treat it as `no_answer` whatever the structured block says. A
+  half-connected call can return a confidently filled-in result.
+- **An empty `offer` object is not an offer.** Require at least a description, a price, or
+  a date.
+- **`reached: "no"` overrides the verdict**, and `"unknown"` does not. A call that cannot
+  say whether it reached anyone has not established that it did not.
+
+## Validate the schema before you dial
+
+CALL-E validates `recipient_result_schema` at call-creation time. Validate the documented
+subset offline before attempting any call.
+
+`scripts/check_evidence_schema.py` checks a returned result. For the schema itself, check
+it against the documented subset before the first call: single `type` values, no
+`$ref`/`oneOf`/`anyOf`/`allOf`, `additionalProperties: false` on every object, every
+`required` name present in `properties`, `items` on every array, and no reserved names at
+the top level.
+
+## Why not just read the transcript
+
+A transcript is not a decision input. It is long, it is unstructured, and every planner
+that reads one ends up re-deriving the same six facts with a second model call. Worse, it
+cannot be replayed: a scripted transcript and a real one differ enough that a run you
+rehearse offline is not the run that happens on the phone.
+
+Filling a fixed schema on the call, while the person is still there to be asked, is both
+cheaper and more accurate — and it means the planner is testable without a phone.

--- a/skills/outcome-completion-agent/references/examples.md
+++ b/skills/outcome-completion-agent/references/examples.md
@@ -1,0 +1,165 @@
+# Worked examples
+
+Every phone number below is in the `+1-555-01xx` range reserved for fiction.
+
+## 1. A full run
+
+**Request**
+
+> "A pallet of insulated shipping boxes arrived crushed on order BK-7741. Get a replacement
+> before Friday, under $500."
+
+**Parsed, and shown back to the user before anything is dialled**
+
+```json
+{
+  "goal": "Get a replacement pallet of 500 insulated shipping boxes for the crushed delivery on order BK-7741.",
+  "constraints": [
+    {"kind": "budget",   "description": "Total cost at or under USD 500", "value": 500, "hard": true},
+    {"kind": "deadline", "description": "Delivered on or before Friday 11 September", "value": "2026-09-11", "hard": true},
+    {"kind": "required_fact", "description": "A reference number", "value": "reference", "hard": false}
+  ],
+  "organizations": [
+    {"name": "Halden Packaging", "phone": "+15550100001", "role": "Original supplier on order BK-7741"}
+  ],
+  "budget": {"max_calls": 6, "max_calls_per_org": 2}
+}
+```
+
+One phone number. The user does not know who else to call, which is why they asked.
+
+**The run**
+
+| # | Party | Verdict | What it produced |
+|---|---|---|---|
+| 1 | Halden Packaging `+*******0001` | `no_answer` | Voicemail, no hold option |
+| 2 | Halden Packaging `+*******0001` | `blocked` | Out of stock until the 30th. **Referral: Northgate Distribution `+15550100002`** |
+| 3 | Northgate Distribution `+*******0002` | `offer` | $612 next-day courier — **rejected, $112 over the limit**. **Referral: Brightwater Depot `+15550100003`** |
+| 4 | Brightwater Depot `+*******0003` | `offer` | $438, local van, 2026-09-10 — **satisfies both hard constraints** |
+| — | *user* | — | *Accept $438 from Brightwater Depot?* → **Approve** |
+| 5 | Brightwater Depot `+*******0003` | `confirmed` | Booked. Reference `BWD-48291` |
+
+Two of the three organisations were never supplied by the user. Both came out of a call.
+
+**Evidence from call 2**, which is where the run actually turns:
+
+```json
+{
+  "reached": "yes",
+  "verdict": "blocked",
+  "facts": [
+    "Order BK-7741 is confirmed damaged in their system.",
+    "The insulated box line is out of stock until the end of the month.",
+    "They will credit the original order but cannot supply a replacement."
+  ],
+  "blockers": ["No stock of insulated shipping boxes until 30 September."],
+  "referrals": [{
+    "org_name": "Northgate Distribution",
+    "phone": "+15550100002",
+    "role": "Regional distributor carrying the same line",
+    "reason": "Halden say Northgate hold stock of the identical box."
+  }],
+  "offer": {
+    "what_is_offered": "",
+    "price": "",
+    "currency": "",
+    "eta": "",
+    "reference": ""
+  }
+}
+```
+
+**Report**
+
+```text
+RESOLVED
+500 insulated shipping boxes, local van delivery with Brightwater Depot
+for USD 438.00, 2026-09-10.
+Reference BWD-48291
+
+  satisfied  USD 438.00 is within the USD 500.00 limit.
+  satisfied  2026-09-10 is on or before the 2026-09-11 deadline.
+  satisfied  reference=BWD-48291
+
+5 of 6 calls used.
+
+  Halden Packaging       +*******0001  2 calls  blocked
+  Northgate Distribution +*******0002  1 call   offer      found by the agent
+  Brightwater Depot      +*******0003  2 calls  confirmed  found by the agent
+
+Turned down: 500 insulated shipping boxes, next-day courier, USD 612.00
+             (USD 112.00 over the USD 500.00 limit)
+```
+
+The turned-down offer is in the report on purpose. An outcome that shows only the winner
+reads like luck.
+
+## 2. Stopping on budget
+
+Same request, `max_calls: 2`.
+
+| # | Party | Verdict |
+|---|---|---|
+| 1 | Halden Packaging | `no_answer` |
+| 2 | Halden Packaging | `blocked` — referral to Northgate |
+
+```text
+NOT RESOLVED
+Call budget reached (2 of 2 calls). Stopping rather than dialling on.
+
+Established:
+  Order BK-7741 is confirmed damaged in their system.
+  The insulated box line is out of stock until 30 September.
+
+Blockers:
+  No stock of insulated shipping boxes until 30 September.
+
+Untried lead: Northgate Distribution +*******0002
+  "Halden say Northgate hold stock of the identical box."
+
+2 of 2 calls used. Raise the budget to continue.
+```
+
+The agent does **not** widen its own budget to chase the lead it just found. It hands the
+user a decision with everything needed to make it.
+
+## 3. Declining at the approval gate
+
+Same run to call 4, then the user declines the $438 offer — say Thursday does not work.
+
+The offer is recorded as declined, and the planner goes back out. In this scenario there is
+nothing left to try: Halden is blocked and at its per-party cap, Northgate is over budget,
+Brightwater's offer was just refused.
+
+```text
+NOT RESOLVED
+Every lead has been followed and nothing meets the requirements.
+4 of 6 calls used.
+```
+
+The important property is what did **not** happen: the planner did not re-propose the $438
+offer. Without recording the decline, "no" is an infinite loop.
+
+## Two failure modes this pattern gets wrong
+
+### Treating a completed call as a completed outcome
+
+Call 3 completed. The recipient was helpful. A structured result came back with a real
+price and a real date. Every telephony-level signal says success — and the outcome is a
+failure, because $612 breaks a limit the user stated.
+
+If the loop routes on call status, it stops here and reports a $612 solution to someone who
+said $500. Route on the **constraint verdict**.
+
+### Flagging every call as a commitment
+
+The gathering script ends with "you are NOT authorised to agree to anything, accept any
+price, or cancel anything". A keyword backstop that reads `agree`, `accept` and `cancel`
+without noticing the negation flags all five calls.
+
+The user then approves five times. By the fifth they have stopped reading, and the approval
+that actually mattered — the one that spends $438 — gets the same reflexive click as the
+four that asked a depot about its van schedule.
+
+A safety net that fires constantly trains the behaviour it exists to prevent. Exclude
+negated lines before matching.

--- a/skills/outcome-completion-agent/references/safety.md
+++ b/skills/outcome-completion-agent/references/safety.md
@@ -1,0 +1,88 @@
+# Safety contract
+
+Every call this pattern places is a real-world side effect: a phone rings, and a person who
+did not ask to be part of an automated workflow answers it. Everything below is a hard
+requirement, not a default.
+
+## Explicit user intent
+
+- The user must confirm the run before the first call, having seen the goal, the constraints
+  as parsed, the starting phone book, and the call budget.
+- The user must be told, before call one, that **the agent may call organisations they did
+  not name**. That is the whole point of the pattern, and it is not what "make some calls
+  for me" usually means. Consent to the first number is not consent to the frontier.
+- Never infer a phone number, a price ceiling, or a deadline. Ask.
+
+## Disclosure
+
+- Every call opens by disclosing that the caller is an AI assistant acting for a customer,
+  before asking anything.
+- If the person asks for a human, asks who is calling, or asks the agent to stop: answer
+  honestly, apologise, end the call politely, record it, and **do not call that number again
+  in this run**.
+- Never claim to be the customer.
+
+## Phone numbers
+
+- E.164 only. Reject anything else rather than normalising a guess.
+- **Mask every number in every summary, preview, log and report** — last four digits at
+  most. An outcome record is a document users forward to other people.
+- Use fictional reserved ranges in all samples and fixtures.
+- De-duplicate the frontier on the number, so one organisation cannot be called twice under
+  two names.
+
+## Authority
+
+- Gathering calls carry no authority to agree, accept, order, cancel or sign. The
+  prohibition goes in the call script, not only in the planner.
+- Exactly one call per run may commit the user, only after explicit approval, and only to
+  the terms named in that approval. Read `approval-gate.md`.
+- If the terms have changed when the commit call connects, do not accept. Bring the new
+  terms back.
+
+## Credentials
+
+- Read the API key from the environment. Never write it to disk, never log it, never put it
+  in a call script.
+- Send it only to CALL-E's own hosts over https. Keep an explicit allowlist: the bearer
+  token is on every request, so the destination is not a free parameter. A configurable base
+  URL exists to reach a staging host, not to point a live credential at an arbitrary
+  collector.
+- Never read a credential, card number, password or one-time code aloud on a call, whoever
+  asks and however plausible the reason.
+
+## Bounded work
+
+- `max_calls` per outcome and `max_calls_per_org` are required, not optional.
+- Check the budget immediately before every dial, never only at planning time.
+- Never widen a budget mid-run to finish a goal. Stop and report; the user decides whether
+  it is worth more calls.
+- Never retry a completed call to get a better answer.
+- Derive the idempotency key from the request payload, so resubmitting an unchanged action
+  cannot ring a second phone. On a polling timeout, raise — never re-POST.
+
+## No hidden recurrence
+
+- This pattern creates **no recurring schedule**. Every call is one-shot.
+- Nothing is queued for later. There is no background job to cancel, and no state that keeps
+  dialling after the user closes the page.
+- To stop a run: stop approving. Nothing commits without an approval.
+- If a host scheduler drives repeated runs, that recurrence belongs to the host and must be
+  visible and cancellable there. Do not put recurrence in the provider.
+
+## Sensitive content
+
+- Medical, legal, financial and emergency matters are **logistics only**: ask about times,
+  availability, stock, status and reference numbers. Give no advice, no interpretation, and
+  no opinion on the merits.
+- Never use this pattern for emergency services. It cannot escalate, it cannot stay on the
+  line, and a retry loop against an emergency number is dangerous.
+- Do not record or transcribe beyond what the structured result needs, and do not ask for or
+  keep the name, role or employee number of the person who answered.
+
+## Reporting
+
+- Report every run, including the ones that failed, with every party touched and every offer
+  turned down.
+- Never report an outcome as resolved unless the other party confirmed it on an approved
+  call. An offer is not a resolution.

--- a/skills/outcome-completion-agent/scripts/check_evidence_schema.py
+++ b/skills/outcome-completion-agent/scripts/check_evidence_schema.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Check one CALL-E structured_result against the outcome evidence schema.
+
+    python3 check_evidence_schema.py result.json
+    cat result.json | python3 check_evidence_schema.py -
+
+No network, no credentials, no calls. Reports two things:
+
+* errors  - the result is malformed and a planner would misread it
+* notes   - the result parses, but something in it will be discarded
+
+The notes matter more than they look. A referral whose number is unusable is the difference
+between an agent that finds the depot and one that stops at the supplier, and nothing else
+in the run will tell you it was dropped.
+
+Exit status is 1 if there are errors, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+VERDICTS = ("no_answer", "refused", "blocked", "partial", "offer", "confirmed")
+REACHED_VALUES = ("yes", "no", "unknown")
+E164 = re.compile(r"^\+[1-9][0-9]{6,14}$")
+ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+MONEY = re.compile(r"-?\d+(?:[\d,]*\d)?(?:\.\d+)?")
+
+
+def parse_money(value: object) -> float | None:
+    """Mirror of the parser a planner should use: unreadable is None, never zero."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    match = MONEY.search(value.replace(" ", ""))
+    if not match:
+        return None
+    try:
+        return float(match.group(0).replace(",", ""))
+    except ValueError:
+        return None
+
+
+def said_no(value: object) -> bool:
+    """Read a yes/no/unknown field without turning "unknown" into "no".
+
+    CALL-E prefers string enums with an `unknown` member over booleans, because
+    a phone call often cannot settle the question. Both shapes are accepted: a
+    model that returns `false` and one that returns `"no"` mean the same thing.
+    "unknown" is not a no.
+    """
+    if value is False:
+        return True
+    return isinstance(value, str) and value.strip().lower() == "no"
+
+
+def check(result: object) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    notes: list[str] = []
+
+    if not isinstance(result, dict):
+        return ([f"Top level must be an object, got {type(result).__name__}."], [])
+
+    # Only `verdict` is required. CALL-E returns null for the whole result when
+    # it cannot satisfy the schema, so a longer required list is a longer list
+    # of ways to lose the entire call.
+    if "verdict" not in result:
+        errors.append("Missing required field 'verdict'.")
+
+    reached = result.get("reached")
+    if "reached" in result and not (
+        isinstance(reached, bool) or (isinstance(reached, str) and reached in REACHED_VALUES)
+    ):
+        errors.append(
+            f"'reached' must be one of {', '.join(REACHED_VALUES)}; got {reached!r}."
+        )
+
+    verdict = result.get("verdict")
+    if "verdict" in result and verdict not in VERDICTS:
+        errors.append(f"'verdict' must be one of {', '.join(VERDICTS)}; got {verdict!r}.")
+
+    for key in ("facts", "blockers"):
+        value = result.get(key, [])
+        if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
+            errors.append(f"{key!r} must be an array of strings.")
+
+    if said_no(reached) and verdict not in (None, "no_answer", "refused"):
+        notes.append(
+            f"reached says no with verdict={verdict!r}: nothing was established, so a "
+            "planner will read this as no_answer and discard the rest."
+        )
+
+    referrals = result.get("referrals", [])
+    if not isinstance(referrals, list):
+        errors.append("'referrals' must be an array.")
+    else:
+        for index, referral in enumerate(referrals):
+            label = f"referrals[{index}]"
+            if not isinstance(referral, dict):
+                errors.append(f"{label} must be an object.")
+                continue
+            name = str(referral.get("org_name") or "").strip()
+            phone = str(referral.get("phone") or "").strip().replace(" ", "").replace("-", "")
+            if not name:
+                errors.append(f"{label} has no org_name.")
+            if not phone:
+                notes.append(f"{label} ({name or 'unnamed'}) has no number and will be dropped.")
+            elif not E164.match(phone):
+                notes.append(
+                    f"{label} ({name or 'unnamed'}) has a phone that is not E.164 and will be "
+                    "dropped. This lead will never be called."
+                )
+
+    offer = result.get("offer")
+    if offer is not None:
+        if not isinstance(offer, dict):
+            errors.append("'offer' must be an object.")
+        else:
+            # `what_is_offered` is the wire name: `summary` is a reserved
+            # recipient response field in CALL-E. Both are read, because a model
+            # handed either description may reach for the shorter word.
+            summary = str(offer.get("what_is_offered") or offer.get("summary") or "").strip()
+            price_raw = offer.get("price")
+            price = parse_money(price_raw)
+            eta = offer.get("eta")
+            if not summary and price is None and not eta:
+                notes.append(
+                    "'offer' has no description, price or date and will be read as no offer."
+                )
+            if price_raw not in (None, "") and price is None:
+                notes.append(
+                    f"offer.price {price_raw!r} is unreadable and will be treated as unknown, "
+                    "so a budget constraint cannot block this offer."
+                )
+            if price is None and price_raw in (None, ""):
+                notes.append(
+                    "offer.price is absent: a budget constraint will judge this unknown, "
+                    "not satisfied."
+                )
+            if eta and not ISO_DATE.match(str(eta)):
+                notes.append(
+                    f"offer.eta {eta!r} is not YYYY-MM-DD; a deadline constraint may not "
+                    "be able to compare it."
+                )
+            if not offer.get("reference") and verdict == "confirmed":
+                notes.append(
+                    "verdict is 'confirmed' but the offer carries no reference number; the "
+                    "user has nothing to quote back."
+                )
+    elif verdict in ("offer", "confirmed"):
+        notes.append(f"verdict is {verdict!r} but there is no offer to evaluate.")
+
+    unknown = set(result) - {
+        "reached", "verdict", "facts", "blockers", "referrals", "offer",
+    }
+    for key in sorted(unknown):
+        notes.append(f"Unknown field {key!r} will be ignored.")
+
+    return errors, notes
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    source = sys.stdin if argv[1] == "-" else open(argv[1], encoding="utf-8")
+    try:
+        payload = json.load(source)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: not valid JSON: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if source is not sys.stdin:
+            source.close()
+
+    errors, notes = check(payload)
+    for message in errors:
+        print(f"ERROR: {message}")
+    for message in notes:
+        print(f"NOTE:  {message}")
+    if not errors and not notes:
+        print("OK: valid, and every field is usable.")
+    elif not errors:
+        print(f"OK: valid, with {len(notes)} note(s) above.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/outcome-completion-agent/scripts/test_check_evidence_schema.py
+++ b/skills/outcome-completion-agent/scripts/test_check_evidence_schema.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for check_evidence_schema.py.
+
+    python3 scripts/test_check_evidence_schema.py
+
+Standard library only. No network, no credentials, no calls.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_evidence_schema import check, parse_money, said_no  # noqa: E402
+
+
+def errors(result: object) -> list[str]:
+    return check(result)[0]
+
+
+def notes(result: object) -> list[str]:
+    return check(result)[1]
+
+
+GOOD = {
+    "reached": "yes",
+    "verdict": "confirmed",
+    "facts": ["Booked onto Thursday's van run."],
+    "blockers": [],
+    "referrals": [],
+    "offer": {
+        "what_is_offered": "500 insulated shipping boxes",
+        "price": "438.00",
+        "currency": "USD",
+        "eta": "2026-09-10",
+        "reference": "BWD-48291",
+    },
+}
+
+
+class Money(unittest.TestCase):
+    def test_reads_the_shapes_a_caller_produces(self):
+        self.assertEqual(
+            [parse_money(v) for v in (438, "438", "$438.00", "USD 1,438", " 612 ")],
+            [438.0, 438.0, 438.0, 1438.0, 612.0],
+        )
+
+    def test_unreadable_is_none_never_zero(self):
+        for value in ("about four hundred", "", None, True, {}, []):
+            self.assertIsNone(parse_money(value), value)
+
+
+class Required(unittest.TestCase):
+    def test_a_complete_result_is_clean(self):
+        self.assertEqual(check(GOOD), ([], []))
+
+    def test_only_verdict_is_required(self):
+        """CALL-E returns null for the whole result when it cannot satisfy the
+        schema, so every extra required field is another way to lose the call."""
+        found = errors({})
+        self.assertEqual(found, ["Missing required field 'verdict'."])
+        self.assertEqual(errors({"verdict": "partial"}), [])
+
+    def test_an_unknown_verdict_is_an_error(self):
+        self.assertTrue(any("verdict" in m for m in errors({**GOOD, "verdict": "maybe"})))
+
+    def test_facts_must_be_strings(self):
+        self.assertTrue(any("facts" in m for m in errors({**GOOD, "facts": "not a list"})))
+
+    def test_a_non_object_result_is_rejected(self):
+        self.assertTrue(errors(["not", "an", "object"]))
+
+
+class Referrals(unittest.TestCase):
+    def test_a_non_e164_number_is_flagged_as_dropped(self):
+        found = notes({**GOOD, "referrals": [{"org_name": "Depot", "phone": "555-0100"}]})
+        self.assertTrue(any("never be called" in m for m in found))
+        self.assertNotIn("555-0100", str(found))
+
+    def test_unicode_digits_are_not_e164(self):
+        found = notes({**GOOD, "referrals": [{"org_name": "Depot", "phone": "+1555010000٣"}]})
+        self.assertTrue(any("not E.164" in m for m in found))
+
+    def test_a_referral_with_no_number_is_flagged(self):
+        found = notes({**GOOD, "referrals": [{"org_name": "Head office"}]})
+        self.assertTrue(any("will be dropped" in m for m in found))
+
+    def test_a_referral_with_no_name_is_an_error(self):
+        self.assertTrue(errors({**GOOD, "referrals": [{"phone": "+15550100002"}]}))
+
+    def test_a_good_referral_is_silent(self):
+        self.assertEqual(
+            notes({**GOOD, "referrals": [{"org_name": "Depot", "phone": "+15550100003"}]}), []
+        )
+
+
+class Offers(unittest.TestCase):
+    def test_an_unreadable_price_warns_that_budget_cannot_block(self):
+        offer = {**GOOD["offer"], "price": "about four hundred"}
+        self.assertTrue(
+            any("cannot block" in m for m in notes({**GOOD, "offer": offer}))
+        )
+
+    def test_an_absent_price_warns_that_budget_reads_unknown(self):
+        offer = {k: v for k, v in GOOD["offer"].items() if k != "price"}
+        self.assertTrue(any("unknown" in m for m in notes({**GOOD, "offer": offer})))
+
+    def test_a_non_iso_date_warns_the_deadline_cannot_compare(self):
+        offer = {**GOOD["offer"], "eta": "next Thursday"}
+        self.assertTrue(any("YYYY-MM-DD" in m for m in notes({**GOOD, "offer": offer})))
+
+    def test_a_confirmation_without_a_reference_is_flagged(self):
+        offer = {**GOOD["offer"], "reference": ""}
+        self.assertTrue(any("reference" in m for m in notes({**GOOD, "offer": offer})))
+
+    def test_an_empty_offer_reads_as_no_offer(self):
+        self.assertTrue(
+            any("no offer" in m for m in notes({**GOOD, "verdict": "offer", "offer": {}}))
+        )
+
+    def test_an_offer_verdict_with_no_offer_is_flagged(self):
+        self.assertTrue(
+            any("no offer to evaluate" in m
+                for m in notes({**GOOD, "verdict": "offer", "offer": None}))
+        )
+
+
+class ReachedIsAnEnum(unittest.TestCase):
+    """CALL-E prefers a string enum with `unknown` over a boolean, because a
+    call often cannot settle the question."""
+
+    def test_the_three_values_are_accepted(self):
+        for value in ("yes", "no", "unknown"):
+            self.assertEqual(errors({**GOOD, "reached": value}), [], value)
+
+    def test_a_boolean_is_still_accepted(self):
+        self.assertEqual(errors({**GOOD, "reached": False}), [])
+
+    def test_anything_else_is_an_error(self):
+        self.assertTrue(errors({**GOOD, "reached": "maybe"}))
+
+    def test_unknown_is_not_a_no(self):
+        self.assertFalse(said_no("unknown"))
+        self.assertTrue(said_no("no"))
+        self.assertTrue(said_no(False))
+
+
+class Consistency(unittest.TestCase):
+    def test_not_reached_with_a_rich_verdict_is_flagged(self):
+        found = notes({**GOOD, "reached": "no"})
+        self.assertTrue(any("nothing was established" in m for m in found))
+
+    def test_unknown_fields_are_reported_as_ignored(self):
+        self.assertTrue(any("Unknown field" in m for m in notes({**GOOD, "surprise": 1})))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `skills/outcome-completion-agent/`, a portable pattern for goals that require a
bounded sequence of phone calls when later recipients are discovered through referrals.

The contribution includes:

- a focused `SKILL.md` covering applicability, approval, budgets, and outcomes;
- a structured evidence schema with CALL-E compatibility guidance;
- deterministic constraint and approval-gate references;
- safety guidance for disclosure, E.164 validation, masking, credentials, ambiguity,
  sensitive content, and one-shot execution; and
- an offline evidence-schema checker with 23 standard-library tests.

The checker has no network or credential path. Live calls are not the default, each run
requires explicit authorization, and an ambiguous provider outcome stops the loop for
human review.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Validation

- `python3 scripts/validate_repository.py`
- `python3 skills/outcome-completion-agent/scripts/test_check_evidence_schema.py`

Both validation paths are offline and place no calls.
