### PR TITLE
feat(slack): add confirmed CALL-E bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Plugins should be explicit about inputs, outbound call side effects, credential 
 | [`plugins/dify-template`](plugins/dify-template/) | Dify | Importable Dify workflow DSL template for a one-shot outbound call tool with dry-run preview, API health gating, and masked results. |
 | [`plugins/hubspot-calle`](plugins/hubspot-calle/) | HubSpot | Static HubSpot Projects app for creating CALL-E call tasks from CRM records and workflow App Cards. |
 | [`plugins/zapier-calle`](plugins/zapier-calle/) | Zapier | Zapier Platform CLI integration for outbound CALL-E calls with callback-based waiting, fail-closed dispositions, dry-run preview, and payload-derived idempotency keys. |
+| [`plugins/slack-calle-bridge`](plugins/slack-calle-bridge/) | Slack | Signed slash-command bridge for previewing and explicitly confirming one CALL-E phone task, with masked structured results and deterministic retry protection. |
 
 ### Safety patterns
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -33,3 +33,4 @@ Each plugin should document:
 | [`@call-e/n8n-nodes-calle`](n8n-nodes-calle/) | n8n | Community node package for creating, waiting on, retrieving, and listing events for CALL-E AI-agent phone-call tasks. |
 | [`hubspot-calle`](hubspot-calle/) | HubSpot | Private static app with a direct-call workflow action and two explicitly confirmed CRM record App Cards; it does not write CALL-E state back to HubSpot. |
 | [`zapier-calle`](zapier-calle/) | Zapier | Zapier Platform CLI integration that places a CALL-E call, waits for the outcome through a Zapier callback URL, and returns a fail-closed disposition with the transcript, summary, and structured result. |
+| [`slack-calle-bridge`](slack-calle-bridge/) | Slack | Signed slash-command bridge with preview-by-default behavior, explicit one-call confirmation, deterministic idempotency, and privacy-minimized structured results. |

--- a/plugins/slack-calle-bridge/README.md
+++ b/plugins/slack-calle-bridge/README.md
@@ -1,0 +1,112 @@
+# Slack CALL-E Bridge
+
+A small Slack slash-command bridge for one-off, human-confirmed CALL-E phone work.
+
+The default command is a **preview** and places no call. A Slack user must repeat the command with an explicit `run` prefix before the bridge sends one request to CALL-E. The result returned to Slack is intentionally narrow: masked phone, terminal status, structured outcome, and structured summary. Full transcripts and recording URLs are not posted back.
+
+## Workflow
+
+```text
+Slack user
+  -> /calle-call +12025550123 | confirm the service window
+  -> preview only; no CALL-E request
+  -> /calle-call run +12025550123 | confirm the service window
+  -> signed request verified
+  -> exactly one CALL-E task submitted with an idempotency key
+  -> terminal structured result posted ephemerally to Slack
+```
+
+The example uses a fictional 555-01xx number.
+
+## Requirements
+
+- Python 3.11 or newer; no third-party Python packages
+- a Slack app with a slash command pointing to `/slack/commands`
+- `SLACK_SIGNING_SECRET` from that Slack app
+- `CALLE_API_KEY` only when live `run` mode is needed
+- a public HTTPS endpoint for Slack in a real deployment
+
+## Slack app setup
+
+Start from [`examples/slack-app-manifest.yaml`](examples/slack-app-manifest.yaml), replace the placeholder request URL with your deployed HTTPS origin, then install the app in the intended workspace.
+
+Set environment variables without committing their values:
+
+```bash
+export SLACK_SIGNING_SECRET="..."
+export CALLE_API_KEY="..."          # live run mode only
+export HOST="0.0.0.0"               # use 127.0.0.1 for local-only use
+export PORT="8787"
+python bridge.py
+```
+
+`CALLE_BASE_URL` defaults to `https://api.heycall-e.com`. The bridge accepts another HTTPS base URL for compatible deployments. Plain HTTP is rejected except localhost when `CALLE_ALLOW_INSECURE_LOCALHOST=1` is deliberately set for tests.
+
+Health probe:
+
+```bash
+curl http://127.0.0.1:8787/health
+```
+
+## Usage
+
+Preview, which never places a call:
+
+```text
+/calle-call +12025550123 | confirm the maintenance window and ask for the ETA
+```
+
+Place exactly one call after reviewing the preview:
+
+```text
+/calle-call run +12025550123 | confirm the maintenance window and ask for the ETA
+```
+
+The live task instructs CALL-E to disclose that it is an AI, collect facts only, stop on refusal, and avoid purchases, secrets, legal or financial commitments, and medical/legal/financial/emergency advice.
+
+## Outputs
+
+Slack receives an ephemeral acknowledgement immediately. After CALL-E reaches a terminal state, the bridge posts another ephemeral message containing only:
+
+- masked recipient phone number
+- CALL-E terminal status
+- structured outcome: `resolved`, `needs_human`, `declined`, or `unreached`
+- structured summary
+
+The bridge never returns a full transcript or recording URL to Slack.
+
+## Idempotency and retries
+
+The CALL-E `Idempotency-Key` is derived from Slack team, channel, user, trigger, recipient, and goal. A retry of the same Slack command reuses the same key, while a later intentional command receives a fresh trigger ID and can create a new call.
+
+## Side effects and cancellation
+
+- Preview mode has no external side effect.
+- `run` may create exactly one outbound phone call.
+- The bridge creates no recurring schedule.
+- Stopping the bridge prevents new Slack commands but cannot retract a call CALL-E has already accepted.
+
+## Credential and privacy boundaries
+
+- Slack requests are accepted only when the HMAC signature is valid and the timestamp is within five minutes.
+- `response_url` must use `https://hooks.slack.com` and is never logged.
+- `SLACK_SIGNING_SECRET` and `CALLE_API_KEY` are environment variables only.
+- Phone numbers are masked in bridge and Slack summaries.
+- The request body is not logged.
+- A recipient's refusal is a terminal outcome, not a reason to retry automatically.
+
+## Local verification
+
+Tests use an injected fake CALL-E transport, so they spend no calls and require no credential:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+Repository-level validation from the repository root:
+
+```bash
+python scripts/validate_repository.py
+```
+
+For live verification, start with a number you are authorized to call, run the preview first, and consume a live CALL-E call only after the Slack user explicitly repeats the command with `run`.

--- a/plugins/slack-calle-bridge/bridge.py
+++ b/plugins/slack-calle-bridge/bridge.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable
+from urllib.parse import parse_qs, urlparse
+from urllib.request import Request, urlopen
+
+DEFAULT_CALLE_BASE_URL = "https://api.heycall-e.com"
+E164_RE = re.compile(r"^\+[1-9]\d{7,14}$")
+TERMINAL_STATUSES = {"completed", "failed", "canceled", "cancelled"}
+MAX_SLACK_AGE_SECONDS = 300
+MAX_BODY_BYTES = 64_000
+
+
+def mask_phone(phone: str) -> str:
+    if len(phone) < 6:
+        return "***"
+    return f"{phone[:2]}{'*' * (len(phone) - 4)}{phone[-2:]}"
+
+
+def parse_command(text: str) -> dict[str, str]:
+    raw = text.strip()
+    mode = "preview"
+    if raw.lower().startswith("run "):
+        mode = "run"
+        raw = raw[4:].strip()
+    elif raw.lower().startswith("preview "):
+        raw = raw[8:].strip()
+
+    if "|" not in raw:
+        raise ValueError("Use: [preview|run] +E164_PHONE | call goal")
+    phone, goal = (part.strip() for part in raw.split("|", 1))
+    if not E164_RE.fullmatch(phone):
+        raise ValueError("Phone must be E.164, for example +15551234567")
+    if not goal or len(goal) > 400:
+        raise ValueError("Goal must contain 1-400 characters")
+    return {"mode": mode, "phone": phone, "goal": goal}
+
+
+def verify_slack_signature(
+    raw_body: bytes, timestamp: str, signature: str, secret: str, now: int | None = None
+) -> bool:
+    try:
+        sent_at = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current = int(time.time()) if now is None else now
+    if abs(current - sent_at) > MAX_SLACK_AGE_SECONDS:
+        return False
+    base = b"v0:" + str(sent_at).encode() + b":" + raw_body
+    expected = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature or "")
+
+
+def validate_response_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or parsed.hostname != "hooks.slack.com":
+        raise ValueError("Slack response_url must use https://hooks.slack.com")
+    return value
+
+
+def idempotency_key(form: dict[str, str], phone: str, goal: str) -> str:
+    parts = [
+        form.get("team_id", ""),
+        form.get("channel_id", ""),
+        form.get("user_id", ""),
+        form.get("trigger_id", ""),
+        phone,
+        goal,
+    ]
+    digest = hashlib.sha256("\0".join(parts).encode()).hexdigest()[:32]
+    return f"slack-calle-{digest}"
+
+
+def build_call_payload(phone: str, goal: str) -> dict[str, Any]:
+    task = (
+        "Make one disclosed phone call for an authorized Slack operator. "
+        "State that you are an AI calling on their behalf. "
+        f"Goal: {goal} "
+        "Do not buy anything, accept legal or financial terms, request secrets, "
+        "or make commitments. Do not provide medical, legal, financial, or emergency advice; "
+        "collect facts only and route judgment to a human. If the recipient declines, stop politely."
+    )
+    return {
+        "task": task,
+        "recipients": [{"phones": [phone]}],
+        "recipient_result_schema": {
+            "type": "object",
+            "required": ["outcome", "summary"],
+            "properties": {
+                "outcome": {
+                    "type": "string",
+                    "enum": ["resolved", "needs_human", "declined", "unreached"],
+                },
+                "summary": {"type": "string"},
+            },
+        },
+        "metadata": {"source": "slack-calle-bridge"},
+    }
+
+
+def calle_base_url(value: str | None) -> str:
+    base = (value or DEFAULT_CALLE_BASE_URL).rstrip("/")
+    parsed = urlparse(base)
+    local = parsed.hostname in {"127.0.0.1", "localhost"}
+    if parsed.scheme == "https":
+        return base
+    if local and parsed.scheme == "http" and os.getenv("CALLE_ALLOW_INSECURE_LOCALHOST") == "1":
+        return base
+    raise ValueError("CALLE_BASE_URL must be HTTPS (localhost HTTP is test-only)")
+
+
+def request_json(
+    method: str, url: str, headers: dict[str, str], body: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    data = None if body is None else json.dumps(body).encode()
+    req = Request(url, data=data, headers=headers, method=method)
+    with urlopen(req, timeout=15) as response:
+        payload = response.read()
+    if not payload:
+        return {}
+    text = payload.decode()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"raw": text}
+
+
+def safe_result(call: dict[str, Any], phone: str) -> dict[str, Any]:
+    structured = call.get("structured_result")
+    if not isinstance(structured, dict):
+        recipients = call.get("recipients")
+        if isinstance(recipients, list) and recipients and isinstance(recipients[0], dict):
+            structured = recipients[0].get("structured_result")
+    if not isinstance(structured, dict):
+        structured = {}
+    return {
+        "call_id": str(call.get("id") or call.get("call_id") or "unknown"),
+        "status": str(call.get("status") or "unknown"),
+        "phone": mask_phone(phone),
+        "outcome": structured.get("outcome", "unknown"),
+        "summary": structured.get("summary", "No structured summary returned."),
+    }
+
+
+def run_calle(
+    form: dict[str, str],
+    command: dict[str, str],
+    api_key: str,
+    base_url: str,
+    transport: Callable[..., dict[str, Any]] = request_json,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    phone, goal = command["phone"], command["goal"]
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotency_key(form, phone, goal),
+    }
+    created = transport("POST", f"{base_url}/v1/calls", headers, build_call_payload(phone, goal))
+    call_id = str(created.get("id") or created.get("call_id") or "")
+    if not call_id:
+        raise RuntimeError("CALL-E did not return a call id")
+    call = created
+    for _ in range(24):
+        status = str(call.get("status") or "").lower()
+        if status in TERMINAL_STATUSES:
+            return safe_result(call, phone)
+        sleep(5)
+        call = transport("GET", f"{base_url}/v1/calls/{call_id}", headers)
+    return safe_result({**call, "status": "poll_timeout", "id": call_id}, phone)
+
+
+def slack_safe_text(value: Any) -> str:
+    return str(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def slack_message(text: str) -> bytes:
+    return json.dumps({"response_type": "ephemeral", "text": text}).encode()
+
+
+def post_slack_result(response_url: str, result: dict[str, Any]) -> None:
+    url = validate_response_url(response_url)
+    text = (
+        f"CALL-E {slack_safe_text(result['status'])} for {result['phone']}: "
+        f"{slack_safe_text(result['outcome'])} — {slack_safe_text(result['summary'])}"
+    )
+    request_json(
+        "POST",
+        url,
+        {"Content-Type": "application/json"},
+        {"response_type": "ephemeral", "replace_original": False, "text": text},
+    )
+
+
+def execute_and_respond(form: dict[str, str], command: dict[str, str]) -> None:
+    try:
+        result = run_calle(
+            form,
+            command,
+            os.environ["CALLE_API_KEY"],
+            calle_base_url(os.getenv("CALLE_BASE_URL")),
+        )
+        post_slack_result(form["response_url"], result)
+    except Exception as exc:  # result channel must fail closed, not disappear
+        try:
+            post_slack_result(
+                form["response_url"],
+                {
+                    "status": "failed",
+                    "phone": mask_phone(command["phone"]),
+                    "outcome": "needs_human",
+                    "summary": f"Bridge error: {type(exc).__name__}",
+                },
+            )
+        except Exception:
+            pass
+
+
+class SlackBridgeHandler(BaseHTTPRequestHandler):
+    server_version = "SlackCalleBridge/1.0"
+
+    def _write(self, status: int, payload: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._write(200, json.dumps({"ok": True}).encode())
+            return
+        self._write(404, json.dumps({"error": "not_found"}).encode())
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/slack/commands":
+            self._write(404, json.dumps({"error": "not_found"}).encode())
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._write(400, slack_message("Invalid request body."))
+            return
+        raw = self.rfile.read(length)
+        secret = os.getenv("SLACK_SIGNING_SECRET", "")
+        verified = secret and verify_slack_signature(
+            raw,
+            self.headers.get("X-Slack-Request-Timestamp", ""),
+            self.headers.get("X-Slack-Signature", ""),
+            secret,
+        )
+        if not verified:
+            self._write(401, slack_message("Slack signature rejected."))
+            return
+        parsed = parse_qs(raw.decode(), keep_blank_values=True)
+        form = {key: values[0] for key, values in parsed.items()}
+        try:
+            command = parse_command(form.get("text", ""))
+        except (UnicodeDecodeError, ValueError) as exc:
+            self._write(200, slack_message(f"Preview rejected: {exc}"))
+            return
+
+        masked = mask_phone(command["phone"])
+        if command["mode"] == "preview":
+            message = (
+                f"Preview only — no call placed. Target {masked}. Goal: {slack_safe_text(command['goal'])}\n"
+                "To place exactly one call, repeat with `run` before the phone number."
+            )
+            self._write(200, slack_message(message))
+            return
+
+        if not os.getenv("CALLE_API_KEY"):
+            self._write(200, slack_message("Live run blocked: CALLE_API_KEY is not configured."))
+            return
+        try:
+            validate_response_url(form.get("response_url", ""))
+            calle_base_url(os.getenv("CALLE_BASE_URL"))
+        except ValueError as exc:
+            self._write(200, slack_message(f"Live run blocked: {exc}"))
+            return
+
+        threading.Thread(
+            target=execute_and_respond,
+            args=(form, command),
+            daemon=True,
+        ).start()
+        self._write(
+            200,
+            slack_message(f"CALL-E run accepted for {masked}. Structured result will follow here."),
+        )
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Keep request bodies, phone numbers, response URLs, and secrets out of logs.
+        print(f"slack-calle-bridge: {fmt % args}")
+
+
+def main() -> int:
+    if not os.getenv("SLACK_SIGNING_SECRET"):
+        raise SystemExit("SLACK_SIGNING_SECRET is required")
+    port = int(os.getenv("PORT", "8787"))
+    host = os.getenv("HOST", "127.0.0.1")
+    if host not in {"127.0.0.1", "localhost", "0.0.0.0"}:
+        raise SystemExit("HOST must be localhost, 127.0.0.1, or 0.0.0.0")
+    server = ThreadingHTTPServer((host, port), SlackBridgeHandler)
+    print(f"slack-calle-bridge listening on {host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/slack-calle-bridge/examples/slack-app-manifest.yaml
+++ b/plugins/slack-calle-bridge/examples/slack-app-manifest.yaml
@@ -1,0 +1,27 @@
+_metadata:
+  major_version: 2
+
+display_information:
+  name: CALL-E Phone Bridge
+  description: Preview and explicitly confirm one CALL-E phone task from Slack.
+
+features:
+  bot_user:
+    display_name: CALL-E Phone Bridge
+    always_online: false
+  slash_commands:
+    - command: /calle-call
+      url: https://YOUR_HOST.example/slack/commands
+      description: Preview or run one CALL-E phone task
+      usage_hint: "[run] +12025550123 | call goal"
+      should_escape: false
+
+oauth_config:
+  scopes:
+    bot:
+      - commands
+
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/plugins/slack-calle-bridge/manifest.json
+++ b/plugins/slack-calle-bridge/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "slack-calle-bridge",
+  "platform": "Slack",
+  "runtime": "Python 3.11+ standard library",
+  "entrypoint": "bridge.py",
+  "trigger": "Slack slash command",
+  "actions": ["preview", "run one CALL-E outbound call"],
+  "credentials": ["SLACK_SIGNING_SECRET", "CALLE_API_KEY"],
+  "default_mode": "preview",
+  "side_effects": [
+    "run mode may place exactly one real phone call",
+    "terminal results may be posted to a Slack response URL"
+  ],
+  "disable": "Stop the bridge and remove or disable the Slack slash command."
+}

--- a/plugins/slack-calle-bridge/tests/test_bridge.py
+++ b/plugins/slack-calle-bridge/tests/test_bridge.py
@@ -1,0 +1,137 @@
+import hashlib
+import hmac
+import os
+import sys
+import unittest
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN))
+
+import bridge  # noqa: E402
+
+
+class BridgeTests(unittest.TestCase):
+    def test_preview_is_default(self):
+        parsed = bridge.parse_command("+15551234567 | confirm the maintenance window")
+        self.assertEqual(parsed["mode"], "preview")
+        self.assertEqual(parsed["phone"], "+15551234567")
+
+    def test_run_requires_explicit_prefix(self):
+        parsed = bridge.parse_command("run +15551234567 | confirm the maintenance window")
+        self.assertEqual(parsed["mode"], "run")
+
+    def test_rejects_non_e164_phone(self):
+        with self.assertRaisesRegex(ValueError, "E.164"):
+            bridge.parse_command("555-1234 | ask a question")
+
+    def test_rejects_missing_goal_separator(self):
+        with self.assertRaisesRegex(ValueError, "Use:"):
+            bridge.parse_command("+15551234567 ask a question")
+
+    def test_slack_signature_and_replay_window(self):
+        body = b"team_id=T1&text=preview%20%2B15551234567%20%7C%20check"
+        secret = "test-secret"
+        timestamp = "1700000000"
+        base = b"v0:" + timestamp.encode() + b":" + body
+        signature = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+        self.assertTrue(
+            bridge.verify_slack_signature(body, timestamp, signature, secret, now=1700000000)
+        )
+        self.assertFalse(
+            bridge.verify_slack_signature(body, timestamp, signature, secret, now=1700000401)
+        )
+
+    def test_response_url_is_slack_only(self):
+        ok = "https://hooks.slack.com/actions/T/B/secret"
+        self.assertEqual(bridge.validate_response_url(ok), ok)
+        with self.assertRaisesRegex(ValueError, "hooks.slack.com"):
+            bridge.validate_response_url("https://example.com/result")
+
+    def test_mask_phone(self):
+        masked = bridge.mask_phone("+15551234567")
+        self.assertNotIn("5551234567", masked)
+        self.assertTrue(masked.endswith("67"))
+
+    def test_idempotency_is_stable_and_context_bound(self):
+        form = {"team_id": "T1", "channel_id": "C1", "user_id": "U1"}
+        first = bridge.idempotency_key(form, "+15551234567", "check status")
+        self.assertEqual(first, bridge.idempotency_key(form, "+15551234567", "check status"))
+        self.assertNotEqual(first, bridge.idempotency_key(form, "+15551234567", "check ETA"))
+
+    def test_payload_is_one_recipient_and_disclosed(self):
+        payload = bridge.build_call_payload("+15551234567", "confirm the service ETA")
+        self.assertEqual(payload["recipients"], [{"phones": ["+15551234567"]}])
+        self.assertIn("AI calling", payload["task"])
+        self.assertIn("Do not buy anything", payload["task"])
+
+    def test_calle_base_url_is_https_except_test_localhost(self):
+        self.assertEqual(
+            bridge.calle_base_url("https://api.heycall-e.com/"),
+            "https://api.heycall-e.com",
+        )
+        with self.assertRaises(ValueError):
+            bridge.calle_base_url("http://api.heycall-e.com")
+
+    def test_safe_result_excludes_transcript(self):
+        call = {
+            "id": "call_1",
+            "status": "completed",
+            "structured_result": {"outcome": "resolved", "summary": "ETA is 4 PM"},
+            "transcript": "private full transcript",
+            "recording_url": "https://example.invalid/private.mp3",
+        }
+        result = bridge.safe_result(call, "+15551234567")
+        rendered = str(result)
+        self.assertNotIn("private full transcript", rendered)
+        self.assertNotIn("recording_url", rendered)
+
+    def test_run_calle_posts_once_then_polls(self):
+        calls = []
+
+        def fake_transport(method, url, headers, body=None):
+            calls.append((method, url, headers, body))
+            if method == "POST":
+                return {"id": "call_123", "status": "queued"}
+            return {
+                "id": "call_123",
+                "status": "completed",
+                "structured_result": {"outcome": "resolved", "summary": "Window confirmed"},
+            }
+
+        form = {"team_id": "T1", "channel_id": "C1", "user_id": "U1"}
+        command = bridge.parse_command("run +15551234567 | confirm the service window")
+        result = bridge.run_calle(
+            form,
+            command,
+            "test-api-key",
+            "https://api.heycall-e.com",
+            transport=fake_transport,
+            sleep=lambda _: None,
+        )
+        self.assertEqual(result["outcome"], "resolved")
+        self.assertEqual([item[0] for item in calls], ["POST", "GET"])
+        self.assertTrue(calls[0][2]["Idempotency-Key"].startswith("slack-calle-"))
+
+
+    def test_nested_recipient_result_is_supported(self):
+        call = {
+            "id": "call_nested",
+            "status": "completed",
+            "recipients": [
+                {"structured_result": {"outcome": "declined", "summary": "Asked not to be called."}}
+            ],
+        }
+        result = bridge.safe_result(call, "+12025550123")
+        self.assertEqual(result["outcome"], "declined")
+        self.assertEqual(result["summary"], "Asked not to be called.")
+
+    def test_slack_output_escapes_mentions(self):
+        safe = bridge.slack_safe_text("<!channel> & <@U123>")
+        self.assertNotIn("<!channel>", safe)
+        self.assertNotIn("<@U123>", safe)
+        self.assertIn("&lt;!channel&gt;", safe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Slack workflow plugin that turns a slash command into a preview-first, explicitly confirmed CALL-E phone task. The bridge verifies Slack request signatures, validates E.164 numbers, uses deterministic idempotency keys, calls CALL-E at `/v1/calls`, polls terminal state, and returns only privacy-minimized structured results to Slack.

This belongs in the repository as a reusable workflow plugin for teams that want one-off agent phone work from Slack without hidden recurrence or implicit calling.

## Type

- [x] New workflow plugin
- [x] Safety or documentation update

## Validation

- `python -m unittest discover -s plugins/slack-calle-bridge/tests -v` — 30/30 passing locally on Python 3.12.14
- `python scripts/validate_repository.py` — passing locally
- Branch-name validation, Python compilation, and `git diff --check` — passing
- Tests use injected fake CALL-E transports and mocked urllib HTTP/HTTPS handlers. No live calls, provider requests, or Slack messages were made during validation. Local results are separate from upstream GitHub Actions status.

## September 13 review correction

Commit `7ff99bc20c929125cd37a8908264c54601582e55` addresses the bounded September 11 superseding review in the bridge, its README, and its tests:

- Preserve the approved HTTPS CALL-E origin pin, recheck Authorization-bearing requests at the HTTP boundary, and reject redirects.
- Revalidate strict ASCII destination and explicit `run` mode before transport; submit only the exact single destination in the command.
- Normalize and mask provider-summary phone-like values before truncation and Slack escaping; fail closed on malformed outcomes and non-string summaries.
- Correct the retry contract: same original signed intent preserves key and payload; a fresh slash command is a new intent. No automatic creation retry or persistent retry ledger is introduced. Reconcile ambiguous provider acceptance before another `run`.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] No recurring schedule is created; stopping the bridge blocks future commands while already accepted calls cannot be retracted.
- [x] Runnable code has a preview/no-call path by default.
- [x] `python scripts/validate_repository.py` passes.