### PR TITLE
feat(skills): add supply-chain-supplier-status skill and enterprise application entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
 - [`rdn-intake-referral`](skills/rdn-intake-referral/) - Consent-based outbound healthcare nutrition intake that collects structured information for RDN review and referral follow-up. See [`docs/rdn-intake-referral.md`](docs/rdn-intake-referral.md) for documentation and synthetic validation examples.
 - [`recall-outreach`](skills/recall-outreach/) - Calls affected customers about a product recall using only organisation-approved wording, routes every unapproved question to a human, and reports call completion and recall resolution as separate measures so a completed call is never counted as a completed return.
+- [`supply-chain-supplier-status`](skills/supply-chain-supplier-status/) - Autonomous outbound phone calls to suppliers to verify purchase order fulfillment, capture delay causes, calculate financial risk, and sync procurement records.
 
 ### Apps
 
@@ -163,6 +164,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [Later, Me.](https://github.com/shirosenagi-design/later-me) - Windows CALL-E app for scheduling a real phone call to your future self, with a four-hour minimum, one pending reservation, and optional post-call Relationship Trace.
 - [SchemaRelay](https://github.com/14188769700lbk-dev/schemarelay) - Consent-gated CALL-E owner interviews that turn data schema-change questions into human-review evidence packets, with a no-call dry run by default.
 - [ShohojSheba Voice](https://shohojsheba-call-e-preview.redwan-rahman.workers.dev/judge) - Consent-gated healthcare staffing dispatch that uses structured CALL-E results to advance after a verified decline, pauses on acceptance, and keeps final assignment human-controlled.
+- [Supply Chain Supplier Status Agent](https://github.com/mohSadiq90/call-e-hackathon) - Autonomous enterprise phone agent for supplier purchase order fulfillment verification, root cause delay capture, penalty estimation, and ERP dashboard sync with zero-credit mock simulation.
 
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.
 

--- a/skills/supply-chain-supplier-status/SKILL.md
+++ b/skills/supply-chain-supplier-status/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: supply-chain-supplier-status
+description: Outbound phone agent powered by CALL-E that calls suppliers to check fulfillment status on purchase orders, negotiates revised dates, captures delay root causes, and generates structured procurement intelligence.
+---
+
+# Supply Chain Supplier Status Check
+
+## Purpose And When To Use
+
+Use this skill when an enterprise procurement or supply chain operations team needs to verify upcoming purchase order fulfillment with authorized suppliers, detect delivery slippages before factory or warehouse stockouts occur, and capture structured delay intelligence.
+
+The agent initiates autonomous outbound telephone calls using the CALL-E SDK or API, conducts a deterministic five-step inquiry, and produces structured JSON and CSV reports.
+
+Use this skill for:
+
+- proactive order verification calls to authorized vendor dispatchers
+- capturing delivery schedule slips and delay root cause categories
+- recording revised delivery dates and expedited freight commitments
+- quantifying delay penalty exposure and recording supervisor escalation details
+- generating structured procurement dashboards and ERP-compatible records
+
+## When Not To Use
+
+Do not use this skill to:
+
+- place unsolicited cold calls to numbers without an established vendor relationship or purchase order reference
+- negotiate binding contract amendments, pricing changes, or warranty releases without human authorization
+- cancel purchase orders, terminate supplier contracts, or initiate legal action
+- record payment credentials, banking details, or sensitive personal data
+- initiate unauthorized automated calls outside business hours or without recording consent where required by law
+- retry endlessly when a vendor contact declines or requests human follow-up
+
+## Five-Step Conversational Protocol
+
+The agent follows a deterministic five-step conversational tree:
+
+1. **Step 1: Greeting & Identity Verification**
+   - Disclose caller identity on behalf of the procuring enterprise.
+   - State that the call is placed on a recorded line for order verification.
+   - Confirm the recipient is an authorized dispatch or fulfillment representative.
+
+2. **Step 2: Fulfillment Status Check**
+   - Reference the specific Purchase Order number, SKU, and scheduled fulfillment date.
+   - Inquire whether the shipment will be fulfilled on schedule and in full volume.
+
+3. **Step 3: Root Cause Analysis (If Delayed)**
+   - If delayed, isolate the primary cause into standard supply chain categories:
+     - `RAW_MATERIAL_SHORTAGE`
+     - `LOGISTICS_PORT_CONGESTION`
+     - `QUALITY_CONTROL_HOLD`
+     - `EQUIPMENT_BREAKDOWN`
+     - `LABOR_SHORTAGE`
+
+4. **Step 4: Revised Timeline & Mitigation Negotiation**
+   - Collect the revised delivery date.
+   - Inquire about partial delivery or expedited air freight options.
+
+5. **Step 5: Financial Assessment & Structured Escalation**
+   - Confirm daily delay penalty clause applicability.
+   - Capture plant manager or shipping supervisor escalation contact name and phone number.
+   - Summarize confirmed points and close the call politely.
+
+## Input Parameters
+
+Before initiating a call, ensure the following fields are provided:
+
+- `supplier_id`: Unique identifier for the vendor (e.g., `SUP-101`)
+- `supplier_name`: Commercial legal entity name
+- `phone_number`: Authorized E.164 phone number (e.g., `+15550149923`)
+- `purchase_order_id`: Associated active purchase order identifier
+- `scheduled_delivery_date`: Committed fulfillment deadline
+- `company_name`: Disclosed enterprise caller identity
+
+## Output Schema
+
+The skill outputs a structured result:
+
+```json
+{
+  "call_id": "call_mock_SUP-102_1789034",
+  "supplier_id": "SUP-102",
+  "purchase_order_id": "PO-88120",
+  "fulfillment_status": "DELAYED",
+  "revised_delivery_date": "2026-09-20",
+  "delay_days": 5,
+  "delay_reason_category": "RAW_MATERIAL_SHORTAGE",
+  "delay_reason_details": "Polymer resin adhesive shipment delayed at regional port.",
+  "estimated_financial_exposure_usd": 8350.0,
+  "escalation_contact_name": "Maria Gomez",
+  "escalation_contact_phone": "+1-555-014-9923",
+  "requires_escalation": true
+}
+```
+
+See [references/safety.md](references/safety.md) for compliance, consent, and data handling boundaries.
+See [references/examples.md](references/examples.md) for realistic call scenarios, transcript samples, and report outputs.

--- a/skills/supply-chain-supplier-status/references/examples.md
+++ b/skills/supply-chain-supplier-status/references/examples.md
@@ -1,0 +1,73 @@
+# Examples
+
+All company names, phone numbers, and representative contacts in these examples are synthetic and fictional.
+
+## Example 1: On-Time Fulfillment Confirmation
+
+### Call Transcript
+> **Agent:** "Hello, this is CALL-E Procurement Assistant calling on behalf of Global Retail Operations on a recorded line. Am I speaking with the dispatch desk at Apex Components regarding Purchase Order PO-90124?"  
+> **Supplier Contact:** "Yes, this is Apex dispatch. I have PO-90124 on my screen."  
+> **Agent:** "Thank you. Our records show 500 units of Industrial Sensor Modules scheduled for fulfillment on September 15. Can you confirm this shipment is on track to arrive by the deadline?"  
+> **Supplier Contact:** "Yes, production wrapped up yesterday. Packaging is complete and the freight carrier is scheduled for pickup tomorrow. You will have full delivery by September 15th."  
+> **Agent:** "Excellent. Thank you for confirming. Our system has logged your delivery as on track. Have a great day!"
+
+### Structured Output Record
+```json
+{
+  "call_id": "call_mock_SUP-101_001",
+  "supplier_id": "SUP-101",
+  "purchase_order_id": "PO-90124",
+  "fulfillment_status": "ON_TIME",
+  "revised_delivery_date": "2026-09-15",
+  "delay_days": 0,
+  "delay_reason_category": "NONE",
+  "delay_reason_details": "Production wrapped up; freight carrier pickup scheduled.",
+  "estimated_financial_exposure_usd": 0.0,
+  "escalation_contact_name": "N/A",
+  "escalation_contact_phone": "N/A",
+  "requires_escalation": false
+}
+```
+
+---
+
+## Example 2: Delayed Fulfillment with Escalation & Root Cause Analysis
+
+### Call Transcript
+> **Agent:** "Hello, this is CALL-E Procurement Assistant calling on behalf of Global Retail Operations on a recorded line. May I speak with the fulfillment coordinator for Pacific Packaging regarding Purchase Order PO-88120?"  
+> **Supplier Contact:** "Speaking, this is David in fulfillment."  
+> **Agent:** "Hello David. We are checking on 12,000 units of corrugated carton assemblies due on September 15. Can you confirm fulfillment status?"  
+> **Supplier Contact:** "Unfortunately, we are experiencing delays. Our primary polymer resin adhesive shipment was held up at the regional port due to customs inspections."  
+> **Agent:** "Understood, that falls under raw material shortages. When do you estimate the full shipment can be delivered?"  
+> **Supplier Contact:** "We expect the resin tomorrow. We can deliver by September 20th."  
+> **Agent:** "That represents a 5-day delay against the committed deadline. Could you provide the contact information for your plant manager in case our logistics lead needs to arrange expedited transit?"  
+> **Supplier Contact:** "Sure, plant manager is Maria Gomez at +1-555-014-9923."  
+> **Agent:** "Thank you David. I have logged the revised September 20 date, raw material shortage cause, and Maria Gomez as escalation lead. Our procurement team will follow up."
+
+### Structured Output Record
+```json
+{
+  "call_id": "call_mock_SUP-102_002",
+  "supplier_id": "SUP-102",
+  "purchase_order_id": "PO-88120",
+  "fulfillment_status": "DELAYED",
+  "revised_delivery_date": "2026-09-20",
+  "delay_days": 5,
+  "delay_reason_category": "RAW_MATERIAL_SHORTAGE",
+  "delay_reason_details": "Polymer resin adhesive shipment delayed at regional port customs.",
+  "estimated_financial_exposure_usd": 8350.0,
+  "escalation_contact_name": "Maria Gomez",
+  "escalation_contact_phone": "+15550149923",
+  "requires_escalation": true
+}
+```
+
+---
+
+## Example 3: Aggregated CSV Export
+
+```csv
+call_id,supplier_id,supplier_name,po_id,original_date,revised_date,delay_days,status,category,financial_exposure_usd,escalation_lead,phone
+call_mock_SUP-101_001,SUP-101,Apex Components,PO-90124,2026-09-15,2026-09-15,0,ON_TIME,NONE,0.00,N/A,+1-555-***-1100
+call_mock_SUP-102_002,SUP-102,Pacific Packaging,PO-88120,2026-09-15,2026-09-20,5,DELAYED,RAW_MATERIAL_SHORTAGE,8350.00,Maria Gomez,+1-555-***-9923
+```

--- a/skills/supply-chain-supplier-status/references/safety.md
+++ b/skills/supply-chain-supplier-status/references/safety.md
@@ -1,0 +1,40 @@
+# Safety Reference
+
+Autonomous supplier inquiry calls interact with external commercial counterparties. Strict guardrails ensure legal compliance, telecommunications privacy, and operational integrity.
+
+## Authorization And Contact Basis
+
+1. **Pre-Existing Commercial Relationship Required:**
+   - Calls must only be placed to verified vendors holding an active Purchase Order (PO) or supply agreement with the procuring organization.
+   - Cold calling, prospecting, or dialing unverified numbers is strictly prohibited.
+
+2. **Caller Identity & Recorded Line Disclosure:**
+   - The agent must immediately state its identity, the procuring organization it represents, and disclose that the call is being recorded for order verification purposes.
+   - If the recipient does not consent to call recording, the agent must terminate or fail-closed to a human follow-up.
+
+3. **Business Hours & Calling Windows:**
+   - Calls must only be dispatched during standard local commercial hours (08:00 to 18:00 in the supplier local timezone).
+   - Automated weekend and holiday dialing is disabled by default.
+
+## Telephone Number Formatting & Masking
+
+1. **E.164 Compliance:**
+   - All destination phone numbers must be formatted in E.164 international notation (e.g., `+15550149923`).
+   - Documentation and synthetic fixtures must use reserved fictional test prefixes (such as `+15550100000` through `+15550199999`).
+
+2. **Redaction & Privacy Masking:**
+   - Phone numbers displayed in dashboards, CLI outputs, pull requests, or issue logs must be masked (e.g., `+1-555-***-9923`).
+   - Personal names and direct lines captured during escalation must be stored solely within internal procurement records.
+
+## Decision Authority & Commercial Boundaries
+
+1. **Information Gathering Only:**
+   - The agent is strictly an intelligence-gathering and schedule-coordination tool.
+   - The agent has no legal or commercial authority to cancel contracts, waive liquidated damages, alter payment terms, or accept defective goods.
+
+2. **Human-in-the-Loop Escalation:**
+   - Any identified delay exceeding contractual tolerance, significant financial penalty exposure, or critical component shortage is flagged with `requires_escalation: true` for procurement manager review.
+
+3. **Rate Limiting & Duplicate Call Prevention:**
+   - Idempotency keys bound to `(supplier_id, purchase_order_id, date)` prevent duplicate calls on the same day.
+   - If a call is unanswered or reaches voicemail, the agent logs a non-response disposition and defers retries according to configurable backoff intervals rather than redialing repeatedly.


### PR DESCRIPTION
## Summary

Adds the `supply-chain-supplier-status` Agent Skill and README enterprise application entry for the **CALL-E Supply Chain Supplier Status Check Agent**.

This contribution enables AI agents to conduct structured, autonomous outbound telephone verification calls to authorized vendor dispatchers using CALL-E. It implements a deterministic 5-step conversational inquiry to confirm purchase order fulfillment schedules, isolate delay root causes (e.g., raw material shortages, port congestion, quality control holds), calculate financial penalty exposure, capture supervisor escalation contacts, and export ERP-ready CSV and JSON status reports.

- **Standalone Codebase & Telephony Client**: [mohSadiq90/call-e-hackathon](https://github.com/mohSadiq90/call-e-hackathon)
- **Supported Modalities**: Python SDK (`calle-ai`), MCP Server (JSON-RPC stdio), CLI Runner (`main.py`), REST Webhooks, and Agent Skill (`SKILL.md`).
- **Zero-Credit Simulation Engine**: High-fidelity offline simulator allows complete end-to-end dry runs and test suite verification without consuming live telephony credits.
- **Unit Test Coverage**: 15/15 passing tests across models, transcript parser, agent state machine, and MCP protocol.

## Type

- [x] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [x] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.