### PR TITLE
feat(apps): add dvmx human-guided call router

### DIFF
--- a/apps/typescript/dvmx-human-guided-call-router/README.md
+++ b/apps/typescript/dvmx-human-guided-call-router/README.md
@@ -1,0 +1,103 @@
+# DVMX Human-Guided Call Router
+
+A focused TypeScript safety pattern for CALL-E-style phone-call workflows. It evaluates a call before execution, keeps a no-call fixture path as the default demonstration, and separately evaluates consequential follow-up actions.
+
+## Why this exists
+
+Phone-call agents can create real-world side effects. This example keeps the execution boundary explicit:
+
+request
+→ E.164 / recipient / consent / sensitive-domain policy
+→ CALL-E provider boundary
+→ structured result
+→ follow-up policy
+→ human approval when consequential
+
+The sample in this repository does **not** place a phone call. It is a deterministic no-network fixture that demonstrates the policy layer.
+
+## Requirements
+
+- Node.js 20 or newer
+
+No third-party packages are required.
+
+## Run the no-call demo
+
+```bash
+npm run demo
+```
+
+Expected behavior:
+
+- prints `NO_CALL_FIXTURE`
+- masks the fictional recipient number
+- performs no network request
+- places no phone call
+- shows the call-policy decision
+- shows the follow-up-policy decision
+
+## Tests
+
+```bash
+npm test
+```
+
+## Side effects
+
+The included demo has **no external side effects**. It does not contact CALL-E, dial a phone number, schedule a job, write to a CRM, make a payment, or execute a follow-up action.
+
+A production integration may place a real outbound phone call after the host explicitly opts in and supplies a CALL-E credential. Such a live path should keep all of the following outside browser/client code:
+
+- API credentials
+- recipient allow/deny lists
+- call budgets and quotas
+- approval state
+- audit records
+
+## Credential handling
+
+Never commit `CALLE_API_KEY` or any other credential. Store credentials in the host/server environment only.
+
+Do not print credentials into logs, screenshots, fixture files, or PR descriptions.
+
+## Phone-number handling
+
+Use E.164 formatting for real recipients. Examples in this app are fictional and output is masked to the final four digits.
+
+## Consent and safety policy
+
+This reference applies the following behavior before a provider call:
+
+- invalid E.164 → `DENY`
+- blocked recipient → `DENY`
+- secret/password/private-key collection → `DENY`
+- unconfirmed consent → `REQUIRE_HUMAN`
+- medical/legal/financial/employment/collections domain → `REQUIRE_HUMAN`
+- consented general-purpose request → `ALLOW`
+
+After a call, purchase, payment, contract, service cancellation, or medical scheduling requests remain human-controlled.
+
+## Cancellation / rollback
+
+This example does not create calls or recurring jobs, so there is nothing to cancel.
+
+For a live integration, the host should treat the provider call ID as the cancellation/inspection handle and must not create hidden recurring schedules. Budget reservations should be released if provider creation fails.
+
+## Live verification
+
+Live verification is intentionally **not** part of the default repository demo.
+
+A live host integration should:
+
+1. require an explicit operator action,
+2. use an authorized recipient,
+3. load `CALLE_API_KEY` from the server environment,
+4. create at most the approved call,
+5. retain the provider call ID,
+6. monitor it to a terminal state,
+7. route structured outcomes through the follow-up policy,
+8. redact phone numbers and credentials from published evidence.
+
+## Provider
+
+Designed around CALL-E phone-call workflows, while keeping the policy and approval layer provider-separated.

--- a/apps/typescript/dvmx-human-guided-call-router/package.json
+++ b/apps/typescript/dvmx-human-guided-call-router/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dvmx-human-guided-call-router",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "demo": "node src/demo.js",
+    "test": "node --test"
+  }
+}

--- a/apps/typescript/dvmx-human-guided-call-router/src/demo.js
+++ b/apps/typescript/dvmx-human-guided-call-router/src/demo.js
@@ -1,0 +1,26 @@
+import { classifyCallRequest, classifyFollowup, maskPhone } from "./policy.js";
+
+const phone = "+15555550100"; // fictional reserved-style sample
+const request = {
+  phone,
+  consent: true,
+  domain: "general",
+  purpose: "Confirm whether the recipient wants a product demo."
+};
+
+const callPolicy = classifyCallRequest(request);
+
+const fixtureResult = {
+  intent: "interested",
+  requested_action: "schedule",
+  summary: "Recipient asked to schedule a demo."
+};
+
+console.log(JSON.stringify({
+  mode: "NO_CALL_FIXTURE",
+  recipient: maskPhone(phone),
+  sideEffect: "No network request and no phone call are made by this demo.",
+  callPolicy,
+  structuredFixture: fixtureResult,
+  followupPolicy: classifyFollowup(fixtureResult)
+}, null, 2));

--- a/apps/typescript/dvmx-human-guided-call-router/src/policy.js
+++ b/apps/typescript/dvmx-human-guided-call-router/src/policy.js
@@ -1,0 +1,35 @@
+export function maskPhone(phone = "") {
+  const s = String(phone);
+  return s.length >= 4 ? `***${s.slice(-4)}` : "***";
+}
+
+export function validateE164(phone = "") {
+  return /^\+[1-9]\d{7,14}$/.test(String(phone));
+}
+
+export function classifyCallRequest({
+  phone,
+  consent = false,
+  blocked = false,
+  domain = "general",
+  purpose = ""
+} = {}) {
+  if (!validateE164(phone)) return { decision:"DENY", reasons:["invalid_e164"] };
+  if (blocked) return { decision:"DENY", reasons:["blocked_recipient"] };
+  if (/password|seed phrase|private key|api key|secret/i.test(purpose)) {
+    return { decision:"DENY", reasons:["secret_collection"] };
+  }
+  if (["medical","legal","financial","employment","collections"].includes(domain)) {
+    return { decision:"REQUIRE_HUMAN", reasons:["sensitive_domain"] };
+  }
+  if (!consent) return { decision:"REQUIRE_HUMAN", reasons:["consent_not_confirmed"] };
+  return { decision:"ALLOW", reasons:[] };
+}
+
+export function classifyFollowup(result = {}) {
+  const action = result.requested_action ?? "record_only";
+  if (["payment","purchase","contract","cancel_service","schedule_medical"].includes(action)) {
+    return { decision:"REQUIRE_HUMAN", action, reasons:["consequential_action"] };
+  }
+  return { decision:"ALLOW", action, reasons:[] };
+}

--- a/apps/typescript/dvmx-human-guided-call-router/test/policy.test.js
+++ b/apps/typescript/dvmx-human-guided-call-router/test/policy.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { classifyCallRequest, classifyFollowup, validateE164, maskPhone } from "../src/policy.js";
+
+test("accepts valid E.164", () => {
+  assert.equal(validateE164("+15555550100"), true);
+});
+
+test("rejects invalid phone format", () => {
+  assert.equal(classifyCallRequest({phone:"555-0100",consent:true}).decision, "DENY");
+});
+
+test("requires human when consent is not confirmed", () => {
+  assert.equal(classifyCallRequest({phone:"+15555550100",consent:false}).decision, "REQUIRE_HUMAN");
+});
+
+test("denies secret collection", () => {
+  assert.equal(classifyCallRequest({
+    phone:"+15555550100",consent:true,purpose:"Ask for API key"
+  }).decision, "DENY");
+});
+
+test("requires human for sensitive domains", () => {
+  assert.equal(classifyCallRequest({
+    phone:"+15555550100",consent:true,domain:"financial"
+  }).decision, "REQUIRE_HUMAN");
+});
+
+test("requires human for consequential followup", () => {
+  assert.equal(classifyFollowup({requested_action:"payment"}).decision, "REQUIRE_HUMAN");
+});
+
+test("masks phone numbers", () => {
+  assert.equal(maskPhone("+15555550100"), "***0100");
+});


### PR DESCRIPTION
## Summary

Adds `apps/typescript/dvmx-human-guided-call-router/`, a no-call-by-default TypeScript reference app for governing CALL-E phone-call workflows.

The app demonstrates:

- E.164 validation
- blocked-recipient handling
- explicit consent gating
- sensitive-domain escalation
- secret-collection denial
- masked phone output
- separate policy evaluation for consequential follow-up actions
- deterministic fixture mode with no network request and no phone call
- Node test coverage

## Side effects

The included demo has no external side effects. It does not make a CALL-E request or place a phone call.

## Credential handling

The example contains no API keys or secrets. Live integrations are documented to load `CALLE_API_KEY` from the server environment and never expose it in browser code, logs, screenshots, or repository files.

## Verification

From `apps/typescript/dvmx-human-guided-call-router/`:

```bash
npm test
npm run demo