### PR TITLE
feat(ringfence): fraud-verification calls for flagged bank transactions

### DIFF
--- a/apps/python/ringfence/.env.example
+++ b/apps/python/ringfence/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env and fill in, or export directly. Never commit a real key.
+
+# Only needed for the operator-run live-call surfaces (CLI --live
+# --confirm-live, webhook, MCP). The demo server never reads it.
+CALLE_API_KEY=
+
+# Required to expose ringfence.demo_server on anything but loopback: the
+# server refuses to start on a public bind without it, and gates every page
+# and API route behind it. Generate with:
+#   python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+RINGFENCE_DEMO_TOKEN=

--- a/apps/python/ringfence/.gitignore
+++ b/apps/python/ringfence/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+results/
+.env
+*.egg-info/

--- a/apps/python/ringfence/README.md
+++ b/apps/python/ringfence/README.md
@@ -442,7 +442,7 @@ python -m ringfence.demo_server --host 0.0.0.0 --port "$PORT"
 |---|---|---|
 | `ringfence case submit --file case.json` | Dry run. Renders the disclosure-first call script, resolves the dial target, validates the case. **No call placed, no credits spent.** | `--live --confirm-live` together — **both required, no override.** `CALLE_API_KEY` must also be set. |
 | `ringfence case resolve --from-fixtures DIR` | Reads local JSON only. No network call, no API key needed. | N/A — read-only. |
-| `POST /cases` (webhook) | Dry run, unless the server itself was started with `--live --confirm-live`. | Start `ringfence.webhook` with `--live --confirm-live`. |
+| `POST /cases` (webhook) | Dry run, unless the server itself was started with `--live --confirm-live`. | Start `ringfence.webhook` with `--live --confirm-live`; live mode is loopback-only. Do not expose it through a public proxy. |
 | `ringfence_submit_case` (MCP) | Dry run. | Pass `live=True` **and** `confirm_live=True` together in the same tool call — omitting either keeps it a preview. |
 | `GET /cases/{id}` / `ringfence_get_case` | Read-only lookup of a stored recommendation. | N/A. |
 | `ringfence case audit` / `case report-index` | Reads local JSON only, writes a report file. No network call. | N/A — read-only. |

--- a/apps/python/ringfence/README.md
+++ b/apps/python/ringfence/README.md
@@ -1,0 +1,687 @@
+# ringfence
+
+**Independent fraud-verification calls for flagged transactions — never a
+number the flagged request itself supplied.**
+
+Scammers now use AI voice-cloning to impersonate a panicked grandchild or a
+company executive and pressure a wire transfer through before anyone can
+think twice. `ringfence` fights back with the same weapon: when a bank or
+company's existing fraud-scoring system flags a transaction as risky,
+`ringfence` places its own AI verification call — to the account holder's
+number **already on file**, never a number that arrived with the flagged
+request — before the money moves. Every result is an **advisory
+recommendation for a human reviewer**, never an automatic action on the
+money: ambiguous, unreachable, or red-flagged always recommends a hold or
+an escalation, never guessed as fine.
+
+**Host / provider:** CALL-E only, via the `calle-ai` Python SDK
+(`POST /v1/calls`, `GET /v1/calls/{id}`, `GET /v1/calls/{id}/events`). No
+other telephony provider is supported.
+
+---
+
+## Why this, why now
+
+Americans 60+ reported **$7.748 billion** lost to online scams in 2025, up
+**59%** from $4.885B in 2024 (FBI/IC3, via AARP's reporting on the 2025
+FBI/FTC data). The FTC's own December 2025 report to Congress estimates real
+losses may be as high as **$81.5 billion**, since fewer than 1 in 20 victims
+ever report.
+([AARP: FBI Report — Internet Crime Losses Hit $20.9 Billion](https://www.aarp.org/money/scams-fraud/fbi-ftc-report-2025-losses/))
+
+Grandparent/family-emergency scams specifically: **$5M+** reported losses in
+2025, with AI voice-cloning explicitly named as a growing driver — criminals
+mimic the sound of a loved one in distress.
+([FBI: Elder Fraud, in Focus](https://www.fbi.gov/news/stories/elder-fraud-in-focus))
+
+These numbers describe real, ongoing losses, not a hypothetical threat model
+— see [`references/scam-red-flags.md`](references/scam-red-flags.md) for how
+each of `ringfence`'s verification questions maps to a specific,
+consumer-protection-documented pressure tactic rather than an invented
+taxonomy.
+
+## Who triggers it
+
+Not the individual watching their own phone — CALL-E cannot intercept or
+monitor a personal incoming call (no OS/carrier-level call-screening
+integration, and it would collide with two-party-consent recording law in
+many jurisdictions). `ringfence` is a **B2B fraud-ops tool**: a bank, payment
+processor, or company finance team's *own* existing fraud-scoring system
+(which already flags unusual transactions today, by whatever rules or ML
+they already run — `ringfence` does not build that part) calls
+`ringfence`'s webhook/API/MCP surface with a **case**. `ringfence`'s job
+starts there. The account holder never installs anything; they just receive
+a smarter verification call than the generic "press 1 to confirm" robocall
+a bank might already run.
+
+---
+
+## The one security invariant everything else depends on
+
+**`ringfence` never calls a phone number that arrived as part of the flagged
+request.** It only ever calls the number on file for the account, sourced
+independently by the institution's own system before the case is submitted.
+A case payload that tries to smuggle in an alternate "callback number" is
+rejected outright for dialing purposes and logged as a security event —
+never used, even if it happens to match the on-file number.
+
+This is enforced in exactly one place —
+[`ringfence/verify_call.py`](ringfence/verify_call.py)'s
+`resolve_dial_target()`, which every surface (CLI, webhook, MCP) calls
+through rather than re-implementing — and proven by a dedicated test:
+
+```bash
+python -m pytest tests/test_invariant_never_calls_request_supplied_number.py -v
+```
+
+`fixtures/12_number_substitution_attack.json` and
+`tests/test_number_substitution_fixture.py` additionally prove this holds
+for a concrete, fixture-shaped case, not just synthetic unit-test data.
+
+---
+
+## What the verification call asks
+
+Disclosure-first: the call states immediately that it is an automated
+verification call from the institution — never "is this really you," which
+a coached or panicked victim will answer "yes" to mid-scam. It then asks
+open, non-leading questions and listens for documented scam red flags:
+
+| Signal asked about | Why (documented red flag) |
+|---|---|
+| "Did anyone ask you to keep this transaction private, or not to tell your bank or family?" | Secrecy/isolation demand is one of the most consistent scam markers — legitimate transactions are never secret. |
+| "Is there time pressure — were you told this has to happen today or right now?" | Manufactured urgency is a core scam pressure tactic. |
+| "Can you describe your relationship to the recipient, in your own words?" | Catches a mismatch between the caller's actual knowledge and the scammer's fabricated story — asked *before* any detail is repeated back to them, never after. |
+| "Were you asked to pay by wire, gift card, or cryptocurrency specifically?" | Scammers prefer irreversible payment rails; legitimate large transactions rarely insist on one specific irreversible method. |
+| Explicit "stop/hold everything" from the account holder, at any point | Immediately blocks — it must be easy to stop a transaction and hard to force one through, never the reverse. |
+
+See [`references/scam-red-flags.md`](references/scam-red-flags.md) for the
+citation behind each question. The structured result schema
+(`ringfence/verify_call.py`'s `RESULT_SCHEMA`) captures each signal as its
+own boolean field.
+
+---
+
+## Decision engine
+
+`ringfence/decide.py` combines two things, neither trusted alone:
+
+1. **Outcome-truth classification of the raw call** (adapted from
+   [`apps/python/calltruth`](../calltruth/)'s `resolve.py`) — was this a
+   real, completed conversation, or an ambiguous/unresolved one? CALL-E's
+   own docs say the Calls API "does not guarantee a distinct no-answer or
+   callee-decline value" and that `failure_code` has "no published enum" —
+   `resolve.classify()` never trusts it directly.
+2. The structured red-flag fields from the verification call.
+
+Fails closed at every branch — a missing or unknown signal is never read as
+"clean":
+
+| Condition | Recommendation |
+|---|---|
+| Any red flag present (secrecy, urgency, unexplained relationship, irreversible-payment insistence) | `ADVISE_BLOCK` |
+| Explicit hold/stop requested by account holder | `ADVISE_BLOCK` |
+| Call resolution is `unresolved_ambiguous`, `no_answer_confirmed`, or `rejected_before_ring` | `ESCALATE_TO_HUMAN` — never `ADVISE_ALLOW` on an unanswered or ambiguous call |
+| Clean conversation, no red flags, explicit confirmation | `ADVISE_ALLOW` |
+| Anything not covered above (including `policy_or_content_refusal`, `malformed_or_unsupported_destination`, `answered_declined`) | `ESCALATE_TO_HUMAN` (the default fallback) |
+
+### Advisory only — a human decides
+
+Every value above is a **recommendation**, not an action, and is named so
+deliberately. It comes from a heuristic chain — speech recognition, then a
+language model's reading of what was said, then the red-flag table in
+[`references/scam-red-flags.md`](references/scam-red-flags.md) — applied to
+a single phone conversation. That chain is not reliable enough to move or
+hold someone's money by itself, so nothing in `ringfence` is wired to do
+that:
+
+- `ADVISE_ALLOW` means "this call surfaced no red flags," never "release
+  the funds";
+- `ADVISE_BLOCK` means "this call surfaced red flags worth a human
+  looking at," never "freeze the account";
+- `ESCALATE_TO_HUMAN` means the call established too little to recommend
+  either way.
+
+Every `Disposition` carries `advisory: true` and
+`requires_human_review: true`, serialized into every API response, stored
+record, audit report, and both demo pages (`tests/test_decide.py`,
+`tests/test_webhook.py`, `tests/test_demo_server.py`). **Integrators must
+not wire these values into an automated approve/hold action**: the
+consequential decision belongs to a person inside the institution, with
+this evidence trail in front of them.
+
+**Scope boundary**: `ringfence` returns a recommendation to the
+institution's own transaction system. It never moves money itself and never
+makes a final legal/compliance determination — the institution's own system,
+and a human in it, retains final authority.
+
+---
+
+## Measured evaluation
+
+The 21-fixture corpus in [`fixtures/`](fixtures/) covers clean-legitimate
+transactions (6, several distinct scenarios — tuition, a car down payment, a
+medical bill, a real-estate deposit, a contractor payment, a family gift),
+scam patterns (9 — every red flag isolated, several multi-flag combinations
+including an elder-fraud framing, a business/CEO-fraud framing, and a
+romance-scam framing), an explicit hold request, never-dialed/no-answer/
+declined/connection-failed escalation cases (5), and the
+number-substitution-attack case (1).
+
+One escalation fixture (`21_connection_failed_during_attempt.json`) locks
+in the provider-failure shape that exposed a real classifier bug: an
+attempt with `started_at == completed_at` (zero ring time) carrying its own
+`failure_code`, which `resolve.classify()` used to mislabel
+`no_answer_confirmed` instead of a genuine connection failure. Fixed with a
+new `connection_failed_during_attempt` outcome (`tests/test_resolve.py`),
+with this fixture as the regression test.
+
+Reproduce it yourself — nothing below is hand-typed:
+
+```bash
+python -m pytest tests/test_evaluation.py -v
+```
+
+As of this fixture corpus: **9/9 (100%)** scam-pattern fixtures correctly
+recommend `ADVISE_BLOCK`/`ESCALATE_TO_HUMAN`, never `ADVISE_ALLOW`, and
+**6/6 (100%)** clean-legitimate fixtures correctly recommend `ADVISE_ALLOW`
+rather than being over-triggered into a false flag — both sides are
+reported honestly, because a tool that flags everything is useless. (These
+15 categorized fixtures are the scored ones; the remaining 6 cover
+escalation and attack shapes asserted individually in `tests/`.)
+
+This is **not** a claim about real-world scam-catch rates, and it measures
+recommendation quality, not decisions this tool is permitted to make on its
+own. It is a small, fixed, illustrative fixture corpus written for this
+project, not a random sample of real calls — see each fixture's
+`_evidence_source` for exactly what documented pattern it is modeled on.
+
+### Exhaustive signal-space coverage
+
+The 21 curated fixtures above are hand-written and narrative — each models
+one specific, named scam or clean pattern. On top of them,
+[`ringfence/synthetic_corpus.py`](ringfence/synthetic_corpus.py) generates a
+**98-case corpus in memory** (not committed as JSON — reproducible, not
+padding) that exhaustively enumerates the actual decision-relevant state
+space `decide()` branches on, rather than sampling it:
+
+- all **32 combinations** (2⁵) of the five boolean verification-call
+  signals, crossed with both outcomes where a real conversation
+  occurred (`answered_success`, `answered_declined`) — 64 cases,
+- one case per documented ambiguity marker in `resolve.py`'s policy-refusal
+  and malformed-destination marker lists — 20 cases, so every individual
+  marker string is proven to resolve correctly, not just the few a
+  hand-picked fixture happened to use,
+- 9 no-conversation variants (no-answer, rejected-before-ring, and three
+  distinct raw-`status` shapes of `unresolved_ambiguous`),
+- 2 **naive-trap** cases where the call-level `status`/`task_completed`
+  fields claim success while the attempt trail disagrees (the exact
+  ambiguity CALL-E's own `errors.mdx` warns integrations not to trust) —
+  with explicitly *clean* signals, so a naive implementation would
+  recommend `ADVISE_ALLOW`,
+- 3 **connection-failed-during-attempt** cases (zero ring time and/or an
+  attempt-level `failure_code`) — the outcome category added after
+  validation against the live API exposed that this was previously
+  conflated with a confirmed no-answer; see the fixture note above.
+
+Each case's expected recommendation is computed by an **independent
+re-implementation** of the decision table (`oracle_disposition()`), written
+separately from `decide.py`, not by calling `decide()` itself — so agreement
+between the two is a real second opinion, not the module grading its own
+homework.
+
+Reproduce the full report (curated + synthetic + naive-vs-resolve
+comparison), nothing below is hand-typed:
+
+```bash
+python -m ringfence.evaluation
+python -m pytest tests/test_synthetic_corpus.py -v
+```
+
+**As of this corpus**: `decide()` agrees with the independent oracle on
+**98/98 (100%)** synthetic cases. Comparing CALL-E's raw
+`status`/`failure_code` (`naive_classify()` — what most integrations do
+today, per CALL-E's own documented warning) against `resolve.classify()`'s
+cross-referenced outcome across the same 98 cases: **28/98** outcome labels
+disagree, and **2 of those** are *unsafe* disagreements — cases where
+trusting the raw call-level flags directly would recommend `ADVISE_ALLOW`
+for a transaction that never actually completed a real conversation, while
+`resolve.classify()` correctly forces `ESCALATE_TO_HUMAN`. Combined with
+the 15 scored curated fixtures, **113 cases** are evaluated in total.
+
+---
+
+## Validation against the live API
+
+RingFence was not built against fixtures alone: before submission its live
+path was exercised end to end against the real CALL-E API, on numbers the
+author controls and with the recipient's consent. Those runs are not
+included in this repository — no call outputs, transcripts, identifiers, or
+timings are committed here, because a verification call's contents are
+exactly the kind of material that should not live in a public repo. What
+they produced, and what remains here, is the code:
+
+**Four real bugs came out of exercising the live API, not out of code
+review**, each fixed with a regression test:
+
+1. **A connection failure read as a confirmed no-answer.**
+   `resolve.classify()` labeled an attempt `no_answer_confirmed` purely
+   because it had both `started_at` and `completed_at` set, never checking
+   whether they were *identical* (zero ring time) or whether the attempt
+   carried its own `failure_code`. A provider that never connected the call
+   and a recipient who chose not to pick up are different events, and an
+   institution should retry them differently. Fixed with a distinct
+   `connection_failed_during_attempt` outcome
+   (`tests/test_resolve.py`, `fixtures/21_connection_failed_during_attempt.json`).
+2. **`region`/`locale` were never sent at all.** Calls to an
+   international number CALL-E's own Supported Regions table documents
+   failed at the provider layer with zero ring time. Every other app in
+   this repo that places international calls sets these per recipient;
+   `ringfence` did not. Fixed on `Case`, with defaults in `verify_call.py`
+   (`tests/test_invariant_never_calls_request_supplied_number.py`).
+3. **The audit trail's speaker labels were a guess.** `audit.py`'s Q&A
+   extraction keyed off `speaker == "agent"` / `speaker == "recipient"` —
+   labels that do not appear in a CALL-E transcript, where the agent side
+   is `"bot"`. Every fixture and the synthetic corpus had the same
+   unverified guess baked in. The bug was silent and total: it would have
+   produced an *empty* Q&A trail for any real call, including a fully
+   successful one — the exact opposite of the audit feature's purpose.
+   Fixed to key off the real label, with anything else treated as the
+   recipient side rather than a second hardcoded string
+   (`tests/test_audit.py`).
+4. **A vague caller identity was refused outright.** CALL-E's own
+   content-policy layer rejected a task that described the caller only as
+   "their financial institution," asking which institution the call should
+   identify as the requester so the recipient is not misled by a vague or
+   hidden identity — which is itself one of the red-flag patterns this
+   project screens callers for. Fixed with an optional
+   `Case.institution_name` (default `"Fictional National Bank"`, per this
+   repo's fictional-demo-data convention), named explicitly in the rendered
+   task.
+
+Bugs 1 and 3 are the substantive ones: both were invisible to fixtures,
+because the fixtures encoded the same wrong assumptions the code did.
+
+## Demo: two-sided simulation
+
+The real system above (`case submit`, the webhook, MCP) is the actual
+integration surface an institution would use — but it's not a visual demo.
+[`ringfence/demo_server.py`](ringfence/demo_server.py) adds a small,
+dependency-light, two-sided *simulation* on top of it, purely for showing
+the mechanism end to end in a demo video.
+
+**This server has no live-call path at all.** It never imports a CALL-E
+client, never reads `CALLE_API_KEY`, and contains no code that could place
+an outbound call — asserted structurally, not just behaviourally, by
+`tests/test_demo_server.py`'s `test_this_server_has_no_live_call_path_at_all`.
+It also collects **no phone number**: there is no field for one and nothing
+stores one. This is the surface that gets deployed to a public URL, and a
+publicly reachable page that can dial a number an anonymous visitor typed
+is not a defensible thing to operate. Real calls live only behind the
+operator-run surfaces that require doubled confirmation per call (see
+"Side effects" below).
+
+What is real in the demo is the decision: a recorded scenario from
+[`fixtures/`](fixtures/) is run through the actual `resolve.classify()` and
+`decide()` modules, and the resulting recommendation — including its
+`requires_human_review` flag — is what both pages display.
+
+The customer page (`demo/customer.html`) uses
+[Alpine.js](https://alpinejs.dev/) (one CDN `<script>` tag, ~15KB, no build
+step) for its state — declarative `form`/`pending`/`resolved` views instead
+of hand-rolled `getElementById`/`innerHTML`, and the in-flight case id is
+persisted to `localStorage` so a page refresh while a verification is still
+resolving picks the right view back up instead of dropping to a blank form.
+The bank dashboard (`demo/bank.html`) stays plain JS deliberately — it has
+no per-viewer state to lose on a refresh, it just re-renders from a fresh
+`GET /api/demo/cases` every poll.
+
+- **Customer side** (`/`) — a "send money" form: name, recipient, amount,
+  payment method. **The customer never decides whether a verification call
+  happens** — there is no scenario picker, no call button, no checkbox.
+  That decision belongs entirely to the bank, exactly like the real product
+  (`webhook.py`: an institution's own fraud system decides what's flagged,
+  RingFence never does).
+- **Bank side** (`/bank`) — a fraud-ops dashboard listing every submitted
+  case, updating live, with a click-through to the full audit trail (what
+  was asked, what was answered, which signals fired, why). Every row is
+  labelled as a recommendation awaiting an analyst; the dashboard never
+  presents a transaction as approved, held, or released.
+
+```bash
+python -m ringfence.demo_server --port 8090
+# customer: http://127.0.0.1:8090/
+# bank:     http://127.0.0.1:8090/bank
+```
+
+**The bank's decision is automatic and has exactly one policy**: any
+transaction at or above `AUTO_APPROVE_BELOW_AMOUNT` ($1,000) requires
+verification; anything below needs no call at all and is recorded as
+`NO_VERIFICATION_REQUIRED` — deliberately *not* one of `decide.py`'s
+recommendations, since no call happened and there is nothing for a human to
+review. When verification is required, it runs immediately and
+automatically, with no button on either side, against a randomly-picked
+recorded scenario (there is no live-call sandbox to demo against safely —
+CALL-E has no test/dummy-number mode). The audit trail shown reflects
+whatever was actually typed into the customer form, not the scenario's own
+placeholder case details.
+
+### Deploying the demo publicly
+
+Simulation mode has no external dependencies (pure stdlib + static
+HTML/JS) — it runs anywhere Python 3.11+ runs, no database, no build step:
+
+```bash
+export RINGFENCE_DEMO_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+python -m ringfence.demo_server --host 0.0.0.0 --port "$PORT"
+# then open:  https://<your-host>/?token=<that value>
+```
+
+- **Any bind reachable from outside the machine requires a token.** With
+  `--host` set to anything but loopback and `RINGFENCE_DEMO_TOKEN` unset,
+  `main()` **refuses to start** and says why — an unauthenticated public URL
+  cannot happen by forgetting an environment variable
+  (`tests/test_demo_server.py`). When the token is set, every page and
+  every API route requires it: `Authorization: Bearer <token>`, a `?token=`
+  query parameter once per browser, or the `HttpOnly` cookie the pages set
+  from that parameter. Anything else gets `401`. The one exception is
+  `GET /healthz`, which returns `{"status": "ok"}` and nothing else, so a
+  platform health check can run without credentials.
+- **Run from a checked-out copy of this repo, not a `pip install`ed
+  package elsewhere.** `fixtures/` and `demo/` are sibling directories
+  looked up by relative path (`Path(__file__).resolve().parent.parent`),
+  and `pyproject.toml`'s `packages.find` only includes `ringfence*` — they
+  are **not** bundled into a built wheel. Deploy by cloning the repo onto
+  the host and running from `apps/python/ringfence/`.
+- `--port` falls back to the `$PORT` environment variable most PaaS
+  platforms inject, if `--port` isn't passed explicitly.
+- There is nothing sensitive behind the token by design — every case is
+  either fixture-derived fictional data or whatever cosmetic fields a
+  visitor typed in themselves — but the deployment is gated anyway, because
+  "there's nothing sensitive in it *today*" is not a property that survives
+  someone pointing different data at the same code.
+- `DemoStore` is in-memory per process: fine for a single instance, but a
+  restart clears the case list and it won't share state across multiple
+  autoscaled replicas.
+
+---
+
+## Safety
+
+- **The invariant above** — tested explicitly, not just documented.
+- **Consent**: the institution's own account-holder agreement already
+  covers being called by the institution — `ringfence` calls on the
+  institution's behalf using their on-file number, which is the same
+  consent basis their existing "we noticed unusual activity" calls already
+  rely on.
+- **No harassment**: one verification attempt per case by default, no
+  automatic re-dial loop; resubmitting the same `case_id` returns the
+  existing record rather than placing a second call — a blocked/declined
+  case requires the institution to submit a **new** case deliberately.
+- **Redaction**: account numbers, transaction amounts, and phone numbers are
+  masked/redacted in all logs, stored records, and API responses
+  (`ringfence/safety.py`) — this data is more sensitive than a generic
+  contact list, treated accordingly.
+- **Fictional-only demo data**: fictional account numbers, fictional
+  institutions, fictional transaction amounts throughout — this is not, and
+  does not imply itself to be, a real bank's real product.
+- **No real live calls unsupervised**: every test, fixture, and example in
+  this repo runs against dry-run/fixtures/mocked clients. A real call
+  requires explicit, doubled confirmation on every surface (see below), and
+  the one deployable surface (the demo server) has no live-call path at all.
+- **Advisory, never automatic**: no output of this project is an action on
+  money. Every recommendation carries `requires_human_review` and the
+  institution's own reviewer decides — see "Advisory only — a human
+  decides" above.
+
+---
+
+## Side effects
+
+| Surface | Default behaviour | To place a real call |
+|---|---|---|
+| `ringfence case submit --file case.json` | Dry run. Renders the disclosure-first call script, resolves the dial target, validates the case. **No call placed, no credits spent.** | `--live --confirm-live` together — **both required, no override.** `CALLE_API_KEY` must also be set. |
+| `ringfence case resolve --from-fixtures DIR` | Reads local JSON only. No network call, no API key needed. | N/A — read-only. |
+| `POST /cases` (webhook) | Dry run, unless the server itself was started with `--live --confirm-live`. | Start `ringfence.webhook` with `--live --confirm-live`. |
+| `ringfence_submit_case` (MCP) | Dry run. | Pass `live=True` **and** `confirm_live=True` together in the same tool call — omitting either keeps it a preview. |
+| `GET /cases/{id}` / `ringfence_get_case` | Read-only lookup of a stored recommendation. | N/A. |
+| `ringfence case audit` / `case report-index` | Reads local JSON only, writes a report file. No network call. | N/A — read-only. |
+| `ringfence.demo_server` | Simulation only, always. Replays a recorded scenario through the real decision modules. | **Not possible** — this server has no live-call path, by construction. |
+
+No recurring schedules and no background jobs are created by any surface.
+Only call numbers the submitting institution has independent, documented
+authorization to call.
+
+**No surface acts on the money.** Every one of them returns an advisory
+recommendation for a human at the institution to act on, never an approve
+or hold instruction — see "Advisory only — a human decides" above.
+
+**Durability**: the webhook's `CaseStore` is backed by a durable, append-only
+`CaseLedger` (`ringfence/ledger.py`) by default — every case survives a
+process restart, and a case already dialed before a crash is never re-dialed
+after one (`tests/test_crash_safety.py`). Pass `--no-persist` to
+`ringfence.webhook` to keep the store in-memory only.
+
+---
+
+## Setup
+
+```bash
+cd apps/python/ringfence
+python3 -m venv .venv && .venv/bin/pip install -e '.[dev]'
+# for the webhook/MCP surfaces:
+.venv/bin/pip install -e '.[webhook,mcp]'
+export CALLE_API_KEY="your-key"   # only needed for --live
+# only needed to expose the demo server beyond loopback:
+export RINGFENCE_DEMO_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+```
+
+Get a key at [dashboard.heycall-e.com](https://dashboard.heycall-e.com). The
+key is read from the environment only.
+
+---
+
+## Usage
+
+**Dry run** — the default, and the recommended first step:
+
+```bash
+python -m ringfence.cli case submit --file example_case.json
+```
+
+```
+ringfence case submit · case=case_example_001 · DRY RUN — nothing is dialed
+
+  dial target : +*********01
+  status      : previewed
+  detail      : goal rendered (949 chars); DRY RUN, no call placed
+```
+
+**Live run** — requires both flags together:
+
+```bash
+python -m ringfence.cli case submit --file example_case.json \
+  --live --confirm-live
+```
+
+**Resolve** a batch of fixture-shaped case records (call + attempts + events
++ structured signals) into recommendations, with a redacted audit report:
+
+```bash
+python -m ringfence.cli case resolve --from-fixtures fixtures/
+```
+
+```
+ringfence resolve · 21 case(s)
+
+  01_clean_legitimate_contractor_payment   outcome=answered_success                 -> ADVISE_ALLOW
+      - clean_conversation_no_red_flags_explicit_confirmation
+  03_scam_secrecy_demand                   outcome=answered_success                 -> ADVISE_BLOCK
+      - secrecy_demand_present
+      - urgency_pressure_present
+      - relationship_not_explained
+      - irreversible_payment_demanded
+  ...
+
+audit report -> results/case_dispositions.jsonl
+```
+
+**Audit** the full evidence trail for one case — what was asked, what was
+answered, which red flags fired, and why:
+
+```bash
+python -m ringfence.cli case audit \
+  --file fixtures/13_scam_ceo_fraud_secrecy_and_urgency.json \
+  --out results/audit/case_f13.json --html results/audit_html/case_f13.html
+```
+
+```
+RingFence case audit -- case_f13
+========================================
+...
+Verification Q&A:
+  1. Q: ...Did anyone ask you to keep this transaction private...?
+     A: Yes, the message said to keep it confidential...
+...
+RECOMMENDATION: ADVISE_BLOCK
+  reason: secrecy_demand_present
+  reason: urgency_pressure_present
+  reason: relationship_not_explained
+  ADVISORY ONLY -- requires human review before any action is taken on this transaction.
+```
+
+Build a static, dependency-free HTML case index (no server, no auth) from a
+directory of exported audit reports:
+
+```bash
+python -m ringfence.cli case report-index \
+  --from-reports results/audit --out-dir results/audit_html
+```
+
+**Webhook** — an institution's fraud system integrates here. Durable by
+default (`--no-persist` for in-memory only):
+
+```bash
+python -m ringfence.webhook --port 8080
+curl -X POST http://127.0.0.1:8080/cases -d @example_case.json \
+  -H 'Content-Type: application/json'
+curl http://127.0.0.1:8080/cases/case_example_001
+```
+
+**MCP** — for an agent host or orchestrator:
+
+```bash
+python -m ringfence.mcp_server
+```
+
+---
+
+## Options
+
+### `case submit`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--file` | *required* | Path to a case JSON file (see `example_case.json`) |
+| `--live` | off | Place a real call |
+| `--confirm-live` | off | Required alongside `--live` — explicit, separate confirmation |
+| `--security-log` | `results/security_events.jsonl` | Where a smuggled-callback-number event is recorded |
+
+### `case resolve`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--from-fixtures` | *required* | Directory of `{case,call,attempts,events,signals}` JSON files |
+| `--out` | `results/case_dispositions.jsonl` | Redacted audit report path |
+
+### `case audit`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--file` | *required* | A `{case,call,attempts,events,signals}` JSON record (fixture format) |
+| `--out` | none | Write the JSON audit report here |
+| `--html` | none | Also write a static HTML case-report page here |
+
+### `case report-index`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--from-reports` | *required* | Directory of JSON audit reports (from `case audit --out`) |
+| `--out-dir` | `results/audit_html` | Where the per-case HTML pages + `index.html` are written |
+
+### `ringfence.webhook`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--ledger-path` | `results/case_ledger.jsonl` | Durable, append-only case ledger — survives a restart |
+| `--no-persist` | off | Keep the case store in-memory only (state lost on restart) |
+
+---
+
+## Self-review
+
+A full adversarial review pass was run against this branch's diff before
+calling it done. It found, and this codebase now fixes:
+
+- `decide()`'s clean branch checked only 2 of the 5 signals
+  (`relationship_explained`, `explicit_hold_requested`) — a
+  partially-populated verification-call result (the other three fields
+  simply absent) could reach `ADVISE_ALLOW` despite the module's own "fails
+  closed at every branch" claim. Now every signal that branch depends on
+  must be explicitly present and clean (`tests/test_decide.py`).
+- `Case.from_dict` never validated its phone fields, so a malformed number
+  crashed uncaught deep inside `resolve_dial_target` instead of surfacing as
+  a clean error at every entry point.
+- The webhook's case-creation and dial-placement were non-atomic under
+  `ThreadingHTTPServer` — a concurrent retry of the same `case_id` could
+  place two real dials for one case. The record is now reserved atomically
+  before any call is placed (`tests/test_webhook.py`'s concurrency test).
+- A live call ending in `ERROR`, or completing with no `call_id` in CALL-E's
+  response, left the recommendation null forever with no signal to the
+  institution (this `case_id` can never be re-dialed by design) — both now
+  escalate explicitly instead.
+- A malformed `Content-Length` header crashed the webhook handler; one
+  malformed fixture record killed `case resolve`'s entire batch instead of
+  just that record.
+- The four bugs that came out of exercising the live API rather than
+  reviewing the code are described in "Validation against the live API"
+  above: the connection-failure/no-answer conflation, the never-sent
+  `region`/`locale`, `audit.py`'s guessed speaker labels, and the
+  unnamed-institution content-policy refusal. Two of them (the first and
+  third) were invisible to the fixture corpus, because the fixtures
+  encoded the same wrong assumption the code did.
+
+**Not fixed, left as a known limitation**: `webhook.py`'s live path makes
+two extra CALL-E API round-trips (`client.calls.get` + `list_events`) to
+re-fetch data `create_and_wait` already had, using a client-holder closure
+to smuggle the constructed client out of `place_verification_call` rather
+than threading the completed call through directly. Real inefficiency, not
+fixed here — noted rather than silently left out of this section.
+
+## Known limitations
+
+- `resolve.classify()` reads the first recipient's first attempt only, same
+  documented limitation as `calltruth` — a natural next step for a
+  multi-recipient case.
+- This is a fixed, illustrative fixture corpus (see "Measured evaluation"
+  above) — not a statistically representative sample of real fraud calls.
+- See "Self-review" above for the one known-but-unfixed inefficiency.
+- Sending `region`/`locale` (see "Validation against the live API" above)
+  was a real, necessary fix, but it did not by itself guarantee a connected
+  call: attempts to the same supported international route continued to
+  fail intermittently afterwards, with differing provider error codes and
+  zero ring time, including one code seen before the fix existed. Stated
+  plainly rather than overclaiming that a one-line fix solved what looks
+  like carrier-level flakiness neither this app nor CALL-E's own docs
+  explain.
+- `audit.py`'s Q&A pairing is 1:1 on individual transcript lines, not on
+  semantic turns, which makes for a noisy report: short backchannel agent
+  lines ("Thanks.", "Okay.") each generate their own spurious "(no answer
+  recorded)" entry, so the four real questions sit among many more
+  entries. The recommendation and signal extraction are unaffected and
+  correct; this is a report-clarity issue, not fixed here. A real fix would
+  group consecutive agent lines into one question before pairing with the
+  next recipient reply.
+- The demo server is simulation-only by design (see "Demo" above), so the
+  deployable surface does not exercise the live call path. That path is
+  covered by the operator-run CLI/webhook/MCP surfaces and their tests.

--- a/apps/python/ringfence/conftest.py
+++ b/apps/python/ringfence/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Lets `pytest` run here without an editable install first.
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/apps/python/ringfence/demo/bank.html
+++ b/apps/python/ringfence/demo/bank.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>RingFence -- Fraud Ops Dashboard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, system-ui, "Segoe UI", sans-serif;
+    max-width: 900px; margin: 2rem auto; padding: 0 1rem;
+    background: #f6f8fa; color: #1f2328;
+  }
+  .banner {
+    background: #1a3a5c; color: #fff; padding: 1rem 1.25rem; border-radius: 10px;
+    margin-bottom: 1rem; display: flex; align-items: center; justify-content: space-between;
+  }
+  .banner h1 { font-size: 1.1rem; margin: 0; display: flex; align-items: center; gap: 0.5rem; }
+  .icon { width: 1.1em; height: 1.1em; vertical-align: -0.2em; flex-shrink: 0; }
+  .sim-tag {
+    background: #ffd54a; color: #1f2328; font-weight: 700; font-size: 0.7rem;
+    padding: 0.2rem 0.6rem; border-radius: 999px; letter-spacing: 0.05em;
+  }
+  .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; border-radius: 10px; }
+  table { width: 100%; min-width: 640px; border-collapse: collapse; background: #fff; }
+  @media (max-width: 480px) {
+    body { margin: 1rem auto; padding: 0 0.75rem; }
+  }
+  th, td { text-align: left; padding: 0.7rem 0.9rem; border-bottom: 1px solid #eaeef2; font-size: 0.9rem; }
+  th { background: #f0f3f6; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; color: #57606a; }
+  tr:last-child td { border-bottom: none; }
+  tr.clickable { cursor: pointer; }
+  tr.clickable:hover { background: #f6f8fa; }
+  .badge {
+    display: inline-block; padding: 0.2em 0.7em; border-radius: 999px; color: #fff;
+    font-weight: 700; font-size: 0.78rem;
+  }
+  .pending { color: #57606a; font-style: italic; }
+  .advisory { color: #9a6700; }
+  .empty { text-align: center; color: #57606a; padding: 2rem; }
+  #overlay {
+    display: none; position: fixed; inset: 0; background: rgba(31,35,40,0.35); z-index: 20;
+  }
+  #overlay.visible { display: block; }
+  #detail {
+    position: fixed; top: 0; right: 0; height: 100vh; width: min(560px, 100vw);
+    background: #fff; border-left: 1px solid #d0d7de; box-shadow: -8px 0 24px rgba(0,0,0,0.15);
+    padding: 1.5rem; overflow-y: auto; z-index: 21;
+    transform: translateX(100%); transition: transform 0.2s ease-out;
+  }
+  #detail.visible { transform: translateX(0); }
+  #detail h3 { margin-top: 0; padding-right: 2rem; }
+  #detail ul { padding-left: 1.2rem; }
+  .qa-item { margin-bottom: 0.6rem; }
+  .qa-q { font-weight: 600; }
+  .qa-a { color: #57606a; margin: 0.1rem 0 0; }
+  .close-btn {
+    position: absolute; top: 1.25rem; right: 1.25rem; cursor: pointer; color: #57606a;
+    background: #f0f3f6; border: none; border-radius: 50%; width: 2rem; height: 2rem;
+    font-size: 1rem; line-height: 1;
+  }
+  .copy-btn {
+    position: absolute; top: 1.25rem; right: 3.5rem; cursor: pointer; color: #57606a;
+    background: #f0f3f6; border: none; border-radius: 6px; padding: 0.35rem 0.7rem;
+    font-size: 0.78rem; font-weight: 600; display: flex; align-items: center; gap: 0.35em;
+  }
+  .copy-btn.copied { background: #d8f0dd; color: #1a7f37; }
+</style>
+</head>
+<body>
+
+<div class="banner">
+  <h1 id="banner-title"></h1>
+  <span class="sim-tag">SIMULATION</span>
+</div>
+
+<p class="advisory" style="margin:0.75rem 0 0;">
+  RingFence returns advisory recommendations from a verification call. Every
+  row below awaits an analyst; nothing here approves, holds, or releases a
+  transaction on its own.
+</p>
+
+<div class="table-wrap">
+  <table>
+    <thead>
+      <tr><th>Case</th><th>Account holder</th><th>Amount</th><th>Recipient</th><th>Recommendation</th></tr>
+    </thead>
+    <tbody id="rows"></tbody>
+  </table>
+</div>
+<div id="empty-state" class="empty" style="display:none;">No flagged transactions yet &mdash; submit one from the customer page.</div>
+
+<div id="overlay" onclick="hideDetail()"></div>
+<div id="detail"></div>
+
+<script>
+const DISPOSITION_COLORS = {
+  NO_VERIFICATION_REQUIRED: "#1a7f37",
+  ADVISE_ALLOW: "#1a7f37",
+  ESCALATE_TO_HUMAN: "#9a6700",
+  ADVISE_BLOCK: "#cf222e",
+};
+
+// Everything derived from a verification call is a recommendation for an
+// analyst, never a completed action on the transaction -- so the UI says
+// so on the row, in the drill-down, and in the copied transcript.
+const REVIEW_NOTICE =
+  "Advisory recommendation \u2014 requires analyst review before any action is taken on this transaction.";
+
+// Small, hand-built icon set (24x24 stroke icons, currentColor) -- no
+// icon-font or JS library dependency, no extra network request. Mirrors
+// demo/customer.html's set exactly.
+const ICONS = {
+  briefcase: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="18" height="13" rx="2"/><path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="3" y1="12" x2="21" y2="12"/></svg>`,
+  clock: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 16 14"/></svg>`,
+  check: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="8 12.5 11 15.5 16 9"/></svg>`,
+  alertTriangle: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 L22 20 L2 20 Z"/><line x1="12" y1="9" x2="12" y2="14"/><circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none"/></svg>`,
+  helpCircle: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.5 9.2a2.5 2.5 0 0 1 4.9.8c0 1.7-2.4 2-2.4 3.5"/><circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none"/></svg>`,
+  dot: `<svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7" fill="currentColor"/></svg>`,
+  list: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="3" width="14" height="18" rx="2"/><line x1="8" y1="8" x2="16" y2="8"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="13" y2="16"/></svg>`,
+  copy: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>`,
+};
+
+const CATEGORY_ICONS = {
+  scam_pattern: ICONS.alertTriangle,
+  clean_legitimate: ICONS.check,
+  escalation_case: ICONS.helpCircle,
+  no_verification_required: ICONS.check,
+};
+
+document.getElementById("banner-title").innerHTML = `${ICONS.briefcase} Fraud Operations Dashboard`;
+
+function categoryIcon(category) {
+  return CATEGORY_ICONS[category] || ICONS.list;
+}
+
+function statusCell(record) {
+  if (record.status !== "resolved") {
+    return `<span class="pending">${ICONS.clock} Verification call in progress&hellip;</span>`;
+  }
+  const color = DISPOSITION_COLORS[record.disposition] || "#57606a";
+  const badge = `<span class="badge" style="background:${color}">${record.disposition}</span>`;
+  return record.requires_human_review ? `${badge} <span class="pending">awaiting review</span>` : badge;
+}
+
+function renderQA(qa) {
+  if (!qa.length) return "<p><em>(no conversation occurred)</em></p>";
+  return "<ul>" + qa.map(item => `
+    <li class="qa-item">
+      <p class="qa-q">Q: ${item.question}</p>
+      <p class="qa-a">A: ${item.answer !== null ? item.answer : "<em>(no answer recorded)</em>"}</p>
+    </li>`).join("") + "</ul>";
+}
+
+const CLOSE_BTN = `<button class="close-btn" onclick="hideDetail()" aria-label="Close">&times;</button>`;
+const COPY_BTN = `<button id="copy-btn" class="copy-btn" onclick="copyCurrentTranscript()">${ICONS.copy} Copy</button>`;
+
+let selectedId = null;
+let currentDetailRecord = null;
+
+function showDetail(record) {
+  currentDetailRecord = record;
+  const detail = document.getElementById("detail");
+  if (record.status !== "resolved") {
+    detail.innerHTML = `${CLOSE_BTN}
+      <h3>${record.id}</h3><p class="pending">Verification call still in progress&hellip;</p>`;
+  } else if (!record.audit) {
+    const color = DISPOSITION_COLORS[record.disposition] || "#57606a";
+    detail.innerHTML = `${CLOSE_BTN}
+      <h3>${record.id} &mdash; <span class="badge" style="background:${color}">${record.disposition}</span></h3>
+      <p>No verification call was needed &mdash; ${(record.disposition_reasons || []).join(", ") || "below the bank's verification threshold"}.</p>`;
+  } else {
+    const a = record.audit;
+    const color = DISPOSITION_COLORS[a.disposition.disposition] || "#57606a";
+    detail.innerHTML = `
+      ${CLOSE_BTN}
+      ${COPY_BTN}
+      <h3>${record.id} &mdash; <span class="badge" style="background:${color}">${a.disposition.disposition}</span></h3>
+      <p><strong>Call outcome:</strong> ${a.call_outcome.outcome} (confidence: ${a.call_outcome.confidence})</p>
+      <p><strong>Verification Q&amp;A:</strong></p>
+      ${renderQA(a.verification_qa)}
+      <p><strong>Extracted signals:</strong></p>
+      <ul>${Object.entries(a.signals).map(([k, v]) => `<li>${k}: ${v}</li>`).join("") || "<li><em>none</em></li>"}</ul>
+      <p><strong>Reasons:</strong> ${a.disposition.reasons.join(", ") || "none"}</p>
+      <p class="advisory"><strong>${REVIEW_NOTICE}</strong></p>
+    `;
+  }
+  detail.classList.add("visible");
+  document.getElementById("overlay").classList.add("visible");
+}
+function hideDetail() {
+  document.getElementById("detail").classList.remove("visible");
+  document.getElementById("overlay").classList.remove("visible");
+  selectedId = null;
+  currentDetailRecord = null;
+}
+
+function transcriptText(record) {
+  const a = record.audit;
+  const lines = [
+    `Case: ${record.id}`,
+    `Recommendation: ${a.disposition.disposition} (${REVIEW_NOTICE})`,
+    `Call outcome: ${a.call_outcome.outcome} (confidence: ${a.call_outcome.confidence})`,
+    "",
+    "Verification Q&A:",
+  ];
+  if (!a.verification_qa.length) {
+    lines.push("(no conversation occurred)");
+  } else {
+    a.verification_qa.forEach(item => {
+      lines.push(`Q: ${item.question}`);
+      lines.push(`A: ${item.answer !== null ? item.answer : "(no answer recorded)"}`);
+    });
+  }
+  lines.push("", "Extracted signals:");
+  const signalEntries = Object.entries(a.signals);
+  if (!signalEntries.length) lines.push("(none)");
+  else signalEntries.forEach(([k, v]) => lines.push(`${k}: ${v}`));
+  lines.push("", `Reasons: ${a.disposition.reasons.join(", ") || "none"}`);
+  return lines.join("\n");
+}
+
+async function copyCurrentTranscript() {
+  if (!currentDetailRecord || !currentDetailRecord.audit) return;
+  const text = transcriptText(currentDetailRecord);
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (e) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+  }
+  const btn = document.getElementById("copy-btn");
+  if (!btn) return;
+  btn.classList.add("copied");
+  btn.innerHTML = `${ICONS.check} Copied`;
+  setTimeout(() => {
+    btn.classList.remove("copied");
+    btn.innerHTML = `${ICONS.copy} Copy`;
+  }, 1500);
+}
+
+async function refresh() {
+  const res = await fetch("/api/demo/cases");
+  const data = await res.json();
+  const rows = document.getElementById("rows");
+  const emptyState = document.getElementById("empty-state");
+  if (!data.cases.length) {
+    rows.innerHTML = "";
+    emptyState.style.display = "block";
+  } else {
+    emptyState.style.display = "none";
+    rows.innerHTML = data.cases.map(r => `
+      <tr class="clickable" onclick='selectCase(${JSON.stringify(r.id)})'>
+        <td>${r.id}<br><small style="color:#57606a">${categoryIcon(r.category)} ${r.scenario_label || ""}</small></td>
+        <td>${r.account_holder_name}</td>
+        <td>$${r.claimed_transaction_amount}</td>
+        <td>${r.claimed_recipient}</td>
+        <td>${statusCell(r)}</td>
+      </tr>`).join("");
+  }
+  if (selectedId) {
+    const record = data.cases.find(r => r.id === selectedId);
+    if (record) showDetail(record);
+  }
+  setTimeout(refresh, 1000);
+}
+
+function selectCase(id) {
+  selectedId = id;
+  fetch(`/api/demo/cases/${id}`).then(r => r.json()).then(showDetail);
+}
+
+refresh();
+</script>
+
+</body>
+</html>

--- a/apps/python/ringfence/demo/customer.html
+++ b/apps/python/ringfence/demo/customer.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en" x-data="app()" x-init="init()">
+<head>
+<meta charset="utf-8">
+<title>Fictional National Bank -- Send Money</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  [x-cloak] { display: none !important; }
+  body {
+    font-family: -apple-system, system-ui, "Segoe UI", sans-serif;
+    max-width: 560px; margin: 2rem auto; padding: 0 1rem;
+    background: #f6f8fa; color: #1f2328;
+  }
+  .icon { width: 1.1em; height: 1.1em; vertical-align: -0.2em; flex-shrink: 0; }
+  .banner {
+    background: #1a3a5c; color: #fff; padding: 1rem 1.25rem; border-radius: 10px;
+    margin-bottom: 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  }
+  .banner h1 { font-size: 1.1rem; margin: 0; display: flex; align-items: center; gap: 0.5rem; }
+  .sim-tag {
+    background: #ffd54a; color: #1f2328; font-weight: 700; font-size: 0.7rem;
+    padding: 0.2rem 0.6rem; border-radius: 999px; letter-spacing: 0.05em;
+  }
+  .card {
+    background: #fff; border: 1px solid #d0d7de; border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1rem; position: relative;
+  }
+  .card-header { display: flex; align-items: center; justify-content: space-between; }
+  .card-header h2 { margin: 0; }
+  .info-btn {
+    width: 1.8rem; height: 1.8rem; border-radius: 50%; border: 1px solid #d0d7de;
+    background: #f6f8fa; color: #57606a; cursor: pointer; display: flex;
+    align-items: center; justify-content: center; padding: 0; margin: 0; flex: none;
+  }
+  .info-popover {
+    position: absolute; top: 3.2rem; right: 1.25rem; z-index: 10;
+    width: 280px; max-width: calc(100vw - 2.5rem);
+    background: #1f2328; color: #fff; padding: 0.9rem 1rem; border-radius: 8px;
+    font-size: 0.8rem; line-height: 1.45; box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  }
+  @media (max-width: 480px) {
+    body { margin: 1rem auto; padding: 0 0.75rem; }
+    .card { padding: 1rem; }
+  }
+  label { display: block; font-size: 0.85rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
+  input, select {
+    width: 100%; padding: 0.55rem 0.7rem; border: 1px solid #d0d7de; border-radius: 6px;
+    font-size: 0.95rem; font-family: inherit;
+  }
+  button {
+    margin-top: 1.25rem; width: 100%; padding: 0.75rem; font-size: 1rem; font-weight: 600;
+    background: #1a3a5c; color: #fff; border: none; border-radius: 8px; cursor: pointer;
+  }
+  button:disabled { background: #9aa5b1; cursor: not-allowed; }
+  button.secondary { background: #eaeef2; color: #1f2328; }
+  .spinner {
+    width: 1.1em; height: 1.1em; border: 2px solid #d0d7de; border-top-color: #1a3a5c;
+    border-radius: 50%; display: inline-block; animation: spin 0.8s linear infinite;
+    vertical-align: -0.2em; margin-right: 0.5em;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .badge {
+    display: inline-flex; align-items: center; gap: 0.3em; padding: 0.25em 0.75em; border-radius: 999px;
+    color: #fff; font-weight: 700; font-size: 0.85rem;
+  }
+  .step { color: #57606a; font-size: 0.9rem; margin: 0.4rem 0; display: flex; align-items: center; gap: 0.4em; }
+  .step.done { color: #1a7f37; }
+  .bank-link-row { text-align: center; margin-top: 1rem; }
+  a.bank-link { font-size: 0.85rem; color: #1a3a5c; }
+  .hist-row { display: flex; align-items: center; gap: 0.6rem; padding: 0.6rem 0; border-bottom: 1px solid #eaeef2; font-size: 0.85rem; }
+  .hist-row:last-child { border-bottom: none; }
+  .hist-main { flex: 1; min-width: 0; }
+  .hist-title { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .hist-meta { color: #57606a; font-size: 0.78rem; }
+  .empty { color: #57606a; font-size: 0.85rem; text-align: center; padding: 1rem 0; }
+  .tabs { display: flex; gap: 0.25rem; margin-bottom: 1rem; background: #eaeef2; border-radius: 8px; padding: 0.25rem; }
+  .tab {
+    flex: 1; width: auto; margin: 0; text-align: center; padding: 0.5rem 0.75rem; border-radius: 6px;
+    font-size: 0.85rem; font-weight: 600; color: #57606a; cursor: pointer; display: flex;
+    align-items: center; justify-content: center; gap: 0.4em; border: none; background: transparent;
+  }
+  .tab.active { background: #fff; color: #1a3a5c; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+</style>
+</head>
+<body>
+
+<div class="banner">
+  <h1 x-html="ICONS.landmark + ' Fictional National Bank'"></h1>
+  <span class="sim-tag">DEMO</span>
+</div>
+
+<div class="tabs">
+  <button class="tab" :class="{ active: activeTab === 'send' }" @click="activeTab = 'send'" x-html="ICONS.landmark + ' Send Money'"></button>
+  <button class="tab" :class="{ active: activeTab === 'history' }" @click="activeTab = 'history'" x-html="ICONS.history + ' History'"></button>
+</div>
+
+<div class="card" x-show="activeTab === 'send' && view === 'form'" x-cloak>
+  <div class="card-header">
+    <h2>Send Money</h2>
+    <button class="info-btn" @click="showInfo = !showInfo" aria-label="How this demo works" x-html="ICONS.info"></button>
+  </div>
+  <div class="info-popover" x-show="showInfo" x-cloak @click.outside="showInfo = false">
+    Whether this transaction needs an independent verification call is
+    decided automatically by the bank on submission &mdash; never by you.
+    Small transactions go straight through; larger ones run a verification
+    call before a recommendation comes back. This demo never places a real
+    call and never asks for a phone number: it replays a recorded call
+    through the real decision engine. Whatever comes back is a
+    recommendation for a fraud analyst, not a decision about your money.
+  </div>
+
+  <label for="account_holder_name">Your name</label>
+  <input id="account_holder_name" x-model="form.account_holder_name">
+
+  <label for="claimed_recipient">Sending to</label>
+  <input id="claimed_recipient" x-model="form.claimed_recipient">
+
+  <label for="claimed_transaction_amount">Amount (USD)</label>
+  <input id="claimed_transaction_amount" x-model="form.claimed_transaction_amount">
+
+  <label for="claimed_payment_method">Payment method</label>
+  <select id="claimed_payment_method" x-model="form.claimed_payment_method">
+    <option value="wire">Wire transfer</option>
+    <option value="ach_transfer">ACH transfer</option>
+    <option value="gift_card">Gift card</option>
+    <option value="cryptocurrency">Cryptocurrency</option>
+    <option value="check">Check</option>
+  </select>
+
+
+  <button @click="submit()" :disabled="submitting" x-text="submitting ? 'Submitting…' : 'Send Money'"></button>
+</div>
+
+<div class="card" x-show="activeTab === 'send' && view !== 'form'" x-cloak>
+  <h2 style="margin-top:0;">Transaction status</h2>
+  <div class="step done" x-html="ICONS.check + ' Transaction submitted'"></div>
+  <div class="step" :class="{ done: view === 'resolved' }" x-show="view === 'pending' || view === 'resolved'">
+    <span x-show="view === 'pending'"><span class="spinner"></span> Your bank is reviewing this transaction&hellip;</span>
+    <span x-show="view === 'resolved'" x-html="ICONS.check + ' Verification complete'"></span>
+  </div>
+
+  <template x-if="view === 'resolved' && record">
+    <div style="margin-top:1rem;">
+      <span class="badge" :style="`background:${dispositionColor()}`">
+        <span x-html="dispositionIcon()"></span>
+        <span x-text="record.disposition"></span>
+      </span>
+      <p style="margin-top:0.75rem;" x-text="dispositionText()"></p>
+      <p class="hist-meta">Reasons: <span x-text="(record.disposition_reasons || []).join(', ') || 'none'"></span></p>
+      <template x-if="record.requires_human_review">
+        <p class="hist-meta">Recommendation only &mdash; a person at your bank makes the final decision on this transaction.</p>
+      </template>
+      <button class="secondary" @click="reset()">Start a new transaction</button>
+    </div>
+  </template>
+</div>
+
+<div class="card" x-show="activeTab === 'history'" x-cloak>
+  <h2 style="margin-top:0; display:flex; align-items:center; gap:0.4em;" x-html="ICONS.history + ' Your transaction history'"></h2>
+  <template x-if="history.length === 0">
+    <p class="empty">No transactions yet.</p>
+  </template>
+  <template x-for="item in history" :key="item.id">
+    <div class="hist-row">
+      <span x-html="categoryIcon(item.category)"></span>
+      <div class="hist-main">
+        <div class="hist-title" x-text="`${item.claimed_recipient} — $${item.claimed_transaction_amount}`"></div>
+        <div class="hist-meta" x-text="formatWhen(item.submitted_at)"></div>
+      </div>
+      <template x-if="item.status === 'resolved'">
+        <span class="badge" :style="`background:${DISPOSITION_COLORS[item.disposition] || '#57606a'}`" x-text="item.disposition"></span>
+      </template>
+      <template x-if="item.status !== 'resolved'">
+        <span class="spinner"></span>
+      </template>
+    </div>
+  </template>
+</div>
+
+<div class="bank-link-row">
+  <a class="bank-link" href="/bank" target="_blank">Open the bank fraud-ops dashboard</a>
+</div>
+
+<script>
+const STORAGE_KEY = "ringfence_demo_case_id";
+const HISTORY_KEY = "ringfence_demo_history";
+const MAX_HISTORY = 25;
+
+const DISPOSITION_COLORS = {
+  NO_VERIFICATION_REQUIRED: "#1a7f37",
+  ADVISE_ALLOW: "#1a7f37",
+  ESCALATE_TO_HUMAN: "#9a6700",
+  ADVISE_BLOCK: "#cf222e",
+};
+// Every one of these is a recommendation awaiting a human at the bank --
+// the wording never claims the transfer has been released or stopped,
+// because this tool does not do either.
+const DISPOSITION_TEXT = {
+  NO_VERIFICATION_REQUIRED: "No verification call needed — below your bank's verification threshold.",
+  ADVISE_ALLOW: "No red flags found in the verification call. Recommended to proceed, pending your bank's review.",
+  ADVISE_BLOCK: "Red flags found in the verification call. Recommended to hold, pending your bank's review.",
+  ESCALATE_TO_HUMAN: "The verification call could not establish enough either way. Sent to your bank's fraud team to review.",
+};
+
+// Small, hand-built icon set (24x24 stroke icons, currentColor) -- no
+// icon-font or JS library dependency, no extra network request.
+const ICONS = {
+  landmark: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 10 12 4 21 10"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="5" y1="10" x2="5" y2="19"/><line x1="10" y1="10" x2="10" y2="19"/><line x1="14" y1="10" x2="14" y2="19"/><line x1="19" y1="10" x2="19" y2="19"/><line x1="3" y1="21" x2="21" y2="21"/></svg>`,
+  info: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="11" x2="12" y2="16"/><circle cx="12" cy="7.5" r="0.5" fill="currentColor" stroke="none"/></svg>`,
+  check: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="8 12.5 11 15.5 16 9"/></svg>`,
+  alertTriangle: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 L22 20 L2 20 Z"/><line x1="12" y1="9" x2="12" y2="14"/><circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none"/></svg>`,
+  helpCircle: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.5 9.2a2.5 2.5 0 0 1 4.9.8c0 1.7-2.4 2-2.4 3.5"/><circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none"/></svg>`,
+  dot: `<svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7" fill="currentColor"/></svg>`,
+  list: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="3" width="14" height="18" rx="2"/><line x1="8" y1="8" x2="16" y2="8"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="13" y2="16"/></svg>`,
+  history: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 16 14"/></svg>`,
+  arrowRight: `<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="13 6 19 12 13 18"/></svg>`,
+};
+
+const CATEGORY_ICONS = {
+  scam_pattern: ICONS.alertTriangle,
+  clean_legitimate: ICONS.check,
+  escalation_case: ICONS.helpCircle,
+  no_verification_required: ICONS.check,
+};
+
+function app() {
+  return {
+    ICONS,
+    DISPOSITION_COLORS,
+    activeTab: "send", // "send" | "history"
+    view: "form", // "form" | "pending" | "resolved"
+    submitting: false,
+    showInfo: false,
+    record: null,
+    history: [],
+    form: {
+      account_holder_name: "Jordan Rivera",
+      claimed_recipient: "Alex Chen",
+      claimed_transaction_amount: "4500.00",
+      claimed_payment_method: "wire",
+    },
+
+    async init() {
+      await this.refreshHistory();
+      const savedId = localStorage.getItem(STORAGE_KEY);
+      if (!savedId) return;
+      const res = await fetch(`/api/demo/cases/${savedId}`);
+      if (!res.ok) { localStorage.removeItem(STORAGE_KEY); return; }
+      const record = await res.json();
+      this.record = record;
+      if (record.status === "resolved") {
+        this.view = "resolved";
+      } else {
+        this.view = "pending";
+        this.poll(savedId);
+      }
+    },
+
+    async submit() {
+      this.submitting = true;
+      let res, record;
+      try {
+        res = await fetch("/api/demo/cases", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(this.form),
+        });
+        record = await res.json();
+      } finally {
+        this.submitting = false;
+      }
+      if (!res.ok) { alert("Error: " + JSON.stringify(record)); return; }
+
+      this.record = record;
+      localStorage.setItem(STORAGE_KEY, record.id);
+      this.addToHistory(record.id);
+      await this.refreshHistory();
+      if (record.status === "resolved") {
+        this.view = "resolved";
+      } else {
+        this.view = "pending";
+        this.poll(record.id);
+      }
+    },
+
+    poll(caseId) {
+      setTimeout(async () => {
+        const res = await fetch(`/api/demo/cases/${caseId}`);
+        const record = await res.json();
+        this.record = record;
+        if (record.status === "resolved") {
+          this.view = "resolved";
+          this.refreshHistory();
+        } else {
+          this.poll(caseId);
+        }
+      }, 700);
+    },
+
+    reset() {
+      localStorage.removeItem(STORAGE_KEY);
+      this.record = null;
+      this.view = "form";
+    },
+
+    addToHistory(caseId) {
+      let ids = [];
+      try { ids = JSON.parse(localStorage.getItem(HISTORY_KEY)) || []; } catch { ids = []; }
+      ids = [caseId, ...ids.filter(id => id !== caseId)].slice(0, MAX_HISTORY);
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(ids));
+    },
+
+    async refreshHistory() {
+      let ids = [];
+      try { ids = JSON.parse(localStorage.getItem(HISTORY_KEY)) || []; } catch { ids = []; }
+      if (!ids.length) { this.history = []; return; }
+      const res = await fetch("/api/demo/cases");
+      if (!res.ok) return;
+      const data = await res.json();
+      const byId = Object.fromEntries(data.cases.map(c => [c.id, c]));
+      this.history = ids.map(id => byId[id]).filter(Boolean);
+    },
+
+    categoryIcon(category) {
+      return CATEGORY_ICONS[category] || ICONS.list;
+    },
+    dispositionIcon() {
+      const map = {
+        NO_VERIFICATION_REQUIRED: ICONS.check,
+        ADVISE_ALLOW: ICONS.check,
+        ADVISE_BLOCK: ICONS.alertTriangle,
+        ESCALATE_TO_HUMAN: ICONS.helpCircle,
+      };
+      return map[this.record?.disposition] || "";
+    },
+    dispositionColor() {
+      return DISPOSITION_COLORS[this.record?.disposition] || "#57606a";
+    },
+    dispositionText() {
+      return DISPOSITION_TEXT[this.record?.disposition] || this.record?.disposition;
+    },
+    formatWhen(unixSeconds) {
+      if (!unixSeconds) return "";
+      return new Date(unixSeconds * 1000).toLocaleString();
+    },
+  };
+}
+</script>
+
+</body>
+</html>

--- a/apps/python/ringfence/example_case.json
+++ b/apps/python/ringfence/example_case.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "case_example_001",
+  "account_holder_name": "Pat Rivera",
+  "on_file_phone": "+14155550101",
+  "claimed_transaction_amount": "4500.00",
+  "claimed_recipient": "Jordan Rivera",
+  "claimed_payment_method": "wire",
+  "request_supplied_callback_number": null
+}

--- a/apps/python/ringfence/fixtures/01_clean_legitimate_contractor_payment.json
+++ b/apps/python/ringfence/fixtures/01_clean_legitimate_contractor_payment.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional contractor-payment scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f01",
+    "account_holder_name": "Pat Rivera",
+    "on_file_phone": "+14155550101",
+    "claimed_transaction_amount": "8200.00",
+    "claimed_recipient": "Rivera Home Renovations LLC",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f01",
+    "status": "completed",
+    "task": "Verify a flagged $8,200 ACH transaction to Rivera Home Renovations LLC.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.95, "label": "high"},
+    "summary": "Account holder confirmed the payment is for a kitchen renovation, no pressure or secrecy reported."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f01",
+      "phone": "+14155550101",
+      "status": "completed",
+      "started_at": "2026-09-10T09:00:00Z",
+      "completed_at": "2026-09-10T09:03:40Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, not at all."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "No, it's just my contractor's final invoice."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "They're the contractor who just finished renovating my kitchen."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "No, just a normal bank transfer, same as the deposit I paid earlier."}
+      ],
+      "provider_call_id": "prov_f01",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f01a", "type": "call.dialing", "call_id": "call_f01", "created_at": "2026-09-10T09:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f01b", "type": "call.completed", "call_id": "call_f01", "created_at": "2026-09-10T09:03:40Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/02_clean_legitimate_family_gift.json
+++ b/apps/python/ringfence/fixtures/02_clean_legitimate_family_gift.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional family-gift scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f02",
+    "account_holder_name": "Sam Okafor",
+    "on_file_phone": "+14155550102",
+    "claimed_transaction_amount": "3000.00",
+    "claimed_recipient": "Ada Okafor",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f02",
+    "status": "completed",
+    "task": "Verify a flagged $3,000 wire transaction to Ada Okafor.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.92, "label": "high"},
+    "summary": "Account holder confirmed this is a planned gift to his daughter for a car down payment."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f02",
+      "phone": "+14155550102",
+      "status": "completed",
+      "started_at": "2026-09-10T10:15:00Z",
+      "completed_at": "2026-09-10T10:18:05Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, my wife knows about it too."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "No, we've been planning this for a couple weeks."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "That's my daughter, Ada."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "It's a regular wire, that's just how we usually send larger amounts."}
+      ],
+      "provider_call_id": "prov_f02",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f02a", "type": "call.dialing", "call_id": "call_f02", "created_at": "2026-09-10T10:15:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f02b", "type": "call.completed", "call_id": "call_f02", "created_at": "2026-09-10T10:18:05Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/03_scam_secrecy_demand.json
+++ b/apps/python/ringfence/fixtures/03_scam_secrecy_demand.json
@@ -1,0 +1,54 @@
+{
+  "_evidence_source": "synthetic: modeled on the FBI/FTC-documented grandparent/imposter-scam secrecy-demand pattern (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f03",
+    "account_holder_name": "Lena Cho",
+    "on_file_phone": "+14155550103",
+    "claimed_transaction_amount": "6500.00",
+    "claimed_recipient": "Unknown bail bond office",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f03",
+    "status": "completed",
+    "task": "Verify a flagged $6,500 wire transaction to an unfamiliar bail bond office.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.9, "label": "high"},
+    "summary": "Account holder said she was told to keep the call about her grandson's arrest private from family."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f03",
+      "phone": "+14155550103",
+      "status": "completed",
+      "started_at": "2026-09-10T11:00:00Z",
+      "completed_at": "2026-09-10T11:04:12Z",
+      "summary": "Account holder reported a secrecy demand.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private, or not to tell your bank or family?"},
+        {"speaker": "user", "text": "Yes — the caller said not to tell anyone, especially not my daughter, or my grandson would stay in jail longer."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Yes, they said it had to happen within the hour."}
+      ],
+      "provider_call_id": "prov_f03",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f03a", "type": "call.dialing", "call_id": "call_f03", "created_at": "2026-09-10T11:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f03b", "type": "call.completed", "call_id": "call_f03", "created_at": "2026-09-10T11:04:12Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": true,
+    "urgency_pressure_present": true,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": true,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/04_scam_urgency_only.json
+++ b/apps/python/ringfence/fixtures/04_scam_urgency_only.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: modeled on FTC-documented manufactured-urgency imposter-scam pressure tactics (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f04",
+    "account_holder_name": "Marcus Webb",
+    "on_file_phone": "+14155550104",
+    "claimed_transaction_amount": "2200.00",
+    "claimed_recipient": "IRS Settlement Office",
+    "claimed_payment_method": "gift_card",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f04",
+    "status": "completed",
+    "task": "Verify a flagged $2,200 gift-card transaction to an 'IRS Settlement Office'.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.88, "label": "high"},
+    "summary": "Account holder reports being told the payment must happen immediately to avoid arrest."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f04",
+      "phone": "+14155550104",
+      "status": "completed",
+      "started_at": "2026-09-10T12:30:00Z",
+      "completed_at": "2026-09-10T12:33:50Z",
+      "summary": "Account holder described urgency and irreversible payment demand.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, they didn't say that part."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Yes, they said I'd be arrested today if I didn't pay right now."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "I don't really know them, they called saying they were from the IRS."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Yes, gift cards, specifically from a pharmacy."}
+      ],
+      "provider_call_id": "prov_f04",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f04a", "type": "call.dialing", "call_id": "call_f04", "created_at": "2026-09-10T12:30:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f04b", "type": "call.completed", "call_id": "call_f04", "created_at": "2026-09-10T12:33:50Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": true,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": true,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/05_scam_unexplained_relationship_only.json
+++ b/apps/python/ringfence/fixtures/05_scam_unexplained_relationship_only.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: modeled on the FBI-documented AI-voice-clone 'grandchild in distress' pattern where the caller cannot explain the claimed relationship (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f05",
+    "account_holder_name": "Dorothy Meyer",
+    "on_file_phone": "+14155550105",
+    "claimed_transaction_amount": "5000.00",
+    "claimed_recipient": "Court clerk's office",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f05",
+    "status": "completed",
+    "task": "Verify a flagged $5,000 wire transaction to a 'court clerk's office'.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.86, "label": "medium"},
+    "summary": "Account holder could not clearly describe her relationship to the claimed recipient."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f05",
+      "phone": "+14155550105",
+      "status": "completed",
+      "started_at": "2026-09-10T13:45:00Z",
+      "completed_at": "2026-09-10T13:48:30Z",
+      "summary": "Account holder gave a vague, non-committal answer about the recipient relationship.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Not really, no."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient, in your own words?"},
+        {"speaker": "user", "text": "I'm not sure, I just heard my grandson's voice on the phone and they said this office needed the money for his bail."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "No, just a wire transfer."}
+      ],
+      "provider_call_id": "prov_f05",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f05a", "type": "call.dialing", "call_id": "call_f05", "created_at": "2026-09-10T13:45:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f05b", "type": "call.completed", "call_id": "call_f05", "created_at": "2026-09-10T13:48:30Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/06_scam_irreversible_payment_only.json
+++ b/apps/python/ringfence/fixtures/06_scam_irreversible_payment_only.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: modeled on the FTC-documented preference scammers show for irreversible payment rails (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f06",
+    "account_holder_name": "Priya Nair",
+    "on_file_phone": "+14155550106",
+    "claimed_transaction_amount": "9800.00",
+    "claimed_recipient": "Unverified crypto wallet",
+    "claimed_payment_method": "cryptocurrency",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f06",
+    "status": "completed",
+    "task": "Verify a flagged $9,800 cryptocurrency transaction to an unverified wallet.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.9, "label": "high"},
+    "summary": "Account holder confirmed she was specifically told to pay in cryptocurrency."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f06",
+      "phone": "+14155550106",
+      "status": "completed",
+      "started_at": "2026-09-10T14:20:00Z",
+      "completed_at": "2026-09-10T14:23:15Z",
+      "summary": "Account holder confirmed irreversible-payment insistence, otherwise calm.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "No, not really."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's a 'support technician' who fixed my computer last week."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Yes, he said it had to be cryptocurrency, no other way would work."}
+      ],
+      "provider_call_id": "prov_f06",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f06a", "type": "call.dialing", "call_id": "call_f06", "created_at": "2026-09-10T14:20:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f06b", "type": "call.completed", "call_id": "call_f06", "created_at": "2026-09-10T14:23:15Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": true,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/07_hold_requested.json
+++ b/apps/python/ringfence/fixtures/07_hold_requested.json
@@ -1,0 +1,53 @@
+{
+  "_evidence_source": "synthetic: models the case the disposition table calls out explicitly — an account holder's own stop/hold request must always block, at any point in the call",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f07",
+    "account_holder_name": "Grace Lindqvist",
+    "on_file_phone": "+14155550107",
+    "claimed_transaction_amount": "12000.00",
+    "claimed_recipient": "Unfamiliar overseas account",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f07",
+    "status": "completed",
+    "task": "Verify a flagged $12,000 wire transaction to an unfamiliar overseas account.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.93, "label": "high"},
+    "summary": "Account holder asked to stop and hold the transaction mid-call after realizing something felt wrong."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f07",
+      "phone": "+14155550107",
+      "status": "completed",
+      "started_at": "2026-09-10T15:05:00Z",
+      "completed_at": "2026-09-10T15:07:40Z",
+      "summary": "Account holder requested an immediate hold.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No — actually, wait, please stop this transaction. I don't think this is real, hold everything."},
+        {"speaker": "bot", "text": "Understood — I'm flagging this transaction to be held immediately. No further questions needed."}
+      ],
+      "provider_call_id": "prov_f07",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f07a", "type": "call.dialing", "call_id": "call_f07", "created_at": "2026-09-10T15:05:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f07b", "type": "call.completed", "call_id": "call_f07", "created_at": "2026-09-10T15:07:40Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": true
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/08_no_answer_confirmed.json
+++ b/apps/python/ringfence/fixtures/08_no_answer_confirmed.json
@@ -1,0 +1,43 @@
+{
+  "_evidence_source": "synthetic: models calltruth's no_answer_confirmed classification (attempt started and completed, empty transcript) feeding into RingFence's fail-closed escalation rather than a guessed ALLOW",
+  "category": "escalation_case",
+  "case": {
+    "case_id": "case_f08",
+    "account_holder_name": "Trevor Adeyemi",
+    "on_file_phone": "+14155550108",
+    "claimed_transaction_amount": "1500.00",
+    "claimed_recipient": "Adeyemi Auto Repair",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f08",
+    "status": "completed",
+    "task": "Verify a flagged $1,500 ACH transaction to Adeyemi Auto Repair.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": false,
+    "completion_confidence": {"score": 0.3, "label": "low"},
+    "summary": "Call connected but no one engaged in conversation."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f08",
+      "phone": "+14155550108",
+      "status": "completed",
+      "started_at": "2026-09-10T16:00:00Z",
+      "completed_at": "2026-09-10T16:00:45Z",
+      "summary": "No conversation occurred.",
+      "transcript_turns": [],
+      "provider_call_id": "prov_f08",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f08a", "type": "call.dialing", "call_id": "call_f08", "created_at": "2026-09-10T16:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f08b", "type": "call.completed", "call_id": "call_f08", "created_at": "2026-09-10T16:00:45Z", "level": "info", "status": "completed", "message": "Call completed, no engagement.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {},
+  "expected_disposition": "ESCALATE_TO_HUMAN"
+}

--- a/apps/python/ringfence/fixtures/09_rejected_before_ring_generic.json
+++ b/apps/python/ringfence/fixtures/09_rejected_before_ring_generic.json
@@ -1,0 +1,29 @@
+{
+  "_evidence_source": "synthetic: models calltruth's rejected_before_ring classification (attempt never started dialing, no policy/destination marker matched) feeding into RingFence's fail-closed escalation",
+  "category": "escalation_case",
+  "case": {
+    "case_id": "case_f09",
+    "account_holder_name": "Nora Kessler",
+    "on_file_phone": "+14155550109",
+    "claimed_transaction_amount": "4100.00",
+    "claimed_recipient": "Kessler family trust",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f09",
+    "status": "failed",
+    "task": "Verify a flagged $4,100 wire transaction to the Kessler family trust.",
+    "failure_code": "call_failed",
+    "failure_message": "The call could not be completed due to a carrier routing error.",
+    "task_completed": false,
+    "completion_confidence": {"score": 0.1, "label": "low"},
+    "summary": "Call never reached a ringing state."
+  },
+  "attempts": [],
+  "events": [
+    {"id": "evt_f09a", "type": "call.rejected", "call_id": "call_f09", "created_at": "2026-09-10T17:00:00Z", "level": "error", "status": "failed", "message": "Pre-flight check failed before dialing began.", "details": {"region": "US"}}
+  ],
+  "signals": {},
+  "expected_disposition": "ESCALATE_TO_HUMAN"
+}

--- a/apps/python/ringfence/fixtures/10_policy_refusal_emergency.json
+++ b/apps/python/ringfence/fixtures/10_policy_refusal_emergency.json
@@ -1,0 +1,29 @@
+{
+  "_evidence_source": "synthetic: modeled on public CALL-E-AI issue #180's content-refusal pattern (a call task containing 'emergency'/credential-adjacent language triggers a pre-dial policy refusal), adapted to a ringfence case where the claimed context itself reads as an urgent-safety framing",
+  "category": "escalation_case",
+  "case": {
+    "case_id": "case_f10",
+    "account_holder_name": "Felix Ibarra",
+    "on_file_phone": "+14155550110",
+    "claimed_transaction_amount": "7300.00",
+    "claimed_recipient": "Emergency medical escrow account",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f10",
+    "status": "failed",
+    "task": "Verify a flagged $7,300 wire transaction described as an urgent medical emergency payment.",
+    "failure_code": "policy_violation",
+    "failure_message": "I can't place a call that involves an emergency safety claim without additional review.",
+    "task_completed": false,
+    "completion_confidence": {"score": 0.1, "label": "low"},
+    "summary": "Call task was refused before dialing due to the emergency-framed content policy check."
+  },
+  "attempts": [],
+  "events": [
+    {"id": "evt_f10a", "type": "call.rejected", "call_id": "call_f10", "created_at": "2026-09-10T17:30:00Z", "level": "error", "status": "failed", "message": "Pre-dial content policy check refused this task.", "details": {"region": "US"}}
+  ],
+  "signals": {},
+  "expected_disposition": "ESCALATE_TO_HUMAN"
+}

--- a/apps/python/ringfence/fixtures/11_answered_declined.json
+++ b/apps/python/ringfence/fixtures/11_answered_declined.json
@@ -1,0 +1,52 @@
+{
+  "_evidence_source": "synthetic: models calltruth's answered_declined classification (transcript has turns, task_completed false) — an account holder who engaged but the verification did not conclude cleanly, which must escalate rather than be guessed as either ALLOW or BLOCK",
+  "category": "escalation_case",
+  "case": {
+    "case_id": "case_f11",
+    "account_holder_name": "Ruth Halloway",
+    "on_file_phone": "+14155550111",
+    "claimed_transaction_amount": "2600.00",
+    "claimed_recipient": "Halloway Landscaping",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f11",
+    "status": "completed",
+    "task": "Verify a flagged $2,600 ACH transaction to Halloway Landscaping.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": false,
+    "completion_confidence": {"score": 0.4, "label": "low"},
+    "summary": "Account holder engaged briefly but hung up before answering all verification questions."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f11",
+      "phone": "+14155550111",
+      "status": "completed",
+      "started_at": "2026-09-10T18:10:00Z",
+      "completed_at": "2026-09-10T18:11:20Z",
+      "summary": "Account holder answered but ended the call early.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "I don't have time for this right now, I'm driving."}
+      ],
+      "provider_call_id": "prov_f11",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f11a", "type": "call.dialing", "call_id": "call_f11", "created_at": "2026-09-10T18:10:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f11b", "type": "call.completed", "call_id": "call_f11", "created_at": "2026-09-10T18:11:20Z", "level": "info", "status": "completed", "message": "Call ended by recipient before completion.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": null,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ESCALATE_TO_HUMAN"
+}

--- a/apps/python/ringfence/fixtures/12_number_substitution_attack.json
+++ b/apps/python/ringfence/fixtures/12_number_substitution_attack.json
@@ -1,0 +1,54 @@
+{
+  "_evidence_source": "synthetic: models the exact attack the security invariant exists to stop — a flagged request that tries to smuggle in a scammer-controlled 'callback number' distinct from the account's real on-file number. See tests/test_number_substitution_fixture.py, which loads this fixture directly and asserts resolve_dial_target() ignores request_supplied_callback_number entirely.",
+  "category": "security_attempt",
+  "case": {
+    "case_id": "case_f12",
+    "account_holder_name": "Ingrid Solberg",
+    "on_file_phone": "+14155550112",
+    "claimed_transaction_amount": "15000.00",
+    "claimed_recipient": "Overseas holding account",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": "+14155559988"
+  },
+  "call": {
+    "id": "call_f12",
+    "status": "completed",
+    "task": "Verify a flagged $15,000 wire transaction to an overseas holding account.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.9, "label": "high"},
+    "summary": "Account holder reported secrecy demand and urgency; the flagged request separately attempted to supply an alternate callback number, which was never dialed."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f12",
+      "phone": "+14155550112",
+      "status": "completed",
+      "started_at": "2026-09-10T19:00:00Z",
+      "completed_at": "2026-09-10T19:03:05Z",
+      "summary": "Account holder confirmed secrecy and urgency pressure, called on the on-file number only.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "Yes, I was told not to mention it to the bank if they called."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Yes, they said it needed to go out today."}
+      ],
+      "provider_call_id": "prov_f12",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f12a", "type": "call.dialing", "call_id": "call_f12", "created_at": "2026-09-10T19:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder on file.", "details": {"region": "US"}},
+    {"id": "evt_f12b", "type": "call.completed", "call_id": "call_f12", "created_at": "2026-09-10T19:03:05Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": true,
+    "urgency_pressure_present": true,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/13_scam_ceo_fraud_secrecy_and_urgency.json
+++ b/apps/python/ringfence/fixtures/13_scam_ceo_fraud_secrecy_and_urgency.json
@@ -1,0 +1,56 @@
+{
+  "_evidence_source": "synthetic: business/CEO-fraud variant (not the elder-fraud framing) — combines the secrecy demand and manufactured urgency red flags together, showing the case schema is generic enough to cover business wire fraud, not just the elder/grandparent scam",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f13",
+    "account_holder_name": "Devon Ashworth",
+    "on_file_phone": "+14155550113",
+    "claimed_transaction_amount": "42000.00",
+    "claimed_recipient": "Ashworth Logistics vendor account",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f13",
+    "status": "completed",
+    "task": "Verify a flagged $42,000 wire transaction to a vendor account, requested via an urgent message purporting to be from the company's CEO.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.91, "label": "high"},
+    "summary": "Finance team member reported being told to keep the wire confidential from the rest of finance and to process it before end of day."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f13",
+      "phone": "+14155550113",
+      "status": "completed",
+      "started_at": "2026-09-10T20:00:00Z",
+      "completed_at": "2026-09-10T20:03:45Z",
+      "summary": "Account holder confirmed secrecy and urgency pressure from a message claiming to be the CEO.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call about a flagged wire transaction. Did anyone ask you to keep this transaction private, or not to tell your bank or colleagues?"},
+        {"speaker": "user", "text": "Yes, the message said to keep it confidential and not loop in the rest of finance until it's done."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Yes, it said it absolutely had to go out before end of business today."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's supposedly a new vendor our CEO approved, but I haven't verified that with anyone else."}
+      ],
+      "provider_call_id": "prov_f13",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f13a", "type": "call.dialing", "call_id": "call_f13", "created_at": "2026-09-10T20:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f13b", "type": "call.completed", "call_id": "call_f13", "created_at": "2026-09-10T20:03:45Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": true,
+    "urgency_pressure_present": true,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/14_scam_urgency_and_irreversible_payment.json
+++ b/apps/python/ringfence/fixtures/14_scam_urgency_and_irreversible_payment.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: combines manufactured urgency and irreversible-payment insistence together, modeled on the FTC-documented pattern where both pressure tactics are used in the same imposter-scam call (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f14",
+    "account_holder_name": "Yolanda Price",
+    "on_file_phone": "+14155550114",
+    "claimed_transaction_amount": "5400.00",
+    "claimed_recipient": "Unverified utility payment processor",
+    "claimed_payment_method": "gift_card",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f14",
+    "status": "completed",
+    "task": "Verify a flagged $5,400 gift-card transaction to an unverified 'utility payment processor'.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.89, "label": "high"},
+    "summary": "Account holder reported being told her power would be shut off within the hour unless she paid by gift card immediately."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f14",
+      "phone": "+14155550114",
+      "status": "completed",
+      "started_at": "2026-09-10T21:00:00Z",
+      "completed_at": "2026-09-10T21:03:10Z",
+      "summary": "Account holder confirmed both urgency and irreversible-payment demand.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, they didn't say anything about that."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Yes — they said my power gets shut off within the hour if I don't pay now."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "They said they were from the utility company, but it's not the number I usually call."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Yes, gift cards only, they were very specific about that."}
+      ],
+      "provider_call_id": "prov_f14",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f14a", "type": "call.dialing", "call_id": "call_f14", "created_at": "2026-09-10T21:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f14b", "type": "call.completed", "call_id": "call_f14", "created_at": "2026-09-10T21:03:10Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": true,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": true,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/15_scam_business_wire_fraud_unexplained_and_irreversible.json
+++ b/apps/python/ringfence/fixtures/15_scam_business_wire_fraud_unexplained_and_irreversible.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: a second business-context variant (unrelated fictional company from fixture 13), combining an unexplained recipient relationship with an irreversible-payment insistence — shows the case schema handling business-wire-fraud framing without relying on the secrecy/urgency flags alone",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f15",
+    "account_holder_name": "Marcy Tanaka",
+    "on_file_phone": "+14155550115",
+    "claimed_transaction_amount": "18500.00",
+    "claimed_recipient": "New international supplier account",
+    "claimed_payment_method": "cryptocurrency",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f15",
+    "status": "completed",
+    "task": "Verify a flagged $18,500 cryptocurrency transaction to a new international supplier account.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.87, "label": "high"},
+    "summary": "Account holder could not confirm the supplier had been previously vetted, and confirmed the payment method was specifically required to be cryptocurrency."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f15",
+      "phone": "+14155550115",
+      "status": "completed",
+      "started_at": "2026-09-10T22:00:00Z",
+      "completed_at": "2026-09-10T22:03:30Z",
+      "summary": "Account holder could not explain the recipient relationship and confirmed irreversible-payment insistence.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Somewhat, but not extreme."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient, in your own words?"},
+        {"speaker": "user", "text": "Honestly I'm not sure, procurement said it's a new supplier but I haven't seen a contract."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Yes, they insisted it had to be cryptocurrency, no wire option was offered."}
+      ],
+      "provider_call_id": "prov_f15",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f15a", "type": "call.dialing", "call_id": "call_f15", "created_at": "2026-09-10T22:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f15b", "type": "call.completed", "call_id": "call_f15", "created_at": "2026-09-10T22:03:30Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": true,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/16_clean_legitimate_tuition_payment.json
+++ b/apps/python/ringfence/fixtures/16_clean_legitimate_tuition_payment.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional tuition-payment scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f16",
+    "account_holder_name": "Marcus Deleon",
+    "on_file_phone": "+14155550116",
+    "claimed_transaction_amount": "11400.00",
+    "claimed_recipient": "Ashcombe State University Bursar's Office",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f16",
+    "status": "completed",
+    "task": "Verify a flagged $11,400 ACH transaction to Ashcombe State University Bursar's Office.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.95, "label": "high"},
+    "summary": "Account holder confirmed the payment is a fall semester tuition installment for his daughter, no pressure or secrecy reported."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f16",
+      "phone": "+14155550116",
+      "status": "completed",
+      "started_at": "2026-09-10T09:15:00Z",
+      "completed_at": "2026-09-10T09:18:20Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, why would they, it's just tuition."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "The deadline is Friday but that's a normal school deadline, not anything unusual."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's my daughter's university, I'm paying her fall semester bill directly to the bursar's office."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "No, it's the same ACH transfer through the school's own payment portal I use every semester."}
+      ],
+      "provider_call_id": "prov_f16",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f16a", "type": "call.dialing", "call_id": "call_f16", "created_at": "2026-09-10T09:15:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f16b", "type": "call.completed", "call_id": "call_f16", "created_at": "2026-09-10T09:18:20Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/17_clean_legitimate_car_down_payment.json
+++ b/apps/python/ringfence/fixtures/17_clean_legitimate_car_down_payment.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional car-down-payment scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f17",
+    "account_holder_name": "Sheila Okonkwo",
+    "on_file_phone": "+14155550117",
+    "claimed_transaction_amount": "6800.00",
+    "claimed_recipient": "Redline Motors of Fairview",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f17",
+    "status": "completed",
+    "task": "Verify a flagged $6,800 ACH transaction to Redline Motors of Fairview.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.94, "label": "high"},
+    "summary": "Account holder confirmed the payment is a down payment on a car purchase from a dealership she visited in person, no pressure or secrecy reported."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f17",
+      "phone": "+14155550117",
+      "status": "completed",
+      "started_at": "2026-09-10T10:05:00Z",
+      "completed_at": "2026-09-10T10:08:15Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, not at all."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "No, I'm picking up the car this weekend, no rush."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's the car dealership, I signed paperwork in person yesterday for a used sedan."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "No, just the finance office's standard bank transfer for the down payment."}
+      ],
+      "provider_call_id": "prov_f17",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f17a", "type": "call.dialing", "call_id": "call_f17", "created_at": "2026-09-10T10:05:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f17b", "type": "call.completed", "call_id": "call_f17", "created_at": "2026-09-10T10:08:15Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/18_clean_legitimate_medical_bill.json
+++ b/apps/python/ringfence/fixtures/18_clean_legitimate_medical_bill.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional medical-bill scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f18",
+    "account_holder_name": "Harold Whitfield",
+    "on_file_phone": "+14155550118",
+    "claimed_transaction_amount": "3950.00",
+    "claimed_recipient": "Cedar Ridge Medical Center Billing Department",
+    "claimed_payment_method": "ach_transfer",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f18",
+    "status": "completed",
+    "task": "Verify a flagged $3,950 ACH transaction to Cedar Ridge Medical Center Billing Department.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.93, "label": "high"},
+    "summary": "Account holder confirmed the payment is a hospital bill following a scheduled surgery, no pressure or secrecy reported."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f18",
+      "phone": "+14155550118",
+      "status": "completed",
+      "started_at": "2026-09-10T11:20:00Z",
+      "completed_at": "2026-09-10T11:23:50Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, this is just my hospital bill."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "There's a due date on the statement but nothing urgent, I've had it for weeks."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's the hospital where I had my knee surgery in July, this is the remaining balance after insurance."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "No, just their normal online billing portal, same as any medical bill."}
+      ],
+      "provider_call_id": "prov_f18",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f18a", "type": "call.dialing", "call_id": "call_f18", "created_at": "2026-09-10T11:20:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f18b", "type": "call.completed", "call_id": "call_f18", "created_at": "2026-09-10T11:23:50Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/19_clean_legitimate_real_estate_deposit.json
+++ b/apps/python/ringfence/fixtures/19_clean_legitimate_real_estate_deposit.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: fictional real-estate-deposit scenario, modeled on an ordinary legitimate large transaction",
+  "category": "clean_legitimate",
+  "case": {
+    "case_id": "case_f19",
+    "account_holder_name": "Priya Nataraj",
+    "on_file_phone": "+14155550119",
+    "claimed_transaction_amount": "24000.00",
+    "claimed_recipient": "Millbrook Title & Escrow Company",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f19",
+    "status": "completed",
+    "task": "Verify a flagged $24,000 wire transaction to Millbrook Title & Escrow Company.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.92, "label": "high"},
+    "summary": "Account holder confirmed the payment is an earnest money deposit on a home purchase, coordinated in advance with her real estate agent and the title company, no pressure or secrecy reported."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f19",
+      "phone": "+14155550119",
+      "status": "completed",
+      "started_at": "2026-09-10T13:40:00Z",
+      "completed_at": "2026-09-10T13:44:05Z",
+      "summary": "Account holder confirmed the transaction.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "No, my agent and I discussed this openly with the title company."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "There's a closing timeline but it's been scheduled for weeks, nothing sudden."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient?"},
+        {"speaker": "user", "text": "It's the escrow company handling my home purchase, I confirmed their wire instructions by calling the number on their official website, not from an email."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Wire, which is standard for a real estate earnest money deposit."}
+      ],
+      "provider_call_id": "prov_f19",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f19a", "type": "call.dialing", "call_id": "call_f19", "created_at": "2026-09-10T13:40:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f19b", "type": "call.completed", "call_id": "call_f19", "created_at": "2026-09-10T13:44:05Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": false,
+    "urgency_pressure_present": false,
+    "relationship_explained": true,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_ALLOW"
+}

--- a/apps/python/ringfence/fixtures/20_scam_secrecy_and_unexplained_relationship.json
+++ b/apps/python/ringfence/fixtures/20_scam_secrecy_and_unexplained_relationship.json
@@ -1,0 +1,58 @@
+{
+  "_evidence_source": "synthetic: romance-scam-style variant combining a secrecy demand with an unexplained recipient relationship — a distinct red-flag combination from fixtures 13-15 (which pair secrecy+urgency, urgency+irreversible-payment, and unexplained-relationship+irreversible-payment respectively), modeled on the FTC-documented pattern where a supposed online partner asks the victim to keep the payment secret from family (see references/scam-red-flags.md)",
+  "category": "scam_pattern",
+  "case": {
+    "case_id": "case_f20",
+    "account_holder_name": "Deborah Lange",
+    "on_file_phone": "+14155550120",
+    "claimed_transaction_amount": "9200.00",
+    "claimed_recipient": "Unverified individual met online",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f20",
+    "status": "completed",
+    "task": "Verify a flagged $9,200 wire transaction to an individual the account holder met online.",
+    "failure_code": null,
+    "failure_message": null,
+    "task_completed": true,
+    "completion_confidence": {"score": 0.88, "label": "high"},
+    "summary": "Account holder reported being asked to keep the payment secret from family and could not confirm the recipient's identity beyond messages exchanged online."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f20",
+      "phone": "+14155550120",
+      "status": "completed",
+      "started_at": "2026-09-10T15:05:00Z",
+      "completed_at": "2026-09-10T15:08:40Z",
+      "summary": "Account holder confirmed secrecy demand and could not explain the recipient relationship.",
+      "transcript_turns": [
+        {"speaker": "bot", "text": "This is an automated verification call from your bank about a flagged transaction. Did anyone ask you to keep this transaction private?"},
+        {"speaker": "user", "text": "Yes, he asked me not to mention it to my kids, said they wouldn't understand."},
+        {"speaker": "bot", "text": "Is there time pressure on this payment?"},
+        {"speaker": "user", "text": "Not really, he said whenever I could send it was fine."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient, in your own words?"},
+        {"speaker": "user", "text": "We met on a dating site about two months ago, we've only spoken online and by phone, I've never met him in person."},
+        {"speaker": "bot", "text": "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"},
+        {"speaker": "user", "text": "Wire, he said it was for a business emergency overseas."}
+      ],
+      "provider_call_id": "prov_f20",
+      "failure_code": null,
+      "failure_message": null
+    }
+  ],
+  "events": [
+    {"id": "evt_f20a", "type": "call.dialing", "call_id": "call_f20", "created_at": "2026-09-10T15:05:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+    {"id": "evt_f20b", "type": "call.completed", "call_id": "call_f20", "created_at": "2026-09-10T15:08:40Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}}
+  ],
+  "signals": {
+    "secrecy_demand_present": true,
+    "urgency_pressure_present": false,
+    "relationship_explained": false,
+    "irreversible_payment_demanded": false,
+    "explicit_hold_requested": false
+  },
+  "expected_disposition": "ADVISE_BLOCK"
+}

--- a/apps/python/ringfence/fixtures/21_connection_failed_during_attempt.json
+++ b/apps/python/ringfence/fixtures/21_connection_failed_during_attempt.json
@@ -1,0 +1,40 @@
+{
+  "_evidence_source": "synthetic: models calltruth's connection_failed_during_attempt classification -- the provider reports a terminal failure with zero ring time (started_at == completed_at) and an attempt-level failure_code, so nothing was ever asked or answered. Distinct from no_answer_confirmed, which requires an attempt that actually rang; conflating the two would let a provider-side failure read as a recipient who chose not to pick up. Unit-tested directly in tests/test_resolve.py.",
+  "category": "escalation_case",
+  "case": {
+    "case_id": "case_f21",
+    "account_holder_name": "Dana Whitfield",
+    "on_file_phone": "+14155550121",
+    "claimed_transaction_amount": "4500.00",
+    "claimed_recipient": "Jordan Rivera",
+    "claimed_payment_method": "wire",
+    "request_supplied_callback_number": null
+  },
+  "call": {
+    "id": "call_f21",
+    "status": "failed",
+    "task": "Verify a flagged $4,500 wire transaction.",
+    "failure_code": "call_failed",
+    "failure_message": "calling task status=FAILED",
+    "task_completed": false,
+    "completion_confidence": {"score": 0.68, "label": "medium"},
+    "summary": "The call did not connect or complete; the recipient may be busy or unavailable."
+  },
+  "attempts": [
+    {
+      "id": "attempt_f21",
+      "phone": "+14155550121",
+      "status": "failed",
+      "started_at": "2026-01-05T10:00:00Z",
+      "completed_at": "2026-01-05T10:00:00Z",
+      "summary": "The call did not connect or complete; the recipient may be busy or unavailable.",
+      "transcript_turns": [],
+      "provider_call_id": "prov_f21",
+      "failure_code": "504",
+      "failure_message": null
+    }
+  ],
+  "events": [],
+  "signals": {},
+  "expected_disposition": "ESCALATE_TO_HUMAN"
+}

--- a/apps/python/ringfence/pyproject.toml
+++ b/apps/python/ringfence/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "ringfence"
+version = "0.1.0"
+description = "Fraud-verification calls for flagged transactions: an independent call to the account holder's on-file number, never a number supplied by the flagged request."
+requires-python = ">=3.11"
+dependencies = [
+    "calle-ai>=0.7.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+webhook = ["fastapi>=0.110", "uvicorn>=0.29"]
+mcp = ["fastmcp>=0.2"]
+
+[project.scripts]
+ringfence = "ringfence.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["ringfence*"]

--- a/apps/python/ringfence/references/scam-red-flags.md
+++ b/apps/python/ringfence/references/scam-red-flags.md
@@ -1,0 +1,68 @@
+# Why these four questions
+
+RingFence's verification call ([`ringfence/verify_call.py`](../ringfence/verify_call.py),
+`QUESTIONS`) never asks "is this really you" — a coached or panicked victim
+mid-scam will answer "yes" to that. Instead it asks four open, non-leading
+questions, each targeting a specific, well-documented imposter-scam red flag
+rather than a taxonomy invented for this project. The FTC's consumer
+guidance on recognizing imposter/impostor scams (ftc.gov/consumer-advice —
+"How to avoid a scam" and its recurring "callers who ask for these things
+are always scammers" framing) and the FBI's elder-fraud reporting
+(fbi.gov/news/stories/elder-fraud-in-focus) both describe the same small set
+of pressure tactics repeatedly, across scam sub-types — that repetition is
+why these four, and not some longer list, were chosen.
+
+## 1. "Did anyone ask you to keep this transaction private, or not to tell your bank or family?"
+
+**Targets: secrecy / isolation demand.** Every major consumer-protection
+source on imposter scams — FTC guidance and FBI elder-fraud reporting alike
+— names secrecy as close to a universal marker: a legitimate transaction is
+never something the other party needs you to hide from your own bank or
+family. Isolating the victim from anyone who might recognize the scam (a
+bank teller, a relative, a friend) is a load-bearing step in the scam
+script, not an incidental detail — remove the target's ability to get a
+second opinion, and the scam's other pressure tactics work far better.
+
+## 2. "Is there time pressure — were you told this has to happen today or right now?"
+
+**Targets: manufactured urgency.** Consumer-protection guidance consistently
+identifies artificial urgency ("you must act right now, before it's too
+late") as a core scam pressure tactic, precisely because it is the
+mechanism that prevents the victim from pausing to verify. A genuine
+institution's transaction rarely depends on completing in the next hour;
+manufactured urgency is a tell, not a legitimate feature of most real
+payments.
+
+## 3. "Can you describe your relationship to the recipient, in your own words?"
+
+**Targets: a relationship-knowledge mismatch.** Fabricated-relative and
+romance-scam narratives depend on the victim accepting a claimed identity
+("your grandson," "your online partner of two months") without being asked
+to describe that relationship in their own words, before any detail the
+scammer said is repeated back to them. Asked in this order — before, not
+after — the question catches a genuine gap between what the victim
+actually knows about the recipient and what the scam's story requires them
+to believe. This is exactly why AI voice-cloning ("your grandson's voice")
+is such an effective attack per the FBI's elder-fraud reporting: it can
+fake a voice, but the underlying relationship still has to be described
+honestly by the person being asked, not supplied by the caller.
+
+## 4. "Were you asked to pay by wire, gift card, or cryptocurrency specifically?"
+
+**Targets: insistence on an irreversible payment method.** Scammers
+consistently prefer payment rails that cannot be reversed or clawed back —
+wire, gift card, and cryptocurrency are the three named again and again in
+FTC guidance and FBI reporting for exactly this reason. A legitimate large
+transaction is rarely conditioned on using one specific irreversible method;
+an insistence on it, named unprompted by the account holder rather than
+suggested by the question, is a strong signal.
+
+## Explicit "stop / hold everything" — not a question, a standing override
+
+At any point in the call, an explicit request from the account holder to
+stop or hold the transaction ends the call and blocks the transaction
+immediately, without the remaining questions being asked. This is stated
+plainly in [`ringfence/decide.py`](../ringfence/decide.py)'s disposition
+table: it must be easy to stop a transaction and hard to force one through,
+never the reverse. See `fixtures/07_hold_requested.json` for the case this
+protects.

--- a/apps/python/ringfence/render.yaml
+++ b/apps/python/ringfence/render.yaml
@@ -1,0 +1,35 @@
+# Render Blueprint for the RingFence demo (customer + bank dashboard).
+#
+# This app is self-contained under apps/python/ringfence/, per this repo's
+# own contribution convention -- this file lives here rather than at the
+# repo root so it doesn't presume anything about how other apps in this
+# monorepo want to be deployed. When creating a Render Blueprint, point it
+# at this file's path directly; paths below are relative to this file's
+# own directory, not the repo root.
+#
+# The demo server is simulation-only and has no live-call path at all: it
+# cannot place a real call regardless of environment, which is why it is
+# the only surface in this project that is safe to deploy publicly. There
+# is deliberately no CALLE_API_KEY here, and setting one would change
+# nothing.
+#
+# RINGFENCE_DEMO_TOKEN is required: the server refuses to start on a
+# non-loopback bind without it, and with it every page and API route needs
+# the token (Authorization: Bearer, or ?token= once per browser). Render
+# generates the value; read it from the dashboard, then open the deployed
+# URL as https://<host>/?token=<value>.
+
+services:
+  - type: web
+    name: ringfence-demo
+    runtime: python
+    plan: free
+    buildCommand: pip install -e .
+    startCommand: python -m ringfence.demo_server --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
+    autoDeployTrigger: commit
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.9
+      - key: RINGFENCE_DEMO_TOKEN
+        generateValue: true

--- a/apps/python/ringfence/ringfence/__init__.py
+++ b/apps/python/ringfence/ringfence/__init__.py
@@ -1,0 +1,12 @@
+"""ringfence: independent fraud-verification calls for flagged transactions."""
+
+__all__ = [
+    "case",
+    "verify_call",
+    "resolve",
+    "safety",
+    "decide",
+    "cli",
+    "webhook",
+    "mcp_server",
+]

--- a/apps/python/ringfence/ringfence/audit.py
+++ b/apps/python/ringfence/ringfence/audit.py
@@ -1,0 +1,127 @@
+"""Audit/case report: the full evidence trail behind one advisory recommendation.
+
+Real fraud-ops requirement (compliance needs to see exactly what was asked,
+what was answered, which red flags fired, and why), not decoration -- and
+it directly demonstrates the classifier's reasoning, which is also good for
+demo clarity. Operates on the same ``{case, call, attempts, events,
+signals}`` record shape as ``fixtures/*.json`` and ``synthetic_corpus.py``,
+so it works identically over a fixture, a synthetic case, or a real
+completed call's data assembled into that shape.
+
+Every value that reaches the report is redacted first (``safety.redact_value``)
+-- a case audit trail is exactly the kind of artifact that gets exported,
+emailed, or archived, and this data is more sensitive than a generic
+contact list.
+"""
+
+from __future__ import annotations
+
+from . import decide as decide_mod
+from . import resolve
+from .safety import mask_phone, redact_value
+
+
+_AGENT_SPEAKER = "bot"  # CALL-E's actual speaker label, confirmed during
+# pre-submission validation against the live API and corroborated by the
+# other apps in this repo that handle real transcripts (mobilize, leash
+# both key off speaker == "user" for the recipient side, never
+# "recipient"). This module originally hardcoded "agent"/"recipient" -- a
+# plausible-sounding guess baked into every fixture and the synthetic
+# corpus, never checked against a provider transcript -- which silently
+# paired zero Q&A turns against any real call, including a fully
+# successful one. Any speaker that is not the agent is treated as the
+# recipient side (not a second hardcoded string) so this stays correct even
+# if CALL-E's transcript ever uses a label other than "user" for the human
+# side.
+
+
+def _pair_questions_with_answers(transcript_turns: list[dict]) -> list[dict]:
+    """Walk a transcript, pairing each agent (``speaker == "bot"``) question
+    with the answer that immediately followed it (``None`` if none did --
+    e.g. the account holder hung up mid-question)."""
+    qa: list[dict] = []
+    pending_question: str | None = None
+    for turn in transcript_turns:
+        speaker = turn.get("speaker")
+        text = turn.get("text", "")
+        if speaker == _AGENT_SPEAKER:
+            if pending_question is not None:
+                qa.append({"question": pending_question, "answer": None})
+            pending_question = text
+        elif speaker is not None and speaker != _AGENT_SPEAKER and pending_question is not None:
+            qa.append({"question": pending_question, "answer": text})
+            pending_question = None
+    if pending_question is not None:
+        qa.append({"question": pending_question, "answer": None})
+    return qa
+
+
+def build_audit_report(record: dict) -> dict:
+    """Build the redacted audit report for one ``{case, call, attempts,
+    events, signals}`` record."""
+    case = record["case"]
+    resolution = resolve.classify(
+        record["call"], record.get("attempts", []), record.get("events", [])
+    )
+    disposition = decide_mod.decide(resolution, record.get("signals", {}))
+
+    attempts = record.get("attempts") or []
+    transcript_turns = (attempts[0].get("transcript_turns") if attempts else None) or []
+
+    report = {
+        "case_id": case["case_id"],
+        "account_holder_name": case["account_holder_name"],
+        "dialed_phone_masked": mask_phone(case["on_file_phone"]),
+        "claimed_transaction_amount": case["claimed_transaction_amount"],
+        "claimed_recipient": case["claimed_recipient"],
+        "claimed_payment_method": case["claimed_payment_method"],
+        "call_outcome": resolution.as_dict(),
+        "verification_qa": _pair_questions_with_answers(transcript_turns),
+        "signals": dict(record.get("signals", {})),
+        "disposition": disposition.as_dict(),
+    }
+    return redact_value(report)
+
+
+def render_terminal_report(report: dict) -> str:
+    lines = [
+        f"RingFence case audit -- {report['case_id']}",
+        "=" * 40,
+        f"Account holder     : {report['account_holder_name']}",
+        f"Dialed (masked)    : {report['dialed_phone_masked']}",
+        f"Claimed amount     : {report['claimed_transaction_amount']}",
+        f"Claimed recipient  : {report['claimed_recipient']}",
+        f"Payment method     : {report['claimed_payment_method']}",
+        "",
+        f"Call outcome       : {report['call_outcome']['outcome']} "
+        f"(confidence: {report['call_outcome']['confidence']})",
+    ]
+    for evidence in report["call_outcome"]["evidence"]:
+        lines.append(f"  evidence: {evidence}")
+
+    lines.append("")
+    lines.append("Verification Q&A:")
+    if not report["verification_qa"]:
+        lines.append("  (no conversation occurred)")
+    for i, qa in enumerate(report["verification_qa"], start=1):
+        lines.append(f"  {i}. Q: {qa['question']}")
+        answer = qa["answer"] if qa["answer"] is not None else "(no answer recorded)"
+        lines.append(f"     A: {answer}")
+
+    lines.append("")
+    lines.append("Extracted signals:")
+    if not report["signals"]:
+        lines.append("  (none -- no conversation occurred, or signals were not returned)")
+    for key, value in report["signals"].items():
+        lines.append(f"  {key}: {value}")
+
+    lines.append("")
+    lines.append(f"RECOMMENDATION: {report['disposition']['disposition']}")
+    for reason in report["disposition"]["reasons"]:
+        lines.append(f"  reason: {reason}")
+    lines.append(
+        "  ADVISORY ONLY -- requires human review before any action is taken "
+        "on this transaction."
+    )
+
+    return "\n".join(lines)

--- a/apps/python/ringfence/ringfence/case.py
+++ b/apps/python/ringfence/ringfence/case.py
@@ -1,0 +1,78 @@
+"""The Case model: what an institution's fraud system submits to ringfence.
+
+A case carries two categories of phone number that must never be confused:
+
+- ``on_file_phone`` — sourced independently by the institution, *before* the
+  flagged request existed (the number on the account, from onboarding/KYC).
+  This is the only number ringfence is ever allowed to dial. See
+  ``verify_call.resolve_dial_target`` for the invariant this enables.
+- ``request_supplied_callback_number`` — a callback number that arrived as
+  part of the flagged transaction request itself (e.g. "call me back at
+  this number to confirm"). This is exactly what a scammer controls and
+  would smuggle in to redirect the verification call to themselves. It is
+  carried on the case only so it can be logged as a security event — it is
+  never dialed, regardless of whether it matches ``on_file_phone``.
+
+``region``/``locale`` are optional and, if unset, default to
+``verify_call.DEFAULT_REGION``/``DEFAULT_LOCALE`` (``"US"``/``"en-US"``).
+Found missing entirely during pre-submission validation against the live
+API: dialing a documented-supported international number (per
+``call-e-integrations``'s own Supported Regions table) without an explicit
+``region`` failed at the provider layer with zero ring time. Every other
+app in this repo that places international calls sets ``region``/``locale``
+explicitly per case — RingFence never did.
+
+``institution_name`` is optional and, if unset, defaults to
+``verify_call.DEFAULT_INSTITUTION_NAME``. Found missing during
+pre-submission validation against the live API: CALL-E's own content-policy
+layer rejected a call whose task described the caller only as "their
+financial institution" — generic, no named entity — asking "which financial
+institution should the call identify as the requester? This is needed so
+the recipient is not misled by a vague or hidden identity." A vague-identity
+caller is itself a red flag this project's own detection logic screens
+for, so naming a concrete (fictional, per this repo's demo-data convention)
+institution is a genuine, not cosmetic, fix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .safety import normalize_e164
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: str
+    account_holder_name: str
+    on_file_phone: str
+    claimed_transaction_amount: str
+    claimed_recipient: str
+    claimed_payment_method: str
+    request_supplied_callback_number: str | None = None
+    region: str | None = None
+    locale: str | None = None
+    institution_name: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Case":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        unknown = set(data) - known
+        if unknown:
+            raise ValueError(f"case payload has unknown field(s): {sorted(unknown)}")
+        optional = {"request_supplied_callback_number", "region", "locale", "institution_name"}
+        missing = known - optional - set(data)
+        if missing:
+            raise ValueError(f"case payload is missing required field(s): {sorted(missing)}")
+
+        # Normalize (and validate) both phone-shaped fields here, at the one
+        # place every entry point (CLI/webhook/MCP) constructs a Case from
+        # untrusted input — a malformed number fails as a clean ValueError
+        # instead of an uncaught crash deep inside resolve_dial_target().
+        data = dict(data)
+        data["on_file_phone"] = normalize_e164(data["on_file_phone"])
+        if data.get("request_supplied_callback_number"):
+            data["request_supplied_callback_number"] = normalize_e164(
+                data["request_supplied_callback_number"]
+            )
+        return cls(**data)

--- a/apps/python/ringfence/ringfence/cli.py
+++ b/apps/python/ringfence/ringfence/cli.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from . import decide as decide_mod
+from . import resolve as resolve_mod
+from .audit import build_audit_report, render_terminal_report
+from .case import Case
+from .html_report import render_html_report, render_index_html
+from .safety import redact_value
+from .verify_call import SecurityEventLog, place_verification_call
+
+
+def _cmd_submit(args: argparse.Namespace) -> int:
+    case_data = json.loads(Path(args.file).read_text(encoding="utf-8"))
+    try:
+        case = Case.from_dict(case_data)
+    except ValueError as exc:
+        raise SystemExit(f"invalid case file {args.file}: {exc}") from exc
+    security_log = SecurityEventLog(Path(args.security_log))
+
+    if args.live and not args.confirm_live:
+        raise SystemExit("--live requires --confirm-live (explicit, separate confirmation)")
+
+    client_factory = None
+    if args.live:
+        def client_factory():  # noqa: ANN202
+            from calle import CalleClient  # imported lazily: not needed for dry runs
+
+            api_key = os.environ.get("CALLE_API_KEY")
+            if not api_key:
+                raise SystemExit("CALLE_API_KEY is required for --live")
+            return CalleClient(api_key=api_key)
+
+    outcome = place_verification_call(
+        case, live=args.live, security_log=security_log, client_factory=client_factory
+    )
+
+    mode_label = "LIVE" if args.live else "DRY RUN — nothing is dialed"
+    print(f"ringfence case submit · case={case.case_id} · {mode_label}\n")
+    print(f"  dial target : {outcome.dialed_phone_masked}")
+    print(f"  status      : {outcome.status}")
+    if outcome.call_id:
+        print(f"  call_id     : {outcome.call_id}")
+    if outcome.detail:
+        print(f"  detail      : {outcome.detail}")
+    if security_log.events:
+        print(
+            f"\n  SECURITY EVENT recorded ({args.security_log}): the request "
+            "supplied a callback number; it was never dialed."
+        )
+    return 0
+
+
+def _cmd_resolve(args: argparse.Namespace) -> int:
+    records: list[tuple[str, dict]] = []
+    fixtures_dir = Path(args.from_fixtures)
+    for path in sorted(fixtures_dir.glob("*.json")):
+        records.append((path.stem, json.loads(path.read_text(encoding="utf-8"))))
+
+    print(f"ringfence resolve · {len(records)} case(s)\n")
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as out_f:
+        for name, record in records:
+            try:
+                resolution = resolve_mod.classify(
+                    record["call"], record.get("attempts", []), record.get("events", [])
+                )
+                disposition = decide_mod.decide(resolution, record.get("signals", {}))
+            except (KeyError, TypeError) as exc:
+                # One malformed fixture must not silently swallow every
+                # fixture after it in the batch.
+                print(f"  {name:<40} ERROR: malformed record ({exc})")
+                out_f.write(json.dumps({"case_id": name, "error": str(exc)}, ensure_ascii=False) + "\n")
+                continue
+
+            print(f"  {name:<40} outcome={resolution.outcome:<32} -> {disposition.disposition}")
+            for reason in disposition.reasons:
+                print(f"      - {reason}")
+
+            report = {
+                "case_id": record.get("case", {}).get("case_id", name),
+                "outcome": resolution.outcome,
+                "outcome_confidence": resolution.confidence,
+                "outcome_evidence": resolution.evidence,
+                "disposition": disposition.disposition,
+                "disposition_reasons": disposition.reasons,
+            }
+            out_f.write(json.dumps(redact_value(report), ensure_ascii=False) + "\n")
+
+    print(f"\naudit report -> {out_path}")
+    return 0
+
+
+def _cmd_audit(args: argparse.Namespace) -> int:
+    """Print (and optionally export) the full evidence-trail audit report
+    for one {case, call, attempts, events, signals} record -- the same
+    shape as fixtures/*.json. Real fraud-ops compliance requirement, not
+    decoration: what was asked, what was answered, which red flags fired,
+    and why the disposition was reached.
+    """
+    record = json.loads(Path(args.file).read_text(encoding="utf-8"))
+    report = build_audit_report(record)
+    print(render_terminal_report(report))
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\nJSON audit report -> {out_path}")
+
+    if args.html:
+        html_path = Path(args.html)
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        html_path.write_text(render_html_report(report), encoding="utf-8")
+        print(f"HTML case report -> {html_path}")
+
+    return 0
+
+
+def _cmd_report_index(args: argparse.Namespace) -> int:
+    """Build a static, dependency-free HTML case index (no server, no auth)
+    from a directory of previously exported JSON audit reports."""
+    reports_dir = Path(args.from_reports)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    reports = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(reports_dir.glob("*.json"))
+    ]
+    for report in reports:
+        (out_dir / f"{report['case_id']}.html").write_text(
+            render_html_report(report), encoding="utf-8"
+        )
+    (out_dir / "index.html").write_text(render_index_html(reports), encoding="utf-8")
+
+    print(f"wrote {len(reports)} case page(s) + index.html -> {out_dir}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="ringfence")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    case_p = sub.add_parser("case", help="Submit or resolve a fraud-verification case.")
+    case_sub = case_p.add_subparsers(dest="case_command", required=True)
+
+    submit_p = case_sub.add_parser("submit", help="Submit a case and place its verification call (dry-run by default).")
+    submit_p.add_argument("--file", required=True, help="Path to a case JSON file (see example_case.json).")
+    submit_p.add_argument("--live", action="store_true", help="Place a real call. Requires --confirm-live.")
+    submit_p.add_argument("--confirm-live", action="store_true", help="Explicit second confirmation required alongside --live.")
+    submit_p.add_argument("--security-log", default="results/security_events.jsonl")
+    submit_p.set_defaults(func=_cmd_submit)
+
+    resolve_p = case_sub.add_parser("resolve", help="Classify outcome + decide disposition for fixture-shaped case records.")
+    resolve_p.add_argument("--from-fixtures", required=True, help="Directory of {case,call,attempts,events,signals} JSON files.")
+    resolve_p.add_argument("--out", default="results/case_dispositions.jsonl")
+    resolve_p.set_defaults(func=_cmd_resolve)
+
+    audit_p = case_sub.add_parser("audit", help="Print/export the full evidence-trail audit report for one case record.")
+    audit_p.add_argument("--file", required=True, help="Path to a {case,call,attempts,events,signals} JSON record (fixture format).")
+    audit_p.add_argument("--out", default=None, help="Optional path to write the JSON audit report.")
+    audit_p.add_argument("--html", default=None, help="Optional path to also write a static HTML case-report page.")
+    audit_p.set_defaults(func=_cmd_audit)
+
+    report_index_p = case_sub.add_parser("report-index", help="Build a static HTML case index from a directory of exported JSON audit reports.")
+    report_index_p.add_argument("--from-reports", required=True, help="Directory of JSON audit reports (from `case audit --out`).")
+    report_index_p.add_argument("--out-dir", default="results/audit_html")
+    report_index_p.set_defaults(func=_cmd_report_index)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/python/ringfence/ringfence/decide.py
+++ b/apps/python/ringfence/ringfence/decide.py
@@ -1,0 +1,128 @@
+"""The recommendation engine: combines calltruth-style outcome resolution
+with the structured red-flag signals from the verification call. Neither
+input is trusted alone — see the module-level table below, mirrored exactly
+from RINGFENCE-BUILD-SPEC.md.
+
+Fails closed at every branch: an unknown/missing signal is never treated as
+"clean," only a signal explicitly and affirmatively clean produces
+``ADVISE_ALLOW``.
+
+| Condition                                                              | Recommendation     |
+|--------------------------------------------------------------------------|-------------------|
+| Any red flag present (secrecy, urgency, unexplained relationship,        | ADVISE_BLOCK      |
+| irreversible-payment insistence)                                        |                   |
+| Explicit hold/stop requested by account holder                           | ADVISE_BLOCK      |
+| resolve.classify() outcome is unresolved_ambiguous, no_answer_confirmed,  | ESCALATE_TO_HUMAN |
+| rejected_before_ring, or connection_failed_during_attempt                |                   |
+| Clean conversation, no red flags, explicit confirmation                  | ADVISE_ALLOW      |
+| Anything not covered above                                               | ESCALATE_TO_HUMAN |
+
+**Advisory only, human review always required.** Every value this module
+returns is a *recommendation* derived from a heuristic interpretation of one
+phone conversation — speech recognition, a language model's reading of what
+was said, and the red-flag table in ``references/scam-red-flags.md``. That
+chain is not reliable enough to move or hold someone's money on its own, so
+no output of this module is an action:
+
+- ``ADVISE_ALLOW`` means "this call surfaced no red flags," never "release
+  the funds";
+- ``ADVISE_BLOCK`` means "this call surfaced red flags worth a human
+  looking at," never "freeze the account";
+- ``ESCALATE_TO_HUMAN`` means the call established too little to recommend
+  either way.
+
+Every ``Disposition`` carries ``advisory=True`` and
+``requires_human_review=True``, both serialized in ``as_dict()`` and
+surfaced on every consuming surface (CLI, webhook, MCP, audit report, demo
+dashboard). The institution's own system — and a human in it — makes the
+consequential decision. Integrators must not wire these values straight
+into an automated approve/hold action.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import resolve
+
+ADVISE_BLOCK = "ADVISE_BLOCK"
+ESCALATE_TO_HUMAN = "ESCALATE_TO_HUMAN"
+ADVISE_ALLOW = "ADVISE_ALLOW"
+
+#: Every recommendation this module can return. All of them are advisory
+#: and all of them require human review before anything happens to money.
+RECOMMENDATIONS = (ADVISE_ALLOW, ADVISE_BLOCK, ESCALATE_TO_HUMAN)
+
+_UNRESOLVED_OUTCOMES = (
+    resolve.UNRESOLVED_AMBIGUOUS,
+    resolve.NO_ANSWER_CONFIRMED,
+    resolve.REJECTED_BEFORE_RING,
+    resolve.CONNECTION_FAILED_DURING_ATTEMPT,
+)
+
+
+@dataclass(frozen=True)
+class Disposition:
+    """One advisory recommendation plus the reasons behind it.
+
+    ``advisory`` and ``requires_human_review`` are structural, not
+    configurable: there is no code path that produces a non-advisory
+    recommendation or one safe to act on without a human. They are fields
+    rather than implicit so that every serialized record, log line, and API
+    response says so explicitly to whatever consumes it.
+    """
+
+    disposition: str
+    reasons: list[str] = field(default_factory=list)
+    advisory: bool = True
+    requires_human_review: bool = True
+
+    def as_dict(self) -> dict:
+        return {
+            "disposition": self.disposition,
+            "reasons": list(self.reasons),
+            "advisory": True,
+            "requires_human_review": True,
+        }
+
+
+def decide(resolution: resolve.Resolution, signals: dict) -> Disposition:
+    """Recommend a disposition for a case. Advisory only — see module docs.
+
+    ``signals`` carries the verification call's structured result fields:
+    ``secrecy_demand_present``, ``urgency_pressure_present``,
+    ``relationship_explained``, ``irreversible_payment_demanded``,
+    ``explicit_hold_requested`` — booleans, or missing/``None`` when the
+    call could not establish one (which must never be read as "clean").
+    """
+    if signals.get("explicit_hold_requested") is True:
+        return Disposition(ADVISE_BLOCK, ["explicit_hold_requested"])
+
+    red_flags: list[str] = []
+    if signals.get("secrecy_demand_present") is True:
+        red_flags.append("secrecy_demand_present")
+    if signals.get("urgency_pressure_present") is True:
+        red_flags.append("urgency_pressure_present")
+    if signals.get("relationship_explained") is False:
+        red_flags.append("relationship_not_explained")
+    if signals.get("irreversible_payment_demanded") is True:
+        red_flags.append("irreversible_payment_demanded")
+    if red_flags:
+        return Disposition(ADVISE_BLOCK, red_flags)
+
+    if resolution.outcome in _UNRESOLVED_OUTCOMES:
+        return Disposition(ESCALATE_TO_HUMAN, [f"calltruth_resolution={resolution.outcome}"])
+
+    if (
+        resolution.outcome == resolve.ANSWERED_SUCCESS
+        and signals.get("secrecy_demand_present") is False
+        and signals.get("urgency_pressure_present") is False
+        and signals.get("relationship_explained") is True
+        and signals.get("irreversible_payment_demanded") is False
+        and signals.get("explicit_hold_requested") is False
+    ):
+        return Disposition(
+            ADVISE_ALLOW, ["clean_conversation_no_red_flags_explicit_confirmation"]
+        )
+
+    return Disposition(ESCALATE_TO_HUMAN, ["fallback_default"])

--- a/apps/python/ringfence/ringfence/demo_server.py
+++ b/apps/python/ringfence/ringfence/demo_server.py
@@ -1,0 +1,502 @@
+"""Two-sided demo simulator: a customer-facing "send money" page and a bank
+fraud-ops dashboard, both served by this one small stdlib server.
+
+**Simulation only. This server has no live-call path at all.** It never
+imports a CALL-E client, never reads ``CALLE_API_KEY``, and holds no code
+that could place a real outbound call -- deliberately, because this is the
+surface that gets deployed to a public URL, and a publicly reachable page
+that can dial a phone number typed by an anonymous visitor is not a
+defensible thing to operate. Real calls live only behind the operator-run
+surfaces that require explicit doubled confirmation per call
+(``cli.py --live --confirm-live``, ``webhook.py``, ``mcp_server.py``); see
+the README's "Side effects" table.
+
+For the same reason this server collects **no phone number** of any kind:
+there is no field for one, nothing stores one, and the simulated audit
+trail uses a fixed fictional number.
+
+The customer never decides whether a verification call happens -- that
+mirrors the real product (``webhook.py``: an institution's own fraud system
+decides what's flagged, RingFence never does). The bank side decides
+automatically, on submission, using one simple policy: any transaction at
+or above ``AUTO_APPROVE_BELOW_AMOUNT`` requires verification; anything below
+is approved with no call at all. When verification is required, a recorded
+scenario is picked automatically from ``fixtures/`` and run through the
+real ``resolve.classify()`` and ``decide()`` -- the decision logic is real,
+the call is not.
+
+**Every recommendation this server displays is advisory** and carries
+``requires_human_review`` (see ``decide.py``): a heuristic reading of one
+phone conversation must never be wired straight into approving or holding
+someone's money, so both pages present results as a recommendation awaiting
+a fraud analyst, never as a completed action.
+
+**Authentication**: when ``RINGFENCE_DEMO_TOKEN`` is set, every page and
+every API route requires that token (``Authorization: Bearer``, a
+``?token=`` query parameter, or the cookie the pages set from one). The one
+exception is ``GET /healthz``, which returns only ``{"status": "ok"}`` so a
+platform health check can run without credentials.
+``main()`` *refuses to start* on a non-loopback bind without it, so a
+deployment reachable from the internet cannot be unauthenticated by
+omission -- the failure mode is a startup error, not a quietly open URL.
+
+See ``tests/test_demo_server.py`` for the tests that prove all of this.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import random
+import threading
+import time
+import urllib.parse
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Mapping
+
+from . import decide as decide_mod
+from . import resolve
+from .audit import build_audit_report
+from .safety import redact_value
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+DEMO_DIR = Path(__file__).resolve().parent.parent / "demo"
+
+SIMULATED_CALL_SECONDS = 4  # dramatized delay before the simulated "call" resolves
+AUTO_APPROVE_BELOW_AMOUNT = 1000.00  # bank policy: below this, no verification call at all
+
+#: Not a recommendation about a call, because no call happened: the amount
+#: was below the institution's own verification threshold. Kept distinct
+#: from decide.py's recommendations so nothing reads a deterministic policy
+#: outcome as a heuristic call interpretation.
+NO_VERIFICATION_REQUIRED = "NO_VERIFICATION_REQUIRED"
+
+#: The fictional number shown in every simulated audit trail. This server
+#: never collects or stores a real one.
+SIMULATED_DEMO_PHONE = "+15555550100"
+
+DEMO_TOKEN_ENV = "RINGFENCE_DEMO_TOKEN"
+DEMO_TOKEN_COOKIE = "ringfence_demo_token"
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+
+def is_loopback_host(host: str) -> bool:
+    return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def token_is_valid(expected: str | None, supplied: str | None) -> bool:
+    """Constant-time token check. No configured token means no gate."""
+    if not expected:
+        return True
+    if not supplied:
+        return False
+    return hmac.compare_digest(expected, supplied)
+
+
+def _pretty_label(key: str) -> str:
+    # Strip a leading "NN_" fixture-ordering prefix, turn underscores into
+    # spaces, title-case it -- generic and data-driven rather than a
+    # hand-maintained label per fixture. Plain text only: category (for
+    # icon selection) is exposed as its own field, not baked into the
+    # label string -- the frontend renders an icon from `category`, not
+    # by parsing an emoji out of this text.
+    stem = key.split("_", 1)[1] if key[:2].isdigit() and "_" in key else key
+    words = stem.replace("_", " ").split()
+    return " ".join(w.upper() if w in ("ceo",) else w.capitalize() for w in words)
+
+
+def load_scenarios(fixtures_dir: Path = FIXTURES_DIR) -> dict[str, dict]:
+    scenarios: dict[str, dict] = {}
+    for path in sorted(fixtures_dir.glob("*.json")):
+        scenarios[path.stem] = json.loads(path.read_text(encoding="utf-8"))
+    return scenarios
+
+
+class DemoStore:
+    """In-memory, thread-safe store for demo cases. Not durable -- this is
+    a demo simulator, not the real case ledger (see webhook.CaseStore for
+    that)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cases: dict[str, dict] = {}
+
+    def create(self, record: dict) -> None:
+        with self._lock:
+            self._cases[record["id"]] = record
+
+    def update(self, case_id: str, **fields: object) -> None:
+        with self._lock:
+            if case_id in self._cases:
+                self._cases[case_id].update(fields)
+
+    def get(self, case_id: str) -> dict | None:
+        with self._lock:
+            record = self._cases.get(case_id)
+            return dict(record) if record is not None else None
+
+    def list_all(self) -> list[dict]:
+        with self._lock:
+            records = list(self._cases.values())
+        return sorted((dict(r) for r in records), key=lambda r: r["submitted_at"], reverse=True)
+
+
+def _resolve_after_delay(
+    store: DemoStore, case_id: str, scenario_record: dict, display_case: dict, delay_seconds: float
+) -> None:
+    time.sleep(delay_seconds)
+    resolution = resolve.classify(
+        scenario_record["call"], scenario_record.get("attempts", []), scenario_record.get("events", [])
+    )
+    disposition = decide_mod.decide(resolution, scenario_record.get("signals", {}))
+    # The decision itself always runs against the scenario fixture's
+    # recorded call/attempts/events/signals -- that's the actual thing being
+    # demonstrated. But the audit report is customer-facing, so its case
+    # fields (name/amount/recipient/method) are swapped for what was
+    # actually typed into the demo form, not the fixture author's
+    # placeholder names -- otherwise the drill-down view visibly
+    # contradicts what the "customer" just submitted.
+    display_record = dict(scenario_record, case=display_case)
+    audit_report = build_audit_report(display_record)
+    store.update(
+        case_id,
+        status="resolved",
+        outcome=resolution.outcome,
+        disposition=disposition.disposition,
+        disposition_reasons=disposition.reasons,
+        advisory=True,
+        requires_human_review=True,
+        audit=audit_report,
+    )
+
+
+def handle_list_scenarios(scenarios: Mapping[str, dict]) -> tuple[int, dict]:
+    items = [
+        {"key": key, "category": record.get("category"), "label": _pretty_label(key)}
+        for key, record in scenarios.items()
+    ]
+    return 200, {"scenarios": items}
+
+
+def handle_submit(
+    store: DemoStore,
+    scenarios: Mapping[str, dict],
+    data: dict,
+    *,
+    delay_seconds: float = SIMULATED_CALL_SECONDS,
+) -> tuple[int, dict]:
+    """The bank's own logic: decides, automatically, whether this
+    transaction requires a verification call at all, and if so runs one
+    simulated verification. The customer never chooses either."""
+    account_holder_name = (data.get("account_holder_name") or "Demo Customer").strip()[:80]
+    claimed_transaction_amount = (data.get("claimed_transaction_amount") or "0.00").strip()[:20]
+    claimed_recipient = (data.get("claimed_recipient") or "Unknown recipient").strip()[:80]
+    claimed_payment_method = (data.get("claimed_payment_method") or "wire").strip()[:40]
+
+    try:
+        amount = float(claimed_transaction_amount)
+    except (TypeError, ValueError):
+        amount = None  # unparseable -- fail closed, treat as requiring verification
+
+    requires_verification = amount is None or amount >= AUTO_APPROVE_BELOW_AMOUNT
+
+    if not requires_verification:
+        case_id = f"demo_{uuid.uuid4().hex[:8]}"
+        record = {
+            "id": case_id,
+            "account_holder_name": account_holder_name,
+            "claimed_transaction_amount": claimed_transaction_amount,
+            "claimed_recipient": claimed_recipient,
+            "claimed_payment_method": claimed_payment_method,
+            "scenario_key": None,
+            "scenario_label": "No verification required (below threshold)",
+            "category": "no_verification_required",
+            "status": "resolved",
+            "submitted_at": time.time(),
+            "dialed_phone_masked": None,
+            "outcome": "no_verification_required",
+            "disposition": NO_VERIFICATION_REQUIRED,
+            "disposition_reasons": [f"amount below ${AUTO_APPROVE_BELOW_AMOUNT:,.2f} verification threshold"],
+            # No call was placed, so there is no call interpretation to
+            # review -- this is the institution's own deterministic
+            # threshold policy, not a recommendation from this tool.
+            "advisory": True,
+            "requires_human_review": False,
+            "audit": None,
+        }
+        store.create(record)
+        return 201, redact_value(record)
+
+    scenario_key = random.choice(sorted(scenarios))
+    return _handle_submit_simulated(
+        store,
+        scenarios,
+        {
+            "account_holder_name": account_holder_name,
+            "claimed_transaction_amount": claimed_transaction_amount,
+            "claimed_recipient": claimed_recipient,
+            "claimed_payment_method": claimed_payment_method,
+            "scenario_key": scenario_key,
+        },
+        delay_seconds=delay_seconds,
+    )
+
+
+def _handle_submit_simulated(
+    store: DemoStore,
+    scenarios: Mapping[str, dict],
+    data: dict,
+    *,
+    delay_seconds: float,
+) -> tuple[int, dict]:
+    scenario_key = data.get("scenario_key")
+    scenario_record = scenarios.get(scenario_key)
+    if not scenario_key or scenario_record is None:
+        return 400, {"error": "unknown_scenario", "known_scenarios": sorted(scenarios)}
+
+    case_id = f"demo_{uuid.uuid4().hex[:8]}"
+    account_holder_name = (data.get("account_holder_name") or "Demo Customer").strip()[:80]
+    claimed_transaction_amount = (data.get("claimed_transaction_amount") or "0.00").strip()[:20]
+    claimed_recipient = (data.get("claimed_recipient") or "Unknown recipient").strip()[:80]
+    claimed_payment_method = (data.get("claimed_payment_method") or "wire").strip()[:40]
+
+    record = {
+        "id": case_id,
+        "account_holder_name": account_holder_name,
+        "claimed_transaction_amount": claimed_transaction_amount,
+        "claimed_recipient": claimed_recipient,
+        "claimed_payment_method": claimed_payment_method,
+        "scenario_key": scenario_key,
+        "scenario_label": _pretty_label(scenario_key),
+        "category": scenario_record.get("category"),
+        "status": "pending_verification_call",
+        "submitted_at": time.time(),
+        "dialed_phone_masked": None,
+        "outcome": None,
+        "disposition": None,
+        "disposition_reasons": [],
+        "advisory": True,
+        "requires_human_review": True,
+        "audit": None,
+    }
+    store.create(record)
+
+    # A fictional demo phone, never a real number -- this server has no
+    # field that collects one and no code that could dial one.
+    display_case = {
+        "case_id": case_id,
+        "account_holder_name": account_holder_name,
+        "on_file_phone": SIMULATED_DEMO_PHONE,
+        "claimed_transaction_amount": claimed_transaction_amount,
+        "claimed_recipient": claimed_recipient,
+        "claimed_payment_method": claimed_payment_method,
+    }
+    threading.Thread(
+        target=_resolve_after_delay,
+        args=(store, case_id, scenario_record, display_case, delay_seconds),
+        daemon=True,
+    ).start()
+    return 201, redact_value(record)
+
+
+def handle_list(store: DemoStore) -> tuple[int, dict]:
+    return 200, {"cases": [redact_value(c) for c in store.list_all()]}
+
+
+def handle_get(store: DemoStore, case_id: str) -> tuple[int, dict]:
+    record = store.get(case_id)
+    if record is None:
+        return 404, {"error": "not_found"}
+    return 200, redact_value(record)
+
+
+class DemoHandler(BaseHTTPRequestHandler):
+    store: DemoStore
+    scenarios: dict[str, dict]
+    delay_seconds: float
+    demo_token: str | None
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _send_json(self, status: int, payload: Mapping[str, object]) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html(self, path: Path, *, set_token_cookie: str | None = None) -> None:
+        if not path.exists():
+            self._send_json(404, {"error": "not_found"})
+            return
+        body = path.read_text(encoding="utf-8").encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        if set_token_cookie:
+            # So the page's own same-origin fetches carry the token
+            # without it living in every link. HttpOnly: the pages never
+            # need to read it from JS.
+            self.send_header(
+                "Set-Cookie",
+                f"{DEMO_TOKEN_COOKIE}={set_token_cookie}; Path=/; HttpOnly; SameSite=Strict",
+            )
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _supplied_token(self, query: str) -> tuple[str | None, bool]:
+        """Returns (token, came_from_query)."""
+        auth = self.headers.get("Authorization") or ""
+        if auth.startswith("Bearer "):
+            return auth[len("Bearer "):].strip() or None, False
+        cookie_header = self.headers.get("Cookie") or ""
+        for part in cookie_header.split(";"):
+            name, _, value = part.strip().partition("=")
+            if name == DEMO_TOKEN_COOKIE and value:
+                return value, False
+        from_query = urllib.parse.parse_qs(query).get("token")
+        if from_query and from_query[0]:
+            return from_query[0], True
+        return None, False
+
+    def _authorize(self, query: str) -> tuple[bool, str | None]:
+        """Returns (authorized, token_to_set_as_cookie)."""
+        supplied, from_query = self._supplied_token(query)
+        if not token_is_valid(self.demo_token, supplied):
+            self._send_json(401, {"error": "unauthorized", "detail": f"A valid {DEMO_TOKEN_ENV} is required."})
+            return False, None
+        return True, (supplied if from_query else None)
+
+    def do_GET(self) -> None:  # noqa: N802
+        split = urllib.parse.urlsplit(self.path)
+        route, query = split.path, split.query
+        if route == "/healthz":
+            # Unauthenticated on purpose, and the only such route: a PaaS
+            # health check runs without credentials. It reveals nothing
+            # beyond "the process is up".
+            self._send_json(200, {"status": "ok"})
+            return
+        authorized, cookie_token = self._authorize(query)
+        if not authorized:
+            return
+        if route == "/":
+            self._send_html(DEMO_DIR / "customer.html", set_token_cookie=cookie_token)
+        elif route == "/bank":
+            self._send_html(DEMO_DIR / "bank.html", set_token_cookie=cookie_token)
+        elif route == "/api/demo/scenarios":
+            status, payload = handle_list_scenarios(self.scenarios)
+            self._send_json(status, payload)
+        elif route == "/api/demo/cases":
+            status, payload = handle_list(self.store)
+            self._send_json(status, payload)
+        elif route.startswith("/api/demo/cases/"):
+            case_id = route[len("/api/demo/cases/"):]
+            status, payload = handle_get(self.store, case_id)
+            self._send_json(status, payload)
+        else:
+            self._send_json(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        split = urllib.parse.urlsplit(self.path)
+        authorized, _ = self._authorize(split.query)
+        if not authorized:
+            return
+        if split.path != "/api/demo/cases":
+            self._send_json(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+        if length <= 0 or length > 65_536:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+        raw = self.rfile.read(length)
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeError):
+            self._send_json(400, {"error": "invalid_json"})
+            return
+        if not isinstance(data, dict):
+            self._send_json(400, {"error": "invalid_request"})
+            return
+        status, payload = handle_submit(
+            self.store, self.scenarios, data, delay_seconds=self.delay_seconds
+        )
+        self._send_json(status, payload)
+
+
+def create_server(
+    host: str = "127.0.0.1",
+    port: int = 8090,
+    *,
+    delay_seconds: float = SIMULATED_CALL_SECONDS,
+    demo_token: str | None = None,
+    store: DemoStore | None = None,
+    scenarios: dict[str, dict] | None = None,
+) -> ThreadingHTTPServer:
+    handler = type(
+        "ConfiguredDemoHandler",
+        (DemoHandler,),
+        {
+            "store": store if store is not None else DemoStore(),
+            "scenarios": scenarios if scenarios is not None else load_scenarios(),
+            "delay_seconds": delay_seconds,
+            "demo_token": demo_token,
+        },
+    )
+    return ThreadingHTTPServer((host, port), handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", 8090)))
+    parser.add_argument("--delay-seconds", type=float, default=SIMULATED_CALL_SECONDS)
+    args = parser.parse_args(argv)
+
+    demo_token = os.environ.get(DEMO_TOKEN_ENV) or None
+
+    # A bind reachable from outside this machine must be authenticated.
+    # Refusing to start is the point: an unauthenticated public URL should
+    # never be reachable by forgetting an environment variable.
+    if not is_loopback_host(args.host) and not demo_token:
+        print(
+            f"refusing to start: --host {args.host} is reachable from outside this machine, "
+            f"so {DEMO_TOKEN_ENV} must be set to a secret value.\n"
+            f"  set it, then open the demo with ?token=<that value> once per browser."
+        )
+        return 2
+
+    server = create_server(
+        host=args.host, port=args.port, delay_seconds=args.delay_seconds, demo_token=demo_token
+    )
+    print("RingFence demo -- SIMULATION ONLY: this server has no live-call path and collects no phone number")
+    print(
+        "  every recommendation shown is advisory and marked as requiring human review"
+    )
+    if demo_token:
+        print(f"  authentication: ON ({DEMO_TOKEN_ENV} set) -- open with ?token=<value> once per browser")
+    else:
+        print(f"  authentication: off (loopback only; set {DEMO_TOKEN_ENV} to require a token)")
+    print(f"  customer side: http://{args.host}:{args.port}/")
+    print(f"  bank side:     http://{args.host}:{args.port}/bank")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/ringfence/ringfence/evaluation.py
+++ b/apps/python/ringfence/ringfence/evaluation.py
@@ -1,0 +1,199 @@
+"""Regenerates the measured-evaluation numbers quoted in README.md.
+
+Small, fixed fixture corpus (see fixtures/) — not a claim about real-world
+scam-catch rates. See the README's "Measured evaluation" section for what
+this does and does not claim.
+
+Reports both directions honestly: how many scam-pattern fixtures correctly
+recommend ADVISE_BLOCK/ESCALATE_TO_HUMAN (never ADVISE_ALLOW), and how many
+clean-legitimate fixtures correctly recommend ADVISE_ALLOW rather than being
+over-triggered into a false ADVISE_BLOCK/ESCALATE — a tool that flags
+everything is useless, so both sides are reported, not just the scam-catch
+side. Every recommendation counted here is advisory and requires human
+review (see decide.py); this measures recommendation quality, not decisions
+the tool is allowed to make on its own.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import decide as decide_mod
+from . import resolve
+from . import synthetic_corpus
+
+
+@dataclass
+class EvaluationResult:
+    scam_pattern_total: int = 0
+    scam_pattern_correct: int = 0
+    clean_legitimate_total: int = 0
+    clean_legitimate_correct: int = 0
+    mismatches: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.scam_pattern_total + self.clean_legitimate_total
+
+    @property
+    def scam_catch_rate_pct(self) -> float:
+        if not self.scam_pattern_total:
+            return 0.0
+        return 100.0 * self.scam_pattern_correct / self.scam_pattern_total
+
+    @property
+    def clean_allow_rate_pct(self) -> float:
+        if not self.clean_legitimate_total:
+            return 0.0
+        return 100.0 * self.clean_legitimate_correct / self.clean_legitimate_total
+
+
+def evaluate_fixture_corpus(fixtures_dir: Path) -> EvaluationResult:
+    result = EvaluationResult()
+    for path in sorted(fixtures_dir.glob("*.json")):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        category = record["category"]
+        resolution = resolve.classify(
+            record["call"], record.get("attempts", []), record.get("events", [])
+        )
+        disposition = decide_mod.decide(resolution, record.get("signals", {}))
+
+        if category == "scam_pattern":
+            result.scam_pattern_total += 1
+            if disposition.disposition in (decide_mod.ADVISE_BLOCK, decide_mod.ESCALATE_TO_HUMAN):
+                result.scam_pattern_correct += 1
+            else:
+                result.mismatches.append(path.stem)
+        elif category == "clean_legitimate":
+            result.clean_legitimate_total += 1
+            if disposition.disposition == decide_mod.ADVISE_ALLOW:
+                result.clean_legitimate_correct += 1
+            else:
+                result.mismatches.append(path.stem)
+    return result
+
+
+@dataclass
+class SyntheticEvaluationResult:
+    """decide() vs the synthetic corpus's independently computed oracle."""
+
+    total: int = 0
+    correct: int = 0
+    mismatches: list[str] = field(default_factory=list)
+    by_disposition: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def accuracy_pct(self) -> float:
+        if not self.total:
+            return 0.0
+        return 100.0 * self.correct / self.total
+
+
+def evaluate_synthetic_corpus(records: list[dict] | None = None) -> SyntheticEvaluationResult:
+    records = synthetic_corpus.generate_corpus() if records is None else records
+    result = SyntheticEvaluationResult()
+    for record in records:
+        resolution = resolve.classify(
+            record["call"], record.get("attempts", []), record.get("events", [])
+        )
+        disposition = decide_mod.decide(resolution, record.get("signals", {}))
+        result.total += 1
+        result.by_disposition[disposition.disposition] = (
+            result.by_disposition.get(disposition.disposition, 0) + 1
+        )
+        if disposition.disposition == record["expected_disposition"]:
+            result.correct += 1
+        else:
+            result.mismatches.append(
+                f"{record['case']['case_id']}: expected {record['expected_disposition']}, "
+                f"got {disposition.disposition} ({disposition.reasons})"
+            )
+    return result
+
+
+@dataclass
+class NaiveComparisonResult:
+    """Naive (trust raw status/failure_code) vs resolve.classify().
+
+    The "measured, not asserted" comparison CALL-E's own errors.mdx
+    motivates: most integrations branch directly on status/failure_code,
+    which CALL-E's docs say offers no guaranteed no-answer/decline enum.
+    This measures how often that naive approach would produce a *less
+    protective* recommendation than resolve.classify()'s cross-referenced
+    outcome, on the same signals.
+    """
+
+    total: int = 0
+    outcome_disagreements: int = 0
+    unsafe_disposition_disagreements: int = 0
+    examples: list[str] = field(default_factory=list)
+
+
+_DISPOSITION_SAFETY_RANK = {
+    decide_mod.ADVISE_ALLOW: 0,
+    decide_mod.ESCALATE_TO_HUMAN: 1,
+    decide_mod.ADVISE_BLOCK: 2,
+}
+
+
+def evaluate_naive_vs_resolve(records: list[dict] | None = None) -> NaiveComparisonResult:
+    records = synthetic_corpus.generate_corpus() if records is None else records
+    result = NaiveComparisonResult()
+    for record in records:
+        call = record["call"]
+        signals = record.get("signals", {})
+        real_resolution = resolve.classify(call, record.get("attempts", []), record.get("events", []))
+        naive_outcome = resolve.naive_classify(call)
+        result.total += 1
+        if naive_outcome == real_resolution.outcome:
+            continue
+        result.outcome_disagreements += 1
+        naive_disposition = decide_mod.decide(
+            resolve.Resolution(outcome=naive_outcome, confidence="n/a"), signals
+        ).disposition
+        real_disposition = decide_mod.decide(real_resolution, signals).disposition
+        if _DISPOSITION_SAFETY_RANK[naive_disposition] < _DISPOSITION_SAFETY_RANK[real_disposition]:
+            result.unsafe_disposition_disagreements += 1
+            if len(result.examples) < 5:
+                result.examples.append(
+                    f"{record['case']['case_id']}: naive={naive_outcome}->{naive_disposition}, "
+                    f"resolve={real_resolution.outcome}->{real_disposition}"
+                )
+    return result
+
+
+def _print_report() -> None:  # pragma: no cover - exercised via `python -m ringfence.evaluation`
+    fixtures_dir = Path(__file__).resolve().parent.parent / "fixtures"
+    hand = evaluate_fixture_corpus(fixtures_dir)
+    synth_records = synthetic_corpus.generate_corpus()
+    synth = evaluate_synthetic_corpus(synth_records)
+    naive = evaluate_naive_vs_resolve(synth_records)
+
+    print("RingFence measured evaluation")
+    print("=" * 40)
+    print(f"\nCurated fixtures ({fixtures_dir}):")
+    print(f"  scam-pattern:      {hand.scam_pattern_correct}/{hand.scam_pattern_total} correctly ADVISE_BLOCK/ESCALATE_TO_HUMAN")
+    print(f"  clean-legitimate:  {hand.clean_legitimate_correct}/{hand.clean_legitimate_total} correctly ADVISE_ALLOW")
+
+    print(f"\nSynthetic exhaustive corpus ({synth.total} cases, generated not committed):")
+    print(f"  decide() vs independent oracle: {synth.correct}/{synth.total} ({synth.accuracy_pct:.1f}%)")
+    for disposition, count in sorted(synth.by_disposition.items()):
+        print(f"    {disposition:<20} {count}")
+    if synth.mismatches:
+        print("  MISMATCHES:")
+        for mismatch in synth.mismatches:
+            print(f"    {mismatch}")
+
+    print("\nNaive (trust status/failure_code) vs resolve.classify():")
+    print(f"  outcome disagreements:  {naive.outcome_disagreements}/{naive.total}")
+    print(f"  unsafe disagreements:   {naive.unsafe_disposition_disagreements} (naive less protective than resolve)")
+    for example in naive.examples:
+        print(f"    {example}")
+
+    print(f"\nTotal corpus evaluated: {hand.total + synth.total} cases")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _print_report()

--- a/apps/python/ringfence/ringfence/html_report.py
+++ b/apps/python/ringfence/ringfence/html_report.py
@@ -1,0 +1,144 @@
+"""Dependency-free static HTML case-report viewer.
+
+No server, no auth, no JS framework, no build step -- a single
+self-contained HTML file per case (plus an optional index linking many),
+matching this project's own "keep it dependency-light" convention
+(``webhook.py`` uses stdlib ``http.server``, ``cli.py`` uses stdlib
+``argparse``). All interpolated values are HTML-escaped: a fraud case's
+account-holder name or claimed-recipient field is untrusted institution
+input and must never be treated as markup.
+"""
+
+from __future__ import annotations
+
+import html
+
+_DISPOSITION_COLORS = {
+    "ADVISE_ALLOW": "#1a7f37",
+    "ESCALATE_TO_HUMAN": "#9a6700",
+    "ADVISE_BLOCK": "#cf222e",
+}
+_ADVISORY_NOTICE = (
+    "Advisory recommendation only \u2014 requires human review before any action "
+    "is taken on this transaction."
+)
+_DEFAULT_COLOR = "#57606a"
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def render_html_report(report: dict) -> str:
+    disposition = report["disposition"]["disposition"]
+    color = _DISPOSITION_COLORS.get(disposition, _DEFAULT_COLOR)
+
+    qa_items = "".join(
+        f"<li><p class='q'>Q: {_e(qa['question'])}</p>"
+        f"<p class='a'>A: {_e(qa['answer']) if qa['answer'] is not None else '<em>(no answer recorded)</em>'}</p></li>"
+        for qa in report["verification_qa"]
+    ) or "<li><em>(no conversation occurred)</em></li>"
+
+    signal_rows = "".join(
+        f"<tr><td>{_e(key)}</td><td>{_e(value)}</td></tr>"
+        for key, value in report["signals"].items()
+    ) or "<tr><td colspan='2'><em>no signal data</em></td></tr>"
+
+    reason_items = "".join(f"<li>{_e(reason)}</li>" for reason in report["disposition"]["reasons"])
+    evidence_items = "".join(f"<li>{_e(ev)}</li>" for ev in report["call_outcome"]["evidence"])
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>RingFence case audit -- {_e(report['case_id'])}</title>
+<style>
+  body {{ font-family: -apple-system, system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #1f2328; background: #fff; }}
+  h1 {{ font-size: 1.25rem; }}
+  .badge {{ display: inline-block; padding: 0.2em 0.6em; border-radius: 999px; color: #fff; font-weight: 600; background: {color}; }}
+  table {{ border-collapse: collapse; width: 100%; margin: 0.5rem 0; }}
+  td {{ border: 1px solid #d0d7de; padding: 0.4em 0.6em; }}
+  ul {{ padding-left: 1.2rem; }}
+  .q {{ font-weight: 600; margin-bottom: 0.1em; }}
+  .a {{ margin-top: 0; color: #57606a; }}
+  section {{ margin-bottom: 1.5rem; }}
+  .advisory {{ color: #9a6700; font-weight: 600; }}
+</style>
+</head>
+<body>
+<h1>RingFence case audit &mdash; {_e(report['case_id'])}</h1>
+<p><span class="badge">{_e(disposition)}</span></p>
+<p class="advisory">{_e(_ADVISORY_NOTICE)}</p>
+
+<section>
+  <h2>Case</h2>
+  <table>
+    <tr><td>Account holder</td><td>{_e(report['account_holder_name'])}</td></tr>
+    <tr><td>Dialed (masked)</td><td>{_e(report['dialed_phone_masked'])}</td></tr>
+    <tr><td>Claimed amount</td><td>{_e(report['claimed_transaction_amount'])}</td></tr>
+    <tr><td>Claimed recipient</td><td>{_e(report['claimed_recipient'])}</td></tr>
+    <tr><td>Payment method</td><td>{_e(report['claimed_payment_method'])}</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Call outcome</h2>
+  <p>{_e(report['call_outcome']['outcome'])} (confidence: {_e(report['call_outcome']['confidence'])})</p>
+  <ul>{evidence_items}</ul>
+</section>
+
+<section>
+  <h2>Verification Q&amp;A</h2>
+  <ul>{qa_items}</ul>
+</section>
+
+<section>
+  <h2>Extracted signals</h2>
+  <table>{signal_rows}</table>
+</section>
+
+<section>
+  <h2>Recommendation</h2>
+  <p><span class="badge">{_e(disposition)}</span></p>
+  <p class="advisory">{_e(_ADVISORY_NOTICE)}</p>
+  <ul>{reason_items}</ul>
+</section>
+</body>
+</html>
+"""
+
+
+def render_index_html(reports: list[dict]) -> str:
+    rows = "".join(
+        f"<tr><td><a href='{_e(r['case_id'])}.html'>{_e(r['case_id'])}</a></td>"
+        f"<td>{_e(r['account_holder_name'])}</td>"
+        f"<td><span class=\"badge\" style=\"background:"
+        f"{_DISPOSITION_COLORS.get(r['disposition']['disposition'], _DEFAULT_COLOR)}\">"
+        f"{_e(r['disposition']['disposition'])}</span></td></tr>"
+        for r in reports
+    ) or "<tr><td colspan='3'><em>no cases</em></td></tr>"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>RingFence case index</title>
+<style>
+  body {{ font-family: -apple-system, system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  td {{ border: 1px solid #d0d7de; padding: 0.4em 0.6em; }}
+  .badge {{ display: inline-block; padding: 0.2em 0.6em; border-radius: 999px; color: #fff; font-weight: 600; }}
+  .advisory {{ color: #9a6700; font-weight: 600; }}
+</style>
+</head>
+<body>
+<h1>RingFence case index</h1>
+<p class="advisory">Every recommendation below is advisory and requires human
+review before any action is taken on the transaction.</p>
+<table>
+<tr><th>Case</th><th>Account holder</th><th>Recommendation</th></tr>
+{rows}
+</table>
+</body>
+</html>
+"""

--- a/apps/python/ringfence/ringfence/ledger.py
+++ b/apps/python/ringfence/ringfence/ledger.py
@@ -1,0 +1,71 @@
+"""Durable, crash-safe case ledger backing ``webhook.CaseStore``.
+
+``CaseStore`` on its own is a pure in-memory dict -- correct, but a case
+record (and, worse, the fact that a call was already placed for it) simply
+disappears if the process restarts. That's not acceptable for a fraud-
+verification case: it must survive a crash between "call placed" and
+"disposition resolved," and a restarted process must never re-dial a case
+it already handled just because its memory was wiped.
+
+``CaseLedger`` is an append-only JSONL event log (``create`` / ``update``
+per ``case_id``). On startup, ``replay()`` reconstructs the exact state
+``CaseStore`` held before an unclean shutdown. A crash mid-write can leave
+the *final* line truncated (a half-written JSON object) -- ``replay()``
+treats that as an expected write-ahead-log artifact and skips it, not as
+a fatal error; a corrupt line anywhere *other* than the last one is a real
+bug and still raises.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+
+
+class CorruptLedgerEntry(ValueError):
+    pass
+
+
+class CaseLedger:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = threading.Lock()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, event: str, case_id: str, record: dict) -> None:
+        line = json.dumps({"event": event, "case_id": case_id, "record": record}, ensure_ascii=False)
+        with self._lock:
+            with open(self.path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+
+    def replay(self) -> dict[str, dict]:
+        """Reconstruct current case state (case_id -> record) from the log."""
+        state: dict[str, dict] = {}
+        if not self.path.exists():
+            return state
+
+        with open(self.path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        last_index = len(lines) - 1
+        for i, raw_line in enumerate(lines):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                if i == last_index:
+                    break  # truncated final line from a mid-write crash: expected, not fatal
+                raise CorruptLedgerEntry(f"ledger line {i} is corrupt and not the final line: {line!r}") from exc
+
+            case_id = entry["case_id"]
+            if entry["event"] == "create":
+                state[case_id] = dict(entry["record"])
+            elif entry["event"] == "update":
+                state.setdefault(case_id, {}).update(entry["record"])
+        return state

--- a/apps/python/ringfence/ringfence/mcp_server.py
+++ b/apps/python/ringfence/ringfence/mcp_server.py
@@ -1,0 +1,79 @@
+"""FastMCP server exposing ringfence's case submission/lookup as agent tools.
+
+There is no existing FastMCP *server* precedent elsewhere in this repo to
+mirror (apps/python/batch-runner ships an MCP *client* that talks to CALL-E's
+own hosted MCP endpoint, which is a different direction) — this follows
+FastMCP's own standard server pattern instead. Wired to the same
+``webhook.handle_submit``/``handle_get`` request-handling functions the HTTP
+receiver uses, so there is exactly one implementation of the dial-target
+invariant and the single-attempt-per-case rule, not a second copy here.
+
+``ringfence_submit_case`` defaults to dry-run; a live call requires both
+``live=True`` and ``confirm_live=True`` in the same call, mirroring the
+CLI's ``--live``/``--confirm-live`` double gate. There is no live-call tool
+exposed without that explicit double confirmation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastmcp import FastMCP
+
+from .webhook import CaseStore, DEFAULT_SECURITY_LOG_PATH, handle_get, handle_submit
+from .verify_call import SecurityEventLog
+
+mcp = FastMCP("ringfence")
+
+_store = CaseStore()
+_security_log = SecurityEventLog(DEFAULT_SECURITY_LOG_PATH)
+
+
+def _live_client_factory() -> object:
+    from calle import CalleClient
+
+    api_key = os.environ.get("CALLE_API_KEY")
+    if not api_key:
+        raise RuntimeError("CALLE_API_KEY is required for a live call")
+    return CalleClient(api_key=api_key)
+
+
+@mcp.tool
+def ringfence_submit_case(case: dict, live: bool = False, confirm_live: bool = False) -> dict:
+    """Submit a flagged transaction case and place (or preview) its
+    independent verification call to the account holder's on-file number.
+
+    ``case`` must match the ringfence Case schema: case_id,
+    account_holder_name, on_file_phone, claimed_transaction_amount,
+    claimed_recipient, claimed_payment_method, and optionally
+    request_supplied_callback_number (never dialed, only logged).
+
+    Dry-run by default. A real call requires both live=True AND
+    confirm_live=True together — omitting either keeps this a preview.
+    """
+    if live and not confirm_live:
+        return {
+            "error": "live_requires_confirm_live",
+            "detail": "pass confirm_live=True together with live=True to place a real call",
+        }
+    client_factory = _live_client_factory if (live and confirm_live) else None
+    _, payload = handle_submit(
+        _store,
+        case,
+        live=bool(live and confirm_live),
+        security_log=_security_log,
+        client_factory=client_factory,
+    )
+    return payload
+
+
+@mcp.tool
+def ringfence_get_case(case_id: str) -> dict:
+    """Look up a previously submitted case's status and disposition by id."""
+    _, payload = handle_get(_store, case_id)
+    return payload
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/apps/python/ringfence/ringfence/resolve.py
+++ b/apps/python/ringfence/ringfence/resolve.py
@@ -1,0 +1,226 @@
+"""Outcome resolution for the verification call's raw CALL-E result.
+
+Adapted from apps/python/calltruth's resolve.py (same repo, same author) —
+kept as a self-contained copy, not a cross-directory import, per this repo's
+contribution rule that each ``apps/*`` entry stays self-contained. The logic
+is unchanged: CALL-E's own docs (docs.heycall-e.com, "Accepted call
+execution outcomes") state that the Calls API "does not guarantee a
+distinct no-answer or callee-decline value" and that ``failure_code`` has
+"no published enum" to branch on. ``decide.py`` must not trust a raw
+``failure_code`` any more here than calltruth does elsewhere — a fraud
+disposition is exactly the kind of decision where silently guessing wrong
+is worse than saying "ambiguous."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+ANSWERED_SUCCESS = "answered_success"
+ANSWERED_DECLINED = "answered_declined"
+POLICY_OR_CONTENT_REFUSAL = "policy_or_content_refusal"
+MALFORMED_OR_UNSUPPORTED_DESTINATION = "malformed_or_unsupported_destination"
+REJECTED_BEFORE_RING = "rejected_before_ring"
+CONNECTION_FAILED_DURING_ATTEMPT = "connection_failed_during_attempt"
+NO_ANSWER_CONFIRMED = "no_answer_confirmed"
+UNRESOLVED_AMBIGUOUS = "unresolved_ambiguous"
+
+ALL_OUTCOMES = (
+    ANSWERED_SUCCESS,
+    ANSWERED_DECLINED,
+    POLICY_OR_CONTENT_REFUSAL,
+    MALFORMED_OR_UNSUPPORTED_DESTINATION,
+    REJECTED_BEFORE_RING,
+    CONNECTION_FAILED_DURING_ATTEMPT,
+    NO_ANSWER_CONFIRMED,
+    UNRESOLVED_AMBIGUOUS,
+)
+
+_POLICY_REFUSAL_MARKERS = (
+    "confirmation-code",
+    "confirmation code",
+    "otp",
+    "credential",
+    "access credential",
+    "emergency",
+    "urgent safety",
+    "policy_violation",
+    "policy violation",
+    "i can't place a call that involves",
+)
+
+_MALFORMED_DESTINATION_MARKERS = (
+    "region",
+    "not supported",
+    "unsupported_region",
+    "unsupported region",
+    "unsupported_language",
+    "invalid",
+    "e.164",
+    "e164",
+    "malformed",
+    "phone number",
+)
+
+
+@dataclass(frozen=True)
+class Resolution:
+    outcome: str
+    confidence: str  # "high" | "medium" | "low"
+    evidence: list[str] = field(default_factory=list)
+    raw_status: str | None = None
+    raw_failure_code: str | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "outcome": self.outcome,
+            "confidence": self.confidence,
+            "evidence": list(self.evidence),
+            "raw_status": self.raw_status,
+            "raw_failure_code": self.raw_failure_code,
+        }
+
+
+def _text_matches(text: str | None, markers: tuple[str, ...]) -> str | None:
+    if not text:
+        return None
+    lowered = text.lower()
+    for marker in markers:
+        if marker in lowered:
+            return marker
+    return None
+
+
+def _combined_text(*parts: str | None) -> str:
+    return " ".join(p for p in parts if p)
+
+
+def classify(call: dict, attempts: list[dict], events: list[dict]) -> Resolution:
+    """Classify one verification call's real outcome from call + attempts + events."""
+    status = call.get("status")
+    failure_code = call.get("failure_code")
+    failure_message = call.get("failure_message")
+    task_completed = call.get("task_completed")
+
+    attempt = attempts[0] if attempts else None
+    attempt_started = attempt.get("started_at") if attempt else None
+    attempt_completed_at = attempt.get("completed_at") if attempt else None
+    transcript_turns = (attempt.get("transcript_turns") if attempt else None) or []
+    attempt_failure_message = attempt.get("failure_message") if attempt else None
+    attempt_failure_code = attempt.get("failure_code") if attempt else None
+
+    event_text = _combined_text(*(e.get("message") for e in events))
+    full_text = _combined_text(failure_message, attempt_failure_message, event_text)
+
+    never_dialed = attempt is None or attempt_started is None
+
+    if status in ("failed", "canceled") and never_dialed:
+        policy_marker = _text_matches(full_text, _POLICY_REFUSAL_MARKERS)
+        if policy_marker:
+            return Resolution(
+                outcome=POLICY_OR_CONTENT_REFUSAL,
+                confidence="high",
+                evidence=["never dialed (no attempt start)", f"message matched policy marker: {policy_marker!r}"],
+                raw_status=status,
+                raw_failure_code=failure_code,
+            )
+        malformed_marker = _text_matches(full_text, _MALFORMED_DESTINATION_MARKERS)
+        if malformed_marker:
+            return Resolution(
+                outcome=MALFORMED_OR_UNSUPPORTED_DESTINATION,
+                confidence="high",
+                evidence=["never dialed (no attempt start)", f"message matched destination marker: {malformed_marker!r}"],
+                raw_status=status,
+                raw_failure_code=failure_code,
+            )
+        return Resolution(
+            outcome=REJECTED_BEFORE_RING,
+            confidence="medium",
+            evidence=["never dialed (no attempt start)", "no known marker matched failure/attempt/event text"],
+            raw_status=status,
+            raw_failure_code=failure_code,
+        )
+
+    if not never_dialed and attempt_completed_at and not transcript_turns:
+        # An attempt with a start and end timestamp but no transcript could
+        # mean two very different real-world things: the phone genuinely
+        # rang with nobody picking up (a confirmed no-answer), or the
+        # provider failed to actually connect the call at all (started_at
+        # and completed_at identical -- zero ring time -- and/or the
+        # attempt itself carries a failure_code). Pre-submission
+        # validation against the live API returned exactly this shape
+        # (attempt-level failure_code, started_at == completed_at), which
+        # this function previously mislabeled no_answer_confirmed. Treat
+        # the two as distinct outcomes: an institution
+        # should retry a genuine no-answer differently than a connection
+        # failure.
+        zero_duration = attempt_started == attempt_completed_at
+        if zero_duration or attempt_failure_code:
+            evidence = ["attempt started and completed", "transcript is empty (no conversation occurred)"]
+            if zero_duration:
+                evidence.append("attempt started_at == completed_at (zero ring time)")
+            if attempt_failure_code:
+                evidence.append(f"attempt carries its own failure_code: {attempt_failure_code!r}")
+            return Resolution(
+                outcome=CONNECTION_FAILED_DURING_ATTEMPT,
+                confidence="high" if attempt_failure_code else "medium",
+                evidence=evidence,
+                raw_status=status,
+                raw_failure_code=failure_code,
+            )
+        return Resolution(
+            outcome=NO_ANSWER_CONFIRMED,
+            confidence="high",
+            evidence=["attempt started and completed", "transcript is empty (no conversation occurred)"],
+            raw_status=status,
+            raw_failure_code=failure_code,
+        )
+
+    if not never_dialed and transcript_turns and task_completed is False:
+        return Resolution(
+            outcome=ANSWERED_DECLINED,
+            confidence="medium",
+            evidence=["transcript has turns (conversation occurred)", "task_completed is false"],
+            raw_status=status,
+            raw_failure_code=failure_code,
+        )
+
+    if not never_dialed and transcript_turns and task_completed is True:
+        return Resolution(
+            outcome=ANSWERED_SUCCESS,
+            confidence="high",
+            evidence=["transcript has turns (conversation occurred)", "task_completed is true"],
+            raw_status=status,
+            raw_failure_code=failure_code,
+        )
+
+    return Resolution(
+        outcome=UNRESOLVED_AMBIGUOUS,
+        confidence="low",
+        evidence=[
+            "no rule above matched with sufficient signal",
+            f"raw status={status!r} failure_code={failure_code!r} task_completed={task_completed!r}",
+        ],
+        raw_status=status,
+        raw_failure_code=failure_code,
+    )
+
+
+def naive_classify(call: dict) -> str:
+    """What most integrations do today: trust status/failure_code directly.
+
+    Used only to measure disagreement in tests/test_evaluation.py — never
+    used in the real disposition path (decide.py always calls classify()).
+    """
+    status = call.get("status")
+    failure_code = call.get("failure_code")
+    task_completed = call.get("task_completed")
+    if status == "completed" and task_completed:
+        return ANSWERED_SUCCESS
+    if status == "completed":
+        return ANSWERED_DECLINED
+    if failure_code and "no_answer" in str(failure_code).lower():
+        return NO_ANSWER_CONFIRMED
+    if status in ("failed", "canceled"):
+        return REJECTED_BEFORE_RING
+    return UNRESOLVED_AMBIGUOUS

--- a/apps/python/ringfence/ringfence/safety.py
+++ b/apps/python/ringfence/ringfence/safety.py
@@ -1,0 +1,102 @@
+"""Shared safety primitives for ringfence: E.164 validation, masking,
+redaction.
+
+Adapted from apps/python/calltruth's safety.py (same repo, same author) —
+kept as a self-contained copy, not a cross-directory import, per this repo's
+own contribution rule that each `apps/*` entry stays self-contained.
+Reduced to what ringfence actually needs: fraud-case data (account numbers,
+transaction amounts, phone numbers) is more sensitive than a generic contact
+list, so every phone/account value that reaches a log or report goes through
+this module first.
+"""
+
+from __future__ import annotations
+
+import re
+
+_E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+
+class InvalidPhoneNumber(ValueError):
+    pass
+
+
+def normalize_e164(raw: str) -> str:
+    """Normalize a phone number to E.164, or raise.
+
+    A number with no country code is rejected outright, never guessed — the
+    same local digits are a valid subscriber number in more than one
+    country, and guessing wrong reaches a stranger.
+    """
+    if raw is None:
+        raise InvalidPhoneNumber("phone number is missing")
+    cleaned = re.sub(r"[\s().-]", "", raw.strip())
+    if cleaned.startswith("00"):
+        cleaned = "+" + cleaned[2:]
+    if not cleaned.startswith("+"):
+        raise InvalidPhoneNumber(
+            f"{raw!r} has no country code; refusing to guess one"
+        )
+    if not _E164_RE.match(cleaned):
+        raise InvalidPhoneNumber(f"{raw!r} is not a valid E.164 number")
+    return cleaned
+
+
+def mask_phone(phone: str) -> str:
+    """Mask a phone number for display, hiding at least half its digits."""
+    if not phone:
+        return phone
+    digits = [c for c in phone if c.isdigit()]
+    if len(digits) < 4:
+        return "*" * len(phone)
+    visible = max(2, len(digits) // 4)
+    masked_digit_count = len(digits) - visible
+    out = []
+    seen_digits = 0
+    for ch in phone:
+        if ch.isdigit():
+            if seen_digits < masked_digit_count:
+                out.append("*")
+            else:
+                out.append(ch)
+            seen_digits += 1
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def mask_account_number(account_number: str) -> str:
+    """Mask an account number, keeping only the last 4 characters visible —
+    the same convention banks themselves use on statements and receipts."""
+    if not account_number:
+        return account_number
+    if len(account_number) <= 4:
+        return "*" * len(account_number)
+    return "*" * (len(account_number) - 4) + account_number[-4:]
+
+
+_REDACT_PATTERNS = (
+    re.compile(r"\+\d{7,15}"),  # E.164-shaped numbers
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),  # emails
+    re.compile(r"\b\d{6,}\b"),  # long digit runs (accounts, cards, OTPs)
+)
+
+
+def redact_text(text: str) -> str:
+    if not text:
+        return text
+    out = text
+    for pattern in _REDACT_PATTERNS:
+        out = pattern.sub("[redacted]", out)
+    return out
+
+
+def redact_value(value):
+    """Recursively redact strings inside dicts/lists, for stored results."""
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        return {k: redact_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_value(v) for v in value]
+    return value

--- a/apps/python/ringfence/ringfence/synthetic_corpus.py
+++ b/apps/python/ringfence/ringfence/synthetic_corpus.py
@@ -1,0 +1,400 @@
+"""Exhaustive combinatorial synthetic corpus for the measured-evaluation report.
+
+Not committed as JSON files (unlike `fixtures/`, which stays a small, curated
+corpus with a narrative `_evidence_source` per case). This module generates
+its corpus in memory, exhaustively enumerating the decision-relevant state
+space `decide()` actually branches on:
+
+- all 2**5 = 32 combinations of the five boolean verification-call signals,
+  crossed with both outcomes where a real conversation occurred
+  (`answered_success`, `answered_declined`) -- 64 cases,
+- one case per documented ambiguity marker in `resolve._POLICY_REFUSAL_MARKERS`
+  and `resolve._MALFORMED_DESTINATION_MARKERS`, proving each marker string
+  actually resolves to its intended outcome rather than just the handful a
+  hand-picked fixture happened to use,
+- a handful of no-conversation variants (no_answer_confirmed,
+  rejected_before_ring, unresolved_ambiguous) with different raw call shapes,
+- 2 naive-trap cases (call-level flags claim success, attempt trail
+  disagrees) and 3 connection_failed_during_attempt cases -- the outcome
+  category added after pre-submission validation against the live API
+  exposed that resolve.classify() mislabeled a zero-ring-time connection
+  failure as a confirmed no-answer.
+
+This is exhaustive-over-branches, not a random sample: reproducible with
+`python -m ringfence.evaluation`, costs nothing (no live calls), and every
+case's `expected_disposition` is computed by `oracle_disposition()` below --
+an independently written re-implementation of decide.py's table, not a call
+into decide.py itself, so the cross-check in tests/test_synthetic_corpus.py
+is a real second opinion, not the module grading its own homework.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Iterable
+
+from . import resolve
+
+SIGNAL_KEYS = (
+    "secrecy_demand_present",
+    "urgency_pressure_present",
+    "relationship_explained",
+    "irreversible_payment_demanded",
+    "explicit_hold_requested",
+)
+
+_PAYMENT_METHODS = ("wire", "ach_transfer", "check", "zelle", "venmo")
+_AMOUNTS = ("850.00", "2400.00", "9999.00", "42000.00", "150.00")
+
+
+def oracle_disposition(outcome: str, signals: dict) -> str:
+    """Independent re-implementation of decide.py's table, for cross-check.
+
+    Deliberately not a call into decide.decide() -- written separately from
+    RINGFENCE-BUILD-SPEC.md's table so agreement between the two is a real
+    second opinion.
+    """
+    if signals.get("explicit_hold_requested") is True:
+        return "ADVISE_BLOCK"
+    if (
+        signals.get("secrecy_demand_present") is True
+        or signals.get("urgency_pressure_present") is True
+        or signals.get("relationship_explained") is False
+        or signals.get("irreversible_payment_demanded") is True
+    ):
+        return "ADVISE_BLOCK"
+    if (
+        outcome == resolve.ANSWERED_SUCCESS
+        and signals.get("secrecy_demand_present") is False
+        and signals.get("urgency_pressure_present") is False
+        and signals.get("relationship_explained") is True
+        and signals.get("irreversible_payment_demanded") is False
+        and signals.get("explicit_hold_requested") is False
+    ):
+        return "ADVISE_ALLOW"
+    return "ESCALATE_TO_HUMAN"
+
+
+def _signal_combo_dicts() -> Iterable[dict]:
+    for combo in itertools.product([True, False], repeat=len(SIGNAL_KEYS)):
+        yield dict(zip(SIGNAL_KEYS, combo))
+
+
+def _transcript_for(signals: dict, declined: bool) -> list[dict]:
+    turns = [
+        {"speaker": "bot", "text": "This is an automated verification call about a flagged transaction. Did anyone ask you to keep this confidential, or not to tell your bank?"},
+        {"speaker": "user", "text": "Yes, I was told to keep it secret." if signals["secrecy_demand_present"] else "No, nobody asked me to keep anything secret."},
+        {"speaker": "bot", "text": "Is there time pressure to complete this payment?"},
+        {"speaker": "user", "text": "Yes, it has to happen immediately." if signals["urgency_pressure_present"] else "No, there's no rush."},
+        {"speaker": "bot", "text": "Can you describe your relationship to the recipient and why you're sending this payment?"},
+        {"speaker": "user", "text": "It's a vendor I've dealt with before." if signals["relationship_explained"] else "I'm not really sure who they are."},
+        {"speaker": "bot", "text": "Is this payment reversible if it turns out to be a mistake?"},
+        {"speaker": "user", "text": "No, once it's sent it's gone." if signals["irreversible_payment_demanded"] else "Yes, it can be reversed or disputed."},
+        {"speaker": "bot", "text": "Would you like to place a hold on this transaction?"},
+        {"speaker": "user", "text": "Yes, please hold it." if signals["explicit_hold_requested"] else "No hold needed, go ahead."},
+    ]
+    if declined:
+        turns.append({"speaker": "user", "text": "Actually, I don't want to continue this call."})
+    return turns
+
+
+def _conversation_case(idx: int, signals: dict, declined: bool) -> dict:
+    label = "declined" if declined else "success"
+    case_id = f"gen_{label}_{idx:02d}"
+    phone = f"+141555{idx:05d}"
+    method = _PAYMENT_METHODS[idx % len(_PAYMENT_METHODS)]
+    amount = _AMOUNTS[idx % len(_AMOUNTS)]
+    outcome = resolve.ANSWERED_DECLINED if declined else resolve.ANSWERED_SUCCESS
+
+    call = {
+        "id": f"call_{case_id}",
+        "status": "completed",
+        "task": f"Verify a flagged {amount} {method} transaction.",
+        "failure_code": None,
+        "failure_message": None,
+        "task_completed": not declined,
+        "completion_confidence": {"score": 0.4 if declined else 0.9, "label": "low" if declined else "high"},
+        "summary": "Synthetic combinatorial signal-space case.",
+    }
+    attempts = [{
+        "id": f"attempt_{case_id}",
+        "phone": phone,
+        "status": "completed",
+        "started_at": "2026-09-10T00:00:00Z",
+        "completed_at": "2026-09-10T00:03:00Z",
+        "summary": "Synthetic combinatorial signal-space case.",
+        "transcript_turns": _transcript_for(signals, declined),
+        "provider_call_id": f"prov_{case_id}",
+        "failure_code": None,
+        "failure_message": None,
+    }]
+    events = [
+        {"id": f"evt_{case_id}a", "type": "call.dialing", "call_id": f"call_{case_id}", "created_at": "2026-09-10T00:00:00Z", "level": "info", "status": "in_progress", "message": "Dialing account holder.", "details": {"region": "US"}},
+        {"id": f"evt_{case_id}b", "type": "call.completed", "call_id": f"call_{case_id}", "created_at": "2026-09-10T00:03:00Z", "level": "info", "status": "completed", "message": "Call completed.", "details": {"region": "US", "locale": "en-US"}},
+    ]
+
+    return {
+        "_evidence_source": f"generated: exhaustive signal-combination case #{idx} ({outcome}), see ringfence/synthetic_corpus.py",
+        "category": "generated_signal_combination",
+        "case": {
+            "case_id": case_id,
+            "account_holder_name": "Synthetic Holder",
+            "on_file_phone": phone,
+            "claimed_transaction_amount": amount,
+            "claimed_recipient": "Synthetic Recipient",
+            "claimed_payment_method": method,
+            "request_supplied_callback_number": None,
+        },
+        "call": call,
+        "attempts": attempts,
+        "events": events,
+        "signals": signals,
+        "expected_disposition": oracle_disposition(outcome, signals),
+    }
+
+
+def _no_conversation_case(
+    idx: int,
+    outcome: str,
+    *,
+    status: str,
+    failure_message: str | None,
+    with_no_answer_attempt: bool,
+    task_completed=None,
+) -> dict:
+    case_id = f"gen_{outcome}_{idx:02d}"
+    phone = f"+141556{idx:05d}"
+    call = {
+        "id": f"call_{case_id}",
+        "status": status,
+        "task": "Verify a flagged transaction.",
+        "failure_code": None,
+        "failure_message": failure_message,
+        "task_completed": task_completed,
+        "completion_confidence": {"score": 0.0, "label": "low"},
+        "summary": "Synthetic no-conversation case.",
+    }
+    attempts: list[dict] = []
+    if with_no_answer_attempt:
+        attempts = [{
+            "id": f"attempt_{case_id}",
+            "phone": phone,
+            "status": "completed",
+            "started_at": "2026-09-10T00:00:00Z",
+            "completed_at": "2026-09-10T00:00:45Z",
+            "summary": "No engagement.",
+            "transcript_turns": [],
+            "provider_call_id": f"prov_{case_id}",
+            "failure_code": None,
+            "failure_message": None,
+        }]
+    events = [{
+        "id": f"evt_{case_id}",
+        "type": "call.failed" if status in ("failed", "canceled") else "call.completed",
+        "call_id": f"call_{case_id}",
+        "created_at": "2026-09-10T00:00:00Z",
+        "level": "warning",
+        "status": status,
+        "message": failure_message or "",
+        "details": {},
+    }]
+    return {
+        "_evidence_source": f"generated: no-conversation case #{idx} ({outcome}), see ringfence/synthetic_corpus.py",
+        "category": "generated_no_conversation",
+        "case": {
+            "case_id": case_id,
+            "account_holder_name": "Synthetic Holder",
+            "on_file_phone": phone,
+            "claimed_transaction_amount": "500.00",
+            "claimed_recipient": "Synthetic Recipient",
+            "claimed_payment_method": "ach_transfer",
+            "request_supplied_callback_number": None,
+        },
+        "call": call,
+        "attempts": attempts,
+        "events": events,
+        "signals": {},
+        "expected_disposition": oracle_disposition(outcome, {}),
+    }
+
+
+def _naive_trap_case(idx: int, *, never_dialed: bool) -> dict:
+    """A call whose top-level `status`/`task_completed` claim success while
+    the attempt trail disagrees -- exactly the ambiguity CALL-E's own
+    errors.mdx warns integrations not to trust. Signals are explicitly
+    clean, so if `decide()` ever trusted the top-level flags the way
+    `naive_classify()` does, this would wrongly `ADVISE_ALLOW`. It doesn't: `decide()`
+    always goes through `resolve.classify()`, which cross-references the
+    attempt trail and returns `unresolved_ambiguous`/`no_answer_confirmed`,
+    forcing `ESCALATE_TO_HUMAN`. See test_naive_vs_resolve_comparison_finds_
+    real_unsafe_disagreements in tests/test_synthetic_corpus.py.
+    """
+    case_id = f"gen_naive_trap_{idx:02d}"
+    phone = f"+141557{idx:05d}"
+    clean_signals = {
+        "secrecy_demand_present": False,
+        "urgency_pressure_present": False,
+        "relationship_explained": True,
+        "irreversible_payment_demanded": False,
+        "explicit_hold_requested": False,
+    }
+    call = {
+        "id": f"call_{case_id}",
+        "status": "completed",
+        "task": "Verify a flagged transaction.",
+        "failure_code": None,
+        "failure_message": None,
+        "task_completed": True,
+        "completion_confidence": {"score": 0.85, "label": "high"},
+        "summary": "Call-level fields claim success; the attempt trail disagrees (synthetic CALL-E ambiguity trap).",
+    }
+    attempts: list[dict] = []
+    if not never_dialed:
+        attempts = [{
+            "id": f"attempt_{case_id}",
+            "phone": phone,
+            "status": "completed",
+            "started_at": "2026-09-10T00:00:00Z",
+            "completed_at": "2026-09-10T00:00:45Z",
+            "summary": "No engagement, despite the call-level task_completed=True.",
+            "transcript_turns": [],
+            "provider_call_id": f"prov_{case_id}",
+            "failure_code": None,
+            "failure_message": None,
+        }]
+    events = [{
+        "id": f"evt_{case_id}", "type": "call.completed", "call_id": f"call_{case_id}",
+        "created_at": "2026-09-10T00:00:45Z", "level": "info", "status": "completed",
+        "message": "Call marked completed.", "details": {},
+    }]
+    real_outcome = resolve.classify(call, attempts, events).outcome
+    return {
+        "_evidence_source": (
+            f"generated: naive-trap case #{idx} (call-level status/task_completed claim success, "
+            "attempt trail disagrees) -- the exact ambiguity CALL-E's errors.mdx warns integrations "
+            "not to trust, see ringfence/synthetic_corpus.py"
+        ),
+        "category": "generated_naive_trap",
+        "case": {
+            "case_id": case_id,
+            "account_holder_name": "Synthetic Holder",
+            "on_file_phone": phone,
+            "claimed_transaction_amount": "500.00",
+            "claimed_recipient": "Synthetic Recipient",
+            "claimed_payment_method": "ach_transfer",
+            "request_supplied_callback_number": None,
+        },
+        "call": call,
+        "attempts": attempts,
+        "events": events,
+        "signals": clean_signals,
+        "expected_disposition": oracle_disposition(real_outcome, clean_signals),
+    }
+
+
+def _connection_failed_case(idx: int, *, zero_duration: bool, attempt_failure_code: str | None) -> dict:
+    """Models the provider failure shape that exposed a real classifier
+    bug: an attempt whose started_at == completed_at, carrying an
+    attempt-level failure_code -- resolve.classify() used to mislabel this
+    no_answer_confirmed. See tests/test_resolve.py.
+    """
+    case_id = f"gen_connfail_{idx:02d}"
+    phone = f"+141558{idx:05d}"
+    started_at = "2026-09-10T00:00:00Z"
+    completed_at = started_at if zero_duration else "2026-09-10T00:00:10Z"
+    call = {
+        "id": f"call_{case_id}",
+        "status": "failed",
+        "task": "Verify a flagged transaction.",
+        "failure_code": "call_failed" if attempt_failure_code else None,
+        "failure_message": None,
+        "task_completed": False,
+        "completion_confidence": {"score": 0.3, "label": "low"},
+        "summary": "Synthetic connection-failure-during-attempt case.",
+    }
+    attempts = [{
+        "id": f"attempt_{case_id}",
+        "phone": phone,
+        "status": "failed",
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "summary": "Connection failed during the attempt.",
+        "transcript_turns": [],
+        "provider_call_id": f"prov_{case_id}",
+        "failure_code": attempt_failure_code,
+        "failure_message": None,
+    }]
+    events = [{
+        "id": f"evt_{case_id}", "type": "call.failed", "call_id": f"call_{case_id}",
+        "created_at": completed_at, "level": "warning", "status": "failed",
+        "message": "Attempt failed to connect.", "details": {},
+    }]
+    return {
+        "_evidence_source": (
+            f"generated: connection-failed-during-attempt case #{idx} "
+            f"(zero_duration={zero_duration}, attempt_failure_code={attempt_failure_code!r}), "
+            "modeled on the provider failure shape seen against the live API"
+        ),
+        "category": "generated_no_conversation",
+        "case": {
+            "case_id": case_id,
+            "account_holder_name": "Synthetic Holder",
+            "on_file_phone": phone,
+            "claimed_transaction_amount": "500.00",
+            "claimed_recipient": "Synthetic Recipient",
+            "claimed_payment_method": "ach_transfer",
+            "request_supplied_callback_number": None,
+        },
+        "call": call,
+        "attempts": attempts,
+        "events": events,
+        "signals": {},
+        "expected_disposition": oracle_disposition(resolve.CONNECTION_FAILED_DURING_ATTEMPT, {}),
+    }
+
+
+def generate_corpus() -> list[dict]:
+    records: list[dict] = []
+
+    for idx, signals in enumerate(_signal_combo_dicts()):
+        records.append(_conversation_case(idx, signals, declined=False))
+    for idx, signals in enumerate(_signal_combo_dicts()):
+        records.append(_conversation_case(idx, signals, declined=True))
+
+    for idx, marker in enumerate(resolve._POLICY_REFUSAL_MARKERS):
+        records.append(_no_conversation_case(
+            idx, resolve.POLICY_OR_CONTENT_REFUSAL, status="failed",
+            failure_message=f"Call refused: message referenced {marker}.",
+            with_no_answer_attempt=False,
+        ))
+    for idx, marker in enumerate(resolve._MALFORMED_DESTINATION_MARKERS):
+        records.append(_no_conversation_case(
+            idx, resolve.MALFORMED_OR_UNSUPPORTED_DESTINATION, status="failed",
+            failure_message=f"Call could not be placed: {marker}.",
+            with_no_answer_attempt=False,
+        ))
+    for idx in range(3):
+        records.append(_no_conversation_case(
+            idx, resolve.REJECTED_BEFORE_RING, status="canceled",
+            failure_message=f"Unspecified provider error #{idx}.",
+            with_no_answer_attempt=False,
+        ))
+    for idx in range(3):
+        records.append(_no_conversation_case(
+            idx, resolve.NO_ANSWER_CONFIRMED, status="completed",
+            failure_message=None, with_no_answer_attempt=True, task_completed=False,
+        ))
+    for idx, status in enumerate(("queued", "unknown", None)):
+        records.append(_no_conversation_case(
+            idx, resolve.UNRESOLVED_AMBIGUOUS, status=status,
+            failure_message=None, with_no_answer_attempt=False, task_completed=None,
+        ))
+
+    records.append(_naive_trap_case(0, never_dialed=True))
+    records.append(_naive_trap_case(1, never_dialed=False))
+
+    records.append(_connection_failed_case(0, zero_duration=True, attempt_failure_code="404"))
+    records.append(_connection_failed_case(1, zero_duration=True, attempt_failure_code=None))
+    records.append(_connection_failed_case(2, zero_duration=False, attempt_failure_code="503"))
+
+    return records

--- a/apps/python/ringfence/ringfence/verify_call.py
+++ b/apps/python/ringfence/ringfence/verify_call.py
@@ -1,0 +1,185 @@
+"""Places the independent verification call for a flagged case.
+
+## The one security invariant everything else depends on
+
+``resolve_dial_target`` returns ``case.on_file_phone`` — always, unconditionally.
+``case.request_supplied_callback_number`` is never read for dialing purposes;
+it exists on the Case model only so an attempt to smuggle one in can be
+logged as a security event. This is proven by
+``tests/test_invariant_never_calls_request_supplied_number.py`` — the load-
+bearing test this whole product's trustworthiness rests on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from .case import Case
+from .safety import InvalidPhoneNumber, mask_phone, normalize_e164
+
+PREVIEWED = "previewed"
+DIALED = "dialed"
+ERROR = "error"
+
+# Matches call-e-integrations's own "Supported Regions and Languages" table
+# convention (region/locale on the recipient). Left unset on a Case, a real
+# international number silently fails at the carrier/provider layer instead
+# of a clean rejection: during pre-submission validation, calls to a
+# documented-supported international number failed instantly (zero ring
+# time, differing provider error codes) because region/locale were never
+# sent at all.
+DEFAULT_REGION = "US"
+DEFAULT_LOCALE = "en-US"
+
+# Fictional, per this repo's own "fictional-only demo data" convention (see
+# README's Safety section) -- named explicitly rather than left generic
+# ("their financial institution") because CALL-E's own content-policy layer
+# rejects a task that doesn't name a concrete requesting entity, citing
+# exactly the vague/hidden-identity risk this project's own detection logic
+# screens callers for. Surfaced only by exercising the live API, not by
+# review.
+DEFAULT_INSTITUTION_NAME = "Fictional National Bank"
+
+# Disclosure-first, open-question script. Never asks "is this really you" —
+# a coached or panicked victim mid-scam will answer "yes" to that. Instead
+# asks about documented scam red flags without leading the account holder
+# toward a "safe" answer. See references/scam-red-flags.md for why each
+# question exists and what it's cited from.
+QUESTIONS = (
+    "Did anyone ask you to keep this transaction private, or not to tell "
+    "your bank or family?",
+    "Is there time pressure — were you told this has to happen today or "
+    "right now?",
+    "Can you describe your relationship to the recipient, in your own "
+    "words?",
+    "Were you asked to pay by wire, gift card, or cryptocurrency "
+    "specifically?",
+)
+
+RESULT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "secrecy_demand_present": {"type": "boolean"},
+        "urgency_pressure_present": {"type": "boolean"},
+        "relationship_explained": {"type": "boolean"},
+        "irreversible_payment_demanded": {"type": "boolean"},
+        "explicit_hold_requested": {"type": "boolean"},
+    },
+    "required": [
+        "secrecy_demand_present",
+        "urgency_pressure_present",
+        "relationship_explained",
+        "irreversible_payment_demanded",
+        "explicit_hold_requested",
+    ],
+}
+
+
+@dataclass
+class VerificationCallOutcome:
+    case_id: str
+    dialed_phone_masked: str
+    status: str
+    call_id: str | None = None
+    detail: str = ""
+
+
+@dataclass
+class SecurityEventLog:
+    path: Path
+    events: list[dict] = field(default_factory=list, repr=False)
+
+    def record(self, event: dict) -> None:
+        self.events.append(event)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+
+def resolve_dial_target(case: Case, security_log: SecurityEventLog | None = None) -> str:
+    """Return the only phone number ringfence may dial for this case.
+
+    Always ``case.on_file_phone``. ``request_supplied_callback_number`` is
+    read here for exactly one purpose — logging that it was present and
+    ignored — never to influence which number gets dialed, even if it is
+    identical to the on-file number.
+    """
+    on_file = normalize_e164(case.on_file_phone)
+    if case.request_supplied_callback_number and security_log is not None:
+        try:
+            smuggled_masked = mask_phone(normalize_e164(case.request_supplied_callback_number))
+        except InvalidPhoneNumber:
+            smuggled_masked = "[unparseable]"
+        security_log.record(
+            {
+                "event": "rejected_request_supplied_callback_number",
+                "case_id": case.case_id,
+                "on_file_phone_masked": mask_phone(on_file),
+                "request_supplied_phone_masked": smuggled_masked,
+            }
+        )
+    return on_file
+
+
+def render_task(case: Case) -> str:
+    institution = case.institution_name or DEFAULT_INSTITUTION_NAME
+    numbered = " ".join(f"({i + 1}) {q}" for i, q in enumerate(QUESTIONS))
+    return (
+        f"You are calling {case.account_holder_name} on behalf of "
+        f"{institution} to independently verify a transaction their own "
+        "fraud system has flagged as unusual. Disclose immediately, "
+        f"before anything else, that this is an automated verification call "
+        f"from {institution} — not the transaction counterparty, and you "
+        "will never ask for a password, one-time code, or account "
+        "credential. Ask the following questions in order, without leading "
+        "the account holder or revealing which answer is 'safe': "
+        f"{numbered} If the account holder says to stop or hold at any "
+        "point, acknowledge immediately and end the call without asking "
+        "any further questions."
+    )
+
+
+def place_verification_call(
+    case: Case,
+    *,
+    live: bool,
+    security_log: SecurityEventLog | None = None,
+    client_factory: Callable[[], object] | None = None,
+) -> VerificationCallOutcome:
+    """Place (or preview) the single verification call for this case.
+
+    Dry-run by default. One attempt per case — callers do not loop this;
+    a blocked/declined case requires the institution to resubmit a new
+    case deliberately, never an automatic re-dial.
+    """
+    dial_target = resolve_dial_target(case, security_log)
+    masked = mask_phone(dial_target)
+    task_text = render_task(case)
+
+    if not live:
+        return VerificationCallOutcome(
+            case.case_id,
+            masked,
+            PREVIEWED,
+            detail=f"goal rendered ({len(task_text)} chars); DRY RUN, no call placed",
+        )
+
+    if client_factory is None:
+        raise ValueError("client_factory is required for a live call")
+    client = client_factory()
+    region = case.region or DEFAULT_REGION
+    locale = case.locale or DEFAULT_LOCALE
+    try:
+        call = client.calls.create_and_wait(
+            task=task_text,
+            recipients=[{"phones": [dial_target], "region": region, "locale": locale}],
+            result_schema=RESULT_SCHEMA,
+            idempotency_key=f"ringfence:{case.case_id}",
+        )
+        call_id = call.get("id") if isinstance(call, dict) else getattr(call, "id", None)
+        return VerificationCallOutcome(case.case_id, masked, DIALED, call_id=call_id)
+    except Exception as exc:  # noqa: BLE001 - surfaced to the caller as a case-level error
+        return VerificationCallOutcome(case.case_id, masked, ERROR, detail=str(exc))

--- a/apps/python/ringfence/ringfence/webhook.py
+++ b/apps/python/ringfence/ringfence/webhook.py
@@ -287,6 +287,8 @@ def create_server(
     store stays in-memory only. Pass a path to make it durable: cases
     survive a server restart, and one already dialed is never re-dialed.
     """
+    if live and host not in {"127.0.0.1", "localhost", "::1"}:
+        raise ValueError("Live webhook is loopback-only; do not expose it through a public bind or proxy.")
     if store is None:
         ledger = CaseLedger(ledger_path) if ledger_path is not None else None
         store = CaseStore(ledger)

--- a/apps/python/ringfence/ringfence/webhook.py
+++ b/apps/python/ringfence/ringfence/webhook.py
@@ -1,0 +1,345 @@
+"""Webhook receiver for ringfence.
+
+``POST /cases`` accepts a flagged transaction case from an institution's own
+fraud system and places (or, by default, previews) the independent
+verification call. ``GET /cases/{id}`` returns that case's current status
+and advisory recommendation (``null`` until a live call has completed and
+been resolved).
+
+Every record this module returns carries ``advisory: true`` and
+``requires_human_review: true``: the ``disposition`` field is a
+recommendation derived from a heuristic reading of one phone call, never an
+instruction to release or hold money. See ``decide.py`` for why, and do not
+wire the field into an automated approve/hold action.
+
+Kept dependency-light (stdlib ``http.server``), matching this repo's own
+apps/python/webhook-result-receiver precedent of not pulling in a web
+framework for a couple of endpoints. That receiver ingests CALL-E's own
+outbound webhook notifications (the opposite direction); this one is an
+inbound API an institution calls into.
+
+This module never re-implements the dial-target invariant — every request
+goes through ``verify_call.place_verification_call`` (which itself always
+calls ``verify_call.resolve_dial_target``), so the same guarantee proven in
+tests/test_invariant_never_calls_request_supplied_number.py holds here too.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Callable, Mapping
+
+from .case import Case
+from .decide import ESCALATE_TO_HUMAN, decide as decide_case
+from .ledger import CaseLedger
+from .resolve import classify as classify_call
+from .safety import redact_value
+from .verify_call import DIALED, ERROR, SecurityEventLog, place_verification_call
+
+MAX_BODY_BYTES = 65_536
+DEFAULT_SECURITY_LOG_PATH = Path("results/security_events.jsonl")
+DEFAULT_LEDGER_PATH = Path("results/case_ledger.jsonl")
+
+
+class CaseNotFound(KeyError):
+    pass
+
+
+class CaseStore:
+    """Thread-safe case ledger, optionally backed by a durable ``CaseLedger``.
+
+    One verification attempt per ``case_id``: a case_id already present is
+    never re-dialed on a repeat POST — the existing record is returned as-is.
+    This is the "no harassment" rule from the build spec: no automatic
+    re-dial loop; a blocked/declined case requires the institution to submit
+    a **new** case deliberately, never a resubmit of the same id.
+
+    Without a ``ledger``, state is in-memory only (fine for tests and the
+    dry-run CLI path). With one, every create/update is durably appended
+    *before* the in-memory dict changes, and the constructor replays the
+    ledger — so a process restart reconstructs exactly which cases were
+    already dialed, and never re-dials one just because memory was wiped.
+    """
+
+    def __init__(self, ledger: CaseLedger | None = None) -> None:
+        self._lock = threading.Lock()
+        self._ledger = ledger
+        self._cases: dict[str, dict] = ledger.replay() if ledger is not None else {}
+
+    def get(self, case_id: str) -> dict | None:
+        with self._lock:
+            record = self._cases.get(case_id)
+            return dict(record) if record is not None else None
+
+    def create_if_absent(self, case_id: str, record: dict) -> tuple[dict, bool]:
+        with self._lock:
+            existing = self._cases.get(case_id)
+            if existing is not None:
+                return dict(existing), False
+            if self._ledger is not None:
+                self._ledger.append("create", case_id, record)
+            self._cases[case_id] = record
+            return dict(record), True
+
+    def update(self, case_id: str, **fields: object) -> None:
+        with self._lock:
+            if case_id not in self._cases:
+                raise CaseNotFound(case_id)
+            if self._ledger is not None:
+                self._ledger.append("update", case_id, fields)
+            self._cases[case_id].update(fields)
+
+
+def _resolve_and_store_disposition(
+    store: CaseStore, case_id: str, client: object, call_id: str
+) -> None:
+    """Fetch the completed call's full detail and store its recommendation.
+
+    Only reached in ``--live`` mode, after ``create_and_wait`` has already
+    returned a terminal call — this is a read of that same call's detail and
+    events, never a second call placed.
+    """
+    call = client.calls.get(call_id)
+    events_page = client.calls.list_events(call_id)
+    events = events_page.get("data", []) if isinstance(events_page, dict) else list(events_page)
+    attempts: list[dict] = []
+    for recipient in call.get("recipients") or []:
+        attempts.extend(recipient.get("attempts") or [])
+
+    resolution = classify_call(call, attempts, events)
+    disposition = decide_case(resolution, call.get("structured_result") or {})
+    store.update(
+        case_id,
+        outcome=resolution.outcome,
+        disposition=disposition.disposition,
+        disposition_reasons=disposition.reasons,
+        advisory=True,
+        requires_human_review=True,
+    )
+
+
+def handle_submit(
+    store: CaseStore,
+    data: dict,
+    *,
+    live: bool,
+    security_log: SecurityEventLog,
+    client_factory: Callable[[], object] | None,
+) -> tuple[int, dict]:
+    """Pure request-handling logic, exercised directly by tests and by the
+    HTTP handler below."""
+    try:
+        case = Case.from_dict(data)
+    except ValueError as exc:
+        return 400, {"error": "invalid_case", "detail": str(exc)}
+
+    # Reserve the record atomically *before* placing any call. Two
+    # concurrent requests for the same never-before-seen case_id (e.g. a
+    # retried webhook delivery) both racing store.get() -> dial -> store
+    # would risk two real outbound dials for one case; reserving first means
+    # only the request that actually wins create_if_absent's lock ever
+    # reaches place_verification_call.
+    placeholder = {
+        "case_id": case.case_id,
+        "status": "reserved",
+        "dialed_phone_masked": None,
+        "call_id": None,
+        "detail": "",
+        "outcome": None,
+        "disposition": None,
+        "disposition_reasons": [],
+        # Structural, not configurable: no code path in this module
+        # produces a disposition that is safe to act on without a human.
+        "advisory": True,
+        "requires_human_review": True,
+    }
+    reserved, created = store.create_if_absent(case.case_id, placeholder)
+    if not created:
+        return 200, redact_value(reserved)
+
+    client_holder: dict[str, object] = {}
+    wrapped_factory = None
+    if client_factory is not None:
+        def wrapped_factory():  # noqa: ANN202
+            client = client_factory()
+            client_holder["client"] = client
+            return client
+
+    outcome = place_verification_call(
+        case, live=live, security_log=security_log, client_factory=wrapped_factory
+    )
+    store.update(
+        case.case_id,
+        status=outcome.status,
+        dialed_phone_masked=outcome.dialed_phone_masked,
+        call_id=outcome.call_id,
+        detail=outcome.detail,
+    )
+
+    if outcome.status == DIALED and "client" in client_holder:
+        if outcome.call_id:
+            _resolve_and_store_disposition(store, case.case_id, client_holder["client"], outcome.call_id)
+        else:
+            # CALL-E's own docs don't guarantee every field is populated on
+            # every response — a DIALED outcome with no call_id can't be
+            # resolved, so escalate rather than crash trying to fetch it.
+            store.update(
+                case.case_id,
+                outcome="missing_call_id",
+                disposition=ESCALATE_TO_HUMAN,
+                disposition_reasons=["dialed_but_no_call_id_returned"],
+            )
+    elif outcome.status == ERROR:
+        # A failed live call must not leave the recommendation null forever — this
+        # case_id can never be re-dialed (single-attempt-per-case), so the
+        # institution needs an explicit signal to follow up, not silence.
+        store.update(
+            case.case_id,
+            outcome="call_error",
+            disposition=ESCALATE_TO_HUMAN,
+            disposition_reasons=[f"live_call_error: {outcome.detail}"],
+        )
+
+    record = store.get(case.case_id) or reserved
+    return 201, redact_value(record)
+
+
+def handle_get(store: CaseStore, case_id: str) -> tuple[int, dict]:
+    record = store.get(case_id)
+    if record is None:
+        return 404, {"error": "not_found"}
+    return 200, redact_value(record)
+
+
+class RingfenceHandler(BaseHTTPRequestHandler):
+    store: CaseStore
+    live: bool
+    client_factory: Callable[[], object] | None
+    security_log: SecurityEventLog
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _send_json(self, status: int, payload: Mapping[str, object]) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/cases":
+            self._send_json(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+        raw = self.rfile.read(length)
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeError):
+            self._send_json(400, {"error": "invalid_json"})
+            return
+        if not isinstance(data, dict):
+            self._send_json(400, {"error": "invalid_case"})
+            return
+        status, payload = handle_submit(
+            self.store,
+            data,
+            live=self.live,
+            security_log=self.security_log,
+            client_factory=self.client_factory,
+        )
+        self._send_json(status, payload)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not self.path.startswith("/cases/"):
+            self._send_json(404, {"error": "not_found"})
+            return
+        case_id = self.path[len("/cases/"):]
+        status, payload = handle_get(self.store, case_id)
+        self._send_json(status, payload)
+
+
+def create_server(
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    *,
+    live: bool = False,
+    client_factory: Callable[[], object] | None = None,
+    security_log_path: Path = DEFAULT_SECURITY_LOG_PATH,
+    store: CaseStore | None = None,
+    ledger_path: Path | None = None,
+) -> ThreadingHTTPServer:
+    """``ledger_path`` is ignored if an explicit ``store`` is passed in.
+
+    Left ``None`` (the default, and what every existing test uses), the
+    store stays in-memory only. Pass a path to make it durable: cases
+    survive a server restart, and one already dialed is never re-dialed.
+    """
+    if store is None:
+        ledger = CaseLedger(ledger_path) if ledger_path is not None else None
+        store = CaseStore(ledger)
+    handler = type(
+        "ConfiguredRingfenceHandler",
+        (RingfenceHandler,),
+        {
+            "store": store,
+            "live": live,
+            "client_factory": client_factory,
+            "security_log": SecurityEventLog(security_log_path),
+        },
+    )
+    return ThreadingHTTPServer((host, port), handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--live", action="store_true", help="Place real calls. Requires --confirm-live.")
+    parser.add_argument("--confirm-live", action="store_true", help="Explicit second confirmation required alongside --live.")
+    parser.add_argument("--ledger-path", default=str(DEFAULT_LEDGER_PATH), help="Durable case ledger (JSONL). Cases survive a restart and are never re-dialed.")
+    parser.add_argument("--no-persist", action="store_true", help="Keep the case store in-memory only (state lost on restart).")
+    args = parser.parse_args(argv)
+
+    if args.live and not args.confirm_live:
+        raise SystemExit("--live requires --confirm-live (explicit, separate confirmation)")
+
+    client_factory = None
+    if args.live:
+        def client_factory():  # noqa: ANN202
+            from calle import CalleClient
+
+            api_key = os.environ.get("CALLE_API_KEY")
+            if not api_key:
+                raise SystemExit("CALLE_API_KEY is required for --live")
+            return CalleClient(api_key=api_key)
+
+    server = create_server(
+        host=args.host, port=args.port, live=args.live, client_factory=client_factory,
+        ledger_path=None if args.no_persist else Path(args.ledger_path),
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/python/ringfence/tests/test_audit.py
+++ b/apps/python/ringfence/tests/test_audit.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+from ringfence.audit import build_audit_report, render_terminal_report
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_audit_report_pairs_every_question_with_its_answer_for_a_full_conversation():
+    record = _load("13_scam_ceo_fraud_secrecy_and_urgency.json")
+    report = build_audit_report(record)
+
+    assert report["case_id"] == "case_f13"
+    assert report["disposition"]["disposition"] == "ADVISE_BLOCK"
+    assert len(report["verification_qa"]) == 3
+    assert all(qa["answer"] is not None for qa in report["verification_qa"])
+    assert "private" in report["verification_qa"][0]["question"]
+    assert "confidential" in report["verification_qa"][0]["answer"]
+
+
+def test_audit_report_on_a_never_dialed_case_has_no_conversation_and_empty_signals():
+    record = _load("09_rejected_before_ring_generic.json")
+    report = build_audit_report(record)
+
+    assert report["verification_qa"] == []
+    assert report["signals"] == {}
+    assert report["disposition"]["disposition"] == "ESCALATE_TO_HUMAN"
+    assert report["call_outcome"]["outcome"] == "rejected_before_ring"
+
+
+def test_audit_report_masks_the_dialed_phone_number():
+    record = _load("13_scam_ceo_fraud_secrecy_and_urgency.json")
+    report = build_audit_report(record)
+
+    assert record["case"]["on_file_phone"] not in report["dialed_phone_masked"]
+    assert "*" in report["dialed_phone_masked"]
+
+
+def test_terminal_report_renders_disposition_and_every_qa_pair():
+    record = _load("13_scam_ceo_fraud_secrecy_and_urgency.json")
+    report = build_audit_report(record)
+    rendered = render_terminal_report(report)
+
+    assert "RECOMMENDATION: ADVISE_BLOCK" in rendered
+    assert "ADVISORY ONLY" in rendered
+    for qa in report["verification_qa"]:
+        assert qa["question"] in rendered
+        assert qa["answer"] in rendered
+
+
+def test_terminal_report_on_no_conversation_case_says_so_explicitly():
+    record = _load("09_rejected_before_ring_generic.json")
+    report = build_audit_report(record)
+    rendered = render_terminal_report(report)
+
+    assert "(no conversation occurred)" in rendered
+
+
+def test_qa_pairing_uses_the_real_calle_speaker_labels_not_a_guess():
+    # Found by reading a provider transcript, not by review: CALL-E's
+    # actual speaker label is "bot", not "agent" -- this module originally
+    # hardcoded "agent"/"recipient" (a guess never checked against a real
+    # transcript) and silently paired zero Q&A turns against any real
+    # call, including a fully successful one.
+    record = {
+        "case": {
+            "case_id": "case_real_shape",
+            "account_holder_name": "Test Holder",
+            "on_file_phone": "+14155550199",
+            "claimed_transaction_amount": "500.00",
+            "claimed_recipient": "Test Recipient",
+            "claimed_payment_method": "wire",
+        },
+        "call": {"status": "completed", "task_completed": True, "failure_code": None, "failure_message": None},
+        "attempts": [{
+            "started_at": "2026-09-10T00:00:00Z",
+            "completed_at": "2026-09-10T00:01:00Z",
+            "transcript_turns": [
+                {"speaker": "bot", "text": "Did anyone ask you to keep this private?"},
+                {"speaker": "user", "text": "No."},
+            ],
+        }],
+        "events": [],
+        "signals": {},
+    }
+    report = build_audit_report(record)
+    assert report["verification_qa"] == [
+        {"question": "Did anyone ask you to keep this private?", "answer": "No."}
+    ]

--- a/apps/python/ringfence/tests/test_cli_audit.py
+++ b/apps/python/ringfence/tests/test_cli_audit.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from ringfence.cli import main
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_case_audit_prints_report_and_writes_json_and_html(tmp_path: Path, capsys):
+    out_json = tmp_path / "audit" / "case_f13.json"
+    out_html = tmp_path / "audit" / "case_f13.html"
+
+    exit_code = main([
+        "case", "audit",
+        "--file", str(FIXTURES_DIR / "13_scam_ceo_fraud_secrecy_and_urgency.json"),
+        "--out", str(out_json),
+        "--html", str(out_html),
+    ])
+
+    assert exit_code == 0
+    printed = capsys.readouterr().out
+    assert "RECOMMENDATION: ADVISE_BLOCK" in printed
+
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["case_id"] == "case_f13"
+    assert out_html.exists()
+    assert "<!doctype html>" in out_html.read_text(encoding="utf-8").lower()
+
+
+def test_case_report_index_builds_one_page_per_report_plus_an_index(tmp_path: Path):
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    for name in ("13_scam_ceo_fraud_secrecy_and_urgency.json", "09_rejected_before_ring_generic.json"):
+        main(["case", "audit", "--file", str(FIXTURES_DIR / name), "--out", str(reports_dir / name)])
+
+    out_dir = tmp_path / "html"
+    exit_code = main([
+        "case", "report-index",
+        "--from-reports", str(reports_dir),
+        "--out-dir", str(out_dir),
+    ])
+
+    assert exit_code == 0
+    assert (out_dir / "index.html").exists()
+    assert (out_dir / "case_f13.html").exists()
+    assert (out_dir / "case_f09.html").exists()
+    assert "case_f13.html" in (out_dir / "index.html").read_text(encoding="utf-8")

--- a/apps/python/ringfence/tests/test_crash_safety.py
+++ b/apps/python/ringfence/tests/test_crash_safety.py
@@ -1,0 +1,131 @@
+"""End-to-end crash-safety: CaseStore backed by CaseLedger, exercised
+through the real webhook handlers -- not just the ledger in isolation
+(see test_ledger.py for that).
+"""
+
+from pathlib import Path
+
+from ringfence.ledger import CaseLedger
+from ringfence.verify_call import PREVIEWED, SecurityEventLog
+from ringfence.webhook import CaseStore, handle_get, handle_submit
+
+_ON_FILE = "+14155550101"
+
+
+def _case_payload(**overrides) -> dict:
+    payload = dict(
+        case_id="case_crash_001",
+        account_holder_name="Pat Rivera",
+        on_file_phone=_ON_FILE,
+        claimed_transaction_amount="4500.00",
+        claimed_recipient="Jordan Rivera",
+        claimed_payment_method="wire",
+        request_supplied_callback_number=None,
+    )
+    payload.update(overrides)
+    return payload
+
+
+class _FakeCalls:
+    def __init__(self):
+        self.create_and_wait_calls = 0
+
+    def create_and_wait(self, **kwargs):
+        self.create_and_wait_calls += 1
+        return {"id": f"call_fake_{self.create_and_wait_calls}"}
+
+    def get(self, call_id: str):
+        return {
+            "id": call_id, "status": "completed", "task_completed": True,
+            "structured_result": {
+                "secrecy_demand_present": False, "urgency_pressure_present": False,
+                "relationship_explained": True, "irreversible_payment_demanded": False,
+                "explicit_hold_requested": False,
+            },
+            "recipients": [{"attempts": [{
+                "started_at": "2026-09-10T00:00:00Z", "completed_at": "2026-09-10T00:01:00Z",
+                "transcript_turns": [{"speaker": "bot", "text": "hi"}],
+            }]}],
+        }
+
+    def list_events(self, call_id: str):
+        return {"data": []}
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = _FakeCalls()
+
+
+def test_dry_run_case_survives_a_simulated_process_restart(tmp_path: Path):
+    ledger_path = tmp_path / "ledger.jsonl"
+    security_log = SecurityEventLog(tmp_path / "security_events.jsonl")
+
+    store_before_restart = CaseStore(CaseLedger(ledger_path))
+    status, payload = handle_submit(
+        store_before_restart, _case_payload(), live=False, security_log=security_log, client_factory=None
+    )
+    assert status == 201
+    assert payload["status"] == PREVIEWED
+
+    # Simulate a restart: a brand new CaseStore/process, same ledger file on disk.
+    store_after_restart = CaseStore(CaseLedger(ledger_path))
+    status, fetched = handle_get(store_after_restart, "case_crash_001")
+    assert status == 200
+    assert fetched["case_id"] == "case_crash_001"
+    assert fetched["status"] == PREVIEWED
+
+
+def test_a_case_already_dialed_before_a_restart_is_never_redialed_after(tmp_path: Path):
+    ledger_path = tmp_path / "ledger.jsonl"
+    security_log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    fake_client = _FakeClient()
+
+    store_before_restart = CaseStore(CaseLedger(ledger_path))
+    status1, payload1 = handle_submit(
+        store_before_restart, _case_payload(), live=True, security_log=security_log,
+        client_factory=lambda: fake_client,
+    )
+    assert status1 == 201
+    assert payload1["disposition"] == "ADVISE_ALLOW"
+    assert fake_client.calls.create_and_wait_calls == 1
+
+    class _ClientThatMustNotBeCalledAgain:
+        class _Calls:
+            def create_and_wait(self, **kwargs):
+                raise AssertionError("a case already resolved before the restart must never be re-dialed")
+
+        calls = _Calls()
+
+    # Simulate a restart with a fresh, empty in-memory store -- only the
+    # ledger on disk carries the fact that this case was already handled.
+    store_after_restart = CaseStore(CaseLedger(ledger_path))
+    status2, payload2 = handle_submit(
+        store_after_restart, _case_payload(), live=True, security_log=security_log,
+        client_factory=lambda: _ClientThatMustNotBeCalledAgain(),
+    )
+    assert status2 == 200  # returned the existing, ledger-restored record
+    assert payload2["disposition"] == "ADVISE_ALLOW"
+    assert payload2["call_id"] == payload1["call_id"]
+
+
+def test_a_crash_mid_write_loses_at_most_the_single_in_flight_write(tmp_path: Path):
+    ledger_path = tmp_path / "ledger.jsonl"
+    security_log = SecurityEventLog(tmp_path / "security_events.jsonl")
+
+    store = CaseStore(CaseLedger(ledger_path))
+    handle_submit(store, _case_payload(case_id="case_a"), live=False, security_log=security_log, client_factory=None)
+    handle_submit(store, _case_payload(case_id="case_b"), live=False, security_log=security_log, client_factory=None)
+
+    # Simulate the process dying mid-append while starting a third case.
+    with open(ledger_path, "a", encoding="utf-8") as f:
+        f.write('{"event": "create", "case_id": "case_c", "record": {"case_id": "case_c", "stat')
+
+    recovered_store = CaseStore(CaseLedger(ledger_path))
+    _, case_a = handle_get(recovered_store, "case_a")
+    _, case_b = handle_get(recovered_store, "case_b")
+    status_c, _ = handle_get(recovered_store, "case_c")
+
+    assert case_a["case_id"] == "case_a"
+    assert case_b["case_id"] == "case_b"
+    assert status_c == 404  # the truncated write for case_c never committed -- correctly absent, not corrupted

--- a/apps/python/ringfence/tests/test_decide.py
+++ b/apps/python/ringfence/tests/test_decide.py
@@ -1,0 +1,160 @@
+from ringfence import decide as decide_mod
+from ringfence import resolve
+
+_CLEAN_SIGNALS = {
+    "secrecy_demand_present": False,
+    "urgency_pressure_present": False,
+    "relationship_explained": True,
+    "irreversible_payment_demanded": False,
+    "explicit_hold_requested": False,
+}
+
+
+def _resolution(outcome: str) -> resolve.Resolution:
+    return resolve.Resolution(outcome=outcome, confidence="high", evidence=["test"])
+
+
+def test_explicit_hold_always_blocks_even_with_otherwise_clean_signals():
+    signals = dict(_CLEAN_SIGNALS, explicit_hold_requested=True)
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+    assert "explicit_hold_requested" in result.reasons
+
+
+def test_secrecy_demand_blocks():
+    signals = dict(_CLEAN_SIGNALS, secrecy_demand_present=True)
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+
+
+def test_urgency_pressure_blocks():
+    signals = dict(_CLEAN_SIGNALS, urgency_pressure_present=True)
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+
+
+def test_unexplained_relationship_blocks():
+    signals = dict(_CLEAN_SIGNALS, relationship_explained=False)
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+
+
+def test_irreversible_payment_demanded_blocks():
+    signals = dict(_CLEAN_SIGNALS, irreversible_payment_demanded=True)
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+
+
+def test_multiple_red_flags_all_reported():
+    signals = dict(
+        _CLEAN_SIGNALS,
+        secrecy_demand_present=True,
+        urgency_pressure_present=True,
+    )
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition == decide_mod.ADVISE_BLOCK
+    assert "secrecy_demand_present" in result.reasons
+    assert "urgency_pressure_present" in result.reasons
+
+
+def test_unresolved_ambiguous_escalates_never_allows():
+    result = decide_mod.decide(_resolution(resolve.UNRESOLVED_AMBIGUOUS), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ESCALATE_TO_HUMAN
+
+
+def test_no_answer_confirmed_escalates_never_allows():
+    result = decide_mod.decide(_resolution(resolve.NO_ANSWER_CONFIRMED), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ESCALATE_TO_HUMAN
+
+
+def test_rejected_before_ring_escalates_never_allows():
+    result = decide_mod.decide(_resolution(resolve.REJECTED_BEFORE_RING), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ESCALATE_TO_HUMAN
+
+
+def test_clean_conversation_with_explicit_confirmation_allows():
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ADVISE_ALLOW
+
+
+def test_missing_signals_never_allow():
+    # No signals at all (e.g. a malformed/incomplete result) must fail
+    # closed, not be read as "clean."
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), {})
+    assert result.disposition != decide_mod.ADVISE_ALLOW
+
+
+def test_missing_secrecy_signal_alone_never_allows():
+    # Only relationship_explained/explicit_hold_requested being clean is not
+    # enough — every signal ALLOW depends on must be affirmatively present.
+    signals = dict(_CLEAN_SIGNALS)
+    del signals["secrecy_demand_present"]
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition != decide_mod.ADVISE_ALLOW
+
+
+def test_missing_urgency_signal_alone_never_allows():
+    signals = dict(_CLEAN_SIGNALS)
+    del signals["urgency_pressure_present"]
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition != decide_mod.ADVISE_ALLOW
+
+
+def test_missing_irreversible_payment_signal_alone_never_allows():
+    signals = dict(_CLEAN_SIGNALS)
+    del signals["irreversible_payment_demanded"]
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_SUCCESS), signals)
+    assert result.disposition != decide_mod.ADVISE_ALLOW
+
+
+def test_decide_checks_every_signal_declared_in_result_schema():
+    # Tripwire against decide.py silently drifting out of sync with
+    # verify_call.RESULT_SCHEMA if a new signal field is ever added there.
+    import inspect
+
+    from ringfence.verify_call import RESULT_SCHEMA
+
+    source = inspect.getsource(decide_mod.decide)
+    for field in RESULT_SCHEMA["required"]:
+        assert field in source, f"decide() never reads {field!r} from RESULT_SCHEMA"
+
+
+def test_answered_declined_falls_to_escalate_not_allow():
+    result = decide_mod.decide(_resolution(resolve.ANSWERED_DECLINED), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ESCALATE_TO_HUMAN
+
+
+def test_policy_or_content_refusal_falls_to_escalate_not_allow():
+    result = decide_mod.decide(_resolution(resolve.POLICY_OR_CONTENT_REFUSAL), _CLEAN_SIGNALS)
+    assert result.disposition == decide_mod.ESCALATE_TO_HUMAN
+
+
+def test_every_recommendation_is_advisory_and_requires_human_review():
+    # The whole module is advisory by construction: no input produces a
+    # value an integrator may act on without a human. Covers every branch
+    # decide() can return through.
+    cases = [
+        (resolve.ANSWERED_SUCCESS, _CLEAN_SIGNALS),                                    # ADVISE_ALLOW
+        (resolve.ANSWERED_SUCCESS, dict(_CLEAN_SIGNALS, secrecy_demand_present=True)),  # ADVISE_BLOCK
+        (resolve.ANSWERED_SUCCESS, dict(_CLEAN_SIGNALS, explicit_hold_requested=True)),  # ADVISE_BLOCK (hold)
+        (resolve.NO_ANSWER_CONFIRMED, _CLEAN_SIGNALS),                                  # ESCALATE (unresolved)
+        (resolve.ANSWERED_SUCCESS, {}),                                                 # ESCALATE (fallback)
+    ]
+    seen = set()
+    for outcome, signals in cases:
+        result = decide_mod.decide(_resolution(outcome), signals)
+        seen.add(result.disposition)
+        assert result.advisory is True
+        assert result.requires_human_review is True
+        as_dict = result.as_dict()
+        assert as_dict["advisory"] is True
+        assert as_dict["requires_human_review"] is True
+    assert seen == set(decide_mod.RECOMMENDATIONS)
+
+
+def test_no_recommendation_is_named_like_an_executable_financial_action():
+    # ALLOW/BLOCK read as instructions to release or freeze money; these
+    # values are recommendations about a phone call, and are named so.
+    for recommendation in decide_mod.RECOMMENDATIONS:
+        assert recommendation not in ("ALLOW", "BLOCK", "APPROVE", "DENY")
+        assert recommendation.startswith(("ADVISE_", "ESCALATE_"))

--- a/apps/python/ringfence/tests/test_demo_server.py
+++ b/apps/python/ringfence/tests/test_demo_server.py
@@ -1,0 +1,383 @@
+"""Demo server tests. The bank decides automatically -- the amount
+threshold decides whether verification is required at all, and if so a
+recorded scenario is picked for it -- never a customer- or operator-driven
+choice. These tests focus on: that automatic decision, that the real
+resolve.classify()/decide() run underneath (not fake logic), that every
+result is marked advisory and human-review-required, that this server has
+no live-call path at all, and that a non-loopback bind cannot run
+unauthenticated.
+"""
+
+import ast
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.client import HTTPResponse
+from pathlib import Path
+
+import pytest
+
+from ringfence import demo_server
+from ringfence.demo_server import (
+    AUTO_APPROVE_BELOW_AMOUNT,
+    DEMO_TOKEN_ENV,
+    NO_VERIFICATION_REQUIRED,
+    DemoStore,
+    create_server,
+    handle_get,
+    handle_list,
+    handle_list_scenarios,
+    handle_submit,
+    is_loopback_host,
+    load_scenarios,
+    main,
+    token_is_valid,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+_SMALL_AMOUNT = f"{AUTO_APPROVE_BELOW_AMOUNT - 1:.2f}"
+_LARGE_AMOUNT = f"{AUTO_APPROVE_BELOW_AMOUNT + 1000:.2f}"
+_ADVISORY_RECOMMENDATIONS = ("ADVISE_ALLOW", "ADVISE_BLOCK", "ESCALATE_TO_HUMAN")
+
+
+@pytest.fixture
+def scenarios():
+    return load_scenarios(FIXTURES_DIR)
+
+
+def test_load_scenarios_finds_every_fixture(scenarios):
+    assert len(scenarios) == len(list(FIXTURES_DIR.glob("*.json")))
+    assert "13_scam_ceo_fraud_secrecy_and_urgency" in scenarios
+
+
+def test_list_scenarios_gives_every_scenario_a_plain_text_label_and_its_own_category(scenarios):
+    # Labels are plain text -- no emoji baked in. The frontend renders an
+    # icon from `category` instead, so category has to actually be present
+    # and correct on every scenario.
+    status, payload = handle_list_scenarios(scenarios)
+    assert status == 200
+    assert len(payload["scenarios"]) == len(scenarios)
+    for item in payload["scenarios"]:
+        assert item["label"]
+        assert item["label"].isascii()
+        assert item["key"] in scenarios
+        assert item["category"] == scenarios[item["key"]]["category"]
+
+
+def test_every_case_record_carries_a_category_for_icon_selection(scenarios):
+    store = DemoStore()
+
+    _, below_threshold = handle_submit(
+        store, scenarios, {"account_holder_name": "A", "claimed_transaction_amount": _SMALL_AMOUNT},
+    )
+    assert below_threshold["category"] == "no_verification_required"
+
+    _, simulated = handle_submit(
+        store, scenarios, {"account_holder_name": "B", "claimed_transaction_amount": _LARGE_AMOUNT},
+        delay_seconds=0.01,
+    )
+    assert simulated["category"] in ("scam_pattern", "clean_legitimate", "escalation_case")
+    assert simulated["scenario_label"].isascii()
+
+
+def test_small_amount_needs_no_verification_and_makes_no_recommendation(scenarios):
+    store = DemoStore()
+    status, record = handle_submit(
+        store, scenarios,
+        {"account_holder_name": "Jordan Rivera", "claimed_transaction_amount": _SMALL_AMOUNT},
+    )
+    assert status == 201
+    assert record["status"] == "resolved"  # no pending state at all -- resolved immediately
+    # No call happened, so this is the institution's own deterministic
+    # threshold policy, not one of decide()'s heuristic recommendations.
+    assert record["disposition"] == NO_VERIFICATION_REQUIRED
+    assert record["disposition"] not in _ADVISORY_RECOMMENDATIONS
+    assert record["requires_human_review"] is False
+    assert record["scenario_key"] is None
+    assert record["audit"] is None  # no call happened, so there's nothing to audit
+
+
+def test_large_amount_runs_a_simulated_verification(scenarios):
+    store = DemoStore()
+    status, record = handle_submit(
+        store, scenarios,
+        {"account_holder_name": "New Customer", "claimed_transaction_amount": _LARGE_AMOUNT},
+        delay_seconds=0.02,
+    )
+    assert status == 201
+    assert record["status"] == "pending_verification_call"
+
+    time.sleep(0.1)
+    _, resolved = handle_get(store, record["id"])
+    assert resolved["status"] == "resolved"
+    assert resolved["scenario_key"] in scenarios
+    assert resolved["disposition"] in _ADVISORY_RECOMMENDATIONS
+
+
+def test_every_call_derived_recommendation_is_advisory_and_needs_human_review(scenarios):
+    # The must-not-regress property: nothing this server produces from a
+    # call interpretation may present as a completed financial action.
+    store = DemoStore()
+    _, record = handle_submit(
+        store, scenarios,
+        {"account_holder_name": "Someone", "claimed_transaction_amount": _LARGE_AMOUNT},
+        delay_seconds=0.02,
+    )
+    assert record["advisory"] is True
+    assert record["requires_human_review"] is True
+
+    time.sleep(0.1)
+    _, resolved = handle_get(store, record["id"])
+    assert resolved["advisory"] is True
+    assert resolved["requires_human_review"] is True
+    assert resolved["disposition"].startswith(("ADVISE_", "ESCALATE_"))
+    assert resolved["audit"]["disposition"]["advisory"] is True
+    assert resolved["audit"]["disposition"]["requires_human_review"] is True
+
+
+def test_the_customer_never_chooses_the_scenario_or_whether_to_call(scenarios):
+    # No API surface accepts a customer-supplied scenario_key at all for a
+    # normal submission -- confirmed by checking the bank's own random
+    # pick lands in the real scenario set even when a bogus one is
+    # supplied in the payload (it's simply ignored).
+    store = DemoStore()
+    status, record = handle_submit(
+        store, scenarios,
+        {
+            "account_holder_name": "Someone", "claimed_transaction_amount": _LARGE_AMOUNT,
+            "scenario_key": "not_a_real_scenario_a_customer_might_try_to_inject",
+        },
+        delay_seconds=0.02,
+    )
+    assert status == 201
+    time.sleep(0.1)
+    _, resolved = handle_get(store, record["id"])
+    assert resolved["scenario_key"] in scenarios
+
+
+def test_using_a_single_known_scenario_confirms_the_real_decision_engine_runs():
+    # Restricting the scenario pool to exactly one fixture makes the
+    # "random" pick deterministic, so this can assert a specific
+    # recommendation end to end -- proving the demo runs the real engine,
+    # not a hardcoded result.
+    one_scenario = load_scenarios(FIXTURES_DIR)
+    one_scenario = {"13_scam_ceo_fraud_secrecy_and_urgency": one_scenario["13_scam_ceo_fraud_secrecy_and_urgency"]}
+
+    store = DemoStore()
+    status, record = handle_submit(
+        store, one_scenario,
+        {
+            "account_holder_name": "Taylor Doe", "claimed_recipient": "Some Vendor",
+            "claimed_transaction_amount": _LARGE_AMOUNT,
+        },
+        delay_seconds=0.05,
+    )
+    assert status == 201
+
+    time.sleep(0.2)
+    _, resolved = handle_get(store, record["id"])
+    assert resolved["status"] == "resolved"
+    assert resolved["disposition"] == "ADVISE_BLOCK"
+    assert "secrecy_demand_present" in resolved["disposition_reasons"]
+    assert resolved["audit"]["verification_qa"]
+    # The audit trail reflects what was actually typed into the demo form,
+    # not the fixture author's own placeholder case details.
+    assert resolved["audit"]["account_holder_name"] == "Taylor Doe"
+    assert resolved["audit"]["claimed_recipient"] == "Some Vendor"
+    assert resolved["audit"]["claimed_transaction_amount"] == _LARGE_AMOUNT
+
+
+def test_this_server_has_no_live_call_path_at_all():
+    # Structural, not behavioural: the deployable surface must not even
+    # contain the machinery for a real call, so there is nothing to
+    # accidentally re-enable with an environment variable.
+    tree = ast.parse(Path(demo_server.__file__).read_text(encoding="utf-8"))
+    # Strip docstrings (which legitimately *discuss* the absent live path)
+    # so this checks real code; ast.unparse drops comments for the same
+    # reason.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            first = node.body[0] if node.body else None
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                node.body.pop(0)
+    code = ast.unparse(tree)
+    for forbidden in ("CALLE_API_KEY", "CalleClient", "place_verification_call", "live_enabled"):
+        assert forbidden not in code, f"demo_server must not reference {forbidden}"
+    assert not hasattr(demo_server, "default_live_client_factory")
+
+
+def test_a_phone_number_is_never_collected_or_stored(scenarios):
+    # Even if a client sends one, nothing accepts it: there is no field to
+    # read it into and no code to dial it.
+    store = DemoStore()
+    _, record = handle_submit(
+        store, scenarios,
+        {
+            "account_holder_name": "Someone", "claimed_transaction_amount": _LARGE_AMOUNT,
+            "on_file_phone": "+14155550199", "region": "US",
+        },
+        delay_seconds=0.02,
+    )
+    assert "+14155550199" not in json.dumps(record)
+
+    time.sleep(0.1)
+    _, resolved = handle_get(store, record["id"])
+    assert "+14155550199" not in json.dumps(resolved)
+
+
+def test_list_returns_all_cases_newest_first(scenarios):
+    store = DemoStore()
+    handle_submit(store, scenarios, {"account_holder_name": "A", "claimed_transaction_amount": _SMALL_AMOUNT})
+    time.sleep(0.02)
+    handle_submit(store, scenarios, {"account_holder_name": "B", "claimed_transaction_amount": _SMALL_AMOUNT})
+
+    status, payload = handle_list(store)
+    assert status == 200
+    assert len(payload["cases"]) == 2
+    assert payload["cases"][0]["submitted_at"] >= payload["cases"][1]["submitted_at"]
+
+
+def test_get_unknown_case_id_is_404():
+    store = DemoStore()
+    status, payload = handle_get(store, "does_not_exist")
+    assert status == 404
+    assert payload["error"] == "not_found"
+
+
+def test_token_check_is_a_no_op_only_when_no_token_is_configured():
+    assert token_is_valid(None, None) is True
+    assert token_is_valid("", None) is True
+    assert token_is_valid("s3cret", None) is False
+    assert token_is_valid("s3cret", "") is False
+    assert token_is_valid("s3cret", "wrong") is False
+    assert token_is_valid("s3cret", "s3cret") is True
+
+
+def test_loopback_detection_covers_the_hosts_that_are_not_publicly_reachable():
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("localhost")
+    assert is_loopback_host("::1")
+    assert not is_loopback_host("0.0.0.0")
+    assert not is_loopback_host("10.0.0.7")
+
+
+def test_a_public_bind_without_a_token_refuses_to_start(monkeypatch, capsys):
+    monkeypatch.delenv(DEMO_TOKEN_ENV, raising=False)
+    assert main(["--host", "0.0.0.0", "--port", "0"]) == 2
+    assert "refusing to start" in capsys.readouterr().out
+
+
+def _request(
+    base: str, method: str, path: str, body: dict | None = None, token: str | None = None
+) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(f"{base}{path}", data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    if token is not None:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        resp: HTTPResponse = urllib.request.urlopen(req, timeout=5)
+        return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _serve(server):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_http_round_trip_submit_then_list_and_get(scenarios):
+    server = create_server(host="127.0.0.1", port=0, delay_seconds=0.05, scenarios=scenarios)
+    thread = _serve(server)
+    try:
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        status, record = _request(
+            base, "POST", "/api/demo/cases",
+            {"account_holder_name": "Jordan Rivera", "claimed_transaction_amount": _SMALL_AMOUNT},
+        )
+        assert status == 201
+        assert record["status"] == "resolved"
+        assert record["disposition"] == NO_VERIFICATION_REQUIRED
+
+        status, listing = _request(base, "GET", "/api/demo/cases")
+        assert status == 200
+        assert len(listing["cases"]) == 1
+
+        status, scenario_list = _request(base, "GET", "/api/demo/scenarios")
+        assert status == 200
+        assert len(scenario_list["scenarios"]) == len(scenarios)
+
+        status, fetched = _request(base, "GET", f"/api/demo/cases/{record['id']}")
+        assert status == 200
+        assert fetched["status"] == "resolved"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_every_route_is_401_without_the_configured_token(scenarios):
+    server = create_server(
+        host="127.0.0.1", port=0, delay_seconds=0.05, scenarios=scenarios, demo_token="s3cret"
+    )
+    thread = _serve(server)
+    try:
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        for method, path, body in (
+            ("GET", "/", None),
+            ("GET", "/bank", None),
+            ("GET", "/api/demo/scenarios", None),
+            ("GET", "/api/demo/cases", None),
+            ("POST", "/api/demo/cases", {"claimed_transaction_amount": _SMALL_AMOUNT}),
+        ):
+            status, payload = _request(base, method, path, body)
+            assert status == 401, f"{method} {path} was reachable without a token"
+            assert payload["error"] == "unauthorized"
+
+        status, payload = _request(base, "GET", "/api/demo/cases", token="wrong")
+        assert status == 401
+
+        # The health check is the one unauthenticated route, and says
+        # nothing but "up".
+        status, payload = _request(base, "GET", "/healthz")
+        assert status == 200
+        assert payload == {"status": "ok"}
+
+        status, payload = _request(base, "GET", "/api/demo/cases", token="s3cret")
+        assert status == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_a_query_parameter_token_authorizes_a_page_and_sets_a_cookie(scenarios):
+    server = create_server(
+        host="127.0.0.1", port=0, delay_seconds=0.05, scenarios=scenarios, demo_token="s3cret"
+    )
+    thread = _serve(server)
+    try:
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        with urllib.request.urlopen(f"{base}/?token=s3cret", timeout=5) as resp:
+            assert resp.status == 200
+            cookie = resp.headers.get("Set-Cookie") or ""
+        assert "ringfence_demo_token=s3cret" in cookie
+        assert "HttpOnly" in cookie
+
+        req = urllib.request.Request(f"{base}/api/demo/cases")
+        req.add_header("Cookie", "ringfence_demo_token=s3cret")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            assert resp.status == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/apps/python/ringfence/tests/test_evaluation.py
+++ b/apps/python/ringfence/tests/test_evaluation.py
@@ -1,0 +1,43 @@
+"""Regenerates the README's measured-evaluation numbers — never hand-typed.
+
+Also checks every fixture's own `expected_disposition` against what
+decide() actually returns, so a fixture author cannot silently mislabel a
+case (the same discipline calltruth's test_resolve.py applies per-fixture).
+"""
+
+import json
+from pathlib import Path
+
+from ringfence import decide as decide_mod
+from ringfence import resolve
+from ringfence.evaluation import evaluate_fixture_corpus
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def test_every_fixture_matches_its_own_expected_disposition():
+    mismatches = []
+    for path in sorted(FIXTURES_DIR.glob("*.json")):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        resolution = resolve.classify(
+            record["call"], record.get("attempts", []), record.get("events", [])
+        )
+        disposition = decide_mod.decide(resolution, record.get("signals", {}))
+        expected = record.get("expected_disposition")
+        if expected and disposition.disposition != expected:
+            mismatches.append(
+                f"{path.name}: expected {expected}, got {disposition.disposition} ({disposition.reasons})"
+            )
+    assert not mismatches, "\n".join(mismatches)
+
+
+def test_scam_pattern_fixtures_never_resolve_to_allow():
+    result = evaluate_fixture_corpus(FIXTURES_DIR)
+    assert result.scam_pattern_total > 0
+    assert result.scam_pattern_correct == result.scam_pattern_total, result.mismatches
+
+
+def test_clean_legitimate_fixtures_are_not_over_triggered_into_a_false_block():
+    result = evaluate_fixture_corpus(FIXTURES_DIR)
+    assert result.clean_legitimate_total > 0
+    assert result.clean_legitimate_correct == result.clean_legitimate_total, result.mismatches

--- a/apps/python/ringfence/tests/test_html_report.py
+++ b/apps/python/ringfence/tests/test_html_report.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from ringfence.audit import build_audit_report
+from ringfence.html_report import render_html_report, render_index_html
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_html_report_escapes_untrusted_case_fields_instead_of_injecting_markup():
+    record = _load("13_scam_ceo_fraud_secrecy_and_urgency.json")
+    record = dict(record)
+    record["case"] = dict(record["case"])
+    record["case"]["account_holder_name"] = "<script>alert(1)</script>"
+    report = build_audit_report(record)
+
+    rendered = render_html_report(report)
+
+    assert "<script>alert(1)</script>" not in rendered
+    assert "&lt;script&gt;" in rendered
+
+
+def test_html_report_shows_disposition_and_qa_content():
+    record = _load("13_scam_ceo_fraud_secrecy_and_urgency.json")
+    report = build_audit_report(record)
+    rendered = render_html_report(report)
+
+    assert "ADVISE_BLOCK" in rendered
+    assert report["verification_qa"][0]["question"] in rendered
+    assert "<!doctype html>" in rendered.lower()
+
+
+def test_html_report_on_no_conversation_case_says_so_explicitly():
+    record = _load("09_rejected_before_ring_generic.json")
+    report = build_audit_report(record)
+    rendered = render_html_report(report)
+
+    assert "no conversation occurred" in rendered
+
+
+def test_index_html_links_to_each_case_and_escapes_untrusted_fields():
+    reports = [
+        build_audit_report(_load("13_scam_ceo_fraud_secrecy_and_urgency.json")),
+        build_audit_report(_load("09_rejected_before_ring_generic.json")),
+    ]
+    rendered = render_index_html(reports)
+
+    assert "case_f13.html" in rendered
+    assert "case_f09.html" in rendered
+    assert "ADVISE_BLOCK" in rendered
+    assert "ESCALATE_TO_HUMAN" in rendered
+
+
+def test_index_html_on_an_empty_report_list_does_not_crash():
+    rendered = render_index_html([])
+    assert "no cases" in rendered

--- a/apps/python/ringfence/tests/test_invariant_never_calls_request_supplied_number.py
+++ b/apps/python/ringfence/tests/test_invariant_never_calls_request_supplied_number.py
@@ -1,0 +1,161 @@
+"""The load-bearing test: RingFence never dials a number that arrived as
+part of the flagged request, even when that number is identical to, or
+disguised to look like, the on-file number.
+"""
+
+from ringfence.case import Case
+from ringfence.verify_call import (
+    DEFAULT_INSTITUTION_NAME,
+    PREVIEWED,
+    SecurityEventLog,
+    place_verification_call,
+    render_task,
+    resolve_dial_target,
+)
+
+_ON_FILE = "+14155550101"
+_SMUGGLED = "+14155559999"
+
+
+def _make_case(**overrides) -> Case:
+    fields = dict(
+        case_id="case_001",
+        account_holder_name="Pat Rivera",
+        on_file_phone=_ON_FILE,
+        claimed_transaction_amount="4500.00",
+        claimed_recipient="Jordan Rivera",
+        claimed_payment_method="wire",
+        request_supplied_callback_number=None,
+    )
+    fields.update(overrides)
+    return Case(**fields)
+
+
+def test_dial_target_is_always_the_on_file_number():
+    case = _make_case(request_supplied_callback_number=_SMUGGLED)
+    assert resolve_dial_target(case) == _ON_FILE
+
+
+def test_dial_target_ignores_request_supplied_number_even_when_absent():
+    case = _make_case(request_supplied_callback_number=None)
+    assert resolve_dial_target(case) == _ON_FILE
+
+
+def test_smuggled_number_identical_to_on_file_is_still_just_on_file():
+    # Not a special case: resolve_dial_target never reads the smuggled field
+    # for dialing purposes, so an attacker who guesses the real number gains
+    # nothing.
+    case = _make_case(request_supplied_callback_number=_ON_FILE)
+    assert resolve_dial_target(case) == _ON_FILE
+
+
+def test_smuggled_number_is_logged_as_a_security_event(tmp_path):
+    case = _make_case(request_supplied_callback_number=_SMUGGLED)
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    target = resolve_dial_target(case, security_log=log)
+    assert target == _ON_FILE
+    assert len(log.events) == 1
+    event = log.events[0]
+    assert event["event"] == "rejected_request_supplied_callback_number"
+    assert event["case_id"] == "case_001"
+    # Neither phone number appears unmasked in the logged event.
+    assert _ON_FILE not in json_dump(event)
+    assert _SMUGGLED not in json_dump(event)
+
+
+def test_no_smuggled_number_logs_nothing(tmp_path):
+    case = _make_case(request_supplied_callback_number=None)
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    resolve_dial_target(case, security_log=log)
+    assert log.events == []
+
+
+def test_place_verification_call_dry_run_dials_on_file_number_only(tmp_path):
+    case = _make_case(request_supplied_callback_number=_SMUGGLED)
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    outcome = place_verification_call(case, live=False, security_log=log)
+    assert outcome.status == PREVIEWED
+    assert len(log.events) == 1
+
+
+def test_place_verification_call_live_dials_on_file_number_via_client(tmp_path):
+    dialed = {}
+
+    class _FakeCalls:
+        def create_and_wait(self, **kwargs):
+            dialed["recipients"] = kwargs["recipients"]
+            return {"id": "call_fake_1"}
+
+    class _FakeClient:
+        calls = _FakeCalls()
+
+    case = _make_case(request_supplied_callback_number=_SMUGGLED)
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    outcome = place_verification_call(
+        case, live=True, security_log=log, client_factory=lambda: _FakeClient()
+    )
+    assert outcome.call_id == "call_fake_1"
+    assert dialed["recipients"] == [{"phones": [_ON_FILE], "region": "US", "locale": "en-US"}]
+    assert _SMUGGLED not in str(dialed)
+
+
+def test_place_verification_call_uses_the_case_s_own_region_and_locale_when_set(tmp_path):
+    # Found missing entirely by a real live-call test to a documented-
+    # supported international number (+91/IN) -- omitting region/locale
+    # caused calls to a supported international number to fail instantly.
+    dialed = {}
+
+    class _FakeCalls:
+        def create_and_wait(self, **kwargs):
+            dialed["recipients"] = kwargs["recipients"]
+            return {"id": "call_fake_2"}
+
+    class _FakeClient:
+        calls = _FakeCalls()
+
+    case = _make_case(on_file_phone="+919876543210", region="IN", locale="en-US")
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    place_verification_call(case, live=True, security_log=log, client_factory=lambda: _FakeClient())
+    assert dialed["recipients"] == [{"phones": ["+919876543210"], "region": "IN", "locale": "en-US"}]
+
+
+def test_place_verification_call_falls_back_to_default_region_and_locale_when_unset(tmp_path):
+    dialed = {}
+
+    class _FakeCalls:
+        def create_and_wait(self, **kwargs):
+            dialed["recipients"] = kwargs["recipients"]
+            return {"id": "call_fake_3"}
+
+    class _FakeClient:
+        calls = _FakeCalls()
+
+    case = _make_case()  # region/locale left unset
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    place_verification_call(case, live=True, security_log=log, client_factory=lambda: _FakeClient())
+    assert dialed["recipients"][0]["region"] == "US"
+    assert dialed["recipients"][0]["locale"] == "en-US"
+
+
+def test_render_task_names_a_concrete_institution_not_a_vague_one():
+    # Found by exercising the live API, not by review: CALL-E's
+    # own content-policy layer rejects a task that never names a concrete
+    # requesting entity, citing exactly the vague/hidden-identity risk this
+    # project's own detection logic screens callers for.
+    case = _make_case()
+    task = render_task(case)
+    assert DEFAULT_INSTITUTION_NAME in task
+    assert "their financial institution" not in task
+
+
+def test_render_task_uses_the_case_s_own_institution_name_when_set():
+    case = _make_case(institution_name="Contoso Federal Credit Union")
+    task = render_task(case)
+    assert "Contoso Federal Credit Union" in task
+    assert DEFAULT_INSTITUTION_NAME not in task
+
+
+def json_dump(obj) -> str:
+    import json
+
+    return json.dumps(obj)

--- a/apps/python/ringfence/tests/test_ledger.py
+++ b/apps/python/ringfence/tests/test_ledger.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from ringfence.ledger import CaseLedger, CorruptLedgerEntry
+
+
+def test_replay_of_a_missing_file_is_an_empty_dict(tmp_path: Path):
+    ledger = CaseLedger(tmp_path / "ledger.jsonl")
+    assert ledger.replay() == {}
+
+
+def test_create_then_replay_round_trips_the_record(tmp_path: Path):
+    ledger = CaseLedger(tmp_path / "ledger.jsonl")
+    ledger.append("create", "case_1", {"case_id": "case_1", "status": "reserved"})
+    assert ledger.replay() == {"case_1": {"case_id": "case_1", "status": "reserved"}}
+
+
+def test_update_events_merge_into_the_existing_record(tmp_path: Path):
+    ledger = CaseLedger(tmp_path / "ledger.jsonl")
+    ledger.append("create", "case_1", {"case_id": "case_1", "status": "reserved", "disposition": None})
+    ledger.append("update", "case_1", {"status": "dialed"})
+    ledger.append("update", "case_1", {"disposition": "ADVISE_ALLOW"})
+    assert ledger.replay() == {
+        "case_1": {"case_id": "case_1", "status": "dialed", "disposition": "ADVISE_ALLOW"}
+    }
+
+
+def test_multiple_cases_are_tracked_independently(tmp_path: Path):
+    ledger = CaseLedger(tmp_path / "ledger.jsonl")
+    ledger.append("create", "case_1", {"case_id": "case_1", "status": "reserved"})
+    ledger.append("create", "case_2", {"case_id": "case_2", "status": "reserved"})
+    ledger.append("update", "case_1", {"status": "dialed"})
+    state = ledger.replay()
+    assert state["case_1"]["status"] == "dialed"
+    assert state["case_2"]["status"] == "reserved"
+
+
+def test_truncated_final_line_from_a_mid_write_crash_is_skipped_not_fatal(tmp_path: Path):
+    path = tmp_path / "ledger.jsonl"
+    ledger = CaseLedger(path)
+    ledger.append("create", "case_1", {"case_id": "case_1", "status": "reserved"})
+    ledger.append("create", "case_2", {"case_id": "case_2", "status": "reserved"})
+    # Simulate a crash mid-write: append a half-written JSON line (no closing brace).
+    with open(path, "a", encoding="utf-8") as f:
+        f.write('{"event": "update", "case_id": "case_2", "record": {"status": "dia')
+
+    state = ledger.replay()
+    assert state == {
+        "case_1": {"case_id": "case_1", "status": "reserved"},
+        "case_2": {"case_id": "case_2", "status": "reserved"},
+    }
+
+
+def test_a_corrupt_line_that_is_not_the_last_one_still_raises(tmp_path: Path):
+    path = tmp_path / "ledger.jsonl"
+    ledger = CaseLedger(path)
+    ledger.append("create", "case_1", {"case_id": "case_1", "status": "reserved"})
+    with open(path, "a", encoding="utf-8") as f:
+        f.write('{"not valid json\n')  # corrupt, but NOT the final line
+    ledger.append("create", "case_2", {"case_id": "case_2", "status": "reserved"})
+
+    with pytest.raises(CorruptLedgerEntry):
+        ledger.replay()

--- a/apps/python/ringfence/tests/test_number_substitution_fixture.py
+++ b/apps/python/ringfence/tests/test_number_substitution_fixture.py
@@ -1,0 +1,26 @@
+"""Proves the number-substitution-attack fixture itself demonstrates the
+security invariant, not just the synthetic cases in
+test_invariant_never_calls_request_supplied_number.py.
+"""
+
+import json
+from pathlib import Path
+
+from ringfence.case import Case
+from ringfence.verify_call import resolve_dial_target
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "12_number_substitution_attack.json"
+)
+
+
+def test_fixture_case_dials_on_file_number_never_the_smuggled_one():
+    record = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    case_data = record["case"]
+    assert case_data["request_supplied_callback_number"] is not None
+    assert case_data["request_supplied_callback_number"] != case_data["on_file_phone"]
+
+    case = Case.from_dict(case_data)
+    assert resolve_dial_target(case) == case_data["on_file_phone"]

--- a/apps/python/ringfence/tests/test_resolve.py
+++ b/apps/python/ringfence/tests/test_resolve.py
@@ -1,0 +1,83 @@
+"""Direct unit tests for resolve.classify() itself.
+
+Previously classify() was only exercised indirectly through fixtures and
+the synthetic corpus -- this covers its branches directly, including the
+connection_failed_during_attempt case, which classify() once mislabeled as
+no_answer_confirmed: a provider-side failure with zero ring time is not a
+recipient who chose not to answer, and treating it as one loses the
+distinction the disposition table depends on.
+"""
+
+from ringfence import resolve
+
+
+def _attempt(**overrides) -> dict:
+    attempt = dict(
+        started_at="2026-01-05T10:00:00Z",
+        completed_at="2026-01-05T10:01:00Z",
+        transcript_turns=[],
+        failure_code=None,
+        failure_message=None,
+    )
+    attempt.update(overrides)
+    return attempt
+
+
+def test_genuine_no_answer_has_nonzero_duration_and_no_attempt_failure_code():
+    call = {"status": "completed", "task_completed": False, "failure_code": None, "failure_message": None}
+    attempt = _attempt(started_at="2026-01-05T10:00:00Z", completed_at="2026-01-05T10:00:45Z")
+    resolution = resolve.classify(call, [attempt], [])
+    assert resolution.outcome == resolve.NO_ANSWER_CONFIRMED
+
+
+def test_zero_duration_attempt_is_a_connection_failure_not_a_confirmed_no_answer():
+    # The shape that exposed the bug: started_at == completed_at (zero
+    # ring time) with an attempt-level failure_code set.
+    call = {"status": "failed", "task_completed": False, "failure_code": "call_failed", "failure_message": "calling task status=FAILED"}
+    attempt = _attempt(started_at="2026-01-05T10:00:00Z", completed_at="2026-01-05T10:00:00Z", failure_code="504")
+    resolution = resolve.classify(call, [attempt], [])
+    assert resolution.outcome == resolve.CONNECTION_FAILED_DURING_ATTEMPT
+    assert resolution.confidence == "high"
+
+
+def test_zero_duration_attempt_without_a_failure_code_is_still_a_connection_failure():
+    call = {"status": "completed", "task_completed": False, "failure_code": None, "failure_message": None}
+    attempt = _attempt(started_at="2026-01-05T10:00:00Z", completed_at="2026-01-05T10:00:00Z")
+    resolution = resolve.classify(call, [attempt], [])
+    assert resolution.outcome == resolve.CONNECTION_FAILED_DURING_ATTEMPT
+    assert resolution.confidence == "medium"  # lower confidence: no explicit failure_code corroborating it
+
+
+def test_nonzero_duration_with_an_attempt_failure_code_is_still_a_connection_failure():
+    # A failure_code present at the attempt level is itself decisive, even
+    # with nonzero (but still transcript-empty) duration.
+    call = {"status": "failed", "task_completed": False, "failure_code": "call_failed", "failure_message": None}
+    attempt = _attempt(started_at="2026-01-05T10:00:00Z", completed_at="2026-01-05T10:00:10Z", failure_code="503")
+    resolution = resolve.classify(call, [attempt], [])
+    assert resolution.outcome == resolve.CONNECTION_FAILED_DURING_ATTEMPT
+
+
+def test_connection_failed_during_attempt_still_escalates_never_allows():
+    from ringfence.decide import ESCALATE_TO_HUMAN, decide
+
+    call = {"status": "failed", "task_completed": False, "failure_code": "call_failed", "failure_message": None}
+    attempt = _attempt(started_at="2026-01-05T10:00:00Z", completed_at="2026-01-05T10:00:00Z", failure_code="504")
+    resolution = resolve.classify(call, [attempt], [])
+    disposition = decide(resolution, {})
+    assert disposition.disposition == ESCALATE_TO_HUMAN
+    assert "connection_failed_during_attempt" in disposition.reasons[0]
+
+
+def test_never_dialed_is_unaffected_by_the_new_branch():
+    call = {"status": "failed", "task_completed": None, "failure_code": None, "failure_message": "Unspecified provider error."}
+    resolution = resolve.classify(call, [], [])
+    assert resolution.outcome == resolve.REJECTED_BEFORE_RING
+
+
+def test_answered_success_and_answered_declined_are_unaffected():
+    call = {"status": "completed", "task_completed": True, "failure_code": None, "failure_message": None}
+    attempt = _attempt(transcript_turns=[{"speaker": "bot", "text": "hi"}])
+    assert resolve.classify(call, [attempt], []).outcome == resolve.ANSWERED_SUCCESS
+
+    call_declined = dict(call, task_completed=False)
+    assert resolve.classify(call_declined, [attempt], []).outcome == resolve.ANSWERED_DECLINED

--- a/apps/python/ringfence/tests/test_safety.py
+++ b/apps/python/ringfence/tests/test_safety.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ringfence.safety import (
+    InvalidPhoneNumber,
+    mask_account_number,
+    mask_phone,
+    normalize_e164,
+    redact_text,
+    redact_value,
+)
+
+
+def test_normalize_e164_accepts_valid_number():
+    assert normalize_e164("+1 415 555 0101") == "+14155550101"
+
+
+def test_normalize_e164_rejects_missing_country_code():
+    with pytest.raises(InvalidPhoneNumber):
+        normalize_e164("4155550101")
+
+
+def test_normalize_e164_converts_00_prefix():
+    assert normalize_e164("0014155550101") == "+14155550101"
+
+
+def test_normalize_e164_rejects_garbage():
+    with pytest.raises(InvalidPhoneNumber):
+        normalize_e164("not a phone number")
+
+
+def test_mask_phone_hides_at_least_half_the_digits():
+    masked = mask_phone("+14155550101")
+    digits = [c for c in "+14155550101" if c.isdigit()]
+    masked_digits = [c for c in masked if c == "*"]
+    assert len(masked_digits) >= len(digits) // 2
+
+
+def test_mask_account_number_keeps_only_last_four():
+    assert mask_account_number("123456789012") == "********9012"
+
+
+def test_mask_account_number_short_value_fully_masked():
+    assert mask_account_number("123") == "***"
+
+
+def test_redact_text_strips_phone_email_and_long_digit_runs():
+    text = "Call +14155550101 or email a@b.com, account 123456789."
+    redacted = redact_text(text)
+    assert "+14155550101" not in redacted
+    assert "a@b.com" not in redacted
+    assert "123456789" not in redacted
+
+
+def test_redact_value_recurses_through_nested_structures():
+    value = {"note": "reach me at +14155550101", "attempts": [{"failure_message": "acct 987654321"}]}
+    redacted = redact_value(value)
+    assert "+14155550101" not in redacted["note"]
+    assert "987654321" not in redacted["attempts"][0]["failure_message"]

--- a/apps/python/ringfence/tests/test_synthetic_corpus.py
+++ b/apps/python/ringfence/tests/test_synthetic_corpus.py
@@ -1,0 +1,120 @@
+"""Exercises the exhaustive synthetic corpus (ringfence/synthetic_corpus.py)
+that backs the README's "Exhaustive signal-space coverage" section.
+
+`oracle_disposition()` is a second, independently written implementation of
+decide.py's table -- these tests check decide() agrees with it, not that
+decide() agrees with itself.
+"""
+
+from ringfence import decide as decide_mod
+from ringfence import resolve
+from ringfence.evaluation import evaluate_naive_vs_resolve, evaluate_synthetic_corpus
+from ringfence.synthetic_corpus import SIGNAL_KEYS, generate_corpus, oracle_disposition
+
+
+def test_corpus_exhaustively_covers_all_32_signal_combinations_for_both_conversation_outcomes():
+    records = generate_corpus()
+    success = [r for r in records if r["case"]["case_id"].startswith("gen_success_")]
+    declined = [r for r in records if r["case"]["case_id"].startswith("gen_declined_")]
+    assert len(success) == 32
+    assert len(declined) == 32
+
+    success_combos = {tuple(r["signals"][k] for k in SIGNAL_KEYS) for r in success}
+    declined_combos = {tuple(r["signals"][k] for k in SIGNAL_KEYS) for r in declined}
+    assert len(success_combos) == 32
+    assert len(declined_combos) == 32
+
+
+def test_corpus_covers_every_documented_ambiguity_marker():
+    records = generate_corpus()
+
+    def outcome_of(record):
+        return resolve.classify(record["call"], record["attempts"], record["events"]).outcome
+
+    policy_hits = [r for r in records if outcome_of(r) == resolve.POLICY_OR_CONTENT_REFUSAL]
+    malformed_hits = [r for r in records if outcome_of(r) == resolve.MALFORMED_OR_UNSUPPORTED_DESTINATION]
+    assert len(policy_hits) == len(resolve._POLICY_REFUSAL_MARKERS)
+    assert len(malformed_hits) == len(resolve._MALFORMED_DESTINATION_MARKERS)
+
+
+def test_every_generated_case_actually_resolves_to_its_intended_real_outcome():
+    # Guards against a generator bug where a case's raw call/attempts/events
+    # don't actually classify() the way its label and expected_disposition
+    # assume -- i.e. that the synthetic data is honest, not just labeled.
+    expected_outcomes = {
+        "gen_success": resolve.ANSWERED_SUCCESS,
+        "gen_declined": resolve.ANSWERED_DECLINED,
+        f"gen_{resolve.POLICY_OR_CONTENT_REFUSAL}": resolve.POLICY_OR_CONTENT_REFUSAL,
+        f"gen_{resolve.MALFORMED_OR_UNSUPPORTED_DESTINATION}": resolve.MALFORMED_OR_UNSUPPORTED_DESTINATION,
+        f"gen_{resolve.REJECTED_BEFORE_RING}": resolve.REJECTED_BEFORE_RING,
+        f"gen_{resolve.NO_ANSWER_CONFIRMED}": resolve.NO_ANSWER_CONFIRMED,
+        f"gen_{resolve.UNRESOLVED_AMBIGUOUS}": resolve.UNRESOLVED_AMBIGUOUS,
+        "gen_connfail": resolve.CONNECTION_FAILED_DURING_ATTEMPT,
+    }
+    mismatches = []
+    for record in generate_corpus():
+        case_id = record["case"]["case_id"]
+        if case_id.startswith("gen_naive_trap_"):
+            continue  # deliberately checks a call/attempt *mismatch*, not a single target outcome
+        prefix = next(p for p in expected_outcomes if case_id.startswith(p))
+        actual = resolve.classify(record["call"], record["attempts"], record["events"]).outcome
+        if actual != expected_outcomes[prefix]:
+            mismatches.append((case_id, expected_outcomes[prefix], actual))
+    assert not mismatches, mismatches
+
+
+def test_oracle_matches_decide_on_every_generated_case():
+    mismatches = []
+    for record in generate_corpus():
+        resolution = resolve.classify(record["call"], record["attempts"], record["events"])
+        actual = decide_mod.decide(resolution, record["signals"]).disposition
+        expected = oracle_disposition(resolution.outcome, record["signals"])
+        if actual != expected:
+            mismatches.append((record["case"]["case_id"], expected, actual))
+    assert not mismatches, mismatches
+
+
+def test_oracle_spot_checks_without_calling_decide_at_all():
+    clean = {k: False for k in SIGNAL_KEYS}
+    clean["relationship_explained"] = True
+    assert oracle_disposition(resolve.ANSWERED_SUCCESS, clean) == "ADVISE_ALLOW"
+
+    secrecy = dict(clean)
+    secrecy["secrecy_demand_present"] = True
+    assert oracle_disposition(resolve.ANSWERED_SUCCESS, secrecy) == "ADVISE_BLOCK"
+
+    assert oracle_disposition(resolve.NO_ANSWER_CONFIRMED, {}) == "ESCALATE_TO_HUMAN"
+    assert oracle_disposition(resolve.UNRESOLVED_AMBIGUOUS, {}) == "ESCALATE_TO_HUMAN"
+
+
+def test_evaluate_synthetic_corpus_reports_full_agreement_with_the_oracle():
+    result = evaluate_synthetic_corpus()
+    assert result.total >= 90
+    assert result.correct == result.total, result.mismatches
+
+
+def test_naive_vs_resolve_comparison_finds_real_unsafe_disagreements():
+    # A comparison that never finds a disagreement would be vacuous --
+    # this proves resolve.classify() is doing real work naive_classify() misses.
+    result = evaluate_naive_vs_resolve()
+    assert result.total >= 90
+    assert result.outcome_disagreements > 0
+    assert result.unsafe_disposition_disagreements > 0
+    assert any("naive_trap" in example for example in result.examples)
+
+
+def test_naive_trap_cases_would_wrongly_allow_under_naive_classification():
+    # decide() itself must still escalate these -- the trap is only in what
+    # naive_classify() + decide() would have done, never in the real path.
+    for record in generate_corpus():
+        if "naive_trap" not in record["case"]["case_id"]:
+            continue
+        real_resolution = resolve.classify(record["call"], record["attempts"], record["events"])
+        assert decide_mod.decide(real_resolution, record["signals"]).disposition == "ESCALATE_TO_HUMAN"
+
+        naive_outcome = resolve.naive_classify(record["call"])
+        assert naive_outcome == resolve.ANSWERED_SUCCESS
+        naive_disposition = decide_mod.decide(
+            resolve.Resolution(outcome=naive_outcome, confidence="n/a"), record["signals"]
+        ).disposition
+        assert naive_disposition == "ADVISE_ALLOW"

--- a/apps/python/ringfence/tests/test_webhook.py
+++ b/apps/python/ringfence/tests/test_webhook.py
@@ -1,0 +1,290 @@
+import json
+import threading
+import time
+import urllib.request
+from http.client import HTTPResponse
+from pathlib import Path
+
+import pytest
+
+from ringfence.decide import ESCALATE_TO_HUMAN
+from ringfence.verify_call import DIALED, PREVIEWED
+from ringfence.webhook import CaseStore, create_server, handle_get, handle_submit
+from ringfence.verify_call import SecurityEventLog, resolve_dial_target
+from ringfence.case import Case
+
+_ON_FILE = "+14155550101"
+_SMUGGLED = "+14155559999"
+
+
+def _case_payload(**overrides) -> dict:
+    payload = dict(
+        case_id="case_wh_001",
+        account_holder_name="Pat Rivera",
+        on_file_phone=_ON_FILE,
+        claimed_transaction_amount="4500.00",
+        claimed_recipient="Jordan Rivera",
+        claimed_payment_method="wire",
+        request_supplied_callback_number=None,
+    )
+    payload.update(overrides)
+    return payload
+
+
+class _FakeCalls:
+    def __init__(self, structured_result: dict | None = None):
+        self.create_and_wait_calls = 0
+        self._structured_result = structured_result or {}
+
+    def create_and_wait(self, **kwargs):
+        self.create_and_wait_calls += 1
+        return {"id": f"call_fake_{self.create_and_wait_calls}"}
+
+    def get(self, call_id: str):
+        return {
+            "id": call_id,
+            "status": "completed",
+            "task_completed": True,
+            "structured_result": self._structured_result,
+            "recipients": [
+                {
+                    "attempts": [
+                        {
+                            "started_at": "2026-09-10T00:00:00Z",
+                            "completed_at": "2026-09-10T00:01:00Z",
+                            "transcript_turns": [{"speaker": "bot", "text": "hi"}],
+                        }
+                    ]
+                }
+            ],
+        }
+
+    def list_events(self, call_id: str):
+        return {"data": []}
+
+
+class _FakeClient:
+    def __init__(self, structured_result: dict | None = None):
+        self.calls = _FakeCalls(structured_result)
+
+
+# ---- pure handle_submit/handle_get, no HTTP ----
+
+
+def test_post_case_dry_run_never_dials_and_status_is_previewed(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    status, payload = handle_submit(
+        store, _case_payload(), live=False, security_log=log, client_factory=None
+    )
+    assert status == 201
+    assert payload["status"] == PREVIEWED
+    assert payload["call_id"] is None
+    assert payload["disposition"] is None
+
+
+def test_get_unknown_case_id_is_404():
+    store = CaseStore()
+    status, payload = handle_get(store, "does_not_exist")
+    assert status == 404
+    assert payload["error"] == "not_found"
+
+
+def test_resubmitting_same_case_id_never_places_a_second_call(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    fake_client = _FakeClient()
+
+    status1, payload1 = handle_submit(
+        store, _case_payload(), live=True, security_log=log, client_factory=lambda: fake_client
+    )
+    status2, payload2 = handle_submit(
+        store, _case_payload(), live=True, security_log=log, client_factory=lambda: fake_client
+    )
+
+    assert status1 == 201
+    assert status2 == 200  # returned the existing record, not a new dial
+    assert payload1["call_id"] == payload2["call_id"]
+    assert fake_client.calls.create_and_wait_calls == 1
+
+
+def test_smuggled_callback_number_is_never_dialed_through_the_webhook(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    fake_client = _FakeClient()
+
+    case_data = _case_payload(request_supplied_callback_number=_SMUGGLED)
+    status, payload = handle_submit(
+        store, case_data, live=True, security_log=log, client_factory=lambda: fake_client
+    )
+
+    assert status == 201
+    assert payload["dialed_phone_masked"] != None  # noqa: E711 - explicit presence check
+    assert _SMUGGLED not in json.dumps(payload)
+    # The webhook never re-implements the invariant: prove independently
+    # that resolve_dial_target (the one real implementation) agrees.
+    case = Case.from_dict(case_data)
+    assert resolve_dial_target(case) == _ON_FILE
+    # A security event was logged for the smuggled number, same as the CLI path.
+    logged = log.path.read_text(encoding="utf-8")
+    assert "rejected_request_supplied_callback_number" in logged
+    assert _SMUGGLED not in logged
+    assert _ON_FILE not in logged
+
+
+def test_live_call_completion_resolves_and_stores_disposition(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+    clean_signals = {
+        "secrecy_demand_present": False,
+        "urgency_pressure_present": False,
+        "relationship_explained": True,
+        "irreversible_payment_demanded": False,
+        "explicit_hold_requested": False,
+    }
+    fake_client = _FakeClient(structured_result=clean_signals)
+
+    status, payload = handle_submit(
+        store, _case_payload(), live=True, security_log=log, client_factory=lambda: fake_client
+    )
+    assert status == 201
+    assert payload["disposition"] == "ADVISE_ALLOW"
+
+    _, fetched = handle_get(store, "case_wh_001")
+    assert fetched["disposition"] == "ADVISE_ALLOW"
+
+    # An institution reading this response must be told, in the response
+    # itself, that it is a recommendation pending human review -- not an
+    # instruction to release the transaction.
+    for record in (payload, fetched):
+        assert record["advisory"] is True
+        assert record["requires_human_review"] is True
+
+
+def test_live_call_error_escalates_rather_than_leaving_disposition_null(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+
+    class _FailingCalls:
+        def create_and_wait(self, **kwargs):
+            raise RuntimeError("simulated CALL-E API failure")
+
+    class _FailingClient:
+        calls = _FailingCalls()
+
+    status, payload = handle_submit(
+        store, _case_payload(), live=True, security_log=log, client_factory=lambda: _FailingClient()
+    )
+    assert status == 201
+    assert payload["disposition"] == ESCALATE_TO_HUMAN
+    assert "call_error" in payload["outcome"]
+
+    _, fetched = handle_get(store, "case_wh_001")
+    assert fetched["disposition"] == ESCALATE_TO_HUMAN
+
+
+def test_dialed_with_no_call_id_escalates_rather_than_crashing(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+
+    class _NoIdCalls:
+        def create_and_wait(self, **kwargs):
+            return {}  # no "id" field, matching CALL-E's undocumented response shape
+
+        def get(self, call_id):
+            raise AssertionError("must not be called when call_id is missing")
+
+    class _NoIdClient:
+        calls = _NoIdCalls()
+
+    status, payload = handle_submit(
+        store, _case_payload(), live=True, security_log=log, client_factory=lambda: _NoIdClient()
+    )
+    assert status == 201
+    assert payload["disposition"] == ESCALATE_TO_HUMAN
+    assert payload["call_id"] is None
+
+
+def test_concurrent_identical_submissions_place_only_one_call(tmp_path: Path):
+    store = CaseStore()
+    log = SecurityEventLog(tmp_path / "security_events.jsonl")
+
+    class _SlowCalls:
+        def __init__(self):
+            self.create_and_wait_calls = 0
+
+        def create_and_wait(self, **kwargs):
+            self.create_and_wait_calls += 1
+            time.sleep(0.05)  # widen the race window
+            return {"id": "call_fake_1"}
+
+        def get(self, call_id):
+            return {"id": call_id, "status": "completed", "task_completed": True,
+                     "structured_result": {}, "recipients": []}
+
+        def list_events(self, call_id):
+            return {"data": []}
+
+    class _SlowClient:
+        def __init__(self, calls):
+            self.calls = calls
+
+    fake_calls = _SlowCalls()
+    results: list[tuple[int, dict]] = []
+
+    def submit():
+        results.append(
+            handle_submit(
+                store, _case_payload(), live=True, security_log=log,
+                client_factory=lambda: _SlowClient(fake_calls),
+            )
+        )
+
+    threads = [threading.Thread(target=submit) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert fake_calls.create_and_wait_calls == 1
+    statuses = sorted(status for status, _ in results)
+    assert statuses == [200, 200, 200, 200, 201]
+
+
+# ---- real HTTP round-trip over a bound socket ----
+
+
+def _request(conn_url: str, method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(f"{conn_url}{path}", data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        resp: HTTPResponse = urllib.request.urlopen(req, timeout=5)
+        return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def test_http_round_trip_post_then_get(tmp_path: Path):
+    server = create_server(
+        host="127.0.0.1", port=0, live=False, security_log_path=tmp_path / "security_events.jsonl"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        status, payload = _request(base, "POST", "/cases", _case_payload(case_id="case_http_001"))
+        assert status == 201
+        assert payload["status"] == PREVIEWED
+
+        status, payload = _request(base, "GET", "/cases/case_http_001")
+        assert status == 200
+        assert payload["case_id"] == "case_http_001"
+
+        status, payload = _request(base, "GET", "/cases/does_not_exist")
+        assert status == 404
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/apps/python/ringfence/tests/test_webhook.py
+++ b/apps/python/ringfence/tests/test_webhook.py
@@ -71,6 +71,23 @@ class _FakeClient:
 # ---- pure handle_submit/handle_get, no HTTP ----
 
 
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.10", "public.example"])
+def test_live_webhook_refuses_non_loopback_before_opening_socket(host, monkeypatch):
+    def unexpected_server(*args, **kwargs):
+        raise AssertionError("must reject the bind before constructing an HTTP server")
+
+    monkeypatch.setattr("ringfence.webhook.ThreadingHTTPServer", unexpected_server)
+    with pytest.raises(ValueError, match="loopback-only"):
+        create_server(host=host, live=True)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_live_webhook_accepts_loopback_without_opening_socket(host, monkeypatch):
+    marker = object()
+    monkeypatch.setattr("ringfence.webhook.ThreadingHTTPServer", lambda *args: marker)
+    assert create_server(host=host, live=True) is marker
+
+
 def test_post_case_dry_run_never_dials_and_status_is_previewed(tmp_path: Path):
     store = CaseStore()
     log = SecurityEventLog(tmp_path / "security_events.jsonl")


### PR DESCRIPTION
## Summary

RingFence is an independent fraud-verification-call service: a bank/company's own fraud system flags a transaction, RingFence places (or, by default, previews) a call to the account holder's **on-file** number — never a number supplied by the flagged request itself — asks a disclosure-first set of documented scam red-flag questions, and returns a fail-closed **advisory recommendation** (`ADVISE_ALLOW` / `ADVISE_BLOCK` / `ESCALATE_TO_HUMAN`) for a human reviewer inside the institution.

**Security invariant** (the one thing the whole project depends on): the dial target is always `case.on_file_phone`; a request-supplied "callback number" is never dialed, only logged as a security event if present. Enforced in one place (`verify_call.resolve_dial_target`) that every surface calls through, and covered by its own dedicated test.

**Advisory only, human review always required.** Nothing this project returns is an action on money. The recommendation comes from a heuristic chain — speech recognition, a language model's reading of what was said, then a documented red-flag table — applied to a single phone conversation, which is not a basis for releasing or holding someone's funds automatically. So every `Disposition` carries `advisory: true` and `requires_human_review: true`, serialized into every API response, stored record, audit report, and both demo pages; `ADVISE_ALLOW` means "this call surfaced no red flags", never "release the funds". The README states plainly that integrators must not wire these values into an automated approve/hold action. Covered by `tests/test_decide.py`, `tests/test_webhook.py` and `tests/test_demo_server.py`.

**Surfaces**: a CLI (`case submit` dry-run by default, `--live --confirm-live` gated), a webhook (`POST /cases` / `GET /cases/{id}`, durable crash-safe case ledger), an MCP server, and a two-sided demo (`ringfence/demo_server.py`) — a customer "send money" page and a bank fraud-ops dashboard, where the bank decides automatically, on an amount threshold, whether a transaction needs verification at all; the customer never chooses.

**The demo server — the only deployable surface — is simulation-only and has no live-call path at all.** It never imports a CALL-E client, never reads `CALLE_API_KEY`, contains no code that could place an outbound call (asserted structurally by `test_this_server_has_no_live_call_path_at_all`, not just behaviourally), and collects no phone number of any kind. It also refuses to start on any non-loopback bind unless `RINGFENCE_DEMO_TOKEN` is set, and with it every page and API route requires that token (`Authorization: Bearer`, `?token=` once per browser, or the `HttpOnly` cookie set from it); the sole unauthenticated route is `GET /healthz`, which returns `{"status": "ok"}` so a platform health check can run. What is real in the demo is the decision: recorded fixtures run through the actual `resolve.classify()` and `decide()`.

**Measured evaluation**: 21 curated fixtures (15 of them categorized and scored) plus a 98-case exhaustive synthetic corpus — every combination of the 5 verification-call signals, every documented CALL-E ambiguity marker — checked against an independently written oracle, not `decide()` grading itself. Naively trusting CALL-E's raw `status`/`failure_code` (what most integrations do, per CALL-E's own documented warning) disagrees with the cross-referenced classification in 28/98 cases, 2 of which are unsafe. 113 cases scored in total, reproducible with `python -m ringfence.evaluation`.

**Validation against the live API**: the live path was exercised end to end against the real CALL-E API before submission, on numbers the author controls and with the recipient's consent. **No call outputs, transcripts, identifiers, or timings from those runs are included in this repository** — a verification call's contents do not belong in a public repo. What remains here is what they produced: four real bugs found by exercising the live API rather than by code review, each fixed with a regression test — a connection failure being read as a confirmed no-answer, `region`/`locale` never being sent at all, `audit.py` keying off guessed transcript speaker labels (which would have produced an empty audit trail for every real call), and a vague caller identity that CALL-E's own content-policy layer refuses outright. Two of the four were invisible to the fixture corpus, because the fixtures encoded the same wrong assumption the code did. Details in the README's "Validation against the live API" section.

Full details, safety rigor, and the security invariant are in `apps/python/ringfence/README.md`.

## Changes since first review

All four must-fix items are addressed:

1. **Real-call material removed from the tree, this description, and the branch history.** The `artifacts/` directory of real-call results is gone, the one fixture modeled on a real call is replaced by a synthetic fixture of the same provider-failure shape (`fixtures/21_connection_failed_during_attempt.json`, so the regression coverage survives), and every call identifier, timestamp, transcript excerpt, and artifact link is gone from the README, source comments, and tests. The branch's two commits were squashed into a single commit whose tree never contained that material, so it is absent from history, not merely deleted in a later commit. (This required a force-push; earlier review comments anchored to removed lines may now show as outdated.)
2. **The deployed demo service is authenticated, and its live path is hard-disabled** — both, rather than either. See the demo paragraph above: no live-call code remains in that server, and a public bind without a token refuses to start instead of serving openly.
3. **Results are advisory with human review**, per the "Advisory only" paragraph above: `ALLOW`/`BLOCK` no longer exist as values, and nothing in the project produces a consequential financial action from a call interpretation.
4. **The nonconforming commit title is gone.** The branch is now a single commit, `feat(ringfence): add fraud-verification calls for flagged transactions`, matching `docs/git-naming-conventions.md`.

## Type

- [x] New runnable app

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior. (N/A — no recurring workflow; single-attempt per case by design, no scheduling.)
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
