### PR TITLE
feat(skills): add invoice-payment-chaser skill

### DIFF
--- a/skills/invoice-payment-chaser/SKILL.md
+++ b/skills/invoice-payment-chaser/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: invoice-payment-chaser
+description: Chase an overdue cross-border invoice by phone when a written reminder has gone unanswered. Drafts a call goal scaled by the buyer's own learned payment history, places an authorized CALL-E call to the buyer, and returns a structured outcome (confirmed payment date or stated reason for delay) for human review before it is treated as resolved.
+---
+
+## When to use this skill
+
+Use when an invoice is significantly overdue relative to the buyer's own
+historical payment pattern, a written chaser has already been sent and gone
+unanswered, and a live phone call is warranted to get an explicit status.
+
+## Intent specification
+
+The agent MUST have explicit intent for the run: the invoice (id, amount,
+currency, days overdue), the buyer's own learned payment pattern (typical
+lag, sample size) so tone is calibrated not generic, the authorized party to
+call, and the two acceptable resolutions — a confirmed payment date, or a
+specific stated reason for the delay.
+
+## Phone number handling
+
+Numbers must be supplied in strict E.164 format (e.g. `+14155550123`).
+Output masking is required in logs/results unless the full number is
+strictly necessary for the call operation. Sample numbers in this skill's
+docs and fixtures use fictional reserved ranges only.
+
+## Stopping mechanisms
+
+One call per invoice per chase cycle — no re-dialing the same invoice within
+a run. Ambiguous outcomes (no answer, refused, vague non-committal answers)
+are treated as unresolved and reported, not auto-escalated.
+
+## High-stakes boundaries
+
+The agent must never confirm, negotiate, or alter payment terms on the
+call, accept a payment or payment instrument over the call, or threaten
+legal/collections action. It only gathers the buyer's stated status — any
+account action is a human decision.
+
+## Safety gate
+
+A call is placed only behind explicit human confirmation (e.g. a
+`--confirm` flag). Planning/drafting the call goal is free and does not
+place a call — this is the recommended default path for dry runs.
+
+## Installation and usage
+
+No install beyond a CALL-E API key and a Python environment with `requests`.
+Reference implementation: `calle_chaser.py` in
+https://github.com/thanawinhvh/gotpaid — `run_for_unpaid_invoice(...,
+confirm=False)` drafts the goal and plans the call with zero side effects;
+pass `confirm=True` (or `--confirm` on the CLI) to place the real call.
+
+## Result
+
+Return: invoice id, amount, days overdue, buyer's historical lag, outcome
+(`confirmed_date` | `stated_reason` | `unresolved`), the specific date/
+reason if given, confidence, and the full call transcript for audit —
+phone numbers masked.

--- a/skills/invoice-payment-chaser/SKILL.md
+++ b/skills/invoice-payment-chaser/SKILL.md
@@ -45,11 +45,13 @@ place a call — this is the recommended default path for dry runs.
 
 ## Installation and usage
 
-No install beyond a CALL-E API key and a Python environment with `requests`.
-Reference implementation: `calle_chaser.py` in
-https://github.com/thanawinhvh/gotpaid — `run_for_unpaid_invoice(...,
-confirm=False)` drafts the goal and plans the call with zero side effects;
-pass `confirm=True` (or `--confirm` on the CLI) to place the real call.
+An implementation of this skill must validate and authorize the exact
+destination number before any call, default to a fake/no-network dry-run
+mode (drafting and planning the call goal with zero side effects), and only
+place a real call behind explicit human confirmation. It must not print or
+persist raw phone numbers, provider identifiers, or call transcripts —
+apply the masking rules above before any log, status output, or stored
+record.
 
 ## Result
 

--- a/skills/invoice-payment-chaser/references/examples.md
+++ b/skills/invoice-payment-chaser/references/examples.md
@@ -8,11 +8,11 @@ own historical average of ~40 days across 34 prior payments.
 The agent has explicit per-run intent (invoice, amount, days overdue,
 buyer's learned pattern), confirms the contact is the buyer's authorized
 billing representative, and calls the fictional/reserved E.164 sample
-number `+15550101234`.
+number `+12025550123`.
 
 The call proceeds only after all required safety checks pass. The result
 is presented for human/reconciliation review before the invoice status is
-updated. The phone number is masked in normal output as `+1•••••••1234`.
+updated. The phone number is masked in normal output as `+1•••••••0123`.
 
 ## Invalid Phone Number
 
@@ -90,19 +90,19 @@ status.
 
 ## Successful Structured Result
 
-Real result from a live test call (transcript and video available at
-https://github.com/thanawinhvh/gotpaid):
+Illustrative structured result (synthetic invoice, no real call/contact
+data):
 
 ```json
 {
-  "invoice_id": "INV-1111",
-  "amount": 6293346.22,
-  "currency": "CNY",
-  "days_overdue": 105,
-  "buyer_usual_lag_days": 40.4,
+  "invoice_id": "INV-0001",
+  "amount": 125000.00,
+  "currency": "USD",
+  "days_overdue": 60,
+  "buyer_usual_lag_days": 20.0,
   "outcome": "confirmed_date",
-  "confirmed_payment_date": "2026-09-20",
-  "confidence": 0.95,
+  "confirmed_payment_date": "2026-10-01",
+  "confidence": 0.9,
   "human_approval_required": true,
   "human_approval_status": "pending",
   "next_action": "Reconcile against the next matching bank deposit"

--- a/skills/invoice-payment-chaser/references/examples.md
+++ b/skills/invoice-payment-chaser/references/examples.md
@@ -1,0 +1,110 @@
+# Invoice Payment Chaser Examples
+
+## Safe Call
+
+Invoice: INV-1111, CNY 6,293,346.22, 105 days overdue against the buyer's
+own historical average of ~40 days across 34 prior payments.
+
+The agent has explicit per-run intent (invoice, amount, days overdue,
+buyer's learned pattern), confirms the contact is the buyer's authorized
+billing representative, and calls the fictional/reserved E.164 sample
+number `+15550101234`.
+
+The call proceeds only after all required safety checks pass. The result
+is presented for human/reconciliation review before the invoice status is
+updated. The phone number is masked in normal output as `+1•••••••1234`.
+
+## Invalid Phone Number
+
+Input:
+
+`415-555-0123`
+
+Expected result:
+
+- Reject the number.
+- Do not place the call.
+- Return a validation error requiring strict E.164 format.
+
+The agent must not silently reformat the number.
+
+## Missing Intent
+
+An invoice is overdue, but there is no explicit call goal or buyer payment
+profile supplied for the run.
+
+Expected result:
+
+- Do not place the call.
+- Return a stopped/rejected status.
+- Require explicit per-run intent, including the buyer's learned payment
+  pattern used to calibrate tone.
+
+## Duplicate Call
+
+An active or recently completed call already covers the same invoice within
+the same chase cycle.
+
+Expected result:
+
+- Do not place another call.
+- Preserve the existing result.
+- Return a duplicate/stopped status.
+- Require explicit new authorization before another call.
+
+## Ambiguous Outcome
+
+The call ends with a vague, non-committal, or contradictory answer about
+payment status — no confirmed date and no specific reason for delay.
+
+Expected result:
+
+`CALL-E call → ambiguous outcome → STOP → invoice remains unresolved → human review`
+
+The agent must not invent a resolution, assume payment, or automatically
+retry the call.
+
+## Cancellation
+
+A pending call is cancelled before execution (e.g. the invoice was paid in
+the interim, matched during the next reconciliation pass).
+
+Expected result:
+
+`authorized workflow → cancellation → CANCELLED → no automatic restart`
+
+A new call requires explicit new authorization.
+
+## High-Stakes Content
+
+The call attempts to negotiate a settlement amount, accept a payment
+instrument, or threaten legal/collections action.
+
+Expected result:
+
+`high-stakes content detected → STOP → human/operator review`
+
+The agent must not autonomously negotiate terms, accept payment, or make
+legal/collections threats — it only gathers and reports the buyer's stated
+status.
+
+## Successful Structured Result
+
+Real result from a live test call (transcript and video available at
+https://github.com/thanawinhvh/gotpaid):
+
+```json
+{
+  "invoice_id": "INV-1111",
+  "amount": 6293346.22,
+  "currency": "CNY",
+  "days_overdue": 105,
+  "buyer_usual_lag_days": 40.4,
+  "outcome": "confirmed_date",
+  "confirmed_payment_date": "2026-09-20",
+  "confidence": 0.95,
+  "human_approval_required": true,
+  "human_approval_status": "pending",
+  "next_action": "Reconcile against the next matching bank deposit"
+}
+```

--- a/skills/invoice-payment-chaser/references/safety.md
+++ b/skills/invoice-payment-chaser/references/safety.md
@@ -1,0 +1,117 @@
+# Safety Reference
+
+Invoice Payment Chaser can initiate real-world phone calls to a buyer's
+billing contact. It must preserve explicit authorization and strict
+execution boundaries.
+
+## Explicit Intent
+
+Before placing a call, require explicit per-run intent identifying:
+
+- the invoice being chased (id, amount, currency, days overdue)
+- the buyer's own learned payment pattern, so the call's tone is calibrated
+  rather than generic
+- the authorized billing/AP contact to call
+- the information the agent may request or disclose
+- the two acceptable resolutions: a confirmed payment date, or a specific
+  stated reason for the delay
+
+Do not infer permission to call merely because an invoice is overdue.
+
+## Phone Numbers
+
+Outbound phone numbers MUST use strict E.164 format.
+
+Valid fictional example:
+
+`+15550101234`
+
+Reject local, punctuation-formatted, whitespace-formatted, or otherwise
+malformed numbers.
+
+Mask phone numbers in user-facing output, normal logs, status summaries,
+and examples.
+
+Example:
+
+`+15550101234` → `+1******1234`
+
+Never include real personal phone numbers in repository examples.
+
+## Authorization and Consent
+
+Call only an authorized billing/accounts-payable contact at the buyer for
+the stated invoice.
+
+Do not disclose unnecessary sensitive information (e.g. other customers'
+invoices or balances).
+
+Do not expose credentials, API keys, tokens, cookies, or provider secrets.
+
+A phone conversation alone does not prove identity, consent, authorization,
+or legal validity.
+
+## Duplicate Calls
+
+Before initiating a call, check for an existing active, pending, or
+recently completed call covering the same invoice within the same chase
+cycle.
+
+If a duplicate exists:
+
+- do not place another call
+- preserve the existing result
+- return a clear stopped/duplicate status
+- require explicit new authorization before another call
+
+## Ambiguous Outcomes
+
+Never treat an ambiguous call outcome as a confirmed payment date.
+
+Ambiguous, incomplete, contradictory, interrupted, unavailable, refused, or
+failed outcomes must stop automated resolution.
+
+Do not invent a payment date or reason, and do not automatically retry
+indefinitely.
+
+Require human or reconciliation-workflow review.
+
+## Cancellation
+
+A pending call must be cancellable before execution (e.g. the invoice was
+matched to a deposit in the interim).
+
+After cancellation:
+
+- mark the workflow as cancelled
+- do not automatically restart it
+- preserve the cancellation state
+- require explicit new authorization before another call
+
+## High-Stakes Boundaries
+
+Do not autonomously make or resolve calls involving:
+
+- negotiating, waiving, or altering payment terms
+- accepting a payment or payment instrument over the call
+- legal or collections decisions, or threatening legal/collections action
+- identity or security verification where a phone call alone is
+  insufficient
+- disclosure of sensitive personal or financial information without
+  appropriate authorization
+
+When high-stakes content is detected:
+
+1. stop the automated workflow
+2. do not negotiate, accept payment, or make legal/collections threats
+3. surface the issue to a human/operator
+4. preserve the invoice and call context
+5. require explicit authorization before any permitted next action
+
+## Human Approval
+
+The phone conversation gathers a payment status. It does not by itself
+authorize the final consequential resolution (write-off, escalation, legal
+referral).
+
+Keep final resolution decisions under human control.

--- a/skills/invoice-payment-chaser/references/safety.md
+++ b/skills/invoice-payment-chaser/references/safety.md
@@ -24,7 +24,7 @@ Outbound phone numbers MUST use strict E.164 format.
 
 Valid fictional example:
 
-`+15550101234`
+`+12025550123`
 
 Reject local, punctuation-formatted, whitespace-formatted, or otherwise
 malformed numbers.
@@ -34,7 +34,7 @@ and examples.
 
 Example:
 
-`+15550101234` → `+1******1234`
+`+12025550123` → `+1•••••••0123`
 
 Never include real personal phone numbers in repository examples.
 


### PR DESCRIPTION
Chase an overdue cross-border invoice by phone when a written reminder goes unanswered. Drafts a call goal from the buyer's learned payment profile, places an authorized CALL-E call, and returns a structured outcome for human review.

Reference implementation: calle_chaser.py in
https://github.com/thanawinhvh/gotpaid, built for the CALL-E Hackathon. Includes a real test result (task_completed: true, confidence 0.95) in references/examples.md.

## Summary

Adds a new Agent Skill for chasing overdue cross-border invoices
by phone when a written reminder has gone unanswered. Call tone
is calibrated from the buyer's own learned payment history.
Built and tested for the CALL-E Hackathon — reference
implementation and a real test result (task_completed: true,
confidence 0.95) are linked in references/examples.md.

## Type

- [X] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [ ] Repository-facing content is written in English.
- [ ] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [ ] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [ ] Real-world side effects are clearly described.
- [ ] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior.
- [ ] Runnable code has a dry-run, fake-server, or no-call path by default.
- [ ] `python3 scripts/validate_repository.py` passes.
