### PR TITLE
feat: add learning recall call skill

### DIFF
--- a/skills/learning-recall-call/SKILL.md
+++ b/skills/learning-recall-call/SKILL.md
@@ -1,0 +1,466 @@
+---
+name: learning-recall-call
+description: Conducts an authorized phone-based active recall session with a learner, asks adaptive questions about a previously studied topic, identifies knowledge gaps and misconceptions, and returns a structured learning assessment.
+---
+
+# Learning Recall Call
+
+## Purpose
+
+Use this skill when a learner wants to test what they actually remember from a topic they previously studied.
+
+The goal is not simply to remind the learner to study. The goal is to:
+
+* test active recall
+* evaluate conceptual understanding
+* identify knowledge gaps
+* detect misconceptions
+* adapt questions based on the learner's responses
+* recommend when the learner should review the topic again
+
+This skill is designed for educational learning workflows.
+
+## Inputs
+
+The skill accepts:
+
+* `topic`: The subject or concept the learner previously studied.
+* `study_context`: Notes, summary, or learning material describing what the learner studied.
+* `previous_score`: Optional score from a previous recall session.
+* `weak_areas`: Optional list of concepts the learner previously struggled with.
+* `review_number`: Number of the current recall session.
+* `learner_name`: Optional name of the learner.
+* `phone_number`: Destination phone number supplied by the host application when a call is authorized.
+
+## Call Flow
+
+### 1. Start the call
+
+Introduce yourself clearly.
+
+Example:
+
+"Hi! This is your learning recall check. You studied {{topic}} recently, and I'm here to see what you still remember."
+
+Do not immediately provide the answer.
+
+Keep the introduction short and focused.
+
+### 2. Ask an open-ended recall question
+
+Start with a question that requires the learner to explain the concept in their own words.
+
+Example:
+
+"Can you explain {{topic}} to me as if you were teaching it to someone who has never learned it?"
+
+Prefer questions that require explanation rather than yes-or-no answers.
+
+### 3. Analyze the response
+
+Evaluate the learner's answer for:
+
+* correct understanding
+* partial understanding
+* missing concepts
+* contradictions
+* confusion between related concepts
+* common misconceptions
+* unsupported claims
+* confidence
+
+Do not interrupt unnecessarily.
+
+Allow the learner enough time to complete their explanation.
+
+### 4. Ask adaptive follow-up questions
+
+Use the learner's previous answer to determine the next question.
+
+If the answer is strong:
+
+* increase conceptual difficulty
+* ask for an example
+* ask why something works
+* ask the learner to compare related concepts
+* ask the learner to apply the concept to a new situation
+
+If the answer is weak:
+
+* ask a simpler question
+* probe the specific weak concept
+* ask for a basic example
+* give a small hint only when appropriate
+* avoid immediately revealing the complete answer
+
+If a possible misconception appears:
+
+* ask a probing question first
+* determine whether the misunderstanding is persistent
+* then explain the correct concept clearly
+* ask a follow-up question to verify understanding
+
+### 5. Detect misconceptions
+
+Record a misconception when the learner expresses a confidently incorrect or conceptually incorrect belief.
+
+Do not label an answer as a misconception simply because the learner says they are unsure or cannot remember.
+
+For each detected misconception, capture:
+
+* `concept`
+* `student_belief`
+* `correct_understanding`
+* `evidence_from_response`
+
+Example:
+
+Student belief:
+
+"Hashing encrypts data so that we can decrypt it later."
+
+Correct understanding:
+
+"Hashing is generally a one-way transformation, while encryption is designed to allow data to be recovered using the appropriate key."
+
+Evidence:
+
+"The learner described hashing as reversible encryption."
+
+A misconception should be based on evidence from the learner's response.
+
+Do not invent misconceptions that were not expressed or reasonably supported by the conversation.
+
+### 6. Evaluate recall
+
+After the conversation, produce a recall assessment.
+
+Evaluate:
+
+* accuracy
+* conceptual understanding
+* ability to explain
+* ability to apply the concept
+* misconceptions
+* confidence
+
+Generate a score from 0–100.
+
+Suggested interpretation:
+
+* `90–100`: Strong recall
+* `75–89`: Good recall
+* `50–74`: Partial recall
+* `0–49`: Weak recall
+
+The score is an educational assessment and should not be presented as a scientifically exact measurement of memory.
+
+### 7. Recommend the next review
+
+Use the current performance and detected misconceptions to recommend the next review interval.
+
+General guidance:
+
+* Strong recall → increase the interval.
+* Good recall → use a moderate interval.
+* Partial recall → review sooner.
+* Weak recall → review soon.
+* Persistent misconception → prioritize an earlier review.
+
+Example intervals may include:
+
+* `1 day`
+* `3 days`
+* `7 days`
+* `14 days`
+* `30 days`
+
+These intervals are adaptive recommendations, not guaranteed optimal memory schedules.
+
+### 8. End the call
+
+Give the learner a short summary.
+
+Example:
+
+"You remembered the main idea well, but you were unsure about key generation. I'll recommend reviewing that part again soon."
+
+Keep the final explanation concise.
+
+Do not overwhelm the learner with a long lecture during the call.
+
+## Conversation Rules
+
+* Be encouraging but honest.
+* Never shame the learner for forgetting.
+* Do not give the answer before attempting recall.
+* Prefer explanation questions over multiple-choice questions.
+* Ask one question at a time.
+* Keep the call focused.
+* Adapt difficulty based on the learner's responses.
+* Distinguish uncertainty from misconception.
+* Do not invent facts that are not supported by the provided study context.
+* If the learner asks for the answer, provide a concise explanation and continue with another recall question.
+* Do not pretend that an incorrect answer is correct.
+* Do not overload the learner with too many questions.
+* Prefer clear and conversational language suitable for a phone call.
+
+## Study Context Handling
+
+The `study_context` is the primary source of truth for the learner's studied material.
+
+When evaluating a response:
+
+1. Compare the learner's explanation against the provided study context.
+2. Identify concepts that match the study context.
+3. Identify important concepts that are missing.
+4. Identify contradictions with the study context.
+5. Avoid introducing unrelated information unless necessary to clarify a misconception.
+
+If the study context is insufficient to determine whether an answer is correct, mark the result as uncertain rather than inventing an evaluation.
+
+## Previous Recall Handling
+
+If `previous_score` or `weak_areas` are available, use them to personalize the session.
+
+For example:
+
+* revisit previously weak concepts
+* ask a slightly more difficult question if recall improved
+* check whether a previous misconception has been corrected
+* avoid repeating exactly the same question unnecessarily
+
+Do not assume that a previous weakness is still present without testing it.
+
+## Output
+
+Return a structured assessment containing:
+
+```json
+{
+  "topic": "",
+  "recall_score": 0,
+  "status": "strong|good|partial|weak|misconception_detected",
+  "concepts_remembered": [],
+  "weak_areas": [],
+  "misconceptions": [
+    {
+      "concept": "",
+      "student_belief": "",
+      "correct_understanding": "",
+      "evidence_from_response": ""
+    }
+  ],
+  "confidence": "high|medium|low",
+  "summary": "",
+  "recommended_next_review": ""
+}
+```
+
+The output should contain valid JSON when structured output is requested by the host application.
+
+## Phone Call Safety
+
+### User Consent
+
+Only place an outbound learning-recall call when the learner has explicitly requested or authorized the call.
+
+Do not initiate an unexpected call.
+
+Before scheduling a recurring recall routine, clearly tell the learner:
+
+* that calls will be placed
+* how often calls will occur
+* which topic will be assessed
+* how the schedule can be cancelled
+
+Do not assume that permission for one call automatically authorizes recurring calls.
+
+### Phone Numbers
+
+Phone numbers must be provided in E.164 format.
+
+Example of a fictional valid format:
+
+`+15550100123`
+
+Do not accept or normalize ambiguous phone numbers silently.
+
+Never expose a learner's full phone number in logs, summaries, examples, or generated reports.
+
+Mask phone numbers when displaying them.
+
+Example:
+
+`+15550100123` → `+155*****0123`
+
+### Credentials
+
+Never request, store, or expose:
+
+* API keys
+* authentication tokens
+* passwords
+* provider secrets
+
+Credentials must be supplied through the host application's secure configuration.
+
+Never place credentials inside `SKILL.md`, examples, logs, or generated assessments.
+
+### Scheduling
+
+Do not create recurring calls unless the learner explicitly requests them.
+
+Before creating a recurring schedule:
+
+1. Confirm the schedule.
+2. Confirm the destination phone number.
+3. Explain that calls will be placed automatically.
+4. Confirm the learning topic.
+5. Provide a cancellation method.
+
+Do not create duplicate schedules for the same learner, topic, and time window.
+
+### Cancellation
+
+The learner must be able to cancel a scheduled recall call.
+
+Cancellation should:
+
+* prevent future calls
+* preserve completed recall assessments
+* not delete previously collected learning results unless explicitly requested
+
+### Dry Run
+
+Implementations should provide a dry-run or preview mode whenever possible.
+
+In dry-run mode:
+
+* no real phone call is placed
+* the proposed call time is displayed
+* the topic is displayed
+* the proposed question flow is displayed
+* the assessment logic can be tested without contacting the learner
+
+Dry-run mode should make it obvious that no real call will occur.
+
+### External Side Effects
+
+An outbound phone call is an external side effect.
+
+The implementation must make the call action visible to the learner and should provide enough information to understand:
+
+* when the call will occur
+* which phone number will be contacted
+* which topic will be assessed
+* whether the call is one-time or recurring
+
+Do not silently place calls or silently create recurring schedules.
+
+### Sensitive Topics
+
+This skill is intended for educational recall.
+
+It must not present itself as a substitute for:
+
+* medical advice
+* legal advice
+* financial advice
+* emergency services
+
+If a learner introduces a sensitive or emergency situation, the call should not attempt to provide professional or emergency intervention.
+
+If the learner appears to require emergency assistance, encourage them to contact the appropriate local emergency service or qualified professional rather than attempting to handle the situation through this educational skill.
+
+## Error Handling
+
+If required learning information is missing:
+
+* do not invent study material
+* explain what information is missing
+* request the required input through the host application
+
+If the learner cannot answer a question:
+
+* do not shame them
+* allow them to continue
+* record the concept as a possible weak area when appropriate
+
+If the phone call cannot be completed:
+
+* do not falsely report that the call occurred
+* return the appropriate failure status through the host application
+* preserve any completed assessment data
+
+## Example
+
+Input:
+
+```text
+topic: Hashing vs Encryption
+
+study_context:
+Hashing is generally a one-way transformation used to produce a fixed-length
+digest. Encryption is designed to allow data to be recovered using the
+appropriate key.
+
+previous_score: 70
+
+weak_areas:
+- Hashing vs encryption
+
+review_number: 2
+```
+
+Learner response:
+
+"Hashing encrypts the password so that we can decrypt it later."
+
+Assessment:
+
+```json
+{
+  "topic": "Hashing vs Encryption",
+  "recall_score": 55,
+  "status": "misconception_detected",
+  "concepts_remembered": [
+    "Hashing can be used in password-related systems"
+  ],
+  "weak_areas": [
+    "Hashing vs encryption"
+  ],
+  "misconceptions": [
+    {
+      "concept": "Hashing vs encryption",
+      "student_belief": "Hashing is reversible encryption.",
+      "correct_understanding": "Hashing is generally one-way, while encryption is designed to allow data to be recovered using the appropriate key.",
+      "evidence_from_response": "The learner described hashing as something that can be decrypted later."
+    }
+  ],
+  "confidence": "medium",
+  "summary": "The learner understands that hashing is relevant to password protection but is confusing hashing with reversible encryption.",
+  "recommended_next_review": "1 day"
+}
+```
+
+## Implementation Notes
+
+This skill defines the learning and conversation behavior.
+
+The host application is responsible for:
+
+* obtaining user consent
+* securely handling phone numbers
+* securely handling provider credentials
+* scheduling calls
+* placing calls
+* cancellation
+* storing assessment results
+* preventing duplicate scheduled calls
+* implementing dry-run behavior
+* connecting the skill to a phone-call provider
+
+The skill itself must not assume a specific phone-call provider.
+
+Provider-specific authentication and call execution should remain in the host application.

--- a/skills/learning-recall-call/references/examples.md
+++ b/skills/learning-recall-call/references/examples.md
@@ -1,0 +1,222 @@
+# Learning Recall Call Examples
+
+## Example 1: Strong Recall
+
+### Topic
+
+Hashing vs Encryption
+
+### Study Context
+
+Hashing is generally a one-way transformation used to produce a fixed-length digest. Encryption is designed to allow data to be recovered using the appropriate key.
+
+### Learner Response
+
+"Hashing converts the input into a fixed-length value, and it is generally one-way. Encryption is different because encrypted data can be recovered using the appropriate key."
+
+### Expected Assessment
+
+- Recall: Strong
+- No misconception detected
+- Increase the next review interval
+- Follow-up question: Ask the learner to explain when hashing would be preferred over encryption.
+
+---
+
+## Example 2: Misconception Detection
+
+### Topic
+
+Hashing vs Encryption
+
+### Study Context
+
+Hashing is generally a one-way transformation used to produce a fixed-length digest. Encryption is designed to allow data to be recovered using the appropriate key.
+
+### Learner Response
+
+"Hashing encrypts the password so that we can decrypt it later."
+
+### Expected Assessment
+
+A misconception should be detected.
+
+The learner is confusing hashing with reversible encryption.
+
+The assessment should identify:
+
+- Concept: Hashing vs encryption
+- Student belief: Hashing is reversible encryption
+- Correct understanding: Hashing is generally one-way, while encryption is designed to allow recovery using the appropriate key.
+- Evidence: The learner explicitly described hashing as something that can be decrypted later.
+
+The learner should then receive a concise explanation and another question to verify whether the misconception has been corrected.
+
+---
+
+## Example 3: Partial Recall
+
+### Topic
+
+Binary Search
+
+### Study Context
+
+Binary search operates on sorted data. It repeatedly compares the target with the middle element and eliminates half of the remaining search space.
+
+### Learner Response
+
+"Binary search looks through the middle of the list to find the value. If it doesn't find it, it keeps searching."
+
+### Expected Assessment
+
+The learner demonstrates partial recall.
+
+The learner remembers that binary search uses the middle element but does not explain that the data must be sorted or that half of the search space is eliminated after each comparison.
+
+Weak areas may include:
+
+- sorted input requirement
+- elimination of half the search space
+
+A suitable follow-up question is:
+
+"Why does binary search need the data to be sorted?"
+
+---
+
+## Example 4: Previous Weak Area
+
+### Topic
+
+TCP vs UDP
+
+### Previous Weak Area
+
+- Reliability differences between TCP and UDP
+
+### Learner Response
+
+"TCP makes sure packets arrive and UDP is faster because it doesn't have all those checks."
+
+### Expected Assessment
+
+The learner demonstrates a reasonable understanding of the main distinction.
+
+The next question should probe deeper:
+
+"What does TCP do when a packet is lost?"
+
+If the learner answers correctly, the previous weak area can be considered improved.
+
+---
+
+## Example 5: Learner Cannot Remember
+
+### Topic
+
+Public Key Cryptography
+
+### Learner Response
+
+"I remember studying this, but I can't remember how the two keys work."
+
+### Expected Behavior
+
+Do not shame the learner.
+
+Do not immediately give a long explanation.
+
+Ask a simpler question or provide a small hint.
+
+Example:
+
+"That's okay. Let's start with one part. Do you remember whether the public key is intended to be kept secret or shared?"
+
+The response should be evaluated as uncertainty or a knowledge gap, not automatically as a misconception.
+
+---
+
+## Example 6: Request for the Answer
+
+### Learner Response
+
+"I don't know. Can you just tell me?"
+
+### Expected Behavior
+
+Provide a concise explanation.
+
+Then continue with another recall question.
+
+Example:
+
+"Sure. The public key can be shared, while the private key is kept secret. Now, can you tell me which key would normally be used to decrypt something encrypted with a public key?"
+
+---
+
+## Example 7: Adaptive Difficulty
+
+### Initial Topic
+
+Recursion
+
+### Strong Learner Response
+
+"Recursion is when a function calls itself, usually with a base case that stops the recursion."
+
+### Expected Follow-Up
+
+Increase difficulty.
+
+Example:
+
+"Why is the base case necessary, and what would happen if a recursive function had no reachable base case?"
+
+### Weak Learner Response
+
+"I think recursion means repeating something until it finishes."
+
+### Expected Follow-Up
+
+Reduce difficulty.
+
+Example:
+
+"Let's make it simpler. What does it mean when a function calls itself?"
+
+---
+
+## Example 8: Review Recommendation
+
+### Strong Recall
+
+If the learner demonstrates accurate understanding and successfully applies the concept:
+
+Recommended next review:
+
+`7 days`
+
+### Good Recall
+
+If the learner understands the main concept but has minor gaps:
+
+Recommended next review:
+
+`3 days`
+
+### Partial Recall
+
+If the learner remembers some important concepts but has significant gaps:
+
+Recommended next review:
+
+`1 day`
+
+### Weak Recall or Persistent Misconception
+
+If the learner demonstrates weak understanding or continues to express a misconception:
+
+Recommended next review:
+
+`1 day`

--- a/skills/learning-recall-call/references/safety.md
+++ b/skills/learning-recall-call/references/safety.md
@@ -1,0 +1,123 @@
+# Learning Recall Call Safety
+
+## Consent
+
+Only place an outbound learning-recall call when the learner has explicitly requested or authorized it.
+
+Do not make unexpected calls.
+
+Permission for a single call does not automatically authorize recurring calls.
+
+Before creating a recurring schedule, clearly communicate:
+
+- that automated calls will occur
+- the frequency of the calls
+- the topic or purpose of the calls
+- how the learner can cancel the schedule
+
+## Phone Numbers
+
+Phone numbers should use E.164 format.
+
+Example:
+
+`+15555550123`
+
+Do not silently guess or transform ambiguous phone numbers.
+
+Never expose complete phone numbers in logs, examples, assessments, or user-facing summaries.
+
+Mask displayed phone numbers.
+
+Example:
+
+`+15555550123` → `+155*****0123`
+
+## Credentials
+
+Never place API keys, authentication tokens, passwords, or provider secrets in skill files.
+
+Credentials must be handled by the host application's secure configuration.
+
+Never expose credentials in logs or assessment output.
+
+## Scheduling
+
+Recurring learning-recall calls require explicit learner authorization.
+
+Before scheduling:
+
+1. Confirm the schedule.
+2. Confirm the destination phone number.
+3. Explain that automated calls will occur.
+4. Confirm the learning topic.
+5. Provide a cancellation method.
+
+Do not create duplicate schedules for the same learner, topic, and time window.
+
+## Cancellation
+
+The learner must be able to cancel scheduled recall calls.
+
+Cancellation should stop future calls while preserving completed recall assessments.
+
+## Dry Run
+
+Implementations should provide a dry-run or preview mode when possible.
+
+A dry run must not place a real phone call.
+
+It should allow the user to inspect:
+
+- proposed call time
+- destination number in masked form
+- learning topic
+- proposed question flow
+- expected assessment behavior
+
+## External Side Effects
+
+An outbound phone call is an external side effect.
+
+The implementation should clearly communicate:
+
+- when the call will occur
+- which number will be contacted
+- what topic will be assessed
+- whether the call is one-time or recurring
+
+Calls must not be placed silently.
+
+## Educational Boundaries
+
+This skill is designed for educational recall.
+
+It must not claim to replace:
+
+- medical professionals
+- legal professionals
+- financial professionals
+- emergency services
+
+If a learner raises a sensitive or emergency situation, the skill should not attempt to provide professional or emergency intervention.
+
+## Assessment Safety
+
+Do not fabricate learning material, learner responses, misconceptions, or assessment evidence.
+
+Distinguish between:
+
+- uncertainty
+- forgetting
+- incomplete understanding
+- genuine misconception
+
+A misconception should only be recorded when the learner's response provides evidence for it.
+
+## Data Minimization
+
+Only use information necessary to conduct the recall session and produce the learning assessment.
+
+Do not expose private learner information unnecessarily.
+
+Provider-specific credentials and phone-call execution should remain in the host application.

--- a/skills/learning-recall-call/scripts/evaluator.py
+++ b/skills/learning-recall-call/scripts/evaluator.py
@@ -1,0 +1,198 @@
+import json
+from typing import Any
+
+
+class RecallEvaluator:
+    """
+    Provider-agnostic interface for evaluating a learner's recall.
+
+    A production implementation can subclass this interface and
+    connect it to an LLM provider.
+    """
+
+    def evaluate(
+        self,
+        topic: str,
+        study_context: str,
+        learner_response: str,
+    ) -> dict[str, Any]:
+        raise NotImplementedError(
+            "Implement evaluate() using the chosen LLM provider."
+        )
+
+
+class DeterministicRecallEvaluator(RecallEvaluator):
+    """
+    Local evaluator used for testing.
+
+    This does not use an LLM or external API.
+    It provides predictable results for repository testing.
+    """
+
+    def evaluate(
+        self,
+        topic: str,
+        study_context: str,
+        learner_response: str,
+    ) -> dict[str, Any]:
+
+        if not topic.strip():
+            raise ValueError("topic is required")
+
+        if not study_context.strip():
+            raise ValueError("study_context is required")
+
+        if not learner_response.strip():
+            raise ValueError("learner_response is required")
+
+        response = learner_response.lower()
+
+        misconceptions = []
+        weak_areas = []
+        concepts_remembered = []
+
+        # Deterministic test behavior for the example topic.
+        if topic.lower() == "hashing vs encryption":
+
+            if "hashing" in response:
+                concepts_remembered.append(
+                    "Hashing is relevant to password-related systems"
+                )
+
+            if "decrypt" in response:
+                misconceptions.append({
+                    "concept": "Hashing vs encryption",
+                    "student_belief": "Hashing is reversible encryption.",
+                    "correct_understanding": (
+                        "Hashing is generally one-way, while encryption "
+                        "is designed to allow data to be recovered using "
+                        "the appropriate key."
+                    ),
+                    "evidence_from_response": (
+                        "The learner described hashing as something "
+                        "that can be decrypted later."
+                    )
+                })
+
+                weak_areas.append("Hashing vs encryption")
+
+        if misconceptions:
+            score = 55
+            status = "misconception_detected"
+            confidence = "medium"
+            next_review = "1 day"
+
+            summary = (
+                "The learner remembers that hashing is related to "
+                "password protection but is confusing hashing with "
+                "reversible encryption."
+            )
+
+        elif concepts_remembered:
+            score = 80
+            status = "good"
+            confidence = "medium"
+            next_review = "3 days"
+
+            summary = (
+                "The learner demonstrated useful recall of the topic "
+                "without a major misconception being detected."
+            )
+
+        else:
+            score = 40
+            status = "weak"
+            confidence = "low"
+            next_review = "1 day"
+
+            summary = (
+                "The learner did not demonstrate enough evidence of "
+                "understanding to establish strong recall."
+            )
+
+        return {
+            "topic": topic,
+            "recall_score": score,
+            "status": status,
+            "concepts_remembered": concepts_remembered,
+            "weak_areas": weak_areas,
+            "misconceptions": misconceptions,
+            "confidence": confidence,
+            "summary": summary,
+            "recommended_next_review": next_review,
+        }
+
+
+def validate_assessment(assessment: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validate the structured assessment returned by an evaluator.
+    """
+
+    required_fields = [
+        "topic",
+        "recall_score",
+        "status",
+        "concepts_remembered",
+        "weak_areas",
+        "misconceptions",
+        "confidence",
+        "summary",
+        "recommended_next_review",
+    ]
+
+    for field in required_fields:
+        if field not in assessment:
+            raise ValueError(
+                f"Missing required assessment field: {field}"
+            )
+
+    if not isinstance(assessment["recall_score"], int):
+        raise ValueError("recall_score must be an integer.")
+
+    if not 0 <= assessment["recall_score"] <= 100:
+        raise ValueError("recall_score must be between 0 and 100.")
+
+    if not isinstance(assessment["concepts_remembered"], list):
+        raise ValueError("concepts_remembered must be a list.")
+
+    if not isinstance(assessment["weak_areas"], list):
+        raise ValueError("weak_areas must be a list.")
+
+    if not isinstance(assessment["misconceptions"], list):
+        raise ValueError("misconceptions must be a list.")
+
+    valid_statuses = {
+        "strong",
+        "good",
+        "partial",
+        "weak",
+        "misconception_detected",
+    }
+
+    if assessment["status"] not in valid_statuses:
+        raise ValueError(
+            f"Invalid status: {assessment['status']}"
+        )
+
+    valid_confidence = {"high", "medium", "low"}
+
+    if assessment["confidence"] not in valid_confidence:
+        raise ValueError(
+            f"Invalid confidence: {assessment['confidence']}"
+        )
+
+    return assessment
+
+
+def format_assessment(assessment: dict[str, Any]) -> str:
+    """
+    Convert an assessment into readable JSON.
+    """
+
+    validated = validate_assessment(assessment)
+
+    return json.dumps(
+        validated,
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/skills/learning-recall-call/scripts/llm_evaluator.py
+++ b/skills/learning-recall-call/scripts/llm_evaluator.py
@@ -1,0 +1,258 @@
+import json
+import os
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+from evaluator import RecallEvaluator, validate_assessment
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Prevent bearer credentials and learner content from following redirects."""
+
+    def redirect_request(
+        self,
+        req,
+        fp,
+        code,
+        msg,
+        headers,
+        newurl,
+    ):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            code,
+            "LLM redirects are disabled for security.",
+            headers,
+            None,
+        )
+
+
+class LLMRecallEvaluator(RecallEvaluator):
+    """
+    Provider-neutral HTTPS LLM evaluator.
+
+    The host application supplies:
+    - LLM endpoint
+    - approved HTTPS origin
+    - API key
+    - model name
+
+    The endpoint must match the explicitly approved origin.
+    Credentials and learner content are never sent to an arbitrary
+    or insecure endpoint.
+    """
+
+    def __init__(
+        self,
+        endpoint=None,
+        api_key=None,
+        model=None,
+        approved_origin=None,
+    ):
+        self.endpoint = endpoint or os.getenv("LLM_ENDPOINT")
+        self.api_key = api_key or os.getenv("LLM_API_KEY")
+        self.model = model or os.getenv("LLM_MODEL")
+        self.approved_origin = (
+            approved_origin or os.getenv("LLM_APPROVED_ORIGIN")
+        )
+
+        if not self.endpoint:
+            raise ValueError("LLM_ENDPOINT is required.")
+
+        if not self.api_key:
+            raise ValueError("LLM_API_KEY is required.")
+
+        if not self.model:
+            raise ValueError("LLM_MODEL is required.")
+
+        if not self.approved_origin:
+            raise ValueError(
+                "LLM_APPROVED_ORIGIN is required."
+            )
+
+        self._validate_endpoint()
+
+    def _validate_endpoint(self):
+        endpoint = urlparse(self.endpoint)
+        approved = urlparse(self.approved_origin)
+
+        if endpoint.scheme != "https":
+            raise ValueError(
+                "LLM_ENDPOINT must use HTTPS."
+            )
+
+        if approved.scheme != "https":
+            raise ValueError(
+                "LLM_APPROVED_ORIGIN must use HTTPS."
+            )
+
+        if not endpoint.netloc:
+            raise ValueError(
+                "LLM_ENDPOINT must contain a valid host."
+            )
+
+        if not approved.netloc:
+            raise ValueError(
+                "LLM_APPROVED_ORIGIN must contain a valid host."
+            )
+
+        if endpoint.username or endpoint.password:
+            raise ValueError(
+                "LLM_ENDPOINT must not contain embedded credentials."
+            )
+
+        if endpoint.scheme != approved.scheme:
+            raise ValueError(
+                "LLM_ENDPOINT scheme does not match "
+                "LLM_APPROVED_ORIGIN."
+            )
+
+        if endpoint.netloc.lower() != approved.netloc.lower():
+            raise ValueError(
+                "LLM_ENDPOINT origin does not match "
+                "LLM_APPROVED_ORIGIN."
+            )
+
+    def build_prompt(
+        self,
+        topic,
+        study_context,
+        learner_response,
+    ):
+        return f"""
+You are an educational active-recall evaluator.
+
+Your job is to evaluate what a learner actually remembers.
+
+Topic:
+{topic}
+
+Study context:
+{study_context}
+
+Learner response:
+{learner_response}
+
+Rules:
+1. Compare the learner response against the study context.
+2. Do not invent facts that are not supported by the study context.
+3. Distinguish uncertainty or forgetting from a genuine misconception.
+4. Only record a misconception when the learner's response provides evidence.
+5. Be honest about missing concepts.
+6. Prefer evidence from the learner's actual response.
+7. Return ONLY valid JSON.
+8. Do not include Markdown code fences.
+
+Return exactly this structure:
+{{
+  "topic": "{topic}",
+  "recall_score": 0,
+  "status": "strong|good|partial|weak|misconception_detected",
+  "concepts_remembered": [],
+  "weak_areas": [],
+  "misconceptions": [
+    {{
+      "concept": "",
+      "student_belief": "",
+      "correct_understanding": "",
+      "evidence_from_response": ""
+    }}
+  ],
+  "confidence": "high|medium|low",
+  "summary": "",
+  "recommended_next_review": ""
+}}
+
+Scoring guidance:
+
+90-100 = strong recall
+75-89 = good recall
+50-74 = partial recall
+0-49 = weak recall
+
+Use "misconception_detected" when a genuine misconception is
+supported by the learner's response.
+
+The recommended review interval should normally be one of:
+
+1 day
+3 days
+7 days
+14 days
+30 days
+"""
+
+    def evaluate(
+        self,
+        topic,
+        study_context,
+        learner_response,
+    ):
+        if not topic.strip():
+            raise ValueError("topic is required")
+
+        if not study_context.strip():
+            raise ValueError("study_context is required")
+
+        if not learner_response.strip():
+            raise ValueError("learner_response is required")
+
+        prompt = self.build_prompt(
+            topic,
+            study_context,
+            learner_response,
+        )
+
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+        }
+
+        request = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            method="POST",
+        )
+
+        opener = urllib.request.build_opener(
+            NoRedirectHandler()
+        )
+
+        try:
+            with opener.open(request, timeout=30) as response:
+                raw_response = response.read().decode("utf-8")
+        except Exception as exc:
+            raise RuntimeError(
+                f"LLM request failed: {exc}"
+            ) from exc
+
+        try:
+            response_data = json.loads(raw_response)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "LLM returned invalid JSON."
+            ) from exc
+
+        model_text = response_data.get("text")
+
+        if model_text is None:
+            model_text = response_data.get("response")
+
+        if model_text is None:
+            raise ValueError(
+                "LLM response did not contain 'text' or 'response'."
+            )
+
+        try:
+            assessment = json.loads(model_text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "LLM output was not valid assessment JSON."
+            ) from exc
+
+        return validate_assessment(assessment)

--- a/skills/learning-recall-call/scripts/test_recall.py
+++ b/skills/learning-recall-call/scripts/test_recall.py
@@ -1,0 +1,68 @@
+import importlib.util
+
+
+def load_evaluator_module():
+    """
+    Load evaluator.py directly so the test does not require
+    the skill directory to be installed as a Python package.
+    """
+
+    spec = importlib.util.spec_from_file_location(
+        "evaluator",
+        "skills/learning-recall-call/scripts/evaluator.py",
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load evaluator.py")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def run_test():
+    evaluator_module = load_evaluator_module()
+
+    evaluator = evaluator_module.DeterministicRecallEvaluator()
+
+    topic = "Hashing vs Encryption"
+
+    study_context = """
+    Hashing is generally a one-way transformation used to produce
+    a fixed-length digest. Encryption is designed to allow data to
+    be recovered using the appropriate key.
+    """
+
+    learner_response = (
+        "Hashing encrypts the password so that we can decrypt it later."
+    )
+
+    # Run the learner response through the evaluator.
+    result = evaluator.evaluate(
+        topic=topic,
+        study_context=study_context,
+        learner_response=learner_response,
+    )
+
+    # Validate the structured assessment.
+    evaluator_module.validate_assessment(result)
+
+    # Display the assessment.
+    print(evaluator_module.format_assessment(result))
+
+    # Verify the expected behavior.
+    assert result["topic"] == topic
+    assert result["status"] == "misconception_detected"
+    assert result["recall_score"] == 55
+    assert len(result["misconceptions"]) == 1
+    assert result["misconceptions"][0]["concept"] == (
+        "Hashing vs encryption"
+    )
+    assert "Hashing vs encryption" in result["weak_areas"]
+
+    print("\nEVALUATOR INTEGRATION TEST PASSED")
+
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
## Summary

Add a reusable `learning-recall-call` Agent Skill for AI-powered learning and active-recall phone conversations.

The skill helps phone agents conduct structured recall sessions, evaluate learner explanations, detect conceptual misconceptions, and generate targeted follow-up questions.

It belongs in this repository because it provides a reusable learning workflow for CALL-E phone agents. The skill is provider-neutral and keeps application-specific credentials, phone numbers, scheduling, persistence, and external integrations in the host application.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.