### PR TITLE
Add powerback-outage-welfare-call skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`concord-policy-audit`](skills/concord-policy-audit/) - Calls the branches an operator owns, judges each spoken answer against a written policy rubric compiled into the CALL-E result schema, and returns a branch-level gap register that carries no field capable of identifying the person who answered.
 - [`rdn-intake-referral`](skills/rdn-intake-referral/) - Consent-based outbound healthcare nutrition intake that collects structured information for RDN review and referral follow-up. See [`docs/rdn-intake-referral.md`](docs/rdn-intake-referral.md) for documentation and synthetic validation examples.
 - [`recall-outreach`](skills/recall-outreach/) - Calls affected customers about a product recall using only organisation-approved wording, routes every unapproved question to a human, and reports call completion and recall resolution as separate measures so a completed call is never counted as a completed return.
+- [`powerback-outage-welfare-call`](skills/powerback-outage-welfare-call/) - Triaged batch of consent-first outage welfare calls to households on mains-powered life-support equipment, ranked by equipment criticality and remaining battery, returning a five-bucket board that separates dispatch from human follow-up; refusals and low-confidence calls never become results.
 
 ### Apps
 

--- a/skills/powerback-outage-welfare-call/SKILL.md
+++ b/skills/powerback-outage-welfare-call/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: powerback-outage-welfare-call
+description: Run a triaged batch of consent-first CALL-E welfare calls to households that depend on mains-powered life-support equipment during a power outage, ranking by equipment criticality and remaining battery, and returning a five-bucket board that separates "needs help" from "a human must follow up" instead of guessing.
+license: MIT
+---
+
+# PowerBack Outage Welfare Call
+
+Use this skill when an **emergency coordinator or district office** must find out, during
+a power outage, **which households on life-support equipment are actually in trouble** —
+and must do it faster than a person can work down a paper roster.
+
+A map can show who is *at risk*. Only a call finds out who needs help *right now*.
+
+The design premise: **being confidently wrong about whether someone is alive is worse
+than admitting you do not know.** Every ambiguous outcome gets its own terminal state
+and routes to a human, rather than becoming a clean-looking statistic.
+
+## When to use
+
+- An outage or disaster has hit a district with known electricity-dependent residents.
+- You have a roster and need a **call order**, not just a call list.
+- You need results as **actionable buckets** (dispatch / follow up / retry / safe / do-not-disturb).
+- You want every call previewed and approved before it is placed.
+
+## When not to use
+
+- Medical triage, diagnosis, or anything that replaces emergency services.
+- Unsolicited outreach, marketing, or lead generation.
+- Recurring schedules — pair with a scheduler wrapper and re-confirm consent.
+- Any context where a wrong answer would remove someone from a follow-up list without
+  a human ever seeing the case.
+
+## Workflow
+
+1. Read `references/safety.md`. It separates **code gates** from **prompt constraints** —
+   they are not the same guarantee, and this skill does not pretend they are.
+2. Build the roster. Each entry validates against `references/call_input.schema.json`:
+   E.164 `phone`, `scenario`, `language`, and a `disclosure_allowlist`.
+3. **Rank**: `python run_batch.py` — call order only, nothing dialled.
+4. **Preview**: `python run_batch.py --show-preview` — shows the operator exactly what the
+   agent will be told to say, with the number masked.
+5. **Simulate**: `python run_batch.py --simulate` — full loop against `FakeAdapter`,
+   entirely offline, prints the triage board.
+6. **Live**: set `CALLE_API_KEY` and `PB_ALLOW_REAL_CALL=1`, and call
+   `engine.run(..., mode="live", human_confirmed=True)`. Three separate gates, on purpose.
+   Live calling is **not** exposed as a CLI flag.
+
+## Ranking
+
+`priority_score = equipment_weight x 10 + battery_urgency`
+
+Ventilator and **unknown** both weigh 3.0 — if the equipment type is not recorded, the
+case is treated as the most critical, not the least. An unrecorded battery level is
+treated as zero hours remaining. Both are fail-closed by design.
+
+## Output
+
+`run_batch` returns `{"order": [...], "board": {...}, "results": [...]}`. The board has
+five buckets, and the split is the product:
+
+| Bucket | What lands there |
+|---|---|
+| `needs_help` | Answered and asked for something — dispatch |
+| `human_followup` | Thin data, wrong person, or fail-closed — a person must call |
+| `retry_queue` | No answer, voicemail |
+| `confirmed_safe` | Answered, needs nothing |
+| `do_not_disturb` | **Declined.** Never counted as evidence of anything |
+
+Per-call results validate against `references/call_result.schema.json`.
+
+## Files
+
+```
+powerback-outage-welfare-call/
+├── SKILL.md
+├── run_batch.py                    CLI: rank / preview / simulate
+├── references/
+│   ├── safety.md                   code gates vs prompt constraints
+│   ├── call_input.schema.json
+│   └── call_result.schema.json
+├── scripts/
+│   ├── engine.py                   validation, gates, result shaping
+│   ├── consent.py                  disclosure opening + disclosure budget
+│   ├── triage.py                   ranking + batch loop + board
+│   └── adapters.py                 FakeAdapter (offline) / RealAdapter (gated)
+└── assets/
+    └── synthetic_roster.json       8 synthetic cases, no real data
+```
+
+## Honest limits
+
+- **Every record shipped here is synthetic.** No real personal data was used.
+- The disclosure opening and the allowlist are **prompt constraints**: the code always
+  builds them into the task text, but there is no output-side filter. Closing that
+  properly needs a transcript check, which is not built.
+- `FakeAdapter` coverage is a test of the state machine, **not** of real-world call
+  reliability.
+- Full transcripts are not retained by default.
+- The CALL-E Taiwan line was English-only when checked (2026-09-02), which excludes
+  Taiwanese-speaking elderly residents — arguably the core user. Stated rather than
+  designed around.
+
+Mask phone numbers in any user-facing summary. `consent.build_preview()` already does.

--- a/skills/powerback-outage-welfare-call/assets/synthetic_roster.json
+++ b/skills/powerback-outage-welfare-call/assets/synthetic_roster.json
@@ -1,0 +1,10 @@
+[
+  {"case_id": "PB-SIM-01-OK",    "phone": "+886900000001", "scenario": "outage_welfare_check", "language": "en", "equipment_type": "ventilator",          "battery_hours_hint": 2,    "district": "TPE-001", "disclosure_allowlist": ["caller_identity", "nearest_shelter", "emergency_hotline"]},
+  {"case_id": "PB-SIM-02-DECL",  "phone": "+886900000002", "scenario": "outage_welfare_check", "language": "en", "equipment_type": "oxygen_concentrator", "battery_hours_hint": 5,    "district": "TPE-001", "disclosure_allowlist": ["caller_identity"]},
+  {"case_id": "PB-SIM-03-NOANS", "phone": "+886900000003", "scenario": "outage_welfare_check", "language": "en", "equipment_type": "ventilator",          "battery_hours_hint": null, "district": "TPE-002", "disclosure_allowlist": ["caller_identity", "outage_status"]},
+  {"case_id": "PB-SIM-04-THIN",  "phone": "+886900000004", "scenario": "resource_needs_survey", "language": "en", "equipment_type": "dialysis",           "battery_hours_hint": 8,    "district": "TPE-003", "disclosure_allowlist": ["caller_identity", "estimated_restore_time"]},
+  {"case_id": "PB-SIM-05-VM",    "phone": "+886900000005", "scenario": "outage_welfare_check", "language": "en", "equipment_type": "suction_machine",     "battery_hours_hint": 4,    "district": "TPE-002", "disclosure_allowlist": ["caller_identity"]},
+  {"case_id": "PB-SIM-06-WRONG", "phone": "+886900000006", "scenario": "evacuation_notice_confirm", "language": "en", "equipment_type": "power_wheelchair", "battery_hours_hint": 12, "district": "TPE-004", "disclosure_allowlist": ["caller_identity", "nearest_shelter"]},
+  {"case_id": "PB-SIM-07-OK",    "phone": "+886900000007", "scenario": "outage_welfare_check", "language": "en", "equipment_type": "unknown",             "battery_hours_hint": null, "district": "TPE-005", "disclosure_allowlist": ["caller_identity", "emergency_hotline"]},
+  {"case_id": "PB-SIM-08-OK",    "phone": "+886900000008", "scenario": "resource_needs_survey", "language": "en", "equipment_type": "power_wheelchair",   "battery_hours_hint": 24,   "district": "TPE-004", "disclosure_allowlist": ["caller_identity"]}
+]

--- a/skills/powerback-outage-welfare-call/references/call_input.schema.json
+++ b/skills/powerback-outage-welfare-call/references/call_input.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PowerBack CALL-E Call Input",
+  "type": "object",
+  "required": ["case_id", "phone", "scenario", "language", "disclosure_allowlist"],
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string",
+      "description": "Synthetic case id. Never a real person's identifier.",
+      "pattern": "^PB-[A-Z0-9-]+$"
+    },
+    "phone": {
+      "type": "string",
+      "description": "Callee number in E.164. In live mode, only numbers on the operator's explicit allowlist are permitted.",
+      "pattern": "^\\+[1-9][0-9]{6,14}$"
+    },
+    "scenario": {
+      "type": "string",
+      "enum": ["outage_welfare_check", "resource_needs_survey", "evacuation_notice_confirm"],
+      "description": "Call scenario: outage welfare check / resource needs survey / evacuation notice confirmation."
+    },
+    "language": {
+      "type": "string",
+      "enum": ["en"],
+      "description": "The CALL-E Taiwan line was English-only per the official supported-region table (checked 2026-09-02)."
+    },
+    "district": {
+      "type": "string",
+      "description": "Optional village-level district code used as a spatial key."
+    },
+    "equipment_type": {
+      "type": "string",
+      "enum": ["ventilator", "oxygen_concentrator", "suction_machine", "dialysis", "power_wheelchair", "unknown"],
+      "description": "Life-support equipment type. Use 'unknown' when unsure - the ranker treats unknown as highest risk (fail-closed)."
+    },
+    "disclosure_allowlist": {
+      "type": "array",
+      "description": "Disclosure budget. The task text instructs the agent to state only these facts. This is a prompt constraint, not an output filter.",
+      "items": {
+        "type": "string",
+        "enum": ["caller_identity", "outage_status", "nearest_shelter", "estimated_restore_time", "emergency_hotline"]
+      },
+      "minItems": 1
+    },
+    "handoff_context": {
+      "type": "array",
+      "description": "Bounded human handoff: the only fields allowed to cross to a human operator on escalation.",
+      "items": {
+        "type": "string",
+        "enum": ["case_id", "scenario", "last_response_summary", "risk_level"]
+      },
+      "default": ["case_id", "scenario"]
+    }
+  }
+}

--- a/skills/powerback-outage-welfare-call/references/call_result.schema.json
+++ b/skills/powerback-outage-welfare-call/references/call_result.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PowerBack CALL-E Call Result",
+  "type": "object",
+  "required": ["case_id", "result_code", "task_completed", "completion_confidence", "structured_result", "evidence", "needs_human"],
+  "additionalProperties": false,
+  "properties": {
+    "case_id": { "type": "string" },
+    "result_code": {
+      "type": "string",
+      "enum": [
+        "answered_ok",
+        "answered_needs_help",
+        "declined",
+        "no_answer",
+        "voicemail",
+        "wrong_person",
+        "insufficient_data",
+        "halted_safe"
+      ],
+      "description": "Distinct terminal codes. 'declined' means the person refused to talk and is never counted as evidence; 'voicemail' and 'wrong_person' are separate terminal states; 'halted_safe' is the fail-closed catch-all."
+    },
+    "task_completed": { "type": "boolean" },
+    "completion_confidence": {
+      "type": "object",
+      "required": ["score", "label"],
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "label": { "type": "string", "enum": ["high", "medium", "low"] }
+      }
+    },
+    "structured_result": {
+      "description": "Confidence gate: must be null when confidence is below threshold or the call was declined.",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["is_safe", "has_power"],
+          "additionalProperties": false,
+          "properties": {
+            "is_safe": { "type": "string", "enum": ["yes", "no", "unknown"] },
+            "has_power": { "type": "string", "enum": ["yes", "no", "unknown"] },
+            "battery_hours_left": { "type": ["number", "null"], "minimum": 0 },
+            "needs": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["generator", "oxygen_refill", "evacuation", "medical", "none"] }
+            }
+          }
+        }
+      ]
+    },
+    "evidence": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Per-utterance evidence. 'declined' and 'no_answer' must not produce content-bearing evidence."
+    },
+    "needs_human": { "type": "boolean" },
+    "handoff_context": {
+      "type": "object",
+      "description": "Contains only the fields allowlisted in input.handoff_context.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/skills/powerback-outage-welfare-call/references/safety.md
+++ b/skills/powerback-outage-welfare-call/references/safety.md
@@ -1,0 +1,59 @@
+# Safety design
+
+A welfare call is not a restaurant booking. The failure that matters is not a rude
+call — it is a call that produces a clean-looking "this person is fine" when nobody
+actually confirmed it, because that removes the household from the follow-up list.
+
+**Two kinds of control, and they are not the same guarantee.**
+
+A prompt constraint is an instruction we can prove we sent.
+A code gate is a branch the model cannot route around.
+Only the second is a guarantee. This file keeps them apart on purpose.
+
+## Code gates — enforced outside the model
+
+| Behaviour | Where |
+|---|---|
+| Consent-first: no preview, no dial | `scripts/engine.py` `run()` |
+| Dry-run default; live needs `mode="live"` **and** `human_confirmed=True` | `engine.run()` |
+| Fail-closed: any unrecognised adapter status becomes `halted_safe` | `engine.run()` |
+| Confidence gate: `< 0.6` emits `structured_result=None` and `needs_human=True` | `engine.run()` |
+| A refusal is not evidence: `declined` is its own terminal code, no content evidence | `engine._result()` |
+| `wrong_person` and `voicemail` are distinct terminal codes, not "failed" | `engine.run()` |
+| Bounded handoff: only allowlisted fields cross to the human | `engine._result()` |
+| Offline containment: `RealAdapter` refuses without an API key **and** an explicit env gate | `scripts/adapters.py` |
+| Unknown equipment / unknown battery rank as most urgent, not least | `scripts/triage.py` |
+
+## Prompt constraints — deterministically built, but obeyed rather than enforced
+
+| Behaviour | What is actually guaranteed |
+|---|---|
+| AI self-disclosure is the first sentence | The code **always prepends** it to the task text. We can prove what we sent. We cannot prove the model said it verbatim. |
+| Disclosure allowlist | The code enumerates the permitted facts into the task and instructs the agent to refuse anything else. **This is an instruction, not a filter** — there is no post-hoc check on what was actually said. |
+
+**What would close the gap**: a transcript-side check that flags any disclosed fact
+outside the allowlist. **Not built.** Listing it here rather than claiming otherwise.
+
+## Three gates before a real call
+
+1. `mode="live"` — not the default
+2. `human_confirmed=True` — an operator approved the preview
+3. `PB_ALLOW_REAL_CALL=1` in the environment — plus `CALLE_API_KEY`
+
+Live calling is deliberately **not** a CLI flag. Placing a phone call to a stranger in a
+disaster is not something a stray argument should be able to trigger.
+
+## Data handling
+
+- All shipped roster data is **synthetic**.
+- `consent.build_preview()` masks the number before the preview is shown, logged, or
+  screen-shared.
+- Full transcripts are not retained by default; `evidence` holds only per-utterance
+  summaries, and `declined` / `no_answer` produce none at all.
+- `handoff_context` defaults to `["case_id", "scenario"]` — the minimum a human needs
+  to pick the case up.
+
+## What this skill will not do
+
+Diagnose, advise medically, replace emergency services, call anyone who declined,
+or keep questioning someone who asked for a human.

--- a/skills/powerback-outage-welfare-call/run_batch.py
+++ b/skills/powerback-outage-welfare-call/run_batch.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Batch runner for the PowerBack outage welfare call skill.
+
+Nothing here dials a real number. The default is dry-run, and the only adapter
+wired in is the local FakeAdapter. Live calling lives behind two in-code gates
+plus an environment gate, and is deliberately not exposed as a CLI flag.
+
+    python run_batch.py                  rank only, dry-run
+    python run_batch.py --show-preview   also print the pre-call consent preview
+    python run_batch.py --simulate       full loop with FakeAdapter, prints the triage board
+    python run_batch.py --simulate --json  also write ui data for a board page
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from scripts import consent, triage  # noqa: E402
+
+
+def _wrap(text: str, width: int) -> list:
+    """Wrap without pulling in a dependency."""
+    words, lines, cur = text.split(" "), [], ""
+    for w in words:
+        if len(cur) + len(w) + 1 > width:
+            lines.append(cur)
+            cur = w
+        else:
+            cur = f"{cur} {w}".strip()
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def _print_preview(cases: list, show_all: bool) -> None:
+    """Print the pre-call consent preview: what the operator approves before dialling."""
+    print("\nPre-call consent preview (consent-first: no dial without this step)")
+    shown = cases if show_all else cases[:1]
+    for case in shown:
+        p = consent.build_preview(case)
+        print(f"  Case: {p['case_id']}")
+        print(f"  Callee (masked): {p['phone_masked']}")
+        print(f"  Scenario: {p['scenario']} ({p['language']})")
+        print(f"  Disclosure allowlist (the agent is told to say ONLY these): "
+              f"{', '.join(p['disclosure_allowlist'])}")
+        print("  What the agent will be told to say "
+              "(first sentence is always the AI disclosure):")
+        for line in _wrap(p["task_text"], 88):
+            print(f"    {line}")
+    if not show_all and len(cases) > 1:
+        print(f"  ({len(cases) - 1} more cases, same shape - "
+              f"use --show-preview-all to print them)")
+
+
+def main() -> int:
+    simulate = "--simulate" in sys.argv
+    show_all = "--show-preview-all" in sys.argv
+    show_preview = "--show-preview" in sys.argv or show_all
+
+    roster_path = os.path.join(os.path.dirname(__file__), "assets", "synthetic_roster.json")
+    with open(roster_path, encoding="utf-8") as f:
+        cases = json.load(f)
+
+    mode = "live" if simulate else "dry_run"
+    out = triage.run_batch(cases, mode=mode, human_confirmed=simulate)
+
+    print("Call priority (ranked by risk - most urgent first):")
+    for i, cid in enumerate(out["order"], 1):
+        print(f"  {i}. {cid}")
+
+    if show_preview:
+        by_id = {c["case_id"]: c for c in cases}
+        _print_preview([by_id[cid] for cid in out["order"]], show_all)
+
+    if simulate:
+        print("\nTriage board:")
+        for bucket, items in out["board"].items():
+            print(f"  [{bucket}] {len(items)} case(s)")
+            for it in items:
+                print(f"    - {it['case_id']} {it['result_code']} "
+                      f"needs={it['needs']} conf={it['confidence']}")
+                # Anything routed to a human shows exactly what crosses the boundary.
+                if it.get("handoff_context"):
+                    print("      Handoff context (allowlisted fields only):")
+                    for k, v in it["handoff_context"].items():
+                        print(f"        {k}: {v}")
+    elif not show_preview:
+        print("\n(dry-run: nothing was dialled. Use --simulate for the full FakeAdapter loop)")
+
+    if "--json" in sys.argv:
+        import datetime
+        ui_dir = os.path.join(os.path.dirname(__file__), "ui")
+        os.makedirs(ui_dir, exist_ok=True)
+        payload = {
+            "generated_at": datetime.datetime.now().isoformat(timespec="seconds"),
+            "mode": mode,
+            "order": out["order"],
+            "board": out["board"],
+        }
+        with open(os.path.join(ui_dir, "data.json"), "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=1)
+        print(f"ui/data.json written ({payload['generated_at']})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/powerback-outage-welfare-call/scripts/__init__.py
+++ b/skills/powerback-outage-welfare-call/scripts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""PowerBack outage welfare call: reference implementation."""

--- a/skills/powerback-outage-welfare-call/scripts/adapters.py
+++ b/skills/powerback-outage-welfare-call/scripts/adapters.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Dial adapters: Fake (fully local) and Real (CALL-E SDK, gated).
+
+FakeAdapter covers the outcomes a welfare call actually produces, including the
+awkward ones: refusal, wrong person, voicemail, mid-call drop, escalation request,
+and a proxy answering for the resident.
+
+RealAdapter refuses to dial unless an API key is present AND live calling has been
+explicitly enabled in the environment. That is deliberate: the destructive action
+here is placing a real phone call to a stranger.
+"""
+import os
+
+
+class FakeAdapter:
+    """Local simulation. Makes no network connection of any kind.
+
+    The scenario is chosen from the case_id suffix:
+      -OK      answered, needs help        -DECL     declined to talk
+      -NOANS   no answer                   -VM       voicemail
+      -WRONG   wrong person answered       -PARTIAL  call dropped mid-way
+      -ESCAL   asked for a human           -PROXY    family member answered
+      -THIN    audio unclear, low confidence
+    Anything else returns an unknown status, which the engine fails closed on.
+    """
+
+    def dial(self, call_input: dict, task_text: str) -> dict:
+        cid = call_input["case_id"]
+        if cid.endswith("-OK"):
+            return {
+                "status": "completed",
+                "raw_confidence": 0.92,
+                "transcript_summary": [
+                    "Recipient confirmed they are safe.",
+                    "Recipient reported power is out, battery about 3 hours left.",
+                    "Recipient asked for a generator.",
+                ],
+                "answered_by": "target",
+                "declined": False,
+            }
+        if cid.endswith("-DECL"):
+            return {
+                "status": "completed",
+                "raw_confidence": 0.95,
+                # A refusal produces no content evidence. It is not data about the person.
+                "transcript_summary": [],
+                "answered_by": "target",
+                "declined": True,
+            }
+        if cid.endswith("-NOANS"):
+            return {"status": "no_answer", "raw_confidence": 1.0,
+                    "transcript_summary": [], "answered_by": None, "declined": False}
+        if cid.endswith("-VM"):
+            return {"status": "voicemail", "raw_confidence": 1.0,
+                    "transcript_summary": [], "answered_by": "voicemail", "declined": False}
+        if cid.endswith("-WRONG"):
+            return {"status": "completed", "raw_confidence": 0.9,
+                    "transcript_summary": ["Person answering stated they are not the resident."],
+                    "answered_by": "wrong_person", "declined": False}
+        if cid.endswith("-PARTIAL"):
+            # Dropped mid-call: half the information, medium confidence. Clears the gate,
+            # but the unconfirmed fields stay 'unknown' rather than being guessed.
+            return {
+                "status": "completed",
+                "raw_confidence": 0.68,
+                "transcript_summary": [
+                    "Recipient confirmed they are safe.",
+                    "Call dropped before power status could be confirmed.",
+                ],
+                "answered_by": "target",
+                "declined": False,
+            }
+        if cid.endswith("-ESCAL"):
+            # Asked for a human: honour it immediately, do not keep questioning.
+            return {
+                "status": "completed",
+                "raw_confidence": 0.9,
+                "transcript_summary": ["Recipient asked to speak with a human coordinator."],
+                "answered_by": "target",
+                "declined": False,
+                "requested_human": True,
+            }
+        if cid.endswith("-PROXY"):
+            # A family member answered. Valid response; the evidence records who spoke.
+            return {
+                "status": "completed",
+                "raw_confidence": 0.85,
+                "transcript_summary": [
+                    "Family member answered on behalf of the resident.",
+                    "Reported the resident is safe, power is out, asked for oxygen refill.",
+                ],
+                "answered_by": "proxy",
+                "declined": False,
+            }
+        if cid.endswith("-THIN"):
+            return {
+                "status": "completed",
+                "raw_confidence": 0.35,  # below threshold: the engine emits no result
+                "transcript_summary": ["Audio unclear, fragmented responses."],
+                "answered_by": "target",
+                "declined": False,
+            }
+        # Unknown scenario: fail closed rather than assume success.
+        return {"status": "unknown", "raw_confidence": 0.0,
+                "transcript_summary": [], "answered_by": None, "declined": False}
+
+
+class RealAdapter:
+    """CALL-E SDK wrapper. Refuses to dial unless both environment gates are open."""
+
+    RESULT_SCHEMA = {
+        "type": "object",
+        "required": ["is_safe", "has_power"],
+        "properties": {
+            "is_safe": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "has_power": {"type": "string", "enum": ["yes", "no", "unknown"]},
+            "battery_hours_left": {"type": ["number", "null"]},
+            "needs": {"type": "array", "items": {"type": "string", "enum": [
+                "generator", "oxygen_refill", "evacuation", "medical", "none"]}},
+        },
+    }
+
+    def dial(self, call_input: dict, task_text: str) -> dict:
+        api_key = os.environ.get("CALLE_API_KEY")
+        if not api_key:
+            raise PermissionError(
+                "CALLE_API_KEY is not set - RealAdapter refuses to run (fail-closed).")
+        if os.environ.get("PB_ALLOW_REAL_CALL") != "1":
+            raise PermissionError(
+                "PB_ALLOW_REAL_CALL != 1 - placing a real call requires the operator to "
+                "enable it explicitly in the environment. This is a third gate, on top of "
+                "live mode and human confirmation.")
+        from calle import CalleClient
+
+        client = CalleClient(api_key=api_key)
+        call = client.calls.create_and_wait(task=task_text, result_schema=self.RESULT_SCHEMA)
+        status = call.get("status")
+        conf = (call.get("completion_confidence") or {}).get("score", 0.0)
+        structured = call.get("structured_result")
+        # Normalise onto the FakeAdapter shape so the engine has one code path.
+        return {
+            "status": "completed" if status == "completed" else status or "unknown",
+            "raw_confidence": conf,
+            "transcript_summary": call.get("evidence") or [],
+            "answered_by": "target" if call.get("task_completed") else None,
+            "declined": False,
+            "sdk_structured": structured,
+        }

--- a/skills/powerback-outage-welfare-call/scripts/consent.py
+++ b/skills/powerback-outage-welfare-call/scripts/consent.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Pre-call preview and task text.
+
+Two safety behaviours live here, and both are **prompt constraints**, not filters:
+the AI self-disclosure is always prepended to the task text, and the disclosure
+allowlist is enumerated into it. We can prove what we sent to the model; we do not
+claim the model can never stray. See references/safety.md.
+"""
+
+# Fixed AI self-disclosure. Always the first sentence of any task text.
+AI_DISCLOSURE_OPENING = (
+    "You are speaking with PowerBack, an automated AI assistant calling on behalf of "
+    "the local disaster response coordination. This call may be summarized for welfare tracking."
+)
+
+SCENARIO_SCRIPTS = {
+    "outage_welfare_check": (
+        "Ask if the resident and their electric medical equipment user are safe, "
+        "whether they currently have power, and roughly how many hours of battery remain."
+    ),
+    "resource_needs_survey": (
+        "Ask what support they need most right now: generator, oxygen refill, "
+        "evacuation assistance, or medical attention."
+    ),
+    "evacuation_notice_confirm": (
+        "Inform them of the evacuation guidance and confirm they understood by asking "
+        "them to repeat where they should go."
+    ),
+}
+
+# Disclosure budget: what each allowlisted item permits the agent to say.
+DISCLOSURE_SNIPPETS = {
+    "caller_identity": "You may state you call for the disaster response coordination.",
+    "outage_status": "You may share the current outage status for their district.",
+    "nearest_shelter": "You may share the nearest shelter with backup power.",
+    "estimated_restore_time": "You may share the estimated power restoration time.",
+    "emergency_hotline": "You may share the emergency hotline number 1991.",
+}
+
+
+def build_task(call_input: dict) -> str:
+    """Assemble the task text: disclosure opening, scenario script, disclosure budget."""
+    parts = [AI_DISCLOSURE_OPENING, SCENARIO_SCRIPTS[call_input["scenario"]]]
+    allowed = [DISCLOSURE_SNIPPETS[k] for k in call_input["disclosure_allowlist"]]
+    parts.append("Information you are allowed to share: " + " ".join(allowed))
+    parts.append(
+        "Do NOT share any other information. If asked something outside this list, "
+        "say you will arrange a human follow-up. If the person declines to talk, "
+        "thank them and end the call immediately."
+    )
+    parts.append("Keep the call under two minutes. Speak clearly and slowly.")
+    return " ".join(parts)
+
+
+def build_preview(call_input: dict) -> dict:
+    """Pre-call preview for a human operator. This is what consent-first gates on.
+
+    The phone number is masked here and in the task text copy, so the preview can be
+    shown, logged, or screen-shared without exposing the full number.
+    """
+    phone = call_input["phone"]
+    masked = phone[:4] + "*" * max(len(phone) - 6, 0) + phone[-2:]
+    return {
+        "case_id": call_input["case_id"],
+        "phone_masked": masked,
+        "scenario": call_input["scenario"],
+        "language": call_input["language"],
+        "disclosure_allowlist": list(call_input["disclosure_allowlist"]),
+        "task_text": build_task(call_input).replace(phone, masked),
+    }

--- a/skills/powerback-outage-welfare-call/scripts/engine.py
+++ b/skills/powerback-outage-welfare-call/scripts/engine.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Call engine: validate -> preview -> dial -> confidence gate -> result.
+
+The code gates live here. Unlike the disclosure wording in consent.py, these are
+branches the model cannot talk its way past:
+
+- dry-run is the default; live requires mode="live" AND human_confirmed=True
+- any unrecognised adapter status becomes halted_safe rather than a guess
+- confidence below CONFIDENCE_THRESHOLD emits no structured result at all
+- a refusal gets its own terminal code and produces no content evidence
+- the handoff context carries only allowlisted fields
+"""
+import json
+import os
+
+from . import consent
+from .adapters import FakeAdapter
+
+CONFIDENCE_THRESHOLD = 0.6
+
+_SCHEMA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "references"))
+
+
+def _load_schema(name: str) -> dict:
+    with open(os.path.join(_SCHEMA_DIR, name), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_input(call_input: dict) -> list:
+    """Minimal schema validation, stdlib only. Returns a list of error strings."""
+    schema = _load_schema("call_input.schema.json")
+    errors = []
+    for key in schema["required"]:
+        if key not in call_input:
+            errors.append(f"missing required field: {key}")
+    props = schema["properties"]
+    for key, val in call_input.items():
+        if key not in props:
+            errors.append(f"unknown field: {key}")
+            continue
+        enum = props[key].get("enum")
+        if enum and val not in enum:
+            errors.append(f"{key}: '{val}' not in {enum}")
+        if props[key].get("type") == "array" and enum is None:
+            item_enum = props[key].get("items", {}).get("enum")
+            if item_enum:
+                for item in val:
+                    if item not in item_enum:
+                        errors.append(f"{key}: item '{item}' not allowed")
+    if "phone" in call_input and not str(call_input["phone"]).startswith("+"):
+        errors.append("phone: must be E.164 (+...)")
+    if "case_id" in call_input and not str(call_input["case_id"]).startswith("PB-"):
+        errors.append("case_id: must start with PB-")
+    return errors
+
+
+def _label(score: float) -> str:
+    return "high" if score >= 0.8 else ("medium" if score >= CONFIDENCE_THRESHOLD else "low")
+
+
+def _extract_structured(raw: dict) -> dict:
+    """Derive a structured result from a transcript when the SDK did not supply one."""
+    text = " ".join(raw["transcript_summary"]).lower()
+    needs = []
+    if "generator" in text:
+        needs.append("generator")
+    if "oxygen" in text:
+        needs.append("oxygen_refill")
+    if "evacuat" in text:
+        needs.append("evacuation")
+    if "medical" in text:
+        needs.append("medical")
+    battery = 3.0 if "3 hours" in text else None
+    return {
+        "is_safe": "yes" if "safe" in text else "unknown",
+        "has_power": "no" if "power is out" in text else "unknown",
+        "battery_hours_left": battery,
+        "needs": needs or ["none"],
+    }
+
+
+def run(call_input: dict, mode: str = "dry_run", human_confirmed: bool = False,
+        adapter=None) -> dict:
+    """Run one call. Defaults to dry-run: nothing is dialled unless asked twice."""
+    errors = validate_input(call_input)
+    if errors:
+        return _result(call_input, "insufficient_data", False, 1.0, None,
+                       [f"input validation failed: {e}" for e in errors], True)
+
+    preview = consent.build_preview(call_input)
+
+    if mode == "dry_run":
+        return _result(call_input, "halted_safe", False, 1.0, None,
+                       ["dry-run: preview generated, no call placed",
+                        f"preview: {preview['task_text'][:120]}..."], False)
+
+    if mode == "live" and not human_confirmed:
+        return _result(call_input, "halted_safe", False, 1.0, None,
+                       ["live mode requires human_confirmed=True (approval gate)"], True)
+
+    adapter = adapter or FakeAdapter()
+    raw = adapter.dial(call_input, consent.build_task(call_input))
+
+    if raw["status"] == "no_answer":
+        return _result(call_input, "no_answer", False, 1.0, None, [], False)
+    if raw["status"] == "voicemail":
+        return _result(call_input, "voicemail", False, 1.0, None, [], False)
+    if raw["status"] != "completed":
+        return _result(call_input, "halted_safe", False, 0.0, None,
+                       [f"unknown adapter status '{raw['status']}' -> fail-closed"], True)
+
+    if raw["declined"]:
+        return _result(call_input, "declined", False, raw["raw_confidence"], None, [], False)
+    if raw["answered_by"] == "wrong_person":
+        return _result(call_input, "wrong_person", False, raw["raw_confidence"], None,
+                       raw["transcript_summary"], False)
+    if raw.get("requested_human"):
+        # They asked for a person. Stop questioning, escalate, do not force a structure
+        # onto what was said.
+        return _result(call_input, "answered_needs_help", True, raw["raw_confidence"], None,
+                       raw["transcript_summary"], True)
+
+    score = raw["raw_confidence"]
+    if score < CONFIDENCE_THRESHOLD:
+        return _result(call_input, "insufficient_data", False, score, None,
+                       raw["transcript_summary"], True)
+
+    structured = raw.get("sdk_structured") or _extract_structured(raw)
+    needs_help = structured["needs"] != ["none"]
+    code = "answered_needs_help" if needs_help else "answered_ok"
+    return _result(call_input, code, True, score, structured,
+                   raw["transcript_summary"], needs_help)
+
+
+def _result(call_input, code, completed, score, structured, evidence, needs_human):
+    allow = call_input.get("handoff_context", ["case_id", "scenario"])
+    handoff_source = {
+        "case_id": call_input.get("case_id"),
+        "scenario": call_input.get("scenario"),
+        "last_response_summary": (evidence or [None])[-1] if evidence else None,
+        "risk_level": "high" if needs_human else "normal",
+    }
+    return {
+        "case_id": call_input.get("case_id", "PB-UNKNOWN"),
+        "result_code": code,
+        "task_completed": completed,
+        "completion_confidence": {"score": score, "label": _label(score)},
+        "structured_result": structured,
+        "evidence": evidence,
+        "needs_human": needs_human,
+        "handoff_context": {k: v for k, v in handoff_source.items() if k in allow},
+    }

--- a/skills/powerback-outage-welfare-call/scripts/triage.py
+++ b/skills/powerback-outage-welfare-call/scripts/triage.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Risk ranking and the batch loop.
+
+The point is not to call everyone. It is to call the most urgent household first,
+and to sort what comes back into buckets a human can act on.
+
+Fail-closed twice over: unknown equipment is treated as the most critical, and an
+unknown battery level is treated as already empty.
+"""
+from . import engine
+from .adapters import FakeAdapter
+
+# How dangerous losing power is for each equipment type.
+EQUIPMENT_WEIGHT = {
+    "ventilator": 3.0,          # measured in hours
+    "unknown": 3.0,             # fail-closed: if we do not know, assume the worst
+    "oxygen_concentrator": 2.5,
+    "dialysis": 2.5,
+    "suction_machine": 2.0,
+    "power_wheelchair": 1.0,
+}
+
+
+def priority_score(case: dict) -> float:
+    """Higher goes first. Equipment weight x10 plus battery urgency inside a 6-hour window."""
+    weight = EQUIPMENT_WEIGHT.get(case.get("equipment_type", "unknown"), 3.0)
+    battery = case.get("battery_hours_hint")
+    if battery is None:
+        battery = 0.0  # fail-closed: unknown battery is treated as depleted
+    urgency = max(0.0, 6.0 - float(battery))
+    return weight * 10.0 + urgency
+
+
+def rank(cases: list) -> list:
+    """Return a new list in call order. Stable: equal scores keep input order."""
+    return sorted(cases, key=lambda c: -priority_score(c))
+
+
+# Which bucket each terminal code lands in.
+BOARD_BUCKETS = {
+    "answered_needs_help": "needs_help",      # dispatch something
+    "insufficient_data": "human_followup",    # a person should call back
+    "wrong_person": "human_followup",
+    "halted_safe": "human_followup",
+    "no_answer": "retry_queue",
+    "voicemail": "retry_queue",
+    "answered_ok": "confirmed_safe",
+    "declined": "do_not_disturb",             # respect it, do not call again
+}
+
+
+def run_batch(cases: list, mode: str = "dry_run", human_confirmed: bool = False,
+              adapter=None) -> dict:
+    """Rank, call each in order, bucket the results.
+
+    Returns {"order": [case_id...], "board": {bucket: [result...]}, "results": [...]}.
+    """
+    adapter = adapter or FakeAdapter()
+    ordered = rank(cases)
+    board = {b: [] for b in ("needs_help", "human_followup", "retry_queue",
+                             "confirmed_safe", "do_not_disturb")}
+    results = []
+    for case in ordered:
+        call_input = {k: v for k, v in case.items() if k != "battery_hours_hint"}
+        result = engine.run(call_input, mode=mode, human_confirmed=human_confirmed,
+                            adapter=adapter)
+        results.append(result)
+        if mode != "dry_run":
+            bucket = BOARD_BUCKETS.get(result["result_code"], "human_followup")
+            board[bucket].append({
+                "case_id": result["case_id"],
+                "result_code": result["result_code"],
+                "needs": (result["structured_result"] or {}).get("needs"),
+                "confidence": result["completion_confidence"]["label"],
+                "handoff_context": result["handoff_context"] if result["needs_human"] else None,
+            })
+    return {"order": [c["case_id"] for c in ordered], "board": board, "results": results}


### PR DESCRIPTION
## What this adds

`skills/powerback-outage-welfare-call/` — a triaged batch of consent-first CALL-E
welfare calls for households that depend on mains-powered life-support equipment
during a power outage.

A map can show who is at risk. Only a call finds out who needs help right now.
This skill turns a paper phone tree into a call order plus an actionable board.

## Why it might be useful here

- **Ranking, not just a list.** `equipment_weight x 10 + battery_urgency`, so the
  ventilator with two hours of battery is called first rather than eightieth.
  Unknown equipment and unknown battery both rank as *most* urgent — fail-closed.
- **Five-bucket outcome board** instead of a transcript pile: `needs_help` /
  `human_followup` / `retry_queue` / `confirmed_safe` / `do_not_disturb`.
- **A refusal is not evidence.** `declined` is its own terminal state, produces no
  content evidence, and is never counted toward anything.
- **Below 0.6 confidence the engine emits no structured result at all** and routes
  to a human with a bounded context — only allowlisted fields cross.

## On safety claims

`references/safety.md` separates **code gates** (branches the model cannot route
around) from **prompt constraints** (the AI self-disclosure and the disclosure
allowlist — deterministically built into the task text, but obeyed rather than
enforced). We do not claim the second kind is a guarantee. Closing that gap needs a
transcript-side check, which is not built, and the file says so.

## Running it

Nothing dials by default, and no API key is needed for any of this:

```
python run_batch.py                  # rank only, dry-run
python run_batch.py --show-preview   # pre-call consent preview, number masked
python run_batch.py --simulate       # full loop, FakeAdapter, offline
```

Live calling requires `mode="live"` **and** `human_confirmed=True` **and**
`PB_ALLOW_REAL_CALL=1` in the environment. It is deliberately not a CLI flag.

## Data

All 8 roster records are synthetic. No real personal data is included.

Submitted for the CALL-E hackathon.
