### PR TITLE
   Add liya-appointment-confirm: single-call appointment confirmation app

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`apps/python/liya-appointment-confirm`](apps/python/liya-appointment-confirm) | Python | Single-call appointment confirmation with phone-number validation, a dry-run preview, and carrier-code-based failure diagnosis distinguishing an unreachable number from a busy line. |
 | [`apps/typescript/clarity`](apps/typescript/clarity/) | TypeScript / Next.js | Clarifies one job-application claim with an adaptive CALL-E follow-up, structured results, timestamped transcript evidence, and a synthetic no-call replay. |
 | [`apps/typescript/payoutproof`](apps/typescript/payoutproof/) | JavaScript / Node | Compiles a publicly sourced reward inquiry into one disclosed, approval-gated CALL-E payout-policy call; masks the number in previews and treats verbal answers as non-contractual until backed by written terms. |
 | [`apps/typescript/creditcall`](apps/typescript/creditcall/) | JavaScript / Node | Human-approved invoice-exception call handoff with a no-call dry run, disclosed test calls, masked phone output, and duplicate-start protection. |

--- a/apps/python/liya-appointment-confirm/README.md
+++ b/apps/python/liya-appointment-confirm/README.md
@@ -1,0 +1,116 @@
+# liya-appointment-confirm
+
+Confirms one existing appointment by phone, using [CALL-E](https://docs.heycall-e.com),
+and returns a structured yes/no plus any alternate time the recipient
+proposed — as either a one-shot CLI command or three importable Python
+functions.
+
+Extracted from a larger personal desktop assistant ("Liya") down to just
+the CALL-E calling capability, so the contribution here is scoped,
+reviewable, and reusable on its own — no unrelated assistant tooling
+(browser control, screen reading, dev tooling, etc.) is included.
+
+## What it does
+
+Given a task description and a phone number, it:
+
+1. Validates and normalizes the phone number (E.164) *before* any network
+   call, catching the most common real-world failure mode: a bare local
+   number (e.g. a 10-digit Indian mobile number typed without `+91`)
+   getting misread as a different country's number entirely.
+2. Shows a preview of exactly what will be sent — recipient (masked in
+   the printed preview), task, region, and result schema — before doing
+   anything.
+3. Places the call through CALL-E's Calls API and polls for a result.
+4. Reports back a structured result: whether the recipient confirmed,
+   why not if they declined, and any alternate time they proposed.
+5. If the call fails, looks past CALL-E's generic "recipient may be busy"
+   message for a sharper signal: an attempt that fails in under two
+   seconds with a carrier-level error code means the number itself was
+   unreachable (wrong digit, disconnected, not a real line) — not that
+   the person was busy.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+export CALLE_API_KEY=sk_...          # from your CALL-E account
+# export CALLE_BASE_URL=...          # optional, defaults to https://api.heycall-e.com
+```
+
+Get a CALL-E account (with 20 free calls) by following the
+[CALL-E Integrations install guide](https://github.com/CALLE-AI/call-e-integrations).
+
+## Usage
+
+**Preview only — validates the number and shows what would be sent. Makes
+no network request and places no call:**
+
+```bash
+python confirm_call.py \
+  --task "Confirm the 10am appointment tomorrow" \
+  --phone +12025550123 --region US \
+  --dry-run
+```
+
+**Place the real call** (prompts for a typed `YES` first, since this has
+a real-world side effect — a phone actually rings):
+
+```bash
+python confirm_call.py \
+  --task "Confirm the 10am appointment tomorrow" \
+  --phone +12025550123 --region US
+```
+
+**Skip the interactive prompt** (e.g. for scripting):
+
+```bash
+python confirm_call.py --task "..." --phone +1... --region US --yes
+```
+
+**Check a call you already placed**, instead of placing a new one:
+
+```bash
+python confirm_call.py --check call_abc123
+```
+
+See [`examples/sample_run.md`](examples/sample_run.md) for a full
+annotated run using a fictional number.
+
+## Side effects
+
+- Placing a call (without `--dry-run`) makes a real outbound phone call
+  through CALL-E and consumes one call from your account's allotment.
+- No recurring job, webhook listener, or background process is created —
+  this is a single one-shot call per invocation.
+- Results are only ever printed to stdout; nothing is written anywhere
+  except the small local dedupe-state file described below.
+
+## Duplicate-call protection
+
+Placing a call to the same number twice within 10 minutes is blocked by
+default (a local state file at `~/.liya_appointment_confirm/recent_calls.json`
+tracks the last call per number), since that pattern is far more often an
+accidental double-run than a deliberate second call to the same person.
+Pass `--force` to override when a second call really is intended.
+
+## Cancellation
+
+There is no recurring job to cancel — each invocation places at most one
+call. Once a call has been placed and is ringing, CALL-E does not expose
+a way to abort it mid-call from this app; the only "cancellation" point
+is the interactive `YES` prompt before dialing (or simply not passing
+`--yes`/typing `YES`).
+
+## Credential handling
+
+The only credential this app reads is `CALLE_API_KEY` from the
+environment — nothing is written to disk, logged, or included in the
+call preview. Do not commit a real key; there is no `config/` file or
+committed secrets anywhere in this app.
+
+## Notes on the phone numbers used in examples
+
+All phone numbers in this README and in `examples/` are fictional
+reserved-for-media numbers (`+1 202 555 01XX`), per the source
+repository's requirement to use fictional or masked numbers in samples.

--- a/apps/python/liya-appointment-confirm/calle_client.py
+++ b/apps/python/liya-appointment-confirm/calle_client.py
@@ -1,0 +1,267 @@
+# calle_client.py
+"""
+Minimal, standalone CALL-E client used by confirm_call.py.
+
+This wraps CALL-E's stable Calls API directly over HTTP (the same surface
+the `calle-ai` 0.2.x SDK uses, per https://docs.heycall-e.com):
+
+    POST /v1/calls              -> create a call, returns {"id": ...}
+    GET  /v1/calls/{id}         -> read call status + structured_result
+
+No desktop UI, no other assistant tools, no local config file — this reads
+one thing from the environment (CALLE_API_KEY) and does one thing (places
+a single outbound call to confirm an appointment, then reports the result).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+import uuid
+from typing import Optional
+
+import requests
+
+_DEFAULT_BASE_URL = "https://api.heycall-e.com"
+_TERMINAL_STATUSES = {"succeeded", "completed", "failed", "canceled", "cancelled", "error"}
+
+
+class CallEError(Exception):
+    """Raised for any CALL-E request/validation failure, with a message
+    that's already safe to print or speak directly to the end user."""
+
+
+def get_api_key() -> str:
+    key = os.environ.get("CALLE_API_KEY")
+    if not key:
+        raise CallEError(
+            "CALLE_API_KEY is not set. Export it before running this app:\n"
+            "  export CALLE_API_KEY=sk_...\n"
+            "Get a key (with 20 free calls) by following "
+            "https://github.com/CALLE-AI/call-e-integrations"
+        )
+    return key
+
+
+def get_base_url() -> str:
+    return os.environ.get("CALLE_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Phone validation — the single most common way a call silently never
+# reaches its recipient: a bare local number gets a "+" tacked on the front
+# and is misread as a completely different country's code (e.g. a 10-digit
+# Indian mobile number "9876543210" becomes "+9876543210", which parses as
+# a Turkmenistan (+993) number with a mangled remainder). Catching this
+# before the network call gives a clear, actionable error instead of a
+# generic "phone number is invalid" rejection from the API — or worse, a
+# real call fired at a wrong number.
+# ---------------------------------------------------------------------------
+def normalize_phone(phone: str, region: str) -> str:
+    phone = (phone or "").strip()
+    if not phone:
+        raise CallEError("No phone number given.")
+
+    try:
+        import phonenumbers
+    except ImportError:
+        digits = "".join(c for c in phone if c.isdigit())
+        if not phone.startswith("+") or len(digits) < 8:
+            raise CallEError(
+                f"'{phone}' doesn't look like a complete phone number. "
+                f"Give the full number with a country code, e.g. "
+                f"+91XXXXXXXXXX for India or +1XXXXXXXXXX for the US."
+            )
+        return phone
+
+    try:
+        parsed = phonenumbers.parse(phone, region or "US")
+    except phonenumbers.NumberParseException:
+        raise CallEError(
+            f"Couldn't read '{phone}' as a phone number. Give the full "
+            f"number including its country code (e.g. +91XXXXXXXXXX for "
+            f"India)."
+        )
+
+    if not phonenumbers.is_valid_number(parsed):
+        region_name = phonenumbers.region_code_for_number(parsed) or region or "US"
+        raise CallEError(
+            f"'{phone}' isn't a valid number for region '{region_name}'. "
+            f"If it belongs to a different country, pass --region for that "
+            f"country (or give it as a full E.164 number) instead of a "
+            f"bare local number — a leading '+' on a raw local number gets "
+            f"misread as a different country's code."
+        )
+
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+
+
+# ---------------------------------------------------------------------------
+# HTTP calls
+# ---------------------------------------------------------------------------
+def _headers(api_key: str, idempotency_key: str) -> dict:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotency_key,
+    }
+
+
+def create_call(task: str, phone: str, region: str, locale: Optional[str],
+                 result_schema: Optional[dict], idempotency_key: str) -> dict:
+    api_key = get_api_key()
+    base_url = get_base_url()
+
+    recipient: dict = {"phones": [phone]}
+    if region:
+        recipient["region"] = region
+    if locale:
+        recipient["locale"] = locale
+
+    payload: dict = {"task": task, "recipients": [recipient]}
+    if result_schema:
+        payload["result_schema"] = result_schema
+
+    try:
+        resp = requests.post(
+            f"{base_url}/v1/calls",
+            headers=_headers(api_key, idempotency_key),
+            json=payload,
+            timeout=30,
+        )
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        detail = ""
+        try:
+            body = e.response.json()
+            err = body.get("error", body)
+            detail = err.get("message", "")
+            errs = (err.get("details") or {}).get("validation_errors")
+            if errs:
+                detail += " (" + "; ".join(
+                    f"{'.'.join(str(p) for p in ve.get('loc', []))}: {ve.get('msg')}"
+                    for ve in errs
+                ) + ")"
+        except Exception:
+            detail = e.response.text[:200] if e.response is not None else str(e)
+        raise CallEError(f"CALL-E rejected the call request: {detail or e}")
+    except requests.exceptions.RequestException as e:
+        raise CallEError(f"Could not reach CALL-E: {e}")
+
+    return resp.json()
+
+
+def get_call(call_id: str) -> dict:
+    api_key = get_api_key()
+    base_url = get_base_url()
+    try:
+        resp = requests.get(
+            f"{base_url}/v1/calls/{call_id}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        detail = e.response.text[:200] if e.response is not None else str(e)
+        raise CallEError(f"CALL-E couldn't return call {call_id}: {detail}")
+    except requests.exceptions.RequestException as e:
+        raise CallEError(f"Could not reach CALL-E: {e}")
+    return resp.json()
+
+
+def poll_until_done(call_id: str, timeout_seconds: int = 180) -> dict:
+    deadline = time.time() + timeout_seconds
+    last_status = None
+    poll_interval = 5
+
+    while time.time() < deadline:
+        call = get_call(call_id)
+        status = str(call.get("status", "")).lower()
+        if status != last_status:
+            print(f"[CallE] call {call_id} -> {status}")
+            last_status = status
+        if status in _TERMINAL_STATUSES:
+            return call
+        time.sleep(poll_interval)
+
+    call = get_call(call_id)
+    call.setdefault("status", "pending")
+    call["_timed_out"] = True
+    return call
+
+
+# ---------------------------------------------------------------------------
+# Result summarization + sharper failure diagnosis
+# ---------------------------------------------------------------------------
+def _parse_calle_timestamp(ts: str):
+    if not ts:
+        return None
+    ts = ts.rstrip("Z")
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return _dt.datetime.strptime(ts, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def diagnose_failure(call: dict) -> Optional[str]:
+    """CALL-E's generic 'may be busy, try again later' summary can hide a
+    much sharper signal: if an attempt ended in a second or two with a
+    carrier-level failure_code, that's not a busy/no-answer signal (those
+    take several seconds of ringing first) — it means the number itself
+    couldn't be reached at all (wrong digit, disconnected, not a real
+    line)."""
+    for recipient in (call.get("recipients") or []):
+        for attempt in (recipient.get("attempts") or []):
+            code = str(attempt.get("failure_code") or "").strip()
+            if not code:
+                continue
+            started = _parse_calle_timestamp(attempt.get("started_at", ""))
+            completed = _parse_calle_timestamp(attempt.get("completed_at", ""))
+            duration = (completed - started).total_seconds() if started and completed else None
+            if duration is not None and duration < 2:
+                phone = (recipient.get("phones") or [""])[0]
+                return (
+                    f"Heads up: that attempt to {phone or 'the recipient'} ended in "
+                    f"under {max(duration, 0):.0f}s with carrier failure code {code} — "
+                    f"too fast for the phone to have even rung. That pattern almost "
+                    f"always means the number itself couldn't be reached at all (a "
+                    f"typo'd digit, disconnected, or not a real line), not that the "
+                    f"recipient was busy or unavailable."
+                )
+    return None
+
+
+def summarize(call: dict) -> str:
+    status = str(call.get("status", "unknown"))
+    call_id = call.get("id", "")
+    structured = call.get("structured_result") or call.get("structuredResult")
+    summary = call.get("summary") or call.get("result_summary")
+    phone = ""
+    recipients = call.get("recipients") or []
+    if recipients:
+        phone = (recipients[0].get("phones") or [""])[0]
+
+    lines = [f"CALL-E call {call_id} to {phone}: {status}."]
+
+    if call.get("_timed_out"):
+        lines.append(f"Still running past the wait window — check back with call id {call_id}.")
+        return " ".join(lines)
+
+    if status.lower() in {"failed", "canceled", "cancelled", "error"}:
+        diagnosis = diagnose_failure(call)
+        if diagnosis:
+            lines.append(diagnosis)
+
+    if summary:
+        lines.append(str(summary))
+    if structured:
+        lines.append(f"Structured result: {json.dumps(structured, ensure_ascii=False)}")
+
+    return " ".join(lines)
+
+
+def new_idempotency_key() -> str:
+    return str(uuid.uuid4())

--- a/apps/python/liya-appointment-confirm/confirm_call.py
+++ b/apps/python/liya-appointment-confirm/confirm_call.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# confirm_call.py
+"""
+liya-appointment-confirm — confirm one appointment over the phone using
+CALL-E, and get a structured yes/no (plus any alternate time) back.
+
+Usage
+-----
+    # Preview only — validates the number and shows exactly what would be
+    # sent. Makes NO network call and places NO real call.
+    python confirm_call.py --task "Confirm the 10am appointment tomorrow" \\
+        --phone +12025550123 --region US --dry-run
+
+    # Place the real call (prompts for an explicit typed confirmation
+    # first, since this has a real-world side effect):
+    python confirm_call.py --task "Confirm the 10am appointment tomorrow" \\
+        --phone +12025550123 --region US
+
+    # Skip the interactive prompt (e.g. for scripting/CI):
+    python confirm_call.py --task "..." --phone +1... --region US --yes
+
+    # Check a call you already placed, instead of placing a new one:
+    python confirm_call.py --check call_abc123
+
+See README.md for setup, side effects, cancellation, and credential
+handling notes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import calle_client as calle
+
+_STATE_DIR = Path.home() / ".liya_appointment_confirm"
+_STATE_FILE = _STATE_DIR / "recent_calls.json"
+_DEDUPE_WINDOW_SECONDS = 600  # 10 minutes
+
+_DEFAULT_RESULT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "confirmed": {
+            "type": "boolean",
+            "description": "Whether the recipient confirmed they can attend.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Reason given if they can't attend, if any.",
+        },
+        "alternate_time_requested": {
+            "type": "string",
+            "description": "An alternate time they proposed, if any.",
+        },
+    },
+    "required": ["confirmed"],
+}
+
+
+def _mask(phone: str) -> str:
+    """Mask everything but the last 3 digits, for anything printed to a
+    shared terminal/log — the destination is only fully shown in the
+    interactive confirmation prompt itself."""
+    digits_only = "".join(c for c in phone if c.isdigit())
+    if len(digits_only) <= 3:
+        return phone
+    return phone[: -len(digits_only) or None] + "*" * (len(digits_only) - 3) + digits_only[-3:]
+
+
+def _load_recent_calls() -> dict:
+    try:
+        return json.loads(_STATE_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_recent_call(phone_digits: str, call_id: str) -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    data = _load_recent_calls()
+    data[phone_digits] = {"call_id": call_id, "placed_at": time.time()}
+    _STATE_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _check_duplicate(phone_digits: str) -> str | None:
+    data = _load_recent_calls()
+    entry = data.get(phone_digits)
+    if not entry:
+        return None
+    age = time.time() - entry.get("placed_at", 0)
+    if age < _DEDUPE_WINDOW_SECONDS:
+        return (
+            f"A call to this same number was already placed {int(age)}s ago "
+            f"(call id {entry.get('call_id')}). Re-run with --force if this "
+            f"is genuinely a new, separate call."
+        )
+    return None
+
+
+def cmd_check(call_id: str) -> int:
+    try:
+        call = calle.get_call(call_id)
+    except calle.CallEError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(calle.summarize(call))
+    return 0
+
+
+def cmd_place(args: argparse.Namespace) -> int:
+    try:
+        phone = calle.normalize_phone(args.phone, args.region)
+    except calle.CallEError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    phone_digits = "".join(c for c in phone if c.isdigit())
+
+    print("=== Call preview ===")
+    print(f"  Recipient : {_mask(phone)}")
+    print(f"  Region    : {args.region}")
+    print(f"  Task      : {args.task}")
+    print(f"  Result schema: confirmed (bool), reason, alternate_time_requested")
+    print()
+
+    if args.dry_run:
+        print("Dry run only — no network request was made, no call was placed.")
+        return 0
+
+    if not args.force:
+        dup = _check_duplicate(phone_digits)
+        if dup:
+            print(f"Skipped: {dup}", file=sys.stderr)
+            return 1
+
+    if not args.yes:
+        print(f"This will place a REAL phone call to {phone}.")
+        confirm = input("Type YES to proceed: ").strip()
+        if confirm != "YES":
+            print("Not placed — confirmation not received.")
+            return 1
+
+    idempotency_key = calle.new_idempotency_key()
+    try:
+        created = calle.create_call(
+            task=args.task,
+            phone=phone,
+            region=args.region,
+            locale=args.locale,
+            result_schema=None if args.no_schema else _DEFAULT_RESULT_SCHEMA,
+            idempotency_key=idempotency_key,
+        )
+    except calle.CallEError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    call_id = created.get("id")
+    if not call_id:
+        print(f"Error: CALL-E did not return a call id: {created}", file=sys.stderr)
+        return 1
+
+    _save_recent_call(phone_digits, call_id)
+    print(f"Call placed. call_id = {call_id}")
+
+    if args.no_wait:
+        print(f"Not waiting for completion — check later with:\n  python confirm_call.py --check {call_id}")
+        return 0
+
+    print("Waiting for the call to finish (this can take up to a few minutes)...")
+    call = calle.poll_until_done(call_id, timeout_seconds=args.timeout)
+    print()
+    print(calle.summarize(call))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--task", help="What the call should accomplish, in plain language.")
+    parser.add_argument("--phone", help="Recipient phone number (E.164 preferred, e.g. +12025550123).")
+    parser.add_argument("--region", default="US", help="Recipient region code CALL-E supports (default: US).")
+    parser.add_argument("--locale", default=None, help="Spoken language/locale, e.g. en-IN.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and preview only — no call is placed.")
+    parser.add_argument("--yes", action="store_true", help="Skip the interactive typed confirmation prompt.")
+    parser.add_argument("--force", action="store_true", help="Bypass the duplicate-call guard.")
+    parser.add_argument("--no-wait", action="store_true", help="Return immediately after placing the call instead of polling for the result.")
+    parser.add_argument("--no-schema", action="store_true", help="Don't request a structured result — just a free-text summary.")
+    parser.add_argument("--timeout", type=int, default=180, help="Max seconds to poll for a result (default: 180).")
+    parser.add_argument("--check", metavar="CALL_ID", help="Check the status/result of a previously placed call instead of placing a new one.")
+    args = parser.parse_args()
+
+    if args.check:
+        return cmd_check(args.check)
+
+    if not args.task or not args.phone:
+        parser.error("--task and --phone are required unless using --check")
+
+    return cmd_place(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/liya-appointment-confirm/examples/sample_run.md
+++ b/apps/python/liya-appointment-confirm/examples/sample_run.md
@@ -1,0 +1,75 @@
+# Sample run
+
+All phone numbers below are from the NANP fictional/reserved-for-media
+range (`+1 202 555 01XX`) — not real numbers.
+
+## 1. Dry run (actual captured output)
+
+```
+$ python confirm_call.py --task "Confirm the 10am appointment tomorrow" \
+    --phone +12025550123 --region US --dry-run
+
+=== Call preview ===
+  Recipient : +********123
+  Region    : US
+  Task      : Confirm the 10am appointment tomorrow
+  Result schema: confirmed (bool), reason, alternate_time_requested
+
+Dry run only — no network request was made, no call was placed.
+```
+
+## 2. Placing a real call (illustrative — requires a real CALLE_API_KEY)
+
+```
+$ python confirm_call.py --task "Confirm the 10am appointment tomorrow" \
+    --phone +12025550123 --region US
+
+=== Call preview ===
+  Recipient : +********123
+  Region    : US
+  Task      : Confirm the 10am appointment tomorrow
+  Result schema: confirmed (bool), reason, alternate_time_requested
+
+This will place a REAL phone call to +12025550123.
+Type YES to proceed: YES
+Call placed. call_id = call_example00000000000000
+Waiting for the call to finish (this can take up to a few minutes)...
+[CallE] call call_example00000000000000 -> in-progress
+[CallE] call call_example00000000000000 -> completed
+
+CALL-E call call_example00000000000000 to +12025550123: completed. The
+recipient confirmed they can attend at 10am. Structured result:
+{"confirmed": true, "reason": null, "alternate_time_requested": null}
+```
+
+## 3. A call that fails instantly (illustrative, based on a real failure
+   pattern this app is designed to catch — carrier code and phone number
+   substituted with fictional values)
+
+```
+$ python confirm_call.py --check call_example_failed000000
+
+CALL-E call call_example_failed000000 to +12025550199: failed. Heads up:
+that attempt to +12025550199 ended in under 0s with carrier failure code
+404 — too fast for the phone to have even rung. That pattern almost
+always means the number itself couldn't be reached at all (a typo'd
+digit, disconnected, or not a real line), not that the recipient was busy
+or unavailable. The first call did not connect or complete; the
+recipient may be busy or unavailable, so I suggest retrying in about 45
+minutes.
+```
+
+Note how the app's own diagnosis (first sentence) directly contradicts
+CALL-E's generic canned summary (last sentence) — the near-zero duration
+plus carrier code is the more reliable signal, and is exactly the pattern
+that comes from a wrong or disconnected number rather than a busy line.
+
+## 4. Duplicate-call guard
+
+```
+$ python confirm_call.py --task "Confirm the 10am appointment tomorrow" \
+    --phone +12025550123 --region US --yes
+Skipped: A call to this same number was already placed 42s ago (call id
+call_example00000000000000). Re-run with --force if this is genuinely a
+new, separate call.
+```

--- a/apps/python/liya-appointment-confirm/requirements.txt
+++ b/apps/python/liya-appointment-confirm/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.28
+phonenumbers>=8.13


### PR DESCRIPTION
## Summary

Adds `apps/python/liya-appointment-confirm`, a standalone CLI app that
confirms one appointment over the phone using CALL-E's Calls API. It
validates and normalizes the phone number before ever calling the API
(catching the common case of a bare local number being misread as a
different country's code), shows a dry-run preview before placing any
real call, and — when a call fails — looks past CALL-E's generic "may be
busy" message to flag carrier-level failures that mean the number itself
was unreachable rather than the recipient being busy.

Extracted and scoped down from a larger personal desktop assistant so
this contribution is self-contained and reviewable on its own.

## Type

- [ ] New skill
- [x] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist