### PR TITLE
test(multi-party-scheduler): give the fixture's slots the clock they belong to

### DIFF
--- a/apps/typescript/multi-party-scheduler/test/fixtures.ts
+++ b/apps/typescript/multi-party-scheduler/test/fixtures.ts
@@ -5,6 +5,15 @@
  * Every party is callable around the clock. Calling hours are real policy and
  * they have their own tests with an injected clock: a fixture that inherits the
  * default window would pass or fail depending on the time of day the suite runs.
+ *
+ * The slots below are fixed calendar times, because the call scripts are asserted
+ * word for word and a floating slot would move "Thursday, August 6 at 2:00 PM" and
+ * the zone label with it. Fixed times need a fixed clock beside them: a slot is
+ * judged against the wall clock in several places, `resume` refusing to settle a
+ * confirm for a slot that has already started among them, so anything that judges
+ * these slots has to be given `FIXTURE_NOW` rather than the machine's clock. The
+ * two came from different sources until 2026-08-06, when the calendar passed the
+ * slots and three recovery tests started failing on code nobody had touched.
  */
 
 import { parseRequest } from "../src/config.js";
@@ -15,6 +24,26 @@ export const TENANT = "+14155550100";
 export const SUPER = "+14155550102";
 
 export const ANY_HOUR = { start: "00:00", end: "23:59", timezone: "UTC" } as const;
+
+/**
+ * Two days before the first slot, inside every party's calling hours, and far
+ * enough from the fixture's own window (`policy.windowMinutes`) that a run and the
+ * resume that finishes it are both comfortably inside it.
+ */
+export const FIXTURE_NOW = Date.parse("2026-08-04T09:00:00-07:00");
+
+/** The clock the fixture's slots belong to. Pass as `now` to anything that reads one. */
+export const fixtureNow = (): number => FIXTURE_NOW;
+
+/**
+ * The same instant as the provider reports it.
+ *
+ * A window is judged against two clocks, ours and CALL-E's, so pinning only ours
+ * moves the fake server's `completed_at` out of the window and every answer comes
+ * back `outside_window`. Pass this to `startFakeCalle` wherever `fixtureNow` is
+ * passed to a run.
+ */
+export const FIXTURE_COMPLETED_AT = new Date(FIXTURE_NOW).toISOString();
 
 export function requestInput(
   overrides: Partial<CoordinationRequestInput> = {},

--- a/apps/typescript/multi-party-scheduler/test/resume.test.ts
+++ b/apps/typescript/multi-party-scheduler/test/resume.test.ts
@@ -18,7 +18,14 @@ import { inspectLedger, resumeCoordination, ResumeError } from "../src/resume.js
 import { confirmSchema, confirmTask } from "../src/script.js";
 import type { CommitResult, LedgerEntry } from "../src/types.js";
 import { startFakeCalle, type FakeScript } from "../fake/calle-server.js";
-import { coordinationRequest, PLUMBER, SUPER, TENANT } from "./fixtures.js";
+import {
+  coordinationRequest,
+  FIXTURE_COMPLETED_AT,
+  fixtureNow,
+  PLUMBER,
+  SUPER,
+  TENANT,
+} from "./fixtures.js";
 
 function gather(phone: string): FakeScript {
   return {
@@ -69,7 +76,7 @@ async function withFake(
     fake: Awaited<ReturnType<typeof startFakeCalle>>,
   ) => Promise<void>,
 ): Promise<void> {
-  const fake = await startFakeCalle(FULL_RUN);
+  const fake = await startFakeCalle(FULL_RUN, { completedAt: FIXTURE_COMPLETED_AT });
   const port = await createSdkPort({ apiKey: "calle_test_key", baseUrl: fake.baseUrl });
   try {
     await body(port, fake);
@@ -93,6 +100,7 @@ test("a crash between the yes and the release call is finished by resume", async
           port,
           ledgerPath: path,
           pollIntervalMs: 5,
+          now: fixtureNow,
           onProgress: (line) => {
             if (line === "  tenant: confirmed.") {
               throw new Error("power cut");
@@ -106,7 +114,7 @@ test("a crash between the yes and the release call is finished by resume", async
     assert.ok(crashed.issues.some((issue) => issue.problem.includes("did not finish")));
     assert.deepEqual(phones(fake, "release"), [], "nobody has been told yet");
 
-    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(resumed.outcome, "not_confirmed");
     assert.deepEqual(resumed.unreleased, []);
     assert.equal(resumed.calls_placed, 7, "5 recorded calls plus the 2 releases the run owed");
@@ -134,7 +142,7 @@ test("a confirm whose create response was lost stops the round, then resume find
       },
     };
 
-    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "unresolved");
     assert.deepEqual(first.unreleased, ["plumber", "tenant"], "both yeses are recorded as owed");
     assert.equal(phones(fake, "confirm").length, 3, "the superintendent was called, we just never saw it");
@@ -145,7 +153,7 @@ test("a confirm whose create response was lost stops the round, then resume find
     );
     assert.match(first.note, /may still be live/);
 
-    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(resumed.outcome, "verbally_confirmed", "the lost call had said yes all along");
     assert.deepEqual(resumed.unreleased, []);
     assert.deepEqual(phones(fake, "release"), [], "so there was never anything to undo");
@@ -163,11 +171,11 @@ test("a finished run with nothing owed is left exactly as it was", async () => {
   await withFake(async (port, fake) => {
     const request = coordinationRequest();
     const path = ledgerPath();
-    const first = await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "verbally_confirmed");
     const before = readFileSync(path, "utf8");
 
-    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(resumed.outcome, "verbally_confirmed");
     assert.equal(resumed.note, "nothing to resume");
     assert.equal(readFileSync(path, "utf8"), before, "resume writes nothing when nothing is owed");
@@ -179,12 +187,12 @@ test("resume refuses a ledger another request wrote", async () => {
   await withFake(async (port) => {
     const request = coordinationRequest();
     const path = ledgerPath();
-    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     const other = coordinationRequest({
       meeting: { ...coordinationRequest().meeting, purpose: "a different job at 14 Ash Lane" },
     });
     await assert.rejects(
-      () => resumeCoordination({ request: other, port, ledgerPath: path, pollIntervalMs: 5 }),
+      () => resumeCoordination({ request: other, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow }),
       (error: unknown) => {
         assert.ok(error instanceof ResumeError);
         assert.match(error.message, /written from a different request/);
@@ -206,11 +214,11 @@ test("resume refuses a ledger when only the request id was edited", async () => 
   await withFake(async (port, fake) => {
     const request = coordinationRequest();
     const path = ledgerPath();
-    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     const placed = fake.created.length;
     const renamed = coordinationRequest({ request_id: "ash-lane-3b-leak-2" });
     await assert.rejects(
-      () => resumeCoordination({ request: renamed, port, ledgerPath: path, pollIntervalMs: 5 }),
+      () => resumeCoordination({ request: renamed, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow }),
       (error: unknown) => {
         assert.ok(error instanceof ResumeError);
         assert.match(error.message, /written from a different request/);
@@ -245,7 +253,7 @@ test("resume re-issues the key the ledger recorded rather than deriving a new on
         return call;
       },
     };
-    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "unresolved");
     const lost = readEntries(path).find(
       (entry) => entry.kind === "commit" && entry.result.party_id === "superintendent",
@@ -278,7 +286,7 @@ test("resume re-issues the key the ledger recorded rather than deriving a new on
         .join("\n")}\n`,
     );
 
-    await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(fake.created.at(-1)?.idempotencyKey, recorded, "resume sent the key it read");
     const reconciled = readEntries(path).find((entry) => entry.kind === "reconcile");
     assert.ok(reconciled !== undefined && reconciled.kind === "reconcile");
@@ -294,7 +302,7 @@ test("resume re-issues the key the ledger recorded rather than deriving a new on
  * re-issuing the recorded key instead of deriving one that would have been new.
  */
 test("a recorded key re-issued with a different body stops rather than ringing again", async () => {
-  const fake = await startFakeCalle([confirmYes(PLUMBER)]);
+  const fake = await startFakeCalle([confirmYes(PLUMBER)], { completedAt: FIXTURE_COMPLETED_AT });
   const port = await createSdkPort({ apiKey: "calle_test_key", baseUrl: fake.baseUrl });
   try {
     const request = coordinationRequest();
@@ -312,6 +320,7 @@ test("a recorded key re-issued with a different body stops rather than ringing a
         schema: confirmSchema(),
         timeoutMs: 2_000,
         pollIntervalMs: 5,
+        now: fixtureNow,
         key,
       });
 
@@ -372,7 +381,7 @@ test("a crash between the create and the ledger append leaves the key resume set
     const path = ledgerPath();
     const keys: string[] = [];
     const watched = watch(port, keys);
-    const first = await runCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "verbally_confirmed");
     const placed = fake.created.length;
     const sent = keys.length;
@@ -408,7 +417,7 @@ test("a crash between the create and the ledger append leaves the key resume set
       JSON.stringify(crashed.issues),
     );
 
-    const resumed = await resumeCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(resumed.outcome, "verbally_confirmed", "the call CALL-E already held had said yes");
     assert.equal(keys.length, sent + 1, "one create, under the key the ledger recorded");
     assert.equal(keys.at(-1), attempt.idempotency_key);
@@ -429,7 +438,7 @@ test("a crash after the accepted id was recorded settles that call without placi
     const path = ledgerPath();
     const keys: string[] = [];
     const watched = watch(port, keys);
-    await runCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5 });
+    await runCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     const placed = fake.created.length;
     const sent = keys.length;
     const key = confirmAttempt(readEntries(path), "superintendent").idempotency_key;
@@ -443,7 +452,7 @@ test("a crash after the accepted id was recorded settles that call without placi
     assert.equal(state.unsettled[0]?.call_id, accepted.call_id, "the accepted id is what resume settles against");
     assert.equal(state.unsettled[0]?.idempotency_key, key);
 
-    const resumed = await resumeCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port: watched, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(resumed.outcome, "verbally_confirmed");
     assert.equal(keys.length, sent, "reading a call places none, so no create went out at all");
     assert.equal(fake.created.length, placed);
@@ -462,7 +471,7 @@ test("a gather call nothing settled is reported for a person, never dialled agai
   await withFake(async (port, fake) => {
     const request = coordinationRequest();
     const path = ledgerPath();
-    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     const kept = cutAt(
       path,
       (entry) => entry.kind === "call_attempt" && entry.phase === "gather" && entry.party_id === "tenant",
@@ -478,6 +487,7 @@ test("a gather call nothing settled is reported for a person, never dialled agai
       port,
       ledgerPath: path,
       pollIntervalMs: 5,
+      now: fixtureNow,
       onProgress: (line) => lines.push(line),
     });
     assert.equal(resumed.outcome, "not_confirmed");
@@ -524,7 +534,7 @@ test("an unsettled call with no key and no call id is refused rather than dialle
         return call;
       },
     };
-    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port: lossy, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "unresolved");
     const lost = readEntries(path).find(
       (entry) => entry.kind === "commit" && entry.result.party_id === "superintendent",
@@ -550,7 +560,7 @@ test("an unsettled call with no key and no call id is refused rather than dialle
     assert.deepEqual(state.unsettled.map((held) => `${held.phase}:${held.party_id}`), ["confirm:superintendent"]);
     assert.equal(state.unsettled[0]?.idempotency_key, null, "nothing to re-issue");
 
-    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const resumed = await resumeCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(
       phones(fake, "confirm").length,
       3,
@@ -590,12 +600,12 @@ async function withOwedRelease(
     fake: Awaited<ReturnType<typeof startFakeCalle>>;
   }) => Promise<void>,
 ): Promise<void> {
-  const fake = await startFakeCalle(MACHINE_RELEASE);
+  const fake = await startFakeCalle(MACHINE_RELEASE, { completedAt: FIXTURE_COMPLETED_AT });
   const port = await createSdkPort({ apiKey: "calle_test_key", baseUrl: fake.baseUrl });
   const request = coordinationRequest();
   const path = ledgerPath();
   try {
-    const first = await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5 });
+    const first = await runCoordination({ request, port, ledgerPath: path, pollIntervalMs: 5, now: fixtureNow });
     assert.equal(first.outcome, "not_confirmed");
     assert.deepEqual(first.unreleased, ["plumber"], "the release call reached a machine");
     await body({ port, path, request, fake });
@@ -657,6 +667,7 @@ test("resume finishes a release nobody acknowledged instead of writing it off", 
       port,
       ledgerPath: path,
       pollIntervalMs: 5,
+      now: fixtureNow,
       retryRelease: true,
     });
     assert.notEqual(resumed.note, "nothing to resume");


### PR DESCRIPTION
## Summary

`apps/typescript/multi-party-scheduler` goes red on `main` on any machine whose clock is past 2026-08-06. Three tests in `test/resume.test.ts` fail with no change to the code they cover:

```
not ok 95 - a confirm whose create response was lost stops the round, then resume finds the yes
not ok 99 - resume re-issues the key the ledger recorded rather than deriving a new one
not ok 101 - a crash between the create and the ledger append leaves the key resume settles that call with
```

All three expect `verbally_confirmed` and get `not_confirmed`.

The cause is a fixture with a calendar but no clock. `test/fixtures.ts` pins three slots to `2026-08-06` and `2026-08-07`, which it has to do because the call scripts are asserted word for word:

```ts
assert.match(task, /option 2, Thursday, August 6 at 2:00 PM/);
```

A floating slot would move that string and its zone label with it. The runs that judge those slots read the machine clock instead, so the fixture and the clock came from two different places. On 2026-08-06 they parted company and this guard in `src/resume.ts` started firing:

```ts
} else if (previous.phase === "confirm" && slot.startMs <= now()) {
```

That guard is right. Confirming a time that has already started is a call nobody should get. It is the fixture that is wrong and the same file already says why:

> Calling hours are real policy and they have their own tests with an injected clock: a fixture that inherits the default window would pass or fail depending on the time of day the suite runs.

Slots need exactly that treatment and were not getting it.

## The change

Fixtures now export the instant they were written for, so both sides read one source:

- `FIXTURE_NOW` and `fixtureNow`, two days before the first slot and inside every party's calling hours, passed as `now` to every `runCoordination` and `resumeCoordination` in `test/resume.test.ts`.
- `FIXTURE_COMPLETED_AT`, the same instant as the provider reports it, passed to `startFakeCalle`.

The second one is needed because a window is judged against two clocks. `judgeWindow` checks CALL-E's `completed_at` as well as ours, so pinning only ours leaves the fake server stamping wall-clock time and every answer comes back `outside_window`. `startFakeCalle` already accepted `completedAt`, so nothing new was added to the fake.

Tests only. No `src/` change and no behaviour change: `npm run demo` produces byte-identical output before and after.

## Type

- [x] Validation or tooling update

## Verification

Run on Node 22.22.2 in `apps/typescript/multi-party-scheduler`.

| Gate | Before | After |
| --- | --- | --- |
| `npm test` | 158 tests, 155 pass, **3 fail** | 158 tests, **158 pass**, 0 fail, 0 skipped |
| `npm run check` (`tsc --noEmit`) | clean | clean |
| `npm run demo` | exit 0 | exit 0, output byte-identical |
| `python3 scripts/validate_repository.py` | passes | passes |

The fix was checked against a moved clock rather than only against today's. Running `test/resume.test.ts` with `Date` shifted five years forward:

- before the change: 13 tests, 10 pass, 3 fail, the same three
- after the change: 13 tests, 13 pass, 0 fail

So the three failures are the calendar rather than a flake. The suite no longer depends on when it runs.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## AI assistance

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: `npm test` 158/158, `npm run check` clean, `npm run demo` exit 0 with byte-identical output, `python3 scripts/validate_repository.py` passes, plus the shifted-clock run above in both directions. No real call was placed.
