### PR TITLE
docs: list required skill reference files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,17 +93,17 @@ python3 scripts/create_branch.py docs/git-naming-conventions
 
 ## Skill folder requirements
 
-A skill should be a directory with a required `SKILL.md` file.
-
-Recommended structure:
+Every skill must include these files to pass repository validation:
 
 ```text
 skills/example-skill/
 ├── SKILL.md
-├── references/
-├── scripts/
-└── assets/
+└── references/
+    ├── safety.md
+    └── examples.md
 ```
+
+Use `references/safety.md` for the workflow's safety rules and `references/examples.md` for usage examples. Additional reference files, `scripts/`, and `assets/` are optional; include them when the skill needs them.
 
 The frontmatter should include at least:
 


### PR DESCRIPTION
## Summary

The Skill contribution guide now lists `SKILL.md`, `references/safety.md`, and `references/examples.md` as required by repository validation. Additional references, `scripts/`, and `assets/` are explicitly optional.

Fixes #452.

## Type

- [x] Safety or documentation update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described (not applicable: documentation only).
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional (no phone numbers added).
- [x] Recurring workflows include cancellation behavior (not applicable).
- [x] Runnable code has a dry-run, fake-server, or no-call path by default (not applicable).
- [x] `python3 scripts/validate_repository.py` passes.

Validation: `python3 scripts/validate_repository.py` and `git diff --check` passed.
