### PR TITLE
feat(apps): add OneReach service follow-up example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 
 ### Apps
 
+- [OneReach service follow-up](apps/typescript/onereach-service-followup/) - Turns an authorized CALL-E service appointment conversation into a validated Operations handoff, with a no-call default and standalone public integration example.
+
 - [Audition Agent](apps/python/audition-agent/) - Producer-reviewed CALL-E role-disclosure calls that collect performer interest, callback availability, and unanswered questions, with a no-call verification path.
 - [CallParity](https://github.com/ruddro-roy/callparity) - Two-call ops workbench for Party A claims, a Party B falsification CALL-E task, and a merged claim graph. Preview and fixture mode by default.
 - [CallmeMaybe](https://github.com/jongan69/callmemaybe) - Shopify order-exception phone workflows that use CALL-E for carrier traces and consent-first customer callbacks, with a no-call fixture mode and merchant approval before every Shopify mutation.

--- a/apps/README.md
+++ b/apps/README.md
@@ -49,6 +49,8 @@ Current apps:
 | [`python/casechaser`](python/casechaser/) | Python | Chases an open claim, refund, repair, or delivery case to closure: every company promise becomes a dated, quoted commitment, broken ones climb a fixed escalation ladder, offers and denials stop at the customer, and a masked evidence pack is ready for the written complaint. Fixture mode by default. |
 | [`python/agency-status-watch`](python/agency-status-watch/) | Python | Recurring status watch for phone-only government application files: CALL-E navigates the agency's published IVR, reads back the status of your own application by reference number, and returns it as structured JSON, re-checking on a decaying cadence until terminal, action-required, or budget spent. Fixture-first with a consent-gated live path. |
 
+- [OneReach service follow-up](typescript/onereach-service-followup/) - Standalone Node.js CALL-E appointment workflow with a no-call default, validated outcomes, and signed webhook handling.
+
 Suggested grouping:
 
 ```text

--- a/apps/typescript/onereach-service-followup/.env.example
+++ b/apps/typescript/onereach-service-followup/.env.example
@@ -1,0 +1,14 @@
+# Load server-only configuration intentionally, e.g. node --env-file=.env src/cli.mjs --live
+CALLE_API_KEY=
+CALLE_WEBHOOK_SECRET=
+# Optional HTTPS endpoint forwarded to the local webhook server.
+CALLE_WEBHOOK_URL=
+# Supply a phone you own or are explicitly authorized to call.
+CALLE_TEST_PHONE=
+CALLE_TEST_REGION=MY
+CALLE_TEST_LOCALE=en-MY
+CALLE_CONTACT_AUTHORIZED=false
+CALLE_LIVE_ENABLED=false
+# A stable unique reference for one demonstration. Reuse it when recovering.
+CALLE_DEMO_ID=
+PORT=3188

--- a/apps/typescript/onereach-service-followup/.env.example
+++ b/apps/typescript/onereach-service-followup/.env.example
@@ -5,6 +5,8 @@ CALLE_WEBHOOK_SECRET=
 CALLE_WEBHOOK_URL=
 # Supply a phone you own or are explicitly authorized to call.
 CALLE_TEST_PHONE=
+# Repeat that exact ASCII E.164 value to bind authorization to this live run.
+CALLE_AUTHORIZED_DESTINATION=
 CALLE_TEST_REGION=MY
 CALLE_TEST_LOCALE=en-MY
 CALLE_CONTACT_AUTHORIZED=false

--- a/apps/typescript/onereach-service-followup/.gitignore
+++ b/apps/typescript/onereach-service-followup/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+.env.local
+.state/
+coverage/

--- a/apps/typescript/onereach-service-followup/LICENSE
+++ b/apps/typescript/onereach-service-followup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OneReach contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/typescript/onereach-service-followup/README.md
+++ b/apps/typescript/onereach-service-followup/README.md
@@ -77,13 +77,14 @@ Live calling is opt-in and may consume CALL-E credits. Use only your own number 
 ```sh
 npm install
 cp .env.example .env
-# Edit .env locally: API key, authorized number, region/locale,
+# Edit .env locally: API key, authorized number, region/locale, and
+# CALLE_AUTHORIZED_DESTINATION set to that exact authorized number,
 # CALLE_CONTACT_AUTHORIZED=true, CALLE_LIVE_ENABLED=true,
 # and a stable CALLE_DEMO_ID such as judge-rehearsal-001.
 node --env-file=.env src/cli.mjs --live
 ```
 
-No fixed number allowlist is used. Valid E.164 formatting is checked; the caller remains responsible for permission and provider-supported destinations. Credentials are server-side; never paste them into the browser or commit `.env`.
+Every live run requires `CALLE_AUTHORIZED_DESTINATION` to be the exact ASCII E.164 value in `CALLE_TEST_PHONE`; changing the recipient without renewing that authorization fails before the SDK is loaded. The caller remains responsible for permission and provider-supported destinations. Credentials are server-side; never paste them into the browser or commit `.env`.
 
 The task identifies the call as a synthetic demonstration, asks whether it is a good time, and discusses only the supplied fictional service appointment. It aims for three minutes, but **SDK 0.2.2 exposes no enforceable maximum duration or cancel/hang-up method**. This example therefore does not enforce a three-minute cap, a financial budget, or ten actual phone dials. Do not use it as an unrestricted shared judge calling service.
 

--- a/apps/typescript/onereach-service-followup/README.md
+++ b/apps/typescript/onereach-service-followup/README.md
@@ -2,7 +2,51 @@
 
 A standalone integration example extracted around OneReach's CALL-E boundary. An approved, synthetic service appointment becomes a CALL-E task; a structured result becomes an actionable Operations handoff. OneReach is the wider workflow product at [onereach.my](https://onereach.my). Its proprietary platform source is not required to run this example.
 
-**Local contribution candidate, not yet published or accepted.** The console demonstration is a standalone reference, not the full OneReach UI. Dry-run output is synthetic and never evidence of a real phone call.
+**Public contribution: [PR #372](https://github.com/CALLE-AI/awesome-phone-call-agents/pull/372).** Maintainer acceptance is separate from publication. The console demonstration is a standalone reference, not the full OneReach UI. Dry-run output is synthetic and never evidence of a real phone call.
+
+## How OneReach manages the task before and after CALL-E
+
+OneReach owns the business workflow: understanding the operator's goal, preparing a reviewable plan, managing execution, and tracking the next action. CALL-E is the outbound calling provider used when the operator chooses a calling workflow. Other OneReach communication surfaces include WhatsApp and web chat, with their own workflows; choosing CALL-E does not imply automatic routing or fallback between these channels.
+
+```mermaid
+flowchart TD
+  A[Operator goal and business records] --> B[OneReach AI-assisted task preparation]
+  B --> C[Required fields, recipients, script, outcomes and action rules]
+  C --> D[Validation and human approval of a versioned plan]
+  D --> E[Selected communication workflow]
+  E --> F[Outbound voice through CALL-E]
+  E --> G[Other separately configured channel workflows]
+  F --> H[CALL-E task, recipient, result schema and correlation metadata]
+  H --> I[Customer conversation]
+  I --> J[Verified webhook and provider reconciliation]
+  J --> K[OneReach outcome and next-action tracking]
+  K --> L[Close, policy retry, suppression or assigned human follow-up]
+```
+
+### Task lifecycle
+
+1. **Prepare the work.** The operator supplies the business objective and recipient records. OneReach's AI-assisted preparation resolves the workflow requirements into a structured plan: objective, expected outcomes, caller identity and disclosure, required business fields, recipient snapshot, conversation script, and prohibited actions. Missing information must be resolved before the plan is ready.
+2. **Review and approve.** OneReach validates the plan and records human approval of its version. The plan also defines execution timing, application retry policy, contact basis, and which outcomes should create follow-up work. AI-generated text alone does not authorize a call.
+3. **Dispatch the selected calling task.** For CALL-E voice execution, the worker checks workspace/run state and recipient suppression before sending recipient-specific instructions. The SDK payload includes the phone, region, locale, task, result schemas, webhook URL, and workspace/run/plan/dispatch correlation metadata. A stable idempotency key identifies the dispatch.
+4. **Track execution and reconcile.** OneReach associates CALL-E's task and recipient identifiers with its stored run and attempts. Verified webhook events and provider retrieval update the execution record. An uncertain provider response must be reconciled rather than treated as permission for a fresh call.
+5. **Turn the answer into work.** OneReach maps the result to the workflow's action rules: record completion, schedule a policy-controlled follow-up, suppress future contact, or create a human task in the responsible queue. A conversation outcome is distinct from completion of the downstream business action: a reschedule request still needs a confirmed calendar change.
+
+### Task types represented in the OneReach platform
+
+These are the platform's defined workflow families, not additional implementations or live-call evidence shipped in this small example.
+
+| Workflow | Work prepared by OneReach | CALL-E conversation purpose | Follow-up owner |
+| --- | --- | --- | --- |
+| Overdue invoice follow-up | Approved invoice context and permitted outcomes | Capture payment status, a stated promise date, dispute, or callback request | Finance |
+| Service and appointment reminders | Existing appointment and allowed alternate times | Confirm attendance or capture a reschedule, cancellation, or question | Operations |
+| HR interview and onboarding scheduling | Administrative event details and approved slots | Confirm or reschedule an interview/onboarding event and capture questions | HR; no candidate scoring or hiring decisions |
+| Social lead introduction booking | Consented enquiry context, approved product information and assigned agent | Confirm interest and capture an introductory-call time or callback request | Sales follow-up |
+
+The same preparation → approval → dispatch → result → action pattern can be adapted to further defined tasks by supplying their required fields, permitted conversation, result schema, and outcome rules. This is an extension pattern, not a claim that every arbitrary task or channel is already implemented. Provider capabilities and each task's business constraints still apply.
+
+### What this public commit demonstrates
+
+This directory implements the **service appointment** slice of that lifecycle: an already-approved synthetic input, CALL-E dispatch, reconciliation, result validation, and a returned Operations action. It does not include the private AI planner, approval UI, scheduler, multi-channel configuration, or team task database. Those platform responsibilities are explained above so maintainers can understand where the reusable CALL-E boundary fits without needing the proprietary repository.
 
 ## Quick start — no account, credentials, or phone call
 
@@ -75,6 +119,6 @@ The timestamp window deliberately rejects old deliveries; recover by polling, no
 
 This example uses the official `@call-e/calle` 0.2.2 SDK and its supported create/get/events/webhook interfaces. Local tests make no network requests and no calls. Passing them does not prove live telephony, provider performance, or a deployment at onereach.my. The hackathon video should independently show the live OneReach UI and an authorized CALL-E call.
 
-Public release scope is this directory only; no parent repository, database, accounts, platform prompts, billing, or internal configuration is included. Before contributing, review this directory and the upstream [contribution guide](https://github.com/CALLE-AI/awesome-phone-call-agents/blob/main/CONTRIBUTING.md). Proposed destination: `apps/typescript/onereach-service-followup/` (confirm against upstream validation before opening the PR).
+Public release scope is this directory only; no parent repository, database, accounts, platform prompts, billing, or internal configuration is included. Before contributing, review this directory and the upstream [contribution guide](https://github.com/CALLE-AI/awesome-phone-call-agents/blob/main/CONTRIBUTING.md). Contribution location: `apps/typescript/onereach-service-followup/`.
 
 License: MIT for the files in this example directory only. It does not license the private OneReach platform or grant rights to third-party trademarks.

--- a/apps/typescript/onereach-service-followup/README.md
+++ b/apps/typescript/onereach-service-followup/README.md
@@ -1,0 +1,80 @@
+# OneReach × CALL-E: service appointment to Operations action
+
+A standalone integration example extracted around OneReach's CALL-E boundary. An approved, synthetic service appointment becomes a CALL-E task; a structured result becomes an actionable Operations handoff. OneReach is the wider workflow product at [onereach.my](https://onereach.my). Its proprietary platform source is not required to run this example.
+
+**Local contribution candidate, not yet published or accepted.** The console demonstration is a standalone reference, not the full OneReach UI. Dry-run output is synthetic and never evidence of a real phone call.
+
+## Quick start — no account, credentials, or phone call
+
+Requires Node.js 22+. From this directory:
+
+```sh
+node src/cli.mjs
+node --test test/*.test.mjs
+```
+
+The default demonstration needs no dependency installation or network access. Two SDK contract tests skip until `npm install`; all other tests run immediately. After installation, the SDK tests use an in-memory transport and synthetic HMAC, never the provider network. It prints a fictional appointment, a clearly labelled synthetic call outcome, and an Operations next action. A requested reschedule is **not** a completed calendar booking.
+
+## What is reusable
+
+- Single-recipient CALL-E task with an explicit approved appointment and alternate slots.
+- Strict result schema and application validation: invalid slots and ambiguous results go to human review.
+- Opt-out / wrong-number handling produces a stop-contact action.
+- Stable request snapshot and idempotency key, saved **before** provider creation.
+- Polling by the original task ID after a timeout, without making a replacement task.
+- Optional raw-body webhook verification, timestamp checks, persistent deduplication, and retryable storage failures.
+
+The example returns actions; it does not write a CRM, update a real calendar, or claim to implement OneReach's full suppression database. Connect those downstream systems explicitly in your application.
+
+## Intentional live test
+
+Live calling is opt-in and may consume CALL-E credits. Use only your own number or a person who has explicitly agreed to this test. The recipient should expect an AI-assisted fictional appointment conversation.
+
+```sh
+npm install
+cp .env.example .env
+# Edit .env locally: API key, authorized number, region/locale,
+# CALLE_CONTACT_AUTHORIZED=true, CALLE_LIVE_ENABLED=true,
+# and a stable CALLE_DEMO_ID such as judge-rehearsal-001.
+node --env-file=.env src/cli.mjs --live
+```
+
+No fixed number allowlist is used. Valid E.164 formatting is checked; the caller remains responsible for permission and provider-supported destinations. Credentials are server-side; never paste them into the browser or commit `.env`.
+
+The task identifies the call as a synthetic demonstration, asks whether it is a good time, and discusses only the supplied fictional service appointment. It aims for three minutes, but **SDK 0.2.2 exposes no enforceable maximum duration or cancel/hang-up method**. This example therefore does not enforce a three-minute cap, a financial budget, or ten actual phone dials. Do not use it as an unrestricted shared judge calling service.
+
+### Timeout, retries and stopping
+
+The console monitors for five minutes. That timeout stops local monitoring, **not the remote call**. Rerun with the **same** `CALLE_DEMO_ID` to use the original saved task/input/key. Do not delete its state or change the ID to recover an uncertain request. One task can have multiple provider attempts; output counts distinct observed attempts with a dialing start time, not guaranteed final billable calls.
+
+Ctrl+C stops this local process only. A recipient can decline or hang up. Provider support/account controls may be needed to stop remote work; this SDK does not expose that operation. There is no automatic task retry in the example. The saved idempotency key protects repeated create requests with identical inputs.
+
+After first creation, changing `.env` does not replace that demonstration's saved recipient/input. Review the local state privately; choose a new ID only for a genuinely new authorized test. `.state/` may contain your test number and webhook results. It is ignored by Git; remove it only after the task is terminal and records are no longer needed, and never reuse that deleted ID.
+
+## Optional webhook receiver
+
+Polling works without a webhook. To receive events, configure the signing secret locally and expose only `/webhooks/calle` through an HTTPS tunnel:
+
+```sh
+node --env-file=.env src/webhook.mjs
+```
+
+Set `CALLE_WEBHOOK_URL` to that HTTPS URL **before starting a new demo ID**. The receiver binds to loopback port 3188. It authenticates the exact raw bytes using the SDK, checks the signed timestamp within five minutes, saves verified events under `.state/events/`, and acknowledges duplicate IDs safely. It does not initiate calls. Polling fetches authoritative task results and performs outcome mapping.
+
+The timestamp window deliberately rejects old deliveries; recover by polling, not by dispatching again. This local filesystem inbox is a single-host reference. Production deployments need coordinated durable storage, retention, monitoring, and per-tenant access controls. Tests cover handler behavior; actual provider delivery still needs live verification.
+
+## Expected demonstration
+
+1. The fictional original appointment is at 10:00, Asia/Kuala_Lumpur, two days after fixture generation.
+2. The consenting recipient asks for 14:00, one of the two approved alternatives.
+3. CALL-E returns `reschedule_requested` with the exact approved slot.
+4. The example outputs an Operations task and `calendarUpdated: false`.
+5. An unapproved time routes to human review. Opt-out returns a stop-contact action.
+
+## Scope and verification
+
+This example uses the official `@call-e/calle` 0.2.2 SDK and its supported create/get/events/webhook interfaces. Local tests make no network requests and no calls. Passing them does not prove live telephony, provider performance, or a deployment at onereach.my. The hackathon video should independently show the live OneReach UI and an authorized CALL-E call.
+
+Public release scope is this directory only; no parent repository, database, accounts, platform prompts, billing, or internal configuration is included. Before contributing, review this directory and the upstream [contribution guide](https://github.com/CALLE-AI/awesome-phone-call-agents/blob/main/CONTRIBUTING.md). Proposed destination: `apps/typescript/onereach-service-followup/` (confirm against upstream validation before opening the PR).
+
+License: MIT for the files in this example directory only. It does not license the private OneReach platform or grant rights to third-party trademarks.

--- a/apps/typescript/onereach-service-followup/package.json
+++ b/apps/typescript/onereach-service-followup/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "onereach-calle-service-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "demo": "node src/cli.mjs",
+    "test": "node --test test/*.test.mjs",
+    "webhook": "node src/webhook.mjs"
+  },
+  "dependencies": { "@call-e/calle": "0.2.2" }
+}

--- a/apps/typescript/onereach-service-followup/src/cli.mjs
+++ b/apps/typescript/onereach-service-followup/src/cli.mjs
@@ -1,0 +1,54 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { appointmentFixture, createInput, normalizeOutcome, syntheticCall } from "./workflow.mjs";
+
+const args = process.argv.slice(2);
+if (args.length && !(args.length === 1 && args[0] === "--live")) throw new Error("Usage: node src/cli.mjs [--live]");
+const live = args[0] === "--live";
+if (!live) {
+  const appointment = appointmentFixture();
+  console.info(JSON.stringify({ mode: "dry-run", realCallPlaced: false, appointment, result: normalizeOutcome(syntheticCall(appointment), appointment) }, null, 2));
+} else {
+  if (process.env.CALLE_LIVE_ENABLED !== "true" || process.env.CALLE_CONTACT_AUTHORIZED !== "true" || !process.env.CALLE_API_KEY) {
+    throw new Error("Live mode requires explicit enablement, contact authorization, and server-side API credentials.");
+  }
+  const demoId = process.env.CALLE_DEMO_ID;
+  if (!/^[a-zA-Z0-9_-]{8,80}$/.test(demoId ?? "")) throw new Error("Provide a stable CALLE_DEMO_ID.");
+  const directory = new URL("../.state/", import.meta.url);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const stateUrl = new URL(`${demoId}.json`, directory);
+  let state;
+  try { state = JSON.parse(await readFile(stateUrl, "utf8")); }
+  catch (error) { if (error.code !== "ENOENT") throw error; }
+  if (!state) {
+    const appointment = appointmentFixture();
+    const input = createInput({ appointment, phone: process.env.CALLE_TEST_PHONE,
+      region: process.env.CALLE_TEST_REGION, locale: process.env.CALLE_TEST_LOCALE,
+      demoId, webhookUrl: process.env.CALLE_WEBHOOK_URL || undefined });
+    const requestHash = createHash("sha256").update(JSON.stringify(input)).digest("hex");
+    state = { appointment, input, requestHash, idempotencyKey: `onereach-demo:${demoId}:${requestHash}`, callId: null };
+    // Exclusive creation prevents two first-run processes from creating different tasks.
+    await writeFile(stateUrl, JSON.stringify(state), { flag: "wx", mode: 0o600 });
+  }
+  const { CalleClient } = await import("@call-e/calle");
+  const client = new CalleClient({ apiKey: process.env.CALLE_API_KEY });
+  if (!state.callId) {
+    // On uncertain errors rerun with the SAME demo id: saved input and idempotency key are reused.
+    const call = await client.calls.create(state.input, { idempotencyKey: state.idempotencyKey });
+    state.callId = call.id;
+    await writeFile(stateUrl, JSON.stringify(state), { mode: 0o600 });
+  }
+  console.info(JSON.stringify({ mode: "live", callId: state.callId, warning: "Polling timeout does not hang up a call. This example has no hard duration or physical-dial quota." }));
+  const deadline = Date.now() + 5 * 60_000;
+  let call;
+  do {
+    call = await client.calls.get(state.callId);
+    if (["completed", "failed", "canceled"].includes(call.status)) break;
+    await sleep(5_000);
+  } while (Date.now() < deadline);
+  const eventPage = await client.calls.listEvents(state.callId);
+  const observedAttempts = new Set(call.recipients.flatMap((recipient) => recipient.attempts.filter((attempt) => attempt.startedAt).map((attempt) => attempt.id))).size;
+  console.info(JSON.stringify({ callId: call.id, providerStatus: call.status, observedStartedAttempts: observedAttempts,
+    eventsOnFirstPage: eventPage.data.length, moreEventsAvailable: Boolean(eventPage.nextCursor), result: normalizeOutcome(call, state.appointment) }, null, 2));
+}

--- a/apps/typescript/onereach-service-followup/src/cli.mjs
+++ b/apps/typescript/onereach-service-followup/src/cli.mjs
@@ -13,6 +13,11 @@ if (!live) {
   if (process.env.CALLE_LIVE_ENABLED !== "true" || process.env.CALLE_CONTACT_AUTHORIZED !== "true" || !process.env.CALLE_API_KEY) {
     throw new Error("Live mode requires explicit enablement, contact authorization, and server-side API credentials.");
   }
+  const testPhone = process.env.CALLE_TEST_PHONE ?? "";
+  const authorizedDestination = process.env.CALLE_AUTHORIZED_DESTINATION ?? "";
+  if (!/^\+[1-9][0-9]{7,14}$/.test(authorizedDestination) || authorizedDestination !== testPhone) {
+    throw new Error("Set CALLE_AUTHORIZED_DESTINATION to the exact ASCII E.164 test phone for this live run.");
+  }
   const demoId = process.env.CALLE_DEMO_ID;
   if (!/^[a-zA-Z0-9_-]{8,80}$/.test(demoId ?? "")) throw new Error("Provide a stable CALLE_DEMO_ID.");
   const directory = new URL("../.state/", import.meta.url);
@@ -23,7 +28,7 @@ if (!live) {
   catch (error) { if (error.code !== "ENOENT") throw error; }
   if (!state) {
     const appointment = appointmentFixture();
-    const input = createInput({ appointment, phone: process.env.CALLE_TEST_PHONE,
+    const input = createInput({ appointment, phone: testPhone,
       region: process.env.CALLE_TEST_REGION, locale: process.env.CALLE_TEST_LOCALE,
       demoId, webhookUrl: process.env.CALLE_WEBHOOK_URL || undefined });
     const requestHash = createHash("sha256").update(JSON.stringify(input)).digest("hex");

--- a/apps/typescript/onereach-service-followup/src/webhook-handler.mjs
+++ b/apps/typescript/onereach-service-followup/src/webhook-handler.mjs
@@ -1,0 +1,19 @@
+export async function handleWebhook({ rawBody, headers, secret, client, store, now = Date.now() }) {
+  const timestamp = headers["call-e-timestamp"];
+  if (typeof timestamp !== "string" || !/^\d+$/.test(timestamp) || Math.abs(now / 1_000 - Number(timestamp)) > 300) {
+    return { status: 401, body: { error: "invalid_webhook_timestamp" } };
+  }
+  let event;
+  try { event = client.webhooks.unwrap({ rawBody, headers, secret }); }
+  catch { return { status: 401, body: { error: "invalid_webhook_signature" } }; }
+  if (!event || typeof event.id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(event.id)) {
+    return { status: 400, body: { error: "invalid_event_id" } };
+  }
+  // Persist before acknowledging. A crash/retry is safe; duplicate IDs are idempotent.
+  try { await store(event); }
+  catch (error) {
+    if (error.code === "EEXIST") return { status: 200, body: { received: true, duplicate: true } };
+    return { status: 503, body: { error: "event_storage_unavailable" } };
+  }
+  return { status: 202, body: { received: true } };
+}

--- a/apps/typescript/onereach-service-followup/src/webhook.mjs
+++ b/apps/typescript/onereach-service-followup/src/webhook.mjs
@@ -1,0 +1,32 @@
+import { createServer } from "node:http";
+import { mkdir, writeFile } from "node:fs/promises";
+import { CalleClient } from "@call-e/calle";
+import { handleWebhook } from "./webhook-handler.mjs";
+
+const secret = process.env.CALLE_WEBHOOK_SECRET;
+if (!secret) throw new Error("Configure a server-side CALLE_WEBHOOK_SECRET.");
+const client = new CalleClient({ apiKey: "local-webhook-verification-only" });
+const directory = new URL("../.state/events/", import.meta.url);
+await mkdir(directory, { recursive: true, mode: 0o700 });
+const server = createServer(async (request, response) => {
+  if (request.method !== "POST" || request.url !== "/webhooks/calle") {
+    response.writeHead(404).end(); return;
+  }
+  try {
+    let size = 0;
+    const chunks = [];
+    for await (const chunk of request) {
+      size += chunk.length;
+      if (size > 256 * 1_024) { response.writeHead(413).end(); return; }
+      chunks.push(chunk);
+    }
+    const result = await handleWebhook({ rawBody: Buffer.concat(chunks), headers: request.headers, secret, client,
+      store: (event) => writeFile(new URL(`${event.id}.json`, directory), JSON.stringify(event), { flag: "wx", mode: 0o600 }),
+    });
+    response.writeHead(result.status, { "content-type": "application/json" }).end(JSON.stringify(result.body));
+  } catch { response.writeHead(500).end(); }
+});
+server.requestTimeout = 15_000;
+server.listen(Number(process.env.PORT || 3188), "127.0.0.1", () => {
+  console.info("CALL-E webhook receiver listening on loopback. Expose only /webhooks/calle through your chosen HTTPS tunnel.");
+});

--- a/apps/typescript/onereach-service-followup/src/workflow.mjs
+++ b/apps/typescript/onereach-service-followup/src/workflow.mjs
@@ -1,0 +1,81 @@
+export const outcomes = ["confirmed", "reschedule_requested", "cancelled", "question", "unreachable", "wrong_number", "opt_out", "needs_human"];
+
+export function appointmentFixture(now = new Date()) {
+  const day = new Date(now.getTime() + 2 * 86_400_000).toISOString().slice(0, 10);
+  return {
+    id: "SYNTHETIC-APPOINTMENT-001", customer: "Alex Demo", service: "equipment service",
+    scheduledAt: `${day}T10:00:00+08:00`, timezone: "Asia/Kuala_Lumpur",
+    location: "Demo service centre", alternateSlots: [`${day}T14:00:00+08:00`, `${day}T16:00:00+08:00`],
+  };
+}
+
+export function createInput({ appointment, phone, region = "MY", locale = "en-MY", demoId, webhookUrl }) {
+  if (!/^[a-zA-Z0-9_-]{8,80}$/.test(demoId ?? "")) throw new Error("Provide a stable CALLE_DEMO_ID (8–80 letters, digits, underscores or hyphens).");
+  if (!/^\+[1-9]\d{7,14}$/.test(phone ?? "")) throw new Error("Provide an authorized E.164 number.");
+  if (webhookUrl && new URL(webhookUrl).protocol !== "https:") throw new Error("Webhook URL must use HTTPS.");
+  return {
+    task: [
+      "You are OneReach Demo Service, an AI-assisted caller in an authorized synthetic demonstration.",
+      "State that this is a demonstration, confirm the intended recipient and ask if now is a good time.",
+      `Discuss only this fictional appointment: ${JSON.stringify(appointment)}.`,
+      "Ask whether the appointment works. On a change request, offer only the supplied alternateSlots.",
+      "Read back their chosen slot and explain that Operations must complete the change; do not claim a calendar was updated.",
+      "Stop immediately on opt-out or wrong number. Route questions or unclear answers to a human.",
+      "Do not collect payment details, give medical advice, invent availability, or make another attempt after refusal.",
+      "Aim to finish within three minutes. This instruction is a conversational target, not a provider-enforced time limit.",
+    ].join("\n"),
+    recipients: [{ phones: [phone], region, locale }],
+    resultSchema: { type: "object", additionalProperties: false, required: ["processed_count"], properties: { processed_count: { type: "integer" } } },
+    recipientResultSchema: {
+      type: "object", additionalProperties: false, required: ["outcome", "requested_slot", "needs_human"],
+      properties: {
+        outcome: { type: "string", enum: outcomes },
+        requested_slot: { type: ["string", "null"] },
+        needs_human: { type: "boolean" },
+      },
+    },
+    metadata: { demo_id: demoId, appointment_id: appointment.id, synthetic: true, integration: "onereach-service-example" },
+    ...(webhookUrl ? { webhookUrl } : {}),
+  };
+}
+
+export function normalizeOutcome(call, appointment) {
+  if (!call || !["completed", "failed", "canceled"].includes(call.status)) {
+    return { state: "pending", nextAction: "Continue monitoring this task; do not create a replacement." };
+  }
+  const human = (reason) => ({ state: "complete", outcome: "needs_human", queue: "Operations", needsHuman: true, nextAction: reason, calendarUpdated: false });
+  if (call.status !== "completed") return human(`CALL-E task ${call.status}; inspect before deciding whether to retry.`);
+  if (call.recipients?.length !== 1) return human("Unexpected recipient count; review provider evidence.");
+  const result = call.recipients[0].structuredResult;
+  if (!result || !outcomes.includes(result.outcome) || typeof result.needs_human !== "boolean" ||
+      !(result.requested_slot === null || typeof result.requested_slot === "string") ||
+      Object.keys(result).some((key) => !["outcome", "requested_slot", "needs_human"].includes(key))) {
+    return human("Missing or invalid structured result; review the conversation.");
+  }
+  if (result.outcome === "opt_out" || result.outcome === "wrong_number") {
+    return { state: "complete", outcome: result.outcome, queue: "Operations", needsHuman: true,
+      suppressFurtherContact: true, nextAction: "Stop contact; have the operator update the contact record.", calendarUpdated: false };
+  }
+  if (result.outcome === "reschedule_requested" && !appointment.alternateSlots.includes(result.requested_slot)) {
+    return human("Requested time is not an approved alternate slot. No booking change was made.");
+  }
+  if (result.outcome !== "reschedule_requested" && result.requested_slot !== null) {
+    return human("Outcome and requested slot conflict. No booking change was made.");
+  }
+  return {
+    state: "complete", outcome: result.outcome, queue: "Operations",
+    requestedSlot: result.requested_slot, needsHuman: result.needs_human || result.outcome !== "confirmed",
+    calendarUpdated: false,
+    nextAction: result.outcome === "reschedule_requested"
+      ? "Operations: confirm availability and complete the requested calendar change."
+      : result.outcome === "confirmed" && !result.needs_human
+        ? "Appointment confirmation recorded; no calendar change required."
+        : "Operations: review the conversation and resolve the next action.",
+  };
+}
+
+export function syntheticCall(appointment) {
+  return { id: "synthetic-call-not-provider-evidence", status: "completed", recipients: [{
+    structuredResult: { outcome: "reschedule_requested", requested_slot: appointment.alternateSlots[0], needs_human: true }, attempts: [],
+  }] };
+}

--- a/apps/typescript/onereach-service-followup/src/workflow.mjs
+++ b/apps/typescript/onereach-service-followup/src/workflow.mjs
@@ -11,7 +11,7 @@ export function appointmentFixture(now = new Date()) {
 
 export function createInput({ appointment, phone, region = "MY", locale = "en-MY", demoId, webhookUrl }) {
   if (!/^[a-zA-Z0-9_-]{8,80}$/.test(demoId ?? "")) throw new Error("Provide a stable CALLE_DEMO_ID (8–80 letters, digits, underscores or hyphens).");
-  if (!/^\+[1-9]\d{7,14}$/.test(phone ?? "")) throw new Error("Provide an authorized E.164 number.");
+  if (!/^\+[1-9][0-9]{7,14}$/.test(phone ?? "")) throw new Error("Provide an authorized ASCII E.164 number.");
   if (webhookUrl && new URL(webhookUrl).protocol !== "https:") throw new Error("Webhook URL must use HTTPS.");
   return {
     task: [

--- a/apps/typescript/onereach-service-followup/test/cli.test.mjs
+++ b/apps/typescript/onereach-service-followup/test/cli.test.mjs
@@ -16,3 +16,17 @@ test("live CLI refuses missing authorization before importing the SDK or writing
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Live mode requires explicit enablement/);
 });
+test("live CLI binds authorization to the exact destination", () => {
+  const result = spawnSync(process.execPath, [cli, "--live"], {
+    env: {
+      CALLE_LIVE_ENABLED: "true",
+      CALLE_CONTACT_AUTHORIZED: "true",
+      CALLE_API_KEY: "test-only",
+      CALLE_TEST_PHONE: "+12025550123",
+      CALLE_AUTHORIZED_DESTINATION: "+12025550124",
+    },
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /exact ASCII E\.164 test phone/);
+});

--- a/apps/typescript/onereach-service-followup/test/cli.test.mjs
+++ b/apps/typescript/onereach-service-followup/test/cli.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const cli = fileURLToPath(new URL("../src/cli.mjs", import.meta.url));
+test("default CLI produces an explicitly synthetic result without credentials", () => {
+  const output = execFileSync(process.execPath, [cli], { env: {}, encoding: "utf8" });
+  const result = JSON.parse(output);
+  assert.equal(result.mode, "dry-run");
+  assert.equal(result.realCallPlaced, false);
+  assert.equal(result.result.outcome, "reschedule_requested");
+});
+test("live CLI refuses missing authorization before importing the SDK or writing state", () => {
+  const result = spawnSync(process.execPath, [cli, "--live"], { env: {}, encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Live mode requires explicit enablement/);
+});

--- a/apps/typescript/onereach-service-followup/test/sdk-contract.test.mjs
+++ b/apps/typescript/onereach-service-followup/test/sdk-contract.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { appointmentFixture, createInput, normalizeOutcome } from "../src/workflow.mjs";
+import { handleWebhook } from "../src/webhook-handler.mjs";
+
+let CalleClient;
+try { ({ CalleClient } = await import(process.env.CALLE_SDK_TEST_MODULE || "@call-e/calle")); }
+catch (error) { if (error.code !== "ERR_MODULE_NOT_FOUND") throw error; }
+const skip = CalleClient ? false : "Install dependencies to exercise the SDK against an in-memory transport.";
+
+test("real SDK serializes our task and maps provider result without network", { skip }, async () => {
+  const appointment = appointmentFixture();
+  const input = createInput({ appointment, phone: "+12025550123", demoId: "sdk-contract-test" });
+  let requests = 0;
+  const client = new CalleClient({ apiKey: "local-test-only", baseUrl: "https://example.invalid",
+    fetch: async (request) => {
+      requests++;
+      assert.equal(request.method, "POST");
+      assert.equal(new URL(request.url).pathname, "/v1/calls");
+      assert.equal(request.headers.get("Idempotency-Key"), "stable-test-id");
+      const body = await request.json();
+      assert.deepEqual(body.recipient_result_schema, input.recipientResultSchema);
+      assert.deepEqual(body.recipients[0].phones, ["+12025550123"]);
+      return Response.json({ id: "call_synthetic", object: "call_task", status: "completed", task: body.task,
+        created_at: new Date().toISOString(), recipients: [{ id: "recipient_synthetic", phones: body.recipients[0].phones,
+          status: "completed", attempts: [], structured_result: { outcome: "reschedule_requested", requested_slot: appointment.alternateSlots[0], needs_human: true } }] });
+    },
+  });
+  const call = await client.calls.create(input, { idempotencyKey: "stable-test-id" });
+  assert.equal(requests, 1);
+  assert.equal(normalizeOutcome(call, appointment).outcome, "reschedule_requested");
+});
+
+test("real SDK accepts valid HMAC raw bytes and rejects altered body", { skip }, async () => {
+  const now = Date.now();
+  const timestamp = String(Math.floor(now / 1_000));
+  const rawBody = Buffer.from('{ "id": "evt_signed_test" }');
+  const secret = "synthetic-test-secret-not-a-credential";
+  const signature = createHmac("sha256", secret).update(Buffer.concat([Buffer.from(`${timestamp}.`), rawBody])).digest("hex");
+  let stored = 0;
+  const input = { rawBody, secret, now, client: new CalleClient({ apiKey: "local-test-only" }),
+    headers: { "call-e-timestamp": timestamp, "call-e-signature": `v1=${signature}` }, store: async () => { stored++; } };
+  assert.equal((await handleWebhook(input)).status, 202);
+  assert.equal((await handleWebhook({ ...input, rawBody: Buffer.from('{"id":"evt_signed_test"}') })).status, 401);
+  assert.equal(stored, 1);
+});

--- a/apps/typescript/onereach-service-followup/test/workflow.test.mjs
+++ b/apps/typescript/onereach-service-followup/test/workflow.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { appointmentFixture, createInput, normalizeOutcome, syntheticCall } from "../src/workflow.mjs";
+import { handleWebhook } from "../src/webhook-handler.mjs";
+
+const fixture = appointmentFixture(new Date("2026-09-08T00:00:00Z"));
+test("rescheduling creates human action, never a claimed calendar booking", () => {
+  const result = normalizeOutcome(syntheticCall(fixture), fixture);
+  assert.equal(result.outcome, "reschedule_requested");
+  assert.equal(result.requestedSlot, fixture.alternateSlots[0]);
+  assert.equal(result.calendarUpdated, false);
+  assert.equal(result.needsHuman, true);
+});
+test("unapproved alternate time fails to human review", () => {
+  const call = syntheticCall(fixture);
+  call.recipients[0].structuredResult.requested_slot = "invented-slot";
+  assert.equal(normalizeOutcome(call, fixture).outcome, "needs_human");
+});
+test("opt out suppresses follow-up; pending calls do not encourage replacement", () => {
+  const call = syntheticCall(fixture);
+  call.recipients[0].structuredResult = { outcome: "opt_out", requested_slot: null, needs_human: false };
+  assert.equal(normalizeOutcome(call, fixture).suppressFurtherContact, true);
+  assert.equal(normalizeOutcome({ status: "in_progress" }, fixture).state, "pending");
+});
+test("invalid and ambiguous provider results require review", () => {
+  for (const call of [{ status: "failed" }, { status: "completed", recipients: [] },
+    { status: "completed", recipients: [{ structuredResult: { outcome: "confirmed" } }] }]) {
+    assert.equal(normalizeOutcome(call, fixture).outcome, "needs_human");
+  }
+});
+test("input preserves locale/schema and rejects invalid number or insecure webhook", () => {
+  const args = { appointment: fixture, phone: "+12025550123", demoId: "synthetic-example" };
+  const input = createInput(args);
+  assert.equal(input.recipients[0].locale, "en-MY");
+  assert.equal(input.metadata.synthetic, true);
+  assert.equal(input.recipientResultSchema.additionalProperties, false);
+  assert.throws(() => createInput({ ...args, phone: "not-a-number" }));
+  assert.throws(() => createInput({ ...args, webhookUrl: "http://localhost" }));
+});
+test("webhook authenticates exact raw body before storage and deduplicates", async () => {
+  const rawBody = Buffer.from('{ "id": "evt_example" }');
+  const now = Date.now();
+  const headers = { "call-e-timestamp": String(Math.floor(now / 1_000)) };
+  let writes = 0;
+  const input = { rawBody, headers, secret: "test-only", now,
+    client: { webhooks: { unwrap: (request) => { assert.equal(request.rawBody, rawBody); return { id: "evt_example" }; } } },
+    store: async () => { if (writes++) throw Object.assign(new Error("duplicate"), { code: "EEXIST" }); },
+  };
+  assert.equal((await handleWebhook(input)).status, 202);
+  assert.equal((await handleWebhook(input)).body.duplicate, true);
+  const invalid = { ...input, client: { webhooks: { unwrap: () => { throw new Error("invalid"); } } } };
+  assert.equal((await handleWebhook(invalid)).status, 401);
+  assert.equal(writes, 2);
+  assert.equal((await handleWebhook({ ...input, now: now + 600_000 })).status, 401);
+  assert.equal((await handleWebhook({ ...input, store: async () => { throw new Error("disk full"); } })).status, 503);
+});


### PR DESCRIPTION
## Summary

This standalone example turns a synthetic service appointment into an authorized CALL-E task and validates the returned outcome for an Operations handoff. Requested times outside the supplied alternatives go to human review; a reschedule request never claims a calendar booking changed.

The Node.js example runs without credentials or calls by default. Its opt-in live path uses the official CALL-E SDK, a saved request and stable idempotency key, polling, and an optional signed webhook inbox. It is independent of the private OneReach platform. The README documents external side effects and the SDK's duration/cancellation limitations.

## How OneReach manages work and uses CALL-E

OneReach manages the business task lifecycle: AI-assisted preparation of the operator's goal and business records, required-field validation, a structured script and outcome plan, human approval, execution tracking, and ownership of the next action. When the operator selects a calling workflow, CALL-E is the outbound voice provider. WhatsApp and web chat have separately configured workflows; this PR does not claim automatic cross-channel fallback.

**Operator goal → OneReach task preparation → validated, versioned plan → human approval → CALL-E voice dispatch → verified results → OneReach action and owner.**

Before dispatch, OneReach checks the workspace/run state and recipient suppression. It sends recipient-specific instructions, phone/region/locale, result schemas, correlation metadata and a stable idempotency key. CALL-E conducts the conversation. Webhook verification and provider reconciliation associate the result with the original run. OneReach then records the outcome and applies its action rules: close, policy retry, suppression or human follow-up. A returned reschedule request does not itself complete a calendar change.

| Defined platform task family | CALL-E task | OneReach follow-up |
| --- | --- | --- |
| Invoice follow-up | Capture payment status, stated promise date, dispute or callback | Finance |
| Service appointments | Confirm or capture rescheduling, cancellation and questions | Operations |
| HR interview/onboarding scheduling | Administrative event confirmation and rescheduling | HR; no scoring or hiring decisions |
| Social lead introductions | Confirm interest and capture an introductory-call time or callback | Sales follow-up |

The README includes a lifecycle diagram and explains how further defined tasks can use the same pattern through their own required inputs, scripts, schemas and outcome rules. These are platform workflow definitions, not claims that every arbitrary task is implemented or that all four have live evidence in this PR. **The runnable public contribution implements the service-appointment slice**; the private AI planner, approval UI, scheduler, multi-channel configuration and team task database remain outside its scope.

## Type

- [x] New runnable app
- [x] README awesome-list entry

## Validation

Ten deterministic tests passed, including SDK serialization using an in-memory transport and actual HMAC verification. The default demo and eight dependency-free tests also passed after extracting the release ZIP outside the private repository. `python3 scripts/validate_repository.py` passed with the example added against upstream eb0e526. No real calls were placed during these checks.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked or clearly fictional.
- [x] No recurring workflows are created; provider cancellation limitations are documented.
- [x] Runnable code has a no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

Only the standalone example is released under its MIT license. OneReach's private platform code, databases, accounts, and configuration are excluded.