### PR TITLE
fix(afterword): redact provider-derived output

### DIFF
--- a/apps/python/afterword/afterword/api.py
+++ b/apps/python/afterword/afterword/api.py
@@ -32,11 +32,11 @@ def _requirement_payload(requirement: Requirement | None) -> dict | None:
     if requirement is None:
         return None
     return {
-        "department": requirement.department,
-        "documents_needed": list(requirement.documents_needed),
+        "department": redact(requirement.department),
+        "documents_needed": list(redact_all(requirement.documents_needed)),
         "certified_copy_accepted": requirement.certified_copy_accepted.value,
         "direct_debits_action": requirement.direct_debits_action.value,
-        "reference_opened": requirement.reference_opened,
+        "reference_opened": redact(requirement.reference_opened),
         "missing": list(requirement.missing),
     }
 
@@ -45,11 +45,11 @@ def _conflict_payload(conflict: Conflict) -> dict:
     """Both sides, no winner. The console renders them side by side."""
     return {
         "field": conflict.field_name,
-        "stated": conflict.stated,
-        "stated_source": conflict.stated_source,
-        "counter": conflict.counter,
-        "counter_source": conflict.counter_source,
-        "quote": conflict.quote,
+        "stated": redact(conflict.stated),
+        "stated_source": redact(conflict.stated_source),
+        "counter": redact(conflict.counter),
+        "counter_source": redact(conflict.counter_source),
+        "quote": redact(conflict.quote),
     }
 
 
@@ -65,7 +65,7 @@ def _result_payload(
         "captured_at": result.captured_at.isoformat(),
         "call_id": result.call_id,
         "grade": result.grade.value,
-        "reasons": list(result.reasons),
+        "reasons": list(redact_all(result.reasons)),
         "requirement": _requirement_payload(result.requirement),
         "conflicts": [_conflict_payload(c) for c in result.conflicts],
         "evidence_quotes": list(redact_all(result.evidence_quotes)),

--- a/apps/python/afterword/afterword/cli.py
+++ b/apps/python/afterword/afterword/cli.py
@@ -13,7 +13,7 @@ import json
 import os
 import sys
 
-from .safety import redact
+from .safety import redact, redact_all
 from . import calle, demo, registry
 from .models import CaptureResult, Grade, Pack
 from .runner import Plan, payload_for, plan_call, run_institution
@@ -23,18 +23,18 @@ def _print_result(plan: Plan, result: CaptureResult) -> None:
     print(f"  institution   {plan.institution.name}  ({plan.institution.institution_id})")
     print(f"  number        {plan.masked_phone()}")
     print(f"  grade         {result.grade.value}")
-    print(f"  reasons       {', '.join(result.reasons)}")
+    print(f"  reasons       {', '.join(redact_all(result.reasons))}")
     requirement = result.requirement
     if requirement is not None:
-        print(f"  department    {requirement.department or '-'}")
-        print(f"  documents     {'; '.join(requirement.documents_needed) or '-'}")
+        print(f"  department    {redact(requirement.department) or '-'}")
+        print(f"  documents     {'; '.join(redact_all(requirement.documents_needed)) or '-'}")
         print(f"  certified ok  {requirement.certified_copy_accepted.value}")
         print(f"  direct debits {requirement.direct_debits_action.value}")
-        print(f"  reference     {requirement.reference_opened or '-'}")
+        print(f"  reference     {redact(requirement.reference_opened) or '-'}")
     for item in result.conflicts:
         print(f"  conflict      {item.field_name}")
-        print(f"    this call   {item.stated}")
-        print(f"    on file     {item.counter}  [{item.counter_source}]")
+        print(f"    this call   {redact(item.stated)}")
+        print(f"    on file     {redact(item.counter)}  [{redact(item.counter_source)}]")
     print(f"  in pack       {result.goes_in_pack}")
     print(f"  closes acct   {result.closes_account}")
     print(f"  accepts terms {result.accepts_terms}")

--- a/apps/python/afterword/tests/test_safety.py
+++ b/apps/python/afterword/tests/test_safety.py
@@ -6,11 +6,18 @@ a terminal or an HTTP response may carry a dialable number.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+
 import pytest
 
 from afterword import calle
-from afterword.api import capture_payload
+from afterword.api import _conflict_payload, _requirement_payload, capture_payload
+from afterword.cli import _print_result
+from afterword.models import CaptureResult, Conflict, Grade, Requirement
+from afterword.runner import plan_call
 from afterword.safety import redact, redact_all
+from tests.builders import make_estate, make_institution
 
 
 class TestCredentialsStayOnTheApprovedOrigin:
@@ -82,3 +89,62 @@ class TestNothingDialableLeaves:
         import re
         for run in re.findall(r"\d[\d\s().-]{5,}\d", blob):
             assert len(re.sub(r"\D", "", run)) < 7, run
+
+    def test_provider_derived_api_fields_are_masked(self) -> None:
+        phone = "+12025550146"
+        requirement = Requirement(
+            department=f"Call {phone}",
+            documents_needed=(f"Send records to {phone}",),
+            reference_opened=f"Reference from {phone}",
+        )
+        conflict = Conflict(
+            field_name="documents_needed",
+            stated=f"Stated by {phone}",
+            stated_source=f"Source {phone}",
+            counter=f"Counter from {phone}",
+            counter_source=f"Policy {phone}",
+            quote=f"Quote {phone}",
+        )
+        blob = json.dumps(
+            {
+                "requirement": _requirement_payload(requirement),
+                "conflict": _conflict_payload(conflict),
+            }
+        )
+        assert phone not in blob
+        assert "*" in blob
+
+    def test_provider_derived_cli_fields_are_masked(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        phone = "+12025550146"
+        plan = plan_call(make_estate(), make_institution())
+        result = CaptureResult(
+            estate_id=plan.estate.estate_id,
+            institution_id=plan.institution.institution_id,
+            run_id="afterword_test-run",
+            captured_at=datetime.now(timezone.utc),
+            grade=Grade.DISPUTED,
+            reasons=(f"Reason from {phone}",),
+            requirement=Requirement(
+                department=f"Department {phone}",
+                documents_needed=(f"Document {phone}",),
+                reference_opened=f"Reference {phone}",
+            ),
+            conflicts=(
+                Conflict(
+                    field_name="documents_needed",
+                    stated=f"Stated by {phone}",
+                    stated_source="this_call",
+                    counter=f"Counter from {phone}",
+                    counter_source=f"Policy {phone}",
+                ),
+            ),
+            evidence_quotes=(f"Quote {phone}",),
+        )
+
+        _print_result(plan, result)
+
+        output = capsys.readouterr().out
+        assert phone not in output
+        assert "*" in output


### PR DESCRIPTION
## Summary

- redact provider-derived requirement and conflict fields before HTTP responses
- redact the same fields before CLI output
- add reserved-number regression coverage for both output paths

This is a bounded maintainer safety follow-up to #391. It does not change call behavior.

## Validation

- `uv run --no-project --python python3.13 --with pytest pytest -q` (167 passed)
- `python3 scripts/validate_repository.py`
- no credentials and no real call used