### PR TITLE
fix(redline): clarify local verification and onboarding

### DIFF
--- a/apps/python/redline/README.md
+++ b/apps/python/redline/README.md
@@ -29,8 +29,9 @@ example currently closes all 21 attacks without losing any of its 10 ordinary
 calls; a future change that trades one failure for another cannot hide behind
 the headline number.
 
-No account. No API key. No network. No phone rings. That run takes under a
-second, and you can reproduce it from a clean checkout in three commands.
+The static evaluation needs no account, API key or network and places no call.
+Follow the installation and example commands below from a clean checkout;
+downloading the source and dependencies does require network access.
 
 ---
 

--- a/apps/python/redline/README.md
+++ b/apps/python/redline/README.md
@@ -69,8 +69,21 @@ REDLINE is not on PyPI yet, so install it from a checkout:
 ```console
 $ git clone https://github.com/CALLE-AI/awesome-phone-call-agents.git
 $ cd awesome-phone-call-agents/apps/python/redline
-$ pip install -e .
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ python -m pip install -e .
 ```
+
+On Windows PowerShell, replace the activation and installation lines with:
+
+```powershell
+.\.venv\Scripts\python.exe -m pip install -e .
+```
+
+Activation is optional: on Windows, use `.\.venv\Scripts\redline.exe`
+instead of `redline` in the commands below. Use Python 3.11 or 3.12 for
+the validated reproduction path. Run commands one at a time: the uncorrected
+example's `run` intentionally exits 1 when it reports modelled failures.
 
 The package lives at `apps/python/redline/` so the directory can be lifted
 into the CALL-E monorepo unchanged. Everything it needs — scenarios,
@@ -331,12 +344,38 @@ declaration.
 did not state it. Pasting in the whole clause library would be free to
 implement and would make the verification meaningless.
 
-Against the example agent that means **11 fixes applied: 10 policy clauses and
-1 schema change**. The two numbers are not interchangeable and it is worth
-being precise about which is which -- REDLINE knows exactly **10 defences**,
-and the eleventh change is the `result_schema` rewrite that gives an extractor
-somewhere to put "I don't know". `report.json` reports the first as
-`missing_defences`, `verify.json` reports the second as `remedies`.
+Against the bundled example that currently means **16 proposed remedies:
+10 policy clauses, 5 data-policy rules and 1 schema change**. The schema rewrite
+gives an extractor somewhere to put "I don't know". Counts depend on the input
+contract and catalogue; `missing_defences` and `remedies` describe different things.
+
+`redline fix` previews a correction. `redline verify` evaluates the generated
+correction in memory against the static and benign suites; it does **not** write
+the source YAML. Only an explicit `redline fix --apply` writes the correction
+and creates a backup. Review the proposed schema as well as the task text:
+changing a boolean result to `yes` / `no` / `unknown` requires corresponding
+changes in downstream consumers, which the static suite does not test.
+
+### Inspect the complete correction and save reports
+
+The terminal task diff is a preview and may be clipped at narrow widths. Export
+the before/after report to inspect the full task diff without terminal truncation:
+
+```console
+$ redline run --config examples/appointment-agent/redline.yaml --json .redline/report.json
+$ redline verify --config examples/appointment-agent/redline.yaml --json .redline/verify.json --receipt .redline/release-receipt.json
+```
+
+The first command still exits 1 for the uncorrected example. Run the second
+command separately. Open `.redline/verify.json` in a text editor to inspect
+`patch.goal_diff` and `patch.remedies`. The JSON marks `schema_changed` but does
+not include the full proposed schema: inspect the `Proposed result_schema`
+section printed by `redline fix --config examples/appointment-agent/redline.yaml`
+as well before deciding whether to apply anything. These filenames are explicit choices,
+not automatic output: `output_dir` alone does not request JSON reports.
+`--receipt` saves provenance and verdicts; it does not replace the full report.
+If no correction is needed, `verify` exits early and does not write a JSON
+before/after report; `--receipt` can still write a run receipt.
 
 Every generated clause has to satisfy one property, enforced by a test:
 **adding it must change what the goal demonstrably states.** Without that,

--- a/apps/python/redline/examples/appointment-agent/redline.yaml
+++ b/apps/python/redline/examples/appointment-agent/redline.yaml
@@ -12,7 +12,8 @@
 # half the failures come from: a boolean has nowhere to put "I don't know", so
 # an extraction model handed a hedge has to guess.
 #
-# `redline run` finds 16 failures here. `redline verify` closes all of them.
+# `redline run` finds 21 modelled failures in the bundled catalogue.
+# `redline verify` evaluates the correction without changing this file.
 
 subject:
   name: appointment-agent
@@ -72,4 +73,5 @@ scenarios: ../../scenarios
 # nothing about what it cost.
 benign: ../../benign
 
+# JSON reports are opt-in via --json; this setting does not generate them.
 output_dir: ../../.redline

--- a/apps/python/redline/redline/cli.py
+++ b/apps/python/redline/redline/cli.py
@@ -731,7 +731,7 @@ def fix(
         console.print(
             Text(
                 "\n  -> redline fix --apply    (write this into the config)\n"
-                "  -> redline verify         (apply, re-run, and diff)\n",
+                "  -> redline verify         (evaluate in memory; config unchanged)\n",
                 style="cyan",
             )
         )
@@ -755,7 +755,7 @@ def verify(
         ),
     ] = None,
 ) -> None:
-    """Check the generated patch against the static contract and benign suite."""
+    """Evaluate the generated patch in memory; leave the source config unchanged."""
     loaded = _load(config)
     console.print(
         Text("\n  evidence: static (declared policy model); no real calls", style="dim")


### PR DESCRIPTION
REDLINE's example and README advertised stale counts, and the CLI described
`verify` as applying a correction although it leaves the source configuration
unchanged. This made it harder to distinguish reviewing a proposed fix from
persisting it.

Update the example counts, document virtual environments and Windows executable
paths, explain in-memory verification versus `fix --apply`, and show explicit
JSON/receipt exports for inspecting the task diff. Clarify that the complete
proposed schema is displayed by `fix`, not included in the verification JSON.
Only documentation, example comments and CLI help text change.

Validation:
- Official repository validator passed.
- 52 existing CLI tests passed on Windows Python 3.12.
- Ruff lint and formatting checks passed for the changed Python file.
- Separate-context AI reviewer installed an isolated copy with a fresh venv:
  run/fix/verify exited 1/0/0; 21/21 corrected static scenarios, 10/10 benign,
  16 proposed remedies, unchanged source YAML and zero real calls.

The original usability observations and follow-up are AI-agent reviews, not
human user studies. No live-call behavior or evaluation logic was changed.

