### PR TITLE
feat: ConfirmCall day-board skill + TypeScript fixture app

### DIFF
--- a/apps/typescript/confirmcall-day-board/README.md
+++ b/apps/typescript/confirmcall-day-board/README.md
@@ -1,0 +1,37 @@
+# ConfirmCall Day Board
+
+Front-desk day board for clinics, tutors, and service shops. Import a day's appointments, preview one disclosed CALL-E confirmation script per booking, run confirmations (fixture by default), and capture **yes / no / reschedule** — without writing the calendar.
+
+Companion skill: [`skills/confirmcall-day-board`](../../../skills/confirmcall-day-board/).
+
+## Problem
+
+No-shows burn staff time. Calling every booking by hand does not scale. ConfirmCall runs a structured confirmation pass and leaves diary changes to a human.
+
+## Safety
+
+- **Fixture by default** — `npm run fixture` never dials.
+- **Preview before live** — `npm run preview` prints scripts with masked numbers.
+- **Live refused without key** — `npm run live` exits unless `CALLE_API_KEY` is set, and this minimal demo still does not auto-dial (points you at CALL-E CLI / full app).
+- **Consent required** per appointment.
+- **No calendar writes.**
+
+## Setup
+
+```bash
+cd apps/typescript/confirmcall-day-board
+npm install
+```
+
+Sample board: `skills/confirmcall-day-board/assets/sample-day-board.json` (fictional numbers).
+
+## Usage
+
+```bash
+npm run preview   # print CALL-E scripts
+npm run fixture   # Maya confirmed, Jordan reschedule, Eli declined
+```
+
+## Full product
+
+The full Next.js ConfirmCall workbench (CSV import, live `@call-e/calle` client, webhook) lives in Mark Yukhimets' ConfirmCall Origin project from the CALL-E hackathon build. This awesome-repo package is the portable skill + dry-run app for community reuse and Devpost PR submission.

--- a/apps/typescript/confirmcall-day-board/confirmcall.js
+++ b/apps/typescript/confirmcall-day-board/confirmcall.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * ConfirmCall Day Board — dry-run / fixture by default.
+ * Live mode requires CALLE_API_KEY and --live. Does not write calendars.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAMPLE = join(
+  __dirname,
+  "../../../skills/confirmcall-day-board/assets/sample-day-board.json"
+);
+
+function maskPhone(e164) {
+  if (!e164 || e164.length < 6) return "***";
+  return `${e164.slice(0, 2)}***${e164.slice(-4)}`;
+}
+
+function loadBoard(path = SAMPLE) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function planScript(business, apt) {
+  const windows = (apt.reschedule_windows || []).join(", ") || "none pre-approved";
+  return (
+    `You are calling on behalf of ${business}. Ask for ${apt.recipient_first_name}. ` +
+    `Disclose this is a confirmation call for their existing ${apt.appointment.service} ` +
+    `on ${apt.appointment.starts_at} at ${apt.appointment.location}. ` +
+    `Ask if they can still attend. If not, ask decline or reschedule into: ${windows}. ` +
+    `No medical/legal/financial advice. No payment. Return yes/no/reschedule only.`
+  );
+}
+
+const FIXTURES = {
+  "apt-maya-1": {
+    disposition: "confirmed",
+    notes: "Recipient confirmed the booked slot",
+    requested_time: null,
+  },
+  "apt-jordan-2": {
+    disposition: "reschedule_requested",
+    notes: "Asked for Thursday after 3pm",
+    requested_time: "2026-09-11T17:00:00-07:00",
+  },
+  "apt-eli-3": {
+    disposition: "declined",
+    notes: "Cannot attend; slot freed for the desk",
+    requested_time: null,
+  },
+};
+
+function assertSafe(apt) {
+  if (apt.consent !== true) throw new Error(`${apt.request_id}: consent required`);
+  if (!/^\+[1-9]\d{7,14}$/.test(apt.to_phone_e164)) {
+    throw new Error(`${apt.request_id}: invalid E.164`);
+  }
+}
+
+function runPreview(board) {
+  console.log(`# Preview — ${board.business_display_name} (${board.timezone})\n`);
+  for (const apt of board.appointments) {
+    assertSafe(apt);
+    console.log(`## ${apt.request_id} → ${apt.recipient_first_name} (${maskPhone(apt.to_phone_e164)})`);
+    console.log(planScript(board.business_display_name, apt));
+    console.log("");
+  }
+}
+
+function runFixture(board) {
+  console.log(`# Fixture run — ${board.business_display_name}\n`);
+  const results = [];
+  for (const apt of board.appointments) {
+    assertSafe(apt);
+    const outcome = FIXTURES[apt.request_id] || {
+      disposition: "failed",
+      notes: "No fixture",
+      requested_time: null,
+    };
+    const row = { request_id: apt.request_id, ...outcome };
+    results.push(row);
+    console.log(
+      `${apt.request_id} ${apt.recipient_first_name}: ${outcome.disposition}` +
+        (outcome.requested_time ? ` → ${outcome.requested_time}` : "")
+    );
+  }
+  console.log("\nJSON:");
+  console.log(JSON.stringify(results, null, 2));
+  return results;
+}
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const board = loadBoard();
+
+  if (args.has("--live")) {
+    if (!process.env.CALLE_API_KEY && !process.env.CALL_E_API_KEY) {
+      console.error("Live mode requires CALLE_API_KEY. Refusing to dial.");
+      process.exit(2);
+    }
+    console.error(
+      "Live CALL-E SDK dialing is not embedded in this minimal awesome-repo demo."
+    );
+    console.error(
+      "Use the full ConfirmCall Next.js app with @call-e/calle, or call CALL-E CLI after preview."
+    );
+    process.exit(3);
+  }
+
+  if (args.has("--preview")) {
+    runPreview(board);
+    return;
+  }
+
+  // default: fixture
+  runFixture(board);
+}
+
+main();

--- a/apps/typescript/confirmcall-day-board/package.json
+++ b/apps/typescript/confirmcall-day-board/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "confirmcall-day-board",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Day-board appointment confirmations via CALL-E with fixture mode by default",
+  "license": "MIT",
+  "scripts": {
+    "fixture": "node confirmcall.js --fixture",
+    "preview": "node confirmcall.js --preview",
+    "live": "node confirmcall.js --live"
+  }
+}

--- a/skills/confirmcall-day-board/SKILL.md
+++ b/skills/confirmcall-day-board/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: confirmcall-day-board
+description: Confirm a full day's existing appointments by phone with CALL-E. Plans one disclosed confirmation call per booking, captures yes/no/reschedule as structured JSON, and leaves calendar writes to a human. Fixture/dry-run by default.
+license: MIT
+---
+
+# ConfirmCall Day Board
+
+Use this skill when a clinic, tutor, or service desk has a **day list** of existing appointments and explicit authority to place disclosed confirmation calls. The skill turns each booking into one CALL-E confirmation task, runs them (or returns fixtures), and writes **yes / no / reschedule** results back to a board for a human.
+
+This skill does not book, move, or cancel calendar events. A human reviews results before any diary change.
+
+## When To Use
+
+- Morning confirmation pass over today's booked appointments
+- Capture declines and reschedule requests into structured results
+- Preview every CALL-E script before any live dial
+- Keep calendar authority with a human coordinator
+
+## When Not To Use
+
+- First-contact sales, lead qualification, or unsolicited outreach
+- Medical advice, legal, financial, emergency, collections, or political calls
+- Calling numbers the coordinator did not authorize
+- Hidden retries, recurring campaigns, or automatic calendar writes
+- Collecting payment, ID numbers, or health details on the call
+
+## Required Inputs (per appointment)
+
+- `request_id`: stable local identifier
+- `business_display_name`: disclosed on the call
+- `recipient_first_name`
+- `to_phone_e164`: E.164, authorized
+- `appointment.service`, `appointment.starts_at` (ISO-8601 with offset), `appointment.location`
+- `timezone`: IANA
+- `consent`: must be true
+- `authorized_reason`: why this specific call is allowed
+
+Optional: `reschedule_windows` (max 6 ISO-8601 times the desk can honor).
+
+## Safety Model
+
+1. Fixture / dry-run by default — no network, no CALL-E dial.
+2. Live mode only when `CALLE_API_KEY` (or `CALL_E_API_KEY`) is set **and** the operator explicitly runs live.
+3. Refuse if `consent` is not true or the number is not on the day's authorized list.
+4. Mask phone numbers in logs (`+1***0100`).
+5. One call plan per appointment — no silent retries.
+6. Calendar remains human-owned.
+
+## Dry-Run (no CALL-E credentials)
+
+From the repository root:
+
+```bash
+cd apps/typescript/confirmcall-day-board
+npm install
+npm run fixture
+```
+
+This loads the Thursday sample board, prints planned CALL-E scripts, and writes fixture outcomes (Maya confirmed, Jordan reschedule, Eli declined).
+
+## Live Path
+
+1. Create a CALL-E API key in the CALL-E dashboard.
+2. Export `CALLE_API_KEY`.
+3. Only call numbers you are authorized to contact.
+4. Run `npm run live` only after reviewing `npm run preview` scripts.
+
+Prefer the runnable app under `apps/typescript/confirmcall-day-board` for the full day-board UX. Use this skill when an agent host should orchestrate the same workflow via CALL-E SDK/API/MCP.
+
+## Result Shape
+
+Each appointment returns fail-closed structured JSON:
+
+```json
+{
+  "request_id": "apt-maya-1",
+  "disposition": "confirmed",
+  "notes": "Recipient confirmed the booked slot",
+  "requested_time": null
+}
+```
+
+`disposition` is one of `confirmed`, `declined`, `reschedule_requested`, `no_answer`, `failed`.
+
+## References
+
+- `references/call-script.md` — disclosed confirmation script template
+- `assets/sample-day-board.json` — fictional Thursday board

--- a/skills/confirmcall-day-board/assets/sample-day-board.json
+++ b/skills/confirmcall-day-board/assets/sample-day-board.json
@@ -1,0 +1,45 @@
+{
+  "business_display_name": "Northside Tutoring",
+  "timezone": "America/Los_Angeles",
+  "appointments": [
+    {
+      "request_id": "apt-maya-1",
+      "recipient_first_name": "Maya",
+      "to_phone_e164": "+15555550101",
+      "appointment": {
+        "service": "Algebra tutoring",
+        "starts_at": "2026-09-10T16:00:00-07:00",
+        "location": "Studio B"
+      },
+      "consent": true,
+      "authorized_reason": "Confirm existing booked session",
+      "reschedule_windows": ["2026-09-11T16:00:00-07:00", "2026-09-12T16:00:00-07:00"]
+    },
+    {
+      "request_id": "apt-jordan-2",
+      "recipient_first_name": "Jordan",
+      "to_phone_e164": "+15555550102",
+      "appointment": {
+        "service": "College essay coaching",
+        "starts_at": "2026-09-10T17:00:00-07:00",
+        "location": "Zoom"
+      },
+      "consent": true,
+      "authorized_reason": "Confirm existing booked session",
+      "reschedule_windows": ["2026-09-11T17:00:00-07:00", "2026-09-11T18:00:00-07:00"]
+    },
+    {
+      "request_id": "apt-eli-3",
+      "recipient_first_name": "Eli",
+      "to_phone_e164": "+15555550103",
+      "appointment": {
+        "service": "SAT math drill",
+        "starts_at": "2026-09-10T18:00:00-07:00",
+        "location": "Studio A"
+      },
+      "consent": true,
+      "authorized_reason": "Confirm existing booked session",
+      "reschedule_windows": []
+    }
+  ]
+}

--- a/skills/confirmcall-day-board/references/call-script.md
+++ b/skills/confirmcall-day-board/references/call-script.md
@@ -1,0 +1,5 @@
+# Confirmation call script (disclosed)
+
+Goal text for CALL-E (adapt per appointment):
+
+> You are calling on behalf of {business_display_name}. Ask for {recipient_first_name}. Clearly disclose that this is a confirmation call for their existing {appointment.service} appointment on {appointment.starts_at} at {appointment.location}. Ask if they can still attend. If not, ask whether they want to decline or request a move into one of the pre-approved windows: {reschedule_windows}. Do not give medical, legal, or financial advice. Do not take payment. Keep the call short. Return structured yes/no/reschedule only.

--- a/skills/confirmcall-day-board/references/examples.md
+++ b/skills/confirmcall-day-board/references/examples.md
@@ -1,0 +1,15 @@
+# Examples
+
+## Safe
+
+- A tutoring desk runs the Thursday fixture board and reviews Maya confirmed / Jordan reschedule / Eli declined before touching the calendar.
+- Previewing masked CALL-E scripts with `npm run preview` for a demo video.
+- A clinic coordinator confirms only bookings that already exist and asked to be called.
+
+## Unsafe
+
+- Calling a scraped lead list or marketing list.
+- Treating voicemail as a yes.
+- Writing Google Calendar events from `requested_time` without a human.
+- Putting an API key on screen during a recording.
+- Automatic retries when CALL-E returns unknown or no_answer.

--- a/skills/confirmcall-day-board/references/safety.md
+++ b/skills/confirmcall-day-board/references/safety.md
@@ -1,0 +1,10 @@
+# Safety
+
+- Fixture / dry-run by default; never dial without an explicit live path and `CALLE_API_KEY`.
+- Require per-appointment `consent: true` and an authorized E.164 number from the booking workflow.
+- Mask phone numbers in logs and demos.
+- Disclose the business name and that this is a confirmation of an existing appointment.
+- No medical, legal, financial, emergency, collections, or political content.
+- No payment or ID collection on the call.
+- One planned call per appointment; no hidden campaigns or recurrence.
+- Calendar create/move/cancel stays with a human after reviewing structured results.


### PR DESCRIPTION
## Summary
Adds **ConfirmCall Day Board** for the CALL-E hackathon / community hub:

- `skills/confirmcall-day-board` — portable Agent Skill for a full-day appointment confirmation pass (yes / no / reschedule), calendar stays human-owned
- `apps/typescript/confirmcall-day-board` — fixture/preview CLI (`npm run fixture`, `npm run preview`); dry-run by default, no secrets

## Safety
- Fixture by default (no dial)
- Consent + E.164 checks
- Masked phone numbers in output
- Live path refused without `CALLE_API_KEY`

## Test plan
- [x] `python3 scripts/validate_repository.py` passes
- [x] `cd apps/typescript/confirmcall-day-board && npm run fixture` → Maya confirmed, Jordan reschedule, Eli declined
- [x] `npm run preview` prints disclosed scripts