### PR TITLE
feat(skills): add recall-outreach customer notice skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`partline-part-sourcing`](skills/partline-part-sourcing/) - Preview-first industrial replacement-part sourcing that calls approved suppliers for exact part identity, quantity and shipping cutoffs, then ranks evidence-backed matches and leaves purchase and alternate approval to a human.
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
 - [`rdn-intake-referral`](skills/rdn-intake-referral/) - Consent-based outbound healthcare nutrition intake that collects structured information for RDN review and referral follow-up. See [`docs/rdn-intake-referral.md`](docs/rdn-intake-referral.md) for documentation and synthetic validation examples.
+- [`recall-outreach`](skills/recall-outreach/) - Calls affected customers about a product recall using only organisation-approved wording, routes every unapproved question to a human, and reports call completion and recall resolution as separate measures so a completed call is never counted as a completed return.
 
 ### Apps
 

--- a/skills/recall-outreach/SKILL.md
+++ b/skills/recall-outreach/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: recall-outreach
+description: Contact affected customers about a product recall or corrective notice with CALL-E. Relays only organisation-approved wording, dispatches a wave as one batch with a strict per-recipient result schema, routes every unapproved question to a human, and never treats a completed call as a completed recall.
+license: MIT
+---
+
+# Recall Outreach
+
+Use this skill when an organisation has issued a product recall or corrective notice and needs
+to reach a list of affected customers by phone: read the approved notice, find out whether each
+person still has the item, offer the return options the business actually runs, and record what
+each person said in a form someone can audit later.
+
+This is the reusable core of [RecallRoute](https://github.com/HectorTa1989/recallroute): the
+approved-wording contract, the batch call plan, a strict
+`recipient_result_schema`, the idempotency and webhook reconciliation rules, and — most
+importantly — the metric model that refuses to report a completed call as a completed recall.
+
+## When To Use
+
+- An organisation has approved recall or corrective-notice wording and needs to relay it by phone
+- The customers are known, and there is a recorded basis for contacting each of them
+- The desired output is a per-customer structured outcome plus a human queue for everything the
+  approved material does not cover
+
+## When Not To Use
+
+- **Any call where the safe next step is not already decided and written down.** This skill
+  relays approved wording; it cannot decide what a customer should do about a hazardous item.
+- Emergency notification, injury response, or anything time-critical to physical safety. Never
+  call emergency services.
+- Cold outreach, marketing, upselling, or collections dressed as a notice
+- Calling anyone the organisation has no recorded authorisation to contact
+- Mass-scale dialling. Keep waves small and supervised.
+- Any workflow that needs a call cancelled after dispatch — the CALL-E Calls API has no cancel
+  endpoint, so a kill switch can only stop *further* waves. Say so plainly in your UI.
+
+## The Rule This Skill Exists To Enforce
+
+**A completed call is not a completed recall.**
+
+A recall is finished for a customer when the item is physically back, not when a phone call went
+well. Any implementation of this skill must keep those as separate states, and the second must
+be reachable only by a named human recording how they know. If you build one boolean called
+`contacted` and set it from a completed call, you have built the thing this skill is designed to
+prevent.
+
+Report these as **separate measures with separate denominators**, never merged:
+
+| Measure | Definition |
+| --- | --- |
+| Call attempted | CALL-E accepted a call task containing this recipient |
+| Call completed | The call task reached `completed` on `GET /v1/calls` |
+| Result validated | A per-recipient result satisfying the full schema came back |
+| Right person reached | `right_person_reached` is exactly `yes` |
+| Notice understood | The reached person confirmed understanding, in their own words |
+| Next step selected | The reached person chose a real return option |
+| Independently resolved | A human confirmed the physical return, and said how they know |
+
+## Required Inputs
+
+- `campaign_id`: stable identity, e.g. `RC-2026-001`
+- `org_name`: the organisation the assistant says it is calling for, in its first sentence
+- `product_label`: what the item is called out loud
+- `product_identifier`: model, lot, or SKU — for the record, **not** for reading to voicemail
+- `approved_notice`: the exact wording the organisation approved, read verbatim
+- `voicemail_text`: a separate, minimal message for answering machines
+- `approved_answers[]`: `{question, answer}` — the **only** questions the assistant may answer
+- `allowed_next_steps[]`: subset of `pickup_request`, `mail_return`, `store_return`, `callback`
+- `approved_by`: the person who signed off the wording
+- `timezone` (IANA) and `calling_window` (`HH:MM`–`HH:MM`) in the customers' local time
+- `escalation_contact`: a human, for the follow-up queue. Never dialled by the assistant.
+- `recipients[]`: `customer_ref`, `phone_e164`, `item_identifier`, `consent_basis`,
+  `consent_source`
+
+See `assets/sample-campaign.json` for a fictional example using NANP test-range numbers.
+
+## Preflight
+
+Run every check below **on the server, at the moment of launch** — not when the checklist was
+rendered. A green checklist from a minute ago authorises nothing.
+
+1. **Credentials.** A server-side `CALLE_API_KEY` and an https webhook origin. Without them,
+   block launching. Never fall back to a simulated result.
+2. **Approved wording exists**, is non-empty, and is attributed to a named approver.
+3. **Voicemail wording exists and is separate.** Scan it for product-identifying tokens — model
+   codes, lot numbers, distinctive product nouns — and warn when found. Exempt the
+   organisation's own name; identifying the caller is required.
+4. **At least one return option** is configured. Zero approved answers is allowed, but warn that
+   every question will escalate.
+5. **Escalation contact** is named.
+6. **Quiet hours** in the customers' timezone. Let a campaign narrow the window, never widen it
+   past a deployment-wide floor. Treat an invalid timezone as a blocker, not as UTC.
+7. **Consent.** Every recipient needs an unrevoked authorisation record naming its source. No
+   record, no call.
+8. **Duplicates.** Enforce phone uniqueness per campaign as a *database constraint*. Nobody is
+   called twice about one notice.
+9. **Retry cap** per recipient, counted only after CALL-E actually accepts a call.
+10. **Kill switch** not engaged.
+
+## Dispatch: one wave is one batch
+
+Send the wave as a single call task with every recipient in the `recipients` array.
+
+```
+POST https://api.heycall-e.com/v1/calls
+Authorization: Bearer $CALLE_API_KEY
+Idempotency-Key: recall-outreach:{campaign_id}:wave{n}:outreach:v1
+```
+
+```json
+{
+  "task": "<see template below>",
+  "recipients": [{ "phones": ["+15005550101"], "locale": "en-US", "region": "US" }],
+  "recipient_result_schema": { "...": "see references/result-schema.json" },
+  "metadata": {
+    "campaign_id": "RC-2026-001",
+    "call_task_id": "RC-2026-001:wave1:outreach",
+    "wave_no": 1,
+    "kind": "outreach"
+  },
+  "webhook_url": "https://your-app.example.com/api/webhooks/calle"
+}
+```
+
+**Put no customer identity in `metadata`** — campaign and wave correlation only. CALL-E already
+has the number it must dial; nothing else about the person is the provider's business.
+
+**Two consequences of batching to design around:**
+
+1. `task` is shared, so it **cannot** contain any one customer's name, order number, or serial
+   number. Treat this as a feature: have the assistant *ask* the person to confirm they are the
+   right person rather than asserting who they are. It is the safer identification method and it
+   discloses nothing to whoever answers.
+2. `metadata` is per call task, so the only per-recipient join key returned is the phone number.
+   This is why phone uniqueness must be a constraint, not a convention. Match on normalised
+   digits, with dispatch order as a fallback.
+
+Persist the returned `call_id` **before** showing anything as started, and create one pending
+outcome row per dialled recipient at the same time, so every person dialled is accounted for
+even if the provider never returns a result for them.
+
+## CALL-E Task Template
+
+```text
+You are an automated voice assistant calling on behalf of {org_name}. Say so in your first
+sentence, and say you are calling about a product notice. Do not claim to be a person.
+
+The organisation has issued a notice about {product_label} ({product_identifier}). Your job is
+to reach the customer, read the approved notice to them, check what they want to do, and record
+their answers accurately. You are a messenger, not an adviser.
+
+First, ask whether you are speaking with the person who bought or uses this product, or the
+person in the household who looks after it. Do not say any customer name, order number, or
+serial number: you have not been given them and you must not guess. If the person who answers
+is not the right person and cannot help, say a person from the organisation will follow up,
+thank them, and end the call.
+
+Once you have the right person, read this approved notice exactly as written, without changing
+its meaning: "{approved_notice}"
+
+Then find out, without pressing them: do they recognise this product; do they still have it, or
+did they already return it, give it away, or throw it away; did they understand the notice and
+what to do next; which of the options below they would like; and whether they have a preferred
+day or time for it.
+
+Offer exactly these options and no others: {phrased_next_steps}. Read them out and let the
+person choose. Do not recommend one over another, and do not invent an option such as a refund,
+a replacement, or a repair unless it is written above.
+
+These are the ONLY answers you are permitted to give. Use the wording as closely as you can:
+{approved_answers}
+Anything not on this list is outside what you may answer, no matter how simple it sounds or how
+confident you feel.
+
+If you reach voicemail or an answering machine, leave only this short message and nothing more:
+"{voicemail_text}" Do not read the full notice, do not describe the product problem, and do not
+leave any detail about the item on a voicemail, because you cannot know who will hear it.
+
+Hard rules you must follow: {boundaries — see references/safety.md}
+
+Before ending, tell the person what will happen next in plain terms, and make clear that
+arranging this is not the same as it being completed: someone from {org_name} will confirm the
+arrangement. Thank them for their time.
+```
+
+The full boundary list is in `references/safety.md`. Every one of them has a matching detection
+or enforcement path; they are not decoration.
+
+## Result Schema
+
+`references/result-schema.json`, with `additionalProperties: false` and every field required.
+Narrow `selected_next_step`'s enum to the options that campaign actually offers, so CALL-E
+structurally cannot return a return channel the business does not run. Always keep `none` and
+`unknown` available — they are honest answers.
+
+Validate offline with:
+
+```bash
+node scripts/validate-result.mjs assets/sample-result-arranged.json
+node scripts/validate-result.mjs assets/sample-result-escalated.json
+node scripts/validate-result.mjs assets/sample-result-invalid.json   # exits non-zero
+```
+
+## Terminal Events And Reconciliation
+
+Handle `call.completed`, `call.failed`, and `call.result_validation_failed` at your webhook.
+
+1. Require `CALL-E-Event-Id` and require it to match the body `id`.
+2. **Reserve the event id before any side effect** — make it a primary key. A duplicate delivery
+   must be a no-op that cannot dial anyone again or queue a second follow-up.
+3. **Re-fetch with `GET /v1/calls/{call_id}` using your own key.** CALL-E sends no signature
+   today, so treat the body as untrusted: it tells you *which* call changed; the fetched
+   snapshot is what changes customer status.
+4. If the fetched call is not terminal, return non-2xx and let the provider retry rather than
+   applying a contradiction.
+5. Fan the snapshot out to one outcome per dialled recipient, validating each independently so
+   one unusable answer never contaminates the others.
+6. Return non-2xx for an unknown call id, so the race between CALL-E accepting a call and your
+   transaction committing resolves by retry.
+
+Also poll `GET /v1/calls/{call_id}` for open waves on a schedule. A lost webhook should cost
+latency, not truth.
+
+## Interpreting A Result
+
+| Provider state | Record as | May count toward |
+| --- | --- | --- |
+| Valid, complete result | `valid` | its funnel stages |
+| Result present, schema-violating | `invalid` | nothing above "call completed" |
+| Completed call, no result | `missing` | nothing above "call completed" |
+| Failed or canceled call | `missing` | "attempted" only |
+
+`unknown` is never agreement. An empty string is never an answer.
+
+**Route to a human on any of:** a non-empty `questions`; `human_follow_up_required = yes`;
+`contact_outcome = escalate`; `certainty` of `low` or `unknown` where someone was reached;
+`right_person_reached = unknown`; a schema-violating result; a failed call.
+
+**Do not route a clean miss to a human.** `right_person_reached = no` with
+`certainty = unknown` is a voicemail or wrong number — that is *not reached*, and treating it as
+ambiguity will flood the queue with every unanswered call. This is a real mistake that is easy
+to make; the distinction is between "we did not reach them" and "we are not sure what happened."
+
+Make the follow-up queue idempotent: unique on `(outcome_id, reason)`, so a retried webhook
+cannot queue duplicate human work.
+
+## Approval-Gated Follow-Up
+
+A narrowly scoped scheduling follow-up is permitted: confirming the day or window for a step the
+customer already chose. It requires an explicit human approval, an explicit stated purpose, and
+an explicit recipient list, and it re-runs every preflight gate.
+
+It may **not** re-read the notice, change the chosen option, or answer anything new. If the
+customer raises something else, the call ends and it becomes human work.
+
+## Side Effects, Credentials, Cancellation
+
+- **Side effects:** real outbound calls to authorised numbers only. Nothing is collected,
+  shipped, refunded, or confirmed automatically.
+- **Credentials:** server-side `CALLE_API_KEY` only. Never in skill files, never in the browser.
+- **Cancellation:** there is no cancel endpoint. A kill switch blocks *further* waves; calls
+  already accepted will finish. Say this in your UI rather than implying otherwise.
+- **Personal data:** mask phone numbers everywhere except the database and the CALL-E request.
+  Provide a retention control that erases names, numbers, item identifiers, and transcripts
+  while keeping call ids, event ids, and statuses, so the organisation can still prove what
+  happened without keeping what proved it.
+
+## Auditability
+
+Every customer status must trace to a provider call id, and where a webhook arrived, to a
+provider event id. Statuses set by a human — the only kind that can exist without a call —
+should say so explicitly and name the person. Export the exact task text and result schema used
+on each wave, so an auditor can read precisely what was said and what was asked for.
+
+## References
+
+- `references/result-schema.json` — the strict schema
+- `references/safety.md` — the full boundary list and why each exists
+- `references/examples.md` — worked outcomes: arranged, escalated, not reached, invalid
+- `assets/sample-campaign.json` — a fictional campaign
+- `scripts/validate-result.mjs` — offline result validator

--- a/skills/recall-outreach/assets/sample-campaign.json
+++ b/skills/recall-outreach/assets/sample-campaign.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "Fictional campaign. Phone numbers are from the NANP +1500555xxxx test range and belong to nobody. Never put real customer data in a skill fixture.",
+  "campaign_id": "RC-2026-001",
+  "org_name": "Harborline Appliances",
+  "product_label": "Harborline 1.7L cordless kettle, model HL-220",
+  "product_identifier": "HL-220, lots 2451 to 2489",
+  "reference": "HL-220-NOTICE-01",
+  "timezone": "Asia/Singapore",
+  "calling_window": { "start": "09:00", "end": "19:00" },
+  "escalation_contact": {
+    "name": "Priya Menon, customer safety desk",
+    "phone_e164": "+15005550199",
+    "_comment": "A human. The assistant never dials this number."
+  },
+  "approved_by": "Compliance lead",
+  "approved_notice": "Harborline Appliances has issued a safety notice for the Harborline 1.7 litre cordless kettle, model HL-220, from production lots 2451 to 2489. Please stop using the kettle and unplug it. Do not attempt to open or repair it. Harborline will arrange to collect the kettle or send you a prepaid return label, and you will receive a full refund once it is returned.",
+  "voicemail_text": "This is an automated call from Harborline Appliances about an important product notice for something you purchased. Please call us back on the number on our website, or we will try you again. Thank you.",
+  "allowed_next_steps": ["pickup_request", "mail_return", "callback"],
+  "approved_answers": [
+    {
+      "question": "Do I get a refund?",
+      "answer": "Yes. Harborline will issue a full refund of the purchase price once the kettle is returned."
+    },
+    {
+      "question": "How long does the return take?",
+      "answer": "A collection is usually arranged within five working days, and a refund is issued within ten working days of the kettle arriving."
+    },
+    {
+      "question": "Do I need the original receipt or box?",
+      "answer": "No. Neither the receipt nor the original packaging is needed for this return."
+    },
+    {
+      "question": "Can I keep using it in the meantime?",
+      "answer": "Harborline asks that you stop using the kettle and unplug it until it has been collected."
+    }
+  ],
+  "recipients": [
+    {
+      "customer_ref": "CUST-1001",
+      "phone_e164": "+15005550101",
+      "item_identifier": "HL220-2481",
+      "consent_basis": "purchase_record",
+      "consent_source": "Order 44821 dated 2026-03-11"
+    },
+    {
+      "customer_ref": "CUST-1002",
+      "phone_e164": "+15005550102",
+      "item_identifier": "HL220-2482",
+      "consent_basis": "warranty_registration",
+      "consent_source": "Warranty registration 9912"
+    },
+    {
+      "customer_ref": "CUST-1003",
+      "phone_e164": "+15005550103",
+      "item_identifier": "HL220-2483",
+      "consent_basis": "purchase_record",
+      "consent_source": "Order 44877 dated 2026-03-14"
+    }
+  ],
+  "idempotency_key": "recall-outreach:RC-2026-001:wave1:outreach:v1",
+  "metadata_sent_to_calle": {
+    "_comment": "Correlation only. No customer name, phone, or item identifier belongs here.",
+    "campaign_id": "RC-2026-001",
+    "call_task_id": "RC-2026-001:wave1:outreach",
+    "wave_no": 1,
+    "kind": "outreach",
+    "script_version": 1
+  }
+}

--- a/skills/recall-outreach/assets/sample-result-arranged.json
+++ b/skills/recall-outreach/assets/sample-result-arranged.json
@@ -1,0 +1,12 @@
+{
+  "right_person_reached": "yes",
+  "item_recognized": "yes",
+  "item_status": "still_has_item",
+  "notice_understood": "yes",
+  "selected_next_step": "pickup_request",
+  "preferred_time": "Thursday morning, before midday",
+  "questions": "",
+  "human_follow_up_required": "no",
+  "contact_outcome": "resolved",
+  "certainty": "high"
+}

--- a/skills/recall-outreach/assets/sample-result-escalated.json
+++ b/skills/recall-outreach/assets/sample-result-escalated.json
@@ -1,0 +1,12 @@
+{
+  "right_person_reached": "yes",
+  "item_recognized": "yes",
+  "item_status": "still_has_item",
+  "notice_understood": "yes",
+  "selected_next_step": "none",
+  "preferred_time": "",
+  "questions": "It leaked and damaged my worktop. Can I claim for that?",
+  "human_follow_up_required": "yes",
+  "contact_outcome": "escalate",
+  "certainty": "high"
+}

--- a/skills/recall-outreach/assets/sample-result-invalid.json
+++ b/skills/recall-outreach/assets/sample-result-invalid.json
@@ -1,0 +1,13 @@
+{
+  "right_person_reached": "yes",
+  "item_recognized": "yes",
+  "item_status": "sold_it",
+  "notice_understood": "yes",
+  "selected_next_step": "refund",
+  "preferred_time": "whenever",
+  "questions": "",
+  "human_follow_up_required": "no",
+  "contact_outcome": "resolved",
+  "certainty": "high",
+  "agent_note": "customer seemed happy"
+}

--- a/skills/recall-outreach/assets/sample-result-not-reached.json
+++ b/skills/recall-outreach/assets/sample-result-not-reached.json
@@ -1,0 +1,12 @@
+{
+  "right_person_reached": "no",
+  "item_recognized": "unknown",
+  "item_status": "unknown",
+  "notice_understood": "unknown",
+  "selected_next_step": "unknown",
+  "preferred_time": "",
+  "questions": "",
+  "human_follow_up_required": "unknown",
+  "contact_outcome": "not_reached",
+  "certainty": "unknown"
+}

--- a/skills/recall-outreach/references/examples.md
+++ b/skills/recall-outreach/references/examples.md
@@ -1,0 +1,138 @@
+# Worked examples
+
+Four outcomes from one wave, and exactly what each does and does not establish. All numbers are
+from the NANP `+1500555xxxx` test range; all names are fictional.
+
+Run any of these through the validator:
+
+```bash
+node scripts/validate-result.mjs assets/sample-result-arranged.json
+```
+
+---
+
+## 1. Arranged a collection — `sample-result-arranged.json`
+
+The customer confirmed who they were, still had the kettle, understood the notice, and asked for
+a Thursday morning collection.
+
+```json
+{
+  "right_person_reached": "yes",
+  "item_recognized": "yes",
+  "item_status": "still_has_item",
+  "notice_understood": "yes",
+  "selected_next_step": "pickup_request",
+  "preferred_time": "Thursday morning, before midday",
+  "questions": "",
+  "human_follow_up_required": "no",
+  "contact_outcome": "resolved",
+  "certainty": "high"
+}
+```
+
+**What this establishes:** the right person was reached, understood the notice, and requested a
+collection. It counts toward *right person reached*, *notice understood*, and *next step
+selected*.
+
+**What it does not establish:** that anything has been collected. Note that `contact_outcome` is
+`resolved` — that field describes **the contact**, not the recall. A correct implementation must
+not wire `contact_outcome: resolved` to a resolved customer state. This is the single most
+likely place to introduce the bug this skill exists to prevent.
+
+**Correct customer state:** `contacted`, with a pending collection request.
+
+---
+
+## 2. Out-of-scope question — `sample-result-escalated.json`
+
+The customer asked about damage to their worktop. The campaign's approved answers cover refunds
+and timing; they say nothing about consequential damage.
+
+```json
+{
+  "right_person_reached": "yes",
+  "notice_understood": "yes",
+  "selected_next_step": "none",
+  "questions": "It leaked and damaged my worktop. Can I claim for that?",
+  "human_follow_up_required": "yes",
+  "contact_outcome": "escalate",
+  "certainty": "high"
+}
+```
+
+**Correct handling:** the assistant did not answer, ended politely, and recorded the question
+verbatim. Two follow-up items are created — one for the unanswered question, one for the
+escalation flag — and the customer moves to `needs_human`.
+
+**Counts toward:** *right person reached* and *notice understood*. **Not** *next step selected*:
+`none` is a real answer meaning they declined to choose, and it must not be inflated.
+
+This is a success, not a failure. The system did the right thing: it recognised the edge of its
+approved material and handed over.
+
+---
+
+## 3. Not reached — `sample-result-not-reached.json`
+
+Voicemail. The minimal message was left; the notice was not.
+
+```json
+{
+  "right_person_reached": "no",
+  "item_recognized": "unknown",
+  "item_status": "unknown",
+  "notice_understood": "unknown",
+  "selected_next_step": "unknown",
+  "questions": "",
+  "human_follow_up_required": "unknown",
+  "contact_outcome": "not_reached",
+  "certainty": "unknown"
+}
+```
+
+**Correct handling:** customer state `not_reached`, attempt count incremented, eligible for one
+more wave if under the retry cap.
+
+**The trap:** `certainty` is `unknown` here, and that is correct — the schema says `unknown` when
+nobody was reached. A naive "escalate anything uncertain" rule will send **every voicemail** to a
+human and bury the queue. Distinguish a clean miss (`right_person_reached: no`) from genuine
+ambiguity (`right_person_reached: unknown`). Only the latter needs a person.
+
+**Counts toward:** *call attempted* and *call completed*. Nothing else.
+
+---
+
+## 4. Unusable result — `sample-result-invalid.json`
+
+The call completed, but what came back does not satisfy the contract: `item_status: "sold_it"`
+and `selected_next_step: "refund"` are not enum members, and `agent_note` is an extra property.
+
+**Correct handling:** record `resultState: invalid`, store the raw payload and the validation
+error for inspection, move the customer to `needs_human`, and create a
+`result_validation_failed` follow-up. **Read none of the fields**, not even the ones that look
+fine — a payload that violates the contract is not partially trustworthy.
+
+**Counts toward:** *call attempted* and *call completed*. Nothing above.
+
+---
+
+## The funnel these four produce
+
+From one wave of four recipients:
+
+| Measure | Count | Why |
+| --- | --- | --- |
+| Call attempted | 4 | all four were dialled |
+| Call completed | 4 | all four calls finished |
+| Result validated | 3 | one payload violated the contract |
+| Right person reached | 2 | one voicemail, one invalid |
+| Notice understood | 2 / 2 reached | both people who answered confirmed |
+| Next step selected | 1 / 2 reached | one declined to choose |
+| **Independently resolved** | **0** | **nobody has confirmed a physical return** |
+
+A single "contacted" number here would read **4 of 4, 100%**. The honest reading is that two
+people were reached, one collection was requested, one question needs a human, and nothing has
+come back yet.
+
+Report all seven. Never report one.

--- a/skills/recall-outreach/references/result-schema.json
+++ b/skills/recall-outreach/references/result-schema.json
@@ -1,0 +1,106 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "right_person_reached",
+    "item_recognized",
+    "item_status",
+    "notice_understood",
+    "selected_next_step",
+    "preferred_time",
+    "questions",
+    "human_follow_up_required",
+    "contact_outcome",
+    "certainty"
+  ],
+  "properties": {
+    "right_person_reached": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "description": "yes only if the person who answered confirmed they are the customer named on the notice, or the household member responsible for the item. no for voicemail, a wrong number, a hang-up, or someone who says the customer is unavailable. unknown if it stayed unclear."
+    },
+    "item_recognized": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "description": "Whether the person recognised owning or having bought the recalled product. no if they say they never had it. unknown if they were not sure or you did not get to ask."
+    },
+    "item_status": {
+      "type": "string",
+      "enum": [
+        "still_has_item",
+        "returned",
+        "transferred",
+        "discarded",
+        "unknown"
+      ],
+      "description": "Where the item is now, according to the person: still_has_item if it is in their possession, returned if they already returned it, transferred if they gave or sold it to someone else, discarded if they threw it away. unknown if not stated. Never infer this from silence."
+    },
+    "notice_understood": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "description": "yes only if the person confirmed in their own words that they understood the notice you read and what they should do next. no if they said they did not understand or asked you to repeat it and still did not confirm. unknown if you never got confirmation either way."
+    },
+    "selected_next_step": {
+      "type": "string",
+      "enum": [
+        "pickup_request",
+        "mail_return",
+        "store_return",
+        "callback",
+        "none",
+        "unknown"
+      ],
+      "description": "The return or pickup option the person explicitly chose. The options offered on this campaign are: pickup_request, mail_return, store_return. Use callback if they asked to be called back or to speak to a person. Use none if they declined to choose any option. Use unknown if the call ended before a choice. Never select an option the person did not clearly say."
+    },
+    "preferred_time": {
+      "type": "string",
+      "description": "The day or time window the person asked for, in their own words, for example 'Thursday morning' or 'after 6pm on weekdays'. Leave empty if they gave no preference. Never invent a time."
+    },
+    "questions": {
+      "type": "string",
+      "description": "Any question the person asked that you were not able to answer from the approved information, quoted as closely as you can. Leave empty if they asked nothing or everything they asked was covered by the approved answers."
+    },
+    "human_follow_up_required": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "description": "yes if the person asked something outside the approved information, disputed the notice, asked about injury, damage, compensation or legal matters, requested a person, or sounded distressed. no only if everything they raised was fully answered by the approved information. unknown if you could not tell."
+    },
+    "contact_outcome": {
+      "type": "string",
+      "enum": [
+        "resolved",
+        "partially_resolved",
+        "not_reached",
+        "escalate",
+        "unknown"
+      ],
+      "description": "resolved if the right person understood the notice and chose a next step. partially_resolved if you reached them but a step or confirmation is still missing. not_reached for voicemail, no answer, or a wrong number. escalate if a human must take over. unknown if none of these fit."
+    },
+    "certainty": {
+      "type": "string",
+      "enum": [
+        "high",
+        "medium",
+        "low",
+        "unknown"
+      ],
+      "description": "How confident you are that the answers above reflect what the person actually said. high for clear explicit statements, medium for hedged answers, low for a noisy or confusing call, unknown if not reached."
+    }
+  }
+}

--- a/skills/recall-outreach/references/safety.md
+++ b/skills/recall-outreach/references/safety.md
@@ -1,0 +1,157 @@
+# Boundaries, and why each one exists
+
+These are the hard rules given to CALL-E on every recall-outreach call. Each has a reason and,
+in the reference implementation, a matching enforcement or detection path. They are not
+decoration, and none of them should be softened to make a call flow more smoothly.
+
+---
+
+## Identification
+
+> Say in your first sentence that you are an automated assistant calling on behalf of the named
+> organisation.
+
+> Do not claim to be a person.
+
+A recall call is an unsolicited call about something the recipient owns. They are entitled to
+know immediately who is calling and that it is automated, before deciding whether to engage.
+
+> Do not say any customer name, order number, or serial number: you have not been given them and
+> you must not guess.
+
+Whoever picks up the phone is not necessarily the customer. Reading out a name and a purchase
+record to an unknown person discloses that a specific household bought a specific item. Asking
+the person to confirm they are the right person achieves the same identification and discloses
+nothing.
+
+In a batched implementation this is structural rather than a matter of trust: the task text is
+shared across recipients, so per-customer details cannot be in it.
+
+---
+
+## Never give safety advice
+
+> You are not a safety expert. Never tell the person to inspect, open, repair, modify, test,
+> dismantle, transport, or dispose of the item, and never describe how to make it safe.
+
+> Never assess how dangerous the item is, whether it has caused harm, or whether it is safe to
+> keep using. If asked, say you cannot advise on that and a person will follow up.
+
+This is the boundary that matters most. A recalled item may be an electrical, chemical, choking,
+or fire hazard. "Just unplug it and pop it in a bag" is the kind of sentence a helpful assistant
+produces and a hazard analysis forbids. The organisation's approved notice already contains
+whatever safe handling instruction was cleared; anything beyond it is invention.
+
+The same applies in reverse. Reassurance is also advice: "it's probably fine" is a hazard
+assessment.
+
+---
+
+## Relay only, answer only from the list
+
+> Read the approved notice as written. Do not rewrite it, shorten its meaning, or add to it.
+
+> Answer only with the approved answers you were given. If the person asks anything else, say
+> plainly that you do not have that information and that a person from the organisation will
+> follow up, then record the question.
+
+> Anything not on this list is outside what you may answer, no matter how simple it sounds or
+> how confident you feel.
+
+Recall wording is usually reviewed by legal or compliance, sometimes by a regulator. Paraphrase
+changes meaning. The last clause is aimed squarely at the failure mode where a question *seems*
+trivial ("is this the same as the one on the news?") and the honest answer requires knowledge
+the assistant does not have.
+
+A campaign with no approved answers is valid — it just means everything escalates. Warn about
+the queue size; do not fill the gap by improvising.
+
+---
+
+## No commitments
+
+> Never give legal, medical, insurance, compensation, or refund commitments of any kind.
+
+> Do not recommend one option over another, and do not invent an option such as a refund, a
+> replacement, or a repair unless it is written above.
+
+A recall frequently involves money and sometimes involves injury. Both are for a person. Note
+that a refund *is* often on offer — but only in the approved wording, phrased as the
+organisation phrased it.
+
+---
+
+## No data collection beyond the task
+
+> Do not ask for or accept payment details, card numbers, government identifiers, dates of
+> birth, or any personal data beyond a return preference and a preferred time.
+
+An automated call asking for identifying details is indistinguishable from a scam, and recalls
+are a known pretext for exactly that. Collecting nothing protects the recipient from real fraud
+and from being trained to expect these calls to ask for data.
+
+---
+
+## Never claim the recall is finished
+
+> Never state or imply that the recall is finished, closed, or resolved. Arranging a next step
+> is not the same as completing it.
+
+> Before ending, make clear that arranging this is not the same as it being completed: someone
+> from the organisation will confirm the arrangement.
+
+A customer who believes the matter is closed stops expecting a courier and may resume using the
+item. The call must leave them expecting a next step, because a next step is what is actually
+pending.
+
+---
+
+## Voicemail says less
+
+> If you reach voicemail or an answering machine, leave only this short message and nothing
+> more. Do not read the full notice, do not describe the product problem, and do not leave any
+> detail about the item on a voicemail, because you cannot know who will hear it.
+
+Answering machines are shared, played on speakers, and transcribed by third-party services. The
+minimal message should be a callback request that names the organisation and nothing else.
+
+Preflight should scan the configured voicemail text for product-identifying tokens — model
+codes, lot numbers, distinctive product nouns — and warn when it finds them, exempting the
+organisation's own name because identifying the caller is required.
+
+---
+
+## Respect the person on the line
+
+> If the person asks to stop being contacted, confirm that you have recorded the request,
+> apologise for the interruption, and end the call.
+
+> If the person is distressed, angry, or says they were hurt, do not argue or reassure beyond
+> the approved wording. Say a person will follow up, and end the call politely.
+
+> Keep the call under three minutes and stay calm and polite throughout.
+
+Someone reporting an injury needs a person, not a script — and an assistant that responds to
+distress with reassurance is both unhelpful and potentially making a claim about liability.
+
+An opt-out heard on a call must reach the system that decides who gets dialled. Do not infer one
+from free text; give a coordinator an explicit action, and make opting out revoke the consent
+record so it holds across every later wave.
+
+---
+
+## What the system must enforce, not just request
+
+Instructions in a prompt are not controls. These must be enforced in code, on the server,
+re-evaluated at the moment of launch:
+
+| Control | Requirement |
+| --- | --- |
+| Consent | An unrevoked authorisation record per recipient, naming its source |
+| Quiet hours | Evaluated in the recipient's timezone; a campaign may narrow, never widen, a deployment floor; an invalid timezone blocks rather than defaults |
+| Retry cap | Counted per recipient, incremented only after CALL-E accepts a call |
+| Opt-out and blocklist | Sticky statuses no call result can overwrite |
+| Duplicate prevention | Phone uniqueness per campaign as a database constraint |
+| Kill switch | Blocks further waves; state honestly that in-flight calls will finish |
+| Emergency numbers | Rejected at import and again at dispatch |
+| Credentials | No key, no calling — and no simulated result as a fallback |

--- a/skills/recall-outreach/scripts/validate-result.mjs
+++ b/skills/recall-outreach/scripts/validate-result.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Offline validator for a recall-outreach recipient result.
+ *
+ * Usage:
+ *   node scripts/validate-result.mjs <path-to-result.json> [--allow pickup_request,mail_return]
+ *
+ * Exits 0 when the result satisfies the contract, 1 otherwise. No network, no CALL-E account.
+ * This exists so an integrator can check a result they captured from a real call without
+ * running the whole application — and so nobody needs a mock provider to test their handling.
+ */
+import { readFileSync } from "node:fs";
+
+const ENUMS = {
+  right_person_reached: ["yes", "no", "unknown"],
+  item_recognized: ["yes", "no", "unknown"],
+  item_status: ["still_has_item", "returned", "transferred", "discarded", "unknown"],
+  notice_understood: ["yes", "no", "unknown"],
+  selected_next_step: ["pickup_request", "mail_return", "store_return", "callback", "none", "unknown"],
+  human_follow_up_required: ["yes", "no", "unknown"],
+  contact_outcome: ["resolved", "partially_resolved", "not_reached", "escalate", "unknown"],
+  certainty: ["high", "medium", "low", "unknown"],
+};
+const FREE_TEXT = ["preferred_time", "questions"];
+const REQUIRED = [...Object.keys(ENUMS), ...FREE_TEXT];
+
+function parseArgs(argv) {
+  const file = argv.find((a) => !a.startsWith("--"));
+  const allowIndex = argv.indexOf("--allow");
+  const allowed = allowIndex >= 0 && argv[allowIndex + 1] ? argv[allowIndex + 1].split(",").map((s) => s.trim()) : null;
+  return { file, allowed };
+}
+
+const { file, allowed } = parseArgs(process.argv.slice(2));
+if (!file) {
+  console.error("Usage: node scripts/validate-result.mjs <result.json> [--allow pickup_request,mail_return]");
+  process.exit(2);
+}
+
+let value;
+try {
+  value = JSON.parse(readFileSync(file, "utf8"));
+} catch (error) {
+  console.error(`Could not read ${file}: ${error.message}`);
+  process.exit(2);
+}
+
+const errors = [];
+
+if (value === null || typeof value !== "object" || Array.isArray(value)) {
+  errors.push("Result must be a JSON object.");
+} else {
+  for (const field of REQUIRED) {
+    if (!(field in value)) errors.push(`Missing required field: ${field}`);
+  }
+  for (const key of Object.keys(value)) {
+    if (!REQUIRED.includes(key)) errors.push(`Unexpected field (additionalProperties is false): ${key}`);
+  }
+  for (const [field, members] of Object.entries(ENUMS)) {
+    if (!(field in value)) continue;
+    if (typeof value[field] !== "string") errors.push(`${field} must be a string`);
+    else if (!members.includes(value[field])) {
+      errors.push(`${field} must be one of ${members.join(", ")} — got "${value[field]}"`);
+    }
+  }
+  for (const field of FREE_TEXT) {
+    if (field in value && typeof value[field] !== "string") errors.push(`${field} must be a string (use "" for no answer)`);
+  }
+  if (allowed && typeof value.selected_next_step === "string") {
+    const permitted = [...allowed, "callback", "none", "unknown"];
+    if (!permitted.includes(value.selected_next_step)) {
+      errors.push(
+        `selected_next_step "${value.selected_next_step}" is not offered by this campaign (allowed: ${permitted.join(", ")})`,
+      );
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`INVALID — ${file}`);
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error("\nA result that fails this check must be recorded as unusable and routed to a human.");
+  console.error("It must never count toward any measure above 'call completed'.");
+  process.exit(1);
+}
+
+// Valid, but say plainly what it does and does not establish.
+const notes = [];
+if (value.right_person_reached !== "yes") notes.push("The right person was NOT confirmed reached; no claim about this customer holds.");
+if (value.questions.trim()) notes.push("An unanswered question was recorded: this belongs to a human.");
+if (value.human_follow_up_required === "yes" || value.contact_outcome === "escalate") notes.push("Flagged for human follow-up.");
+if (["low", "unknown"].includes(value.certainty) && value.right_person_reached !== "no") {
+  notes.push("Certainty is low or unknown: do not act on these answers without a human check.");
+}
+if (!["none", "unknown"].includes(value.selected_next_step) && value.right_person_reached === "yes") {
+  notes.push(`Next step requested: ${value.selected_next_step}. This is a REQUEST, not a completed return.`);
+}
+
+console.log(`VALID — ${file}`);
+for (const n of notes) console.log(`  · ${n}`);
+console.log("\nReminder: a valid result never means the recall is resolved for this customer.");
+console.log("Only a human confirming the physical return can establish that.");


### PR DESCRIPTION
## Summary

Adds `skills/recall-outreach`, a reusable Agent Skill for product recall and corrective-notice
outreach. It packages the approved-wording contract, the batch call plan, a strict
`recipient_result_schema`, the idempotency and webhook reconciliation rules, and the metric
model extracted from RecallRoute (CALL-E: Your Code Is Calling submission, Most Practical Use
Case).

## What it does

- Reads organisation-approved recall wording verbatim; the skill never generates recall language
  and never gives safety, repair, disposal, or transport advice.
- Dispatches a wave as **one CALL-E call task containing every recipient**, with a stable
  idempotency key, and fans `recipients[].structured_result` out to one outcome per person.
- Uses one strict per-recipient schema (`additionalProperties: false`, every field required),
  with `selected_next_step` narrowed per campaign so CALL-E structurally cannot return a return
  channel the business does not offer.
- Answers only pre-approved questions. Everything else — injury, compensation, legal, or simply
  unanticipated — ends the call politely and becomes a human follow-up. There is no improvisation
  path.
- Reconciles `call.completed` / `call.failed` / `call.result_validation_failed` by
  `CALL-E-Event-Id`, then re-fetches with `GET /v1/calls/{call_id}` before changing any customer
  status; the webhook body is treated as untrusted input.
- Reports **seven separate measures** rather than one success rate, and keeps
  *independently resolved* reachable only by a named human recording how they know the item
  physically came back.

## Why the metric model is the point

Recall tooling is easy to make dishonest: one `contacted` boolean set from a completed call
reads as 100% and means nothing. The skill's `references/examples.md` works through a four-call
wave that a naive implementation would report as "4 of 4, 100%", and shows the honest reading —
two people reached, one collection requested, one question needing a human, nothing returned yet.

## Notable design decision: batching as a privacy property

Because a wave is one batch, `task` is shared across recipients and structurally cannot contain
any one customer's name, order number, or serial number. The assistant asks the person to confirm
they are the right person rather than asserting who they are — safer identification, and it
discloses nothing to whoever answers the phone. The skill documents this so implementers do not
work around it by sending one call per recipient purely to personalise.

## Side effects, credentials, cancellation

- **Side effects:** real outbound calls to authorised numbers only. Nothing is collected,
  shipped, refunded, or confirmed automatically.
- **Credentials:** server-side `CALLE_API_KEY` only; never in the skill files, never in a
  browser. Without a key, an implementation must block launching rather than simulate a result.
- **Cancellation:** the Calls API has no cancel endpoint. A kill switch can only stop further
  waves; calls already accepted will finish. The skill requires implementations to say this
  plainly rather than imply otherwise.
- **Personal data:** phone numbers masked outside the database and the CALL-E request; no
  customer identity in `metadata`; a retention control that erases personal data while keeping
  call ids, event ids, and statuses.

## Not for

Emergency notification, injury response, hazard classification, regulatory determination,
medical or legal advice, cold outreach, or mass-scale dialling. Each is called out in the skill's
"When Not To Use" section.

## Testing

`scripts/validate-result.mjs` validates a captured result offline with no network and no CALL-E
account, and exits non-zero on a contract violation:


---

Reference implementation: https://github.com/HectorTa1989/recallroute
