### PR TITLE
fix(call-on-behalf): stop classifying diagnostic failure codes

### DIFF
--- a/apps/typescript/call-on-behalf/docs/scope-and-limits.md
+++ b/apps/typescript/call-on-behalf/docs/scope-and-limits.md
@@ -211,9 +211,8 @@ the next step says not to.
 
 A call CALL-E has not finished with lands in the same place. Only a terminal status
 is read as a result: `completed`, `failed` or `canceled`, which is every terminal
-value in the SDK's own `CallStatus`. A no answer or a voicemail arrives as `failed`
-with a failure code or as a completed call whose transcript is a machine, so neither
-needs a status of its own. A call that is still `queued` or `in_progress` when the timeout runs
+value in the SDK's own `CallStatus`. No-answer and voicemail are not separate
+documented call statuses. A call that is still `queued` or `in_progress` when the timeout runs
 out has a transcript that is still being written, so the app reports
 `outcome_unknown` with `call_status` unknown and the call id kept. It states no
 verdict, no commitment and no privacy finding. Reading a call in flight as a result
@@ -229,9 +228,12 @@ the slot was held carries the whole errand: the questions, the answers and the
 agreement. That status is not read as nobody having answered. What was said comes
 from the transcript and the notes name the status as `call_failed` or
 `call_canceled` with the failure code beside it. The outcome is never `goal_met`,
-because a call that ended early may have been cut off partway through. A call with
-nobody on its transcript is still read from its failure code, which is where
-`voicemail` and `not_reached` come from.
+because a call that ended early may have been cut off partway through. Transcript
+evidence of a machine produces `voicemail` for any terminal status. Without person
+or machine evidence, a failed or canceled call produces the generic `call_failed`;
+a completed call produces `not_reached`. The Calls API's `failureCode` is
+[diagnostic context without a published enum](https://docs.heycall-e.com/errors#accepted-call-execution-outcomes),
+so its words or numbers never decide the outcome or establish why nobody answered.
 
 ## Who you may call
 

--- a/apps/typescript/call-on-behalf/src/calle.ts
+++ b/apps/typescript/call-on-behalf/src/calle.ts
@@ -53,10 +53,9 @@ export class CalleWaitTimeout extends Error {}
  *
  * `CallStatus` in the SDK's generated schema is `queued`, `in_progress`,
  * `completed`, `failed` or `canceled`. The SDK's own `waitForResult` returns on
- * exactly the last three, so those three are the whole set here. A no answer, a
- * busy line or a voicemail is not a status of its own: it arrives as `failed` with
- * a failure code or as a completed call whose transcript is a machine, both of
- * which are read further down.
+ * exactly the last three, so those three are the whole set here. The Calls API
+ * does not guarantee distinct no-answer, busy or voicemail failure codes.
+ * Machine-answer evidence is read from the transcript of a terminal call.
  *
  * Anything not in this list is a call with no result yet. A call with no result
  * is not something to report an outcome from.

--- a/apps/typescript/call-on-behalf/src/errand.ts
+++ b/apps/typescript/call-on-behalf/src/errand.ts
@@ -84,17 +84,6 @@ function readString(structured: Record<string, unknown> | null, key: string): st
   return typeof value === "string" ? value.trim() : "";
 }
 
-function failureOutcome(failureCode: string | null): ErrandOutcome {
-  const code = (failureCode ?? "").toLowerCase();
-  if (code.includes("voicemail") || code.includes("machine")) {
-    return "voicemail";
-  }
-  if (code.includes("answer") || code.includes("busy") || code.includes("unreachable")) {
-    return "not_reached";
-  }
-  return "call_failed";
-}
-
 /** A call this app could not read at all. Nobody knows whether it was even made. */
 const UNREAD_NEXT_STEP =
   "CALL-E took the errand and this app could not read what happened, so nobody knows yet whether the call was made or what was said. Treat nothing as arranged. Running this same errand file again reads that same call back instead of ringing anybody, because the key is unchanged. Edit the file first and it becomes a different call, so do not edit it.";
@@ -420,9 +409,10 @@ export async function runErrand(options: RunOptions): Promise<ErrandReport> {
   } else if (reading.machineAnswered) {
     outcome = "voicemail";
   } else if (endedEarly && !reading.reachedPerson) {
-    // Nobody was on the line and the call is over, so nothing was asked. The
-    // failure code says why when there is one and the status says it otherwise.
-    outcome = failureOutcome(attempt?.failureCode ?? call.failureCode ?? call.status);
+    // The call failed or was canceled without transcript evidence of a person.
+    // failureCode is diagnostic context, not a stable outcome enum, so it cannot
+    // distinguish no answer, a busy line or voicemail here.
+    outcome = "call_failed";
   } else if (!reading.reachedPerson) {
     outcome = "not_reached";
   } else {

--- a/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.e2e.test.ts
@@ -492,6 +492,38 @@ test("a call that ended early still reports the conversation it carried", async 
   }
 });
 
+for (const failureCode of ["404", "486", "603", "unexpected_diagnostic", null, "busy", "no_answer", "unreachable", "voicemail", "machine"]) {
+  for (const machineAnswered of [false, true]) {
+    test(`failed call with ${String(failureCode)} and ${machineAnswered ? "machine" : "empty"} transcript`, async () => {
+      await withFake(
+        [{
+          phone: CLINIC,
+          status: "failed",
+          failureCode,
+          botLines: [],
+          userLines: machineAnswered
+            ? ["You have reached Bayview Family Clinic. Please leave a message after the tone."]
+            : [],
+          structuredResult: null,
+        }],
+        async (port, fake) => {
+          const report = await runErrand({ request: errandRequest(), port, pollIntervalMs: 5 });
+          assert.equal(report.call_status, "failed");
+          assert.equal(report.outcome, machineAnswered ? "voicemail" : "call_failed");
+          assert.equal(report.reached_person, false);
+          assert.equal(report.transcript.length, machineAnswered ? 1 : 0);
+          assert.equal(report.answers.every((answer) => !answer.answered), true);
+          assert.equal(report.commitment, "none_sought");
+          assert.equal(fake.created.length, 1);
+          if (machineAnswered) {
+            assert.match(report.next_step, /went to a machine/);
+          }
+        },
+      );
+    });
+  }
+}
+
 test("the transcript says who was on the line, not the failure code beside it", async () => {
   // A machine on the transcript is a machine, whatever code CALL-E filed the call
   // under. The ordering is the point here: the transcript is read before the code.

--- a/apps/typescript/call-on-behalf/test/errand.stub.test.ts
+++ b/apps/typescript/call-on-behalf/test/errand.stub.test.ts
@@ -109,9 +109,8 @@ test("a call CALL-E has not finished with is no result, whatever the extraction 
 });
 
 test("no state short of finished is evaluated, whichever one it is", async () => {
-  // The last three are not CallStatus values at all. A no answer, a busy line or a
-  // voicemail arrives as a failure code on a failed call or as a machine on the
-  // transcript, so a status spelled this way is one this app does not understand.
+  // The last three are not CallStatus values at all. Diagnostic failure codes
+  // do not define additional statuses, so these cannot establish a terminal call.
   for (const status of [
     "queued",
     "in_progress",


### PR DESCRIPTION
## Summary

`call-on-behalf` previously classified failed calls by words such as `busy` or `voicemail` inside `failureCode`, although the Calls API defines that field as diagnostic context without a stable enum.

- Remove those guesses: failed/canceled calls without person or machine transcript evidence now return the generic `call_failed` outcome. No numeric-code mapping is introduced.
- Preserve transcript-based voicemail detection and existing conversation-evidence priority.
- Add 20 full-workflow cases through the real SDK and localhost fake API: `404`, `486`, `603`, an unknown value, `null`, and five legacy word values, each with empty and machine transcripts.
- Correct the related scope documentation and comments. No live calls, production credentials, or CALL-E credits were used.

Closes #375

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

Bug fix in an existing app, with matching documentation updates. No recurring workflow is introduced.

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.

## Validation

- `npm test` on Ubuntu / Node 22.14.0: 162 passed, 0 failed, 0 skipped, using an unchanged temporary copy of the app.
- `npm run check`: passed on Windows and Ubuntu.
- `python scripts/validate_repository.py`: passed (Python 3.13.1; Windows interpreter name).
- `git diff --check`: passed.

The Windows test run passed 160 tests but failed two existing POSIX file-mode assertions (`0666` versus `0600`). The complete unchanged suite passed on Ubuntu; no tests were removed or skipped.