### PR TITLE
feat(apps): add CallProof authority-aware verification app

### DIFF
--- a/apps/python/callproof/README.md
+++ b/apps/python/callproof/README.md
@@ -1,0 +1,148 @@
+# CallProof
+
+CallProof is an authority-aware operational verification app built for CALL-E. It turns a specific real-world assumption into one of three bounded outcomes: `VERIFIED`, `CONTRADICTED`, or `UNRESOLVED`.
+
+The key design rule is simple: **a completed phone call is not proof**. CallProof only upgrades a claim when the answer is direct and the person answering is authoritative for that fact. Otherwise it abstains.
+
+## Why this exists
+
+Operational plans routinely depend on facts that are difficult to settle through web data or internal systems alone: access windows, site permissions, delivery constraints, approval status, dispatch readiness, and similar last-mile conditions.
+
+CallProof uses CALL-E to ask the accountable real world, then separates:
+
+- whether the claim itself was established;
+- whether the recipient was authoritative;
+- evidence quality;
+- material qualifiers or conditions; and
+- confidence in the returned evidence/result.
+
+That means a result can correctly be **high-confidence `UNRESOLVED`** when the recipient clearly says they cannot authoritatively confirm the claim.
+
+## Core loop
+
+```text
+CLAIM -> CALL-E -> WARRANT
+```
+
+1. State one operational claim precisely enough that the answer changes what happens next.
+2. CALL-E contacts the nominated operational recipient and asks only what is needed to test the claim.
+3. CallProof returns `VERIFIED`, `CONTRADICTED`, or `UNRESOLVED`, with authority, evidence quality, qualifiers, confidence and provenance.
+
+## Run locally
+
+Python 3.11+ is recommended.
+
+```bash
+cd apps/python/callproof
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --host 127.0.0.1 --port 8000 --reload
+```
+
+On Windows PowerShell you can instead run:
+
+```powershell
+.\run.ps1
+```
+
+Then open `http://127.0.0.1:8000`.
+
+The **Production scenario** and **Recorded live proof** modes are no-call paths and work without credentials.
+
+## Live CALL-E mode
+
+Live Developer API calls require a server-side CALL-E credential:
+
+```bash
+export CALLE_API_KEY="..."
+```
+
+or in PowerShell:
+
+```powershell
+$env:CALLE_API_KEY="..."
+```
+
+The live UI requires an operator-supplied E.164 phone number plus region and locale. Only use a number you are authorized to contact and a region/language combination currently supported by CALL-E. Example displays use masked phone placeholders rather than real personal numbers.
+
+A live verification creates a real outbound phone call and may consume CALL-E quota or billable usage. Review the claim, contact, region and locale before dispatch.
+
+## Result contract
+
+The CALL-E recipient result schema captures:
+
+- `claim_status`: `confirmed`, `contradicted`, or `unknown`;
+- `answer`: concise factual answer;
+- `authority_status`: `authoritative`, `non_authoritative`, or `unknown`;
+- `evidence_quality`: `direct`, `qualified`, or `insufficient`; and
+- `qualifier`: any material condition, dependency or approval requirement.
+
+The deterministic warrant policy is intentionally conservative:
+
+- `VERIFIED` requires an authoritative recipient plus direct confirmation.
+- `CONTRADICTED` requires an authoritative recipient plus direct or materially qualified contradiction.
+- everything else is `UNRESOLVED`.
+
+Result confidence is confidence in the evidence/result, not a probability that the claim itself is true.
+
+## Example
+
+Claim:
+
+> A 7.5-tonne production vehicle may enter the site at 05:30 tomorrow.
+
+A site contact says normal access starts at 06:00 and earlier access requires written duty-manager approval. Because the contact is authoritative and the answer directly rejects the 05:30 assumption, CallProof returns `CONTRADICTED` and preserves the approval condition as a material qualifier.
+
+## Recorded live CALL-E proof
+
+The app includes a sanitized replay of a real CALL-E MCP run against the official hackathon test hotline.
+
+The test claim was:
+
+> The verification call successfully reached the test endpoint.
+
+The call connected, but the hotline explicitly said it could identify itself only as a general inbound test hotline and could not confirm the stronger claim about a specific test endpoint. CALL-E completed the task with 0.90 (`high`) result confidence.
+
+CallProof therefore returns:
+
+```text
+UNRESOLVED
+Result confidence: 90%
+Authority: non_authoritative
+Evidence: insufficient
+```
+
+This is intentional: successful contact is not automatically evidence for the claim being tested.
+
+## Side effects, cancellation and rollback
+
+- **Production scenario:** deterministic, no call.
+- **Recorded live proof:** fixture replay, no call.
+- **Live verification:** creates a real outbound CALL-E call after the operator clicks the live action.
+- CallProof does **not** implement post-dispatch cancellation or rollback. Treat dispatch as the side-effect boundary and do not start a live call unless the recipient, claim and routing inputs are ready.
+- If infrastructure fails or the recipient is non-authoritative, ambiguous or unable to confirm, the app does not promote that failure into a positive claim verdict.
+
+## Safety boundaries
+
+- Live calls require explicit operator action; there are no hidden or recurring schedules.
+- Only call numbers the operator is authorized to contact.
+- Credentials remain server-side in `CALLE_API_KEY` and are never shown in the browser UI or fixtures.
+- A call connecting is never treated as evidence that the claim is true.
+- Non-authoritative, ambiguous, failed or insufficient outcomes resolve to `UNRESOLVED`.
+- Material qualifiers are surfaced rather than silently flattened into a yes/no result.
+- CallProof does not make legal, medical, financial, emergency, identity or other high-stakes personal decisions.
+
+## Validation
+
+```bash
+python -m unittest test_verdicts.py
+```
+
+The tests cover authority gating, direct verification, contradiction, ambiguity, qualified evidence and high-confidence unresolved results.
+
+## Standalone source
+
+The standalone prototype, submission material and development history live at:
+
+https://github.com/adamblackoak/tool_shed/tree/main/callproof

--- a/apps/python/callproof/README.md
+++ b/apps/python/callproof/README.md
@@ -66,6 +66,8 @@ $env:CALLE_API_KEY="..."
 
 The live UI requires an operator-supplied E.164 phone number plus region and locale. Only use a number you are authorized to contact and a region/language combination currently supported by CALL-E. Example displays use masked phone placeholders rather than real personal numbers.
 
+Live requests are loopback-only and require a fresh recipient-authorization checkbox for each run (`authorized: true` for local API clients). Do not expose the live endpoint through a tunnel or reverse proxy. This local operator demo is not a remotely hosted calling service. Displayed live results mask phone numbers, and provider error bodies are not returned to the browser.
+
 A live verification creates a real outbound phone call and may consume CALL-E quota or billable usage. Review the claim, contact, region and locale before dispatch.
 
 ## Result contract
@@ -122,6 +124,7 @@ This is intentional: successful contact is not automatically evidence for the cl
 - **Live verification:** creates a real outbound CALL-E call after the operator clicks the live action.
 - CallProof does **not** implement post-dispatch cancellation or rollback. Treat dispatch as the side-effect boundary and do not start a live call unless the recipient, claim and routing inputs are ready.
 - If infrastructure fails or the recipient is non-authoritative, ambiguous or unable to confirm, the app does not promote that failure into a positive claim verdict.
+- After a timeout or unknown provider outcome, stop and reconcile in the CALL-E dashboard before requesting another call; refreshing the UI does not cancel an accepted call.
 
 ## Safety boundaries
 
@@ -136,7 +139,7 @@ This is intentional: successful contact is not automatically evidence for the cl
 ## Validation
 
 ```bash
-python -m unittest test_verdicts.py
+python -m unittest test_verdicts.py test_safety.py
 ```
 
 The tests cover authority gating, direct verification, contradiction, ambiguity, qualified evidence and high-confidence unresolved results.

--- a/apps/python/callproof/app.py
+++ b/apps/python/callproof/app.py
@@ -1,14 +1,16 @@
 import asyncio
 import json
 import os
+import re
 import uuid
+from ipaddress import ip_address
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
 
 CALLE_API_BASE = "https://api.heycall-e.com/v1"
@@ -34,6 +36,45 @@ class VerifyRequest(BaseModel):
     contact_context: str = Field(default="Operational contact", max_length=300)
     region: str = Field(default="GB", min_length=2, max_length=2)
     locale: str = Field(default="en-GB", min_length=2, max_length=16)
+    authorized: bool = False
+
+
+def is_loopback(host: str | None) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        return ip_address(host or "").is_loopback
+    except ValueError:
+        return False
+
+
+@app.middleware("http")
+async def local_live_only(request: Request, call_next):
+    if request.url.path == "/verify" and (
+        not request.client
+        or not is_loopback(request.client.host)
+        or not is_loopback(request.url.hostname)
+    ):
+        return JSONResponse(status_code=403, content={"detail": "Live verification is local-only; use the documented loopback server."})
+    return await call_next(request)
+
+
+def mask_phone_text(value: str) -> str:
+    return re.sub(
+        r"\+[1-9](?:[ ()-]*[0-9]){7,14}(?![0-9])",
+        lambda match: "+***" + re.sub(r"[^0-9]", "", match.group())[-4:],
+        value,
+    )
+
+
+def masked_result(value: Any) -> Any:
+    if isinstance(value, str):
+        return mask_phone_text(value)
+    if isinstance(value, list):
+        return [masked_result(item) for item in value]
+    if isinstance(value, dict):
+        return {key: masked_result(item) for key, item in value.items()}
+    return value
 
 
 class VerifyResponse(BaseModel):
@@ -150,6 +191,10 @@ def first_recipient(call: dict[str, Any]) -> dict[str, Any]:
 
 
 async def create_call(req: VerifyRequest) -> dict[str, Any]:
+    if not req.authorized:
+        raise HTTPException(status_code=403, detail="Confirm authorization to contact this recipient for this live run.")
+    if not re.fullmatch(r"\+[1-9][0-9]{7,14}", req.phone):
+        raise HTTPException(status_code=422, detail="Supply a valid E.164 destination with a leading + and ASCII digits.")
     api_key = os.getenv("CALLE_API_KEY")
     if not api_key:
         raise HTTPException(status_code=503, detail="CALLE_API_KEY is not configured")
@@ -176,7 +221,7 @@ async def create_call(req: VerifyRequest) -> dict[str, Any]:
     async with httpx.AsyncClient(timeout=30) as client:
         response = await client.post(f"{CALLE_API_BASE}/calls", json=payload, headers=headers)
         if response.status_code >= 400:
-            raise HTTPException(status_code=502, detail=f"CALL-E create failed: {response.text[:500]}")
+            raise HTTPException(status_code=502, detail=f"CALL-E create returned HTTP {response.status_code}. Do not redial until the provider outcome is reconciled.")
         return response.json()
 
 
@@ -189,7 +234,7 @@ async def wait_for_terminal(call_id: str, *, max_wait_seconds: int = 240) -> dic
         while True:
             response = await client.get(f"{CALLE_API_BASE}/calls/{call_id}", headers=headers)
             if response.status_code >= 400:
-                raise HTTPException(status_code=502, detail=f"CALL-E status failed: {response.text[:500]}")
+                raise HTTPException(status_code=502, detail=f"CALL-E status returned HTTP {response.status_code}. The call may still be running; reconcile before redialing.")
             call = response.json()
             if str(call.get("status", "")).lower() in TERMINAL:
                 return call
@@ -250,6 +295,7 @@ button.live{border-style:dashed}.empty{display:flex;min-height:495px;align-items
 <label>Phone</label><input id="phone" placeholder="+44…">
 <label>Contact context</label><input id="context" value="Site operations contact responsible for vehicle access">
 <div class="row"><div><label>Region</label><input id="region" value="GB"></div><div><label>Locale</label><input id="locale" value="en-GB"></div></div>
+<label><input id="authorized" type="checkbox" style="width:auto"> I am authorized to contact this recipient and intend one real call now.</label>
 <div class="buttons">
 <button class="primary" onclick="run('demo')">Production scenario</button>
 <button onclick="run('fixture')">Recorded live proof</button>
@@ -270,10 +316,11 @@ const liveButton=document.getElementById('liveButton');
 if(!LIVE_AVAILABLE){liveButton.disabled=true;liveButton.textContent='Live API unavailable locally';liveButton.title='Set CALLE_API_KEY to enable the Developer API path.';}
 async function run(mode){
  const r=document.getElementById('result');
+ if(mode==='live'&&!document.getElementById('authorized').checked){r.textContent='Confirm recipient authorization before a live call.';return;}
  r.innerHTML='<div class="empty"><div><b>Resolving evidence…</b><br><br>CALL-E is testing the claim against the real world.</div></div>';
  const url=mode==='demo'?'/verify/demo':mode==='fixture'?'/verify/live-fixture':'/verify';
  const opts={method:'POST',headers:{'Content-Type':'application/json'}};
- if(mode==='live')opts.body=JSON.stringify({claim:claim.value,phone:phone.value,contact_context:context.value,region:region.value,locale:locale.value});
+ if(mode==='live'){opts.body=JSON.stringify({claim:claim.value,phone:phone.value,contact_context:context.value,region:region.value,locale:locale.value,authorized:true});document.getElementById('authorized').checked=false;liveButton.disabled=true;}
  try{
    const res=await fetch(url,opts);const d=await res.json();if(!res.ok)throw new Error(d.detail||'Verification failed');
    const evidence=(d.evidence||[]).map(x=>`<li>${esc(x)}</li>`).join('');
@@ -291,7 +338,7 @@ async function run(mode){
  }catch(e){
    r.innerHTML=`<div class="eyebrow">03 · Warrant</div><div class="verdict UNRESOLVED">UNRESOLVED</div><div class="summary">${esc(e.message)}</div>
    <div class="note">Infrastructure failure is never upgraded into a claim verdict.</div>`;
- }
+ }finally{if(mode==='live')liveButton.disabled=!LIVE_AVAILABLE;}
 }
 </script>
 </body></html>
@@ -312,7 +359,7 @@ async def health() -> dict[str, str | bool]:
 @app.post("/verify", response_model=VerifyResponse)
 async def verify(req: VerifyRequest) -> VerifyResponse:
     created = await create_call(req)
-    call = await wait_for_terminal(created["id"])
+    call = masked_result(await wait_for_terminal(created["id"]))
     recipient = first_recipient(call)
     structured = recipient.get("structured_result") or call.get("structured_result") or {}
     verdict = map_verdict(structured)
@@ -326,7 +373,7 @@ async def verify(req: VerifyRequest) -> VerifyResponse:
     return VerifyResponse(
         verification_id=verification_id,
         verdict=verdict,
-        claim=req.claim,
+        claim=mask_phone_text(req.claim),
         evidence=evidence,
         confidence=confidence_for(call),
         call_id=call.get("id") or call.get("call_id"),

--- a/apps/python/callproof/app.py
+++ b/apps/python/callproof/app.py
@@ -1,0 +1,381 @@
+import asyncio
+import json
+import os
+import uuid
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+CALLE_API_BASE = "https://api.heycall-e.com/v1"
+TERMINAL = {"completed", "failed", "canceled"}
+LIVE_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "live_hotline_unresolved.json"
+
+app = FastAPI(
+    title="CallProof",
+    version="0.3.1",
+    description="Phone-verified operational claims with bounded, authority-aware verdicts.",
+)
+
+
+class Verdict(str, Enum):
+    VERIFIED = "VERIFIED"
+    CONTRADICTED = "CONTRADICTED"
+    UNRESOLVED = "UNRESOLVED"
+
+
+class VerifyRequest(BaseModel):
+    claim: str = Field(min_length=8, max_length=1000)
+    phone: str = Field(min_length=7, max_length=32)
+    contact_context: str = Field(default="Operational contact", max_length=300)
+    region: str = Field(default="GB", min_length=2, max_length=2)
+    locale: str = Field(default="en-GB", min_length=2, max_length=16)
+
+
+class VerifyResponse(BaseModel):
+    verification_id: str
+    verdict: Verdict
+    claim: str
+    evidence: list[str]
+    confidence: float = Field(ge=0.0, le=1.0)
+    call_id: str | None = None
+    summary: str | None = None
+    raw_status: str | None = None
+    authority_status: str = "unknown"
+    evidence_quality: str = "insufficient"
+    qualifier: str | None = None
+    provenance: str | None = None
+
+
+RECIPIENT_RESULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "claim_status",
+        "answer",
+        "authority_status",
+        "evidence_quality",
+        "qualifier",
+    ],
+    "properties": {
+        "claim_status": {
+            "type": "string",
+            "enum": ["confirmed", "contradicted", "unknown"],
+            "description": (
+                "Use confirmed only when the recipient clearly confirms the claim. "
+                "Use contradicted only when the recipient clearly rejects or corrects it. "
+                "Use unknown if the answer is ambiguous or cannot be established."
+            ),
+        },
+        "answer": {
+            "type": "string",
+            "description": "Concise factual answer obtained from the recipient, without embellishment.",
+        },
+        "authority_status": {
+            "type": "string",
+            "enum": ["authoritative", "non_authoritative", "unknown"],
+            "description": (
+                "authoritative = the recipient is clearly competent to confirm this operational fact; "
+                "non_authoritative = they explicitly lack that authority; "
+                "unknown = authority was not established."
+            ),
+        },
+        "evidence_quality": {
+            "type": "string",
+            "enum": ["direct", "qualified", "insufficient"],
+            "description": (
+                "direct = authoritative and unambiguous wording; "
+                "qualified = answer contains material conditions or caveats; "
+                "insufficient = no reliable answer was obtained."
+            ),
+        },
+        "qualifier": {
+            "type": "string",
+            "description": (
+                "Any material condition, permission, time window, dependency, named approver, "
+                "or other caveat. Use an empty string if none was stated."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def task_for(req: VerifyRequest) -> str:
+    return f"""
+You are verifying one operational claim for a decision-support system.
+
+Claim: {req.claim}
+Contact context: {req.contact_context}
+
+Call the recipient and identify yourself as an AI assistant making a verification call on behalf of an operator.
+Ask only what is necessary to determine whether the claim is currently true.
+Establish whether the person answering is actually authoritative for this operational fact.
+Where an answer depends on a condition, permission, time window, named approver, or other qualifier, ask one concise follow-up to capture it.
+Do not persuade, negotiate, make commitments, or infer beyond what the recipient says.
+If the recipient is not authoritative, cannot confirm, or gives an ambiguous answer, return unknown rather than guessing.
+Return the factual answer, authority status, evidence quality, and any material qualifier.
+""".strip()
+
+
+def map_verdict(structured: dict[str, Any] | None) -> Verdict:
+    data = structured or {}
+    status = data.get("claim_status")
+    quality = data.get("evidence_quality")
+    authority = data.get("authority_status")
+
+    # Contact is not proof. An operational verdict requires established authority.
+    if authority != "authoritative":
+        return Verdict.UNRESOLVED
+    if status == "confirmed" and quality == "direct":
+        return Verdict.VERIFIED
+    if status == "contradicted" and quality in {"direct", "qualified"}:
+        return Verdict.CONTRADICTED
+    return Verdict.UNRESOLVED
+
+
+def confidence_for(call: dict[str, Any]) -> float:
+    """Confidence in the evidence/result, not probability that the claim is true."""
+    raw = call.get("completion_confidence") or {}
+    score = raw.get("score") if isinstance(raw, dict) else None
+    return max(0.0, min(1.0, float(score))) if isinstance(score, (int, float)) else 0.5
+
+
+def first_recipient(call: dict[str, Any]) -> dict[str, Any]:
+    recipients = call.get("recipients") or []
+    return recipients[0] if recipients and isinstance(recipients[0], dict) else {}
+
+
+async def create_call(req: VerifyRequest) -> dict[str, Any]:
+    api_key = os.getenv("CALLE_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=503, detail="CALLE_API_KEY is not configured")
+
+    verification_id = str(uuid.uuid4())
+    payload = {
+        "task": task_for(req),
+        "recipients": [
+            {
+                "phones": [req.phone],
+                "region": req.region.upper(),
+                "locale": req.locale,
+            }
+        ],
+        "recipient_result_schema": RECIPIENT_RESULT_SCHEMA,
+        "metadata": {"app": "callproof", "verification_id": verification_id},
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Idempotency-Key": f"callproof-{verification_id}",
+    }
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(f"{CALLE_API_BASE}/calls", json=payload, headers=headers)
+        if response.status_code >= 400:
+            raise HTTPException(status_code=502, detail=f"CALL-E create failed: {response.text[:500]}")
+        return response.json()
+
+
+async def wait_for_terminal(call_id: str, *, max_wait_seconds: int = 240) -> dict[str, Any]:
+    api_key = os.getenv("CALLE_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    deadline = asyncio.get_running_loop().time() + max_wait_seconds
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        while True:
+            response = await client.get(f"{CALLE_API_BASE}/calls/{call_id}", headers=headers)
+            if response.status_code >= 400:
+                raise HTTPException(status_code=502, detail=f"CALL-E status failed: {response.text[:500]}")
+            call = response.json()
+            if str(call.get("status", "")).lower() in TERMINAL:
+                return call
+            if asyncio.get_running_loop().time() >= deadline:
+                raise HTTPException(status_code=504, detail="Verification call did not reach a terminal state in time")
+            await asyncio.sleep(5)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home() -> str:
+    live_available = "true" if os.getenv("CALLE_API_KEY") else "false"
+    html = """
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>CallProof</title>
+<style>
+:root{--bg:#090c11;--panel:#121720;--panel2:#0d1219;--line:#263140;--text:#eef3f8;--muted:#94a3b8;--green:#5ee39a;--amber:#f7c873;--red:#ff8b8b;--blue:#83b8ff}
+*{box-sizing:border-box}body{font-family:Inter,ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 25% 0,#17202d 0,#090c11 38%);color:var(--text);margin:0}
+.wrap{max-width:1080px;margin:0 auto;padding:30px 24px 56px}.top{display:flex;justify-content:space-between;align-items:center;margin-bottom:24px}
+.brand{font-weight:850;letter-spacing:-.03em;font-size:22px}.tag{border:1px solid var(--line);color:var(--muted);padding:7px 10px;border-radius:999px;font-size:12px}
+h1{font-size:clamp(38px,5.5vw,62px);line-height:1;letter-spacing:-.05em;margin:0;max-width:900px}.sub{max-width:790px;color:#b8c4d3;font-size:18px;line-height:1.45;margin:16px 0 24px}
+.rail{display:grid;grid-template-columns:1fr 28px 1fr 28px 1fr;align-items:center;margin:20px 0 24px}.step{background:rgba(18,23,32,.8);border:1px solid var(--line);border-radius:15px;padding:13px 15px}
+.step span,.eyebrow{display:block;color:var(--muted);font-size:11px;letter-spacing:.12em;text-transform:uppercase;margin-bottom:5px}.arrow{text-align:center;color:#64748b}
+.grid{display:grid;grid-template-columns:.92fr 1.08fr;gap:18px;align-items:stretch}.card{background:rgba(18,23,32,.92);border:1px solid var(--line);border-radius:18px;padding:24px;box-shadow:0 18px 60px rgba(0,0,0,.18)}
+#result{min-height:548px}.card h2{margin:0 0 4px;font-size:18px}.hint{color:var(--muted);font-size:13px;margin:0 0 18px;line-height:1.4}
+label{display:block;color:#9eacbd;font-size:12px;margin:14px 0 6px}.row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+input,textarea{width:100%;background:var(--panel2);color:var(--text);border:1px solid #354154;border-radius:10px;padding:12px;font:inherit;outline:none}
+input:focus,textarea:focus{border-color:#6c87aa}.buttons{display:flex;flex-wrap:wrap;gap:8px;margin-top:17px}
+button{border:1px solid #374559;background:#1a2330;color:var(--text);border-radius:10px;padding:11px 14px;font-weight:720;cursor:pointer}
+button.primary{background:#eef3f8;color:#0b1016;border-color:#eef3f8}button:hover:not(:disabled){filter:brightness(1.08)}button:disabled{opacity:.48;cursor:not-allowed}
+button.live{border-style:dashed}.empty{display:flex;min-height:495px;align-items:center;justify-content:center;text-align:center;color:var(--muted);padding:40px}
+.verdict{font-size:44px;font-weight:900;letter-spacing:-.025em;margin:7px 0 10px}.VERIFIED{color:var(--green)}.CONTRADICTED{color:var(--red)}.UNRESOLVED{color:var(--amber)}
+.claim{font-size:13px;color:#c5d0dc;border-left:2px solid #475569;padding-left:12px;margin:12px 0 18px}.summary{font-size:16px;line-height:1.55;max-width:52ch}
+.chips{display:flex;flex-wrap:wrap;gap:7px;margin:16px 0}.chip{font-size:11px;border:1px solid #344156;background:#0d1219;padding:7px 9px;border-radius:999px;color:#c5d0dc}
+.evidence{margin:18px 0 0;padding:0;list-style:none}.evidence li{border-top:1px solid #273241;padding:11px 0 0;margin-top:11px;line-height:1.45;font-size:14px}
+.prov{font-size:11px;color:#8492a5;margin-top:18px;border-top:1px solid #273241;padding-top:12px;line-height:1.45}.prov b{color:#aab8c9;letter-spacing:.08em}.note{margin-top:18px;border:1px solid #3b4656;background:#0d1219;border-radius:12px;padding:12px;color:#aebacc;font-size:12px;line-height:1.5}
+.footer{color:#65758a;font-size:12px;margin-top:22px}
+@media(max-width:800px){.grid{grid-template-columns:1fr}.rail{grid-template-columns:1fr}.arrow{transform:rotate(90deg);padding:4px}.top{margin-bottom:22px}.wrap{padding-top:24px}#result{min-height:auto}.empty{min-height:260px}}
+</style>
+</head>
+<body><div class="wrap">
+<div class="top"><div class="brand">CallProof</div><div class="tag">CALL-E · bounded operational verification</div></div>
+<h1>Don’t ask whether the call completed. Ask what the evidence warrants.</h1>
+<div class="sub">CallProof turns a fragile real-world assumption into a phone-verified operational verdict: <strong>VERIFIED</strong>, <strong>CONTRADICTED</strong>, or <strong>UNRESOLVED</strong>.</div>
+
+<div class="rail">
+  <div class="step"><span>01 · Claim</span><b>State the operational assumption</b></div><div class="arrow">→</div>
+  <div class="step"><span>02 · CALL-E</span><b>Ask the accountable real world</b></div><div class="arrow">→</div>
+  <div class="step"><span>03 · Warrant</span><b>Return only what was established</b></div>
+</div>
+
+<div class="grid">
+<div class="card">
+<h2>Operational claim</h2><p class="hint">The claim should be specific enough that the answer changes what happens next.</p>
+<label>Claim</label><textarea id="claim" rows="4">A 7.5-tonne production vehicle may enter the site at 05:30 tomorrow</textarea>
+<label>Phone</label><input id="phone" placeholder="+44…">
+<label>Contact context</label><input id="context" value="Site operations contact responsible for vehicle access">
+<div class="row"><div><label>Region</label><input id="region" value="GB"></div><div><label>Locale</label><input id="locale" value="en-GB"></div></div>
+<div class="buttons">
+<button class="primary" onclick="run('demo')">Production scenario</button>
+<button onclick="run('fixture')">Recorded live proof</button>
+<button class="live" id="liveButton" onclick="run('live')">Run live API verification</button>
+</div>
+<div class="note"><strong>Decision rule:</strong> a claim is never verified merely because a call connected. The answer must be direct and the recipient must be authoritative for that fact.</div>
+</div>
+
+<div class="card" id="result"><div class="empty"><div><b>No verdict yet.</b><br><br>Contact is an event.<br>Evidence is a warrant.</div></div></div>
+</div>
+<div class="footer">CallProof v0.3.1 · Result confidence measures confidence in the evidence/result, not probability that the claim itself is true.</div>
+</div>
+
+<script>
+const LIVE_AVAILABLE=__LIVE_AVAILABLE__;
+const esc=v=>String(v??'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));
+const liveButton=document.getElementById('liveButton');
+if(!LIVE_AVAILABLE){liveButton.disabled=true;liveButton.textContent='Live API unavailable locally';liveButton.title='Set CALLE_API_KEY to enable the Developer API path.';}
+async function run(mode){
+ const r=document.getElementById('result');
+ r.innerHTML='<div class="empty"><div><b>Resolving evidence…</b><br><br>CALL-E is testing the claim against the real world.</div></div>';
+ const url=mode==='demo'?'/verify/demo':mode==='fixture'?'/verify/live-fixture':'/verify';
+ const opts={method:'POST',headers:{'Content-Type':'application/json'}};
+ if(mode==='live')opts.body=JSON.stringify({claim:claim.value,phone:phone.value,contact_context:context.value,region:region.value,locale:locale.value});
+ try{
+   const res=await fetch(url,opts);const d=await res.json();if(!res.ok)throw new Error(d.detail||'Verification failed');
+   const evidence=(d.evidence||[]).map(x=>`<li>${esc(x)}</li>`).join('');
+   const q=d.qualifier?`<div class="note"><strong>Material qualifier:</strong> ${esc(d.qualifier)}</div>`:'';
+   r.innerHTML=`<div class="eyebrow">03 · Warrant</div><div class="verdict ${esc(d.verdict)}">${esc(d.verdict)}</div>
+     <div class="claim">${esc(d.claim)}</div>
+     <div class="summary">${esc(d.summary||'')}</div>
+     <div class="chips">
+       <span class="chip">Result confidence ${Math.round((d.confidence||0)*100)}%</span>
+       <span class="chip">Authority ${esc(d.authority_status)}</span>
+       <span class="chip">Evidence ${esc(d.evidence_quality)}</span>
+     </div>${q}
+     <ul class="evidence">${evidence}</ul>
+     <div class="prov"><b>PROVENANCE</b><br>${esc(d.provenance||'CALL-E')}<br>Trace ${esc(d.call_id||d.verification_id||'unavailable')}</div>`;
+ }catch(e){
+   r.innerHTML=`<div class="eyebrow">03 · Warrant</div><div class="verdict UNRESOLVED">UNRESOLVED</div><div class="summary">${esc(e.message)}</div>
+   <div class="note">Infrastructure failure is never upgraded into a claim verdict.</div>`;
+ }
+}
+</script>
+</body></html>
+"""
+    return html.replace("__LIVE_AVAILABLE__", live_available)
+
+
+@app.get("/health")
+async def health() -> dict[str, str | bool]:
+    return {
+        "status": "ok",
+        "app": "callproof",
+        "version": "0.3.1",
+        "developer_api_configured": bool(os.getenv("CALLE_API_KEY")),
+    }
+
+
+@app.post("/verify", response_model=VerifyResponse)
+async def verify(req: VerifyRequest) -> VerifyResponse:
+    created = await create_call(req)
+    call = await wait_for_terminal(created["id"])
+    recipient = first_recipient(call)
+    structured = recipient.get("structured_result") or call.get("structured_result") or {}
+    verdict = map_verdict(structured)
+
+    evidence = list(call.get("evidence") or [])
+    answer = structured.get("answer")
+    if answer and answer not in evidence:
+        evidence.insert(0, answer)
+
+    verification_id = (call.get("metadata") or {}).get("verification_id") or str(uuid.uuid4())
+    return VerifyResponse(
+        verification_id=verification_id,
+        verdict=verdict,
+        claim=req.claim,
+        evidence=evidence,
+        confidence=confidence_for(call),
+        call_id=call.get("id") or call.get("call_id"),
+        summary=recipient.get("summary") or call.get("summary"),
+        raw_status=call.get("status"),
+        authority_status=structured.get("authority_status", "unknown"),
+        evidence_quality=structured.get("evidence_quality", "insufficient"),
+        qualifier=structured.get("qualifier") or None,
+        provenance="Live CALL-E Developer API result",
+    )
+
+
+@app.post("/verify/demo", response_model=VerifyResponse)
+async def verify_demo() -> VerifyResponse:
+    return VerifyResponse(
+        verification_id="demo_7p5t_0530",
+        verdict=Verdict.CONTRADICTED,
+        claim="A 7.5-tonne production vehicle may enter the site at 05:30 tomorrow",
+        evidence=[
+            "Site operations stated that normal vehicle access begins at 06:00.",
+            "The 05:30 arrival is not authorized under the current plan.",
+        ],
+        confidence=0.94,
+        call_id="scenario_demo",
+        summary="The 05:30 access assumption is contradicted by the accountable site contact.",
+        raw_status="completed",
+        authority_status="authoritative",
+        evidence_quality="direct",
+        qualifier="Earlier access requires written approval from the duty manager.",
+        provenance="Deterministic production-access scenario",
+    )
+
+
+@app.post("/verify/live-fixture", response_model=VerifyResponse)
+async def verify_live_fixture() -> VerifyResponse:
+    if not LIVE_FIXTURE_PATH.exists():
+        raise HTTPException(status_code=404, detail="Live CALL-E evidence fixture is missing")
+    fixture = json.loads(LIVE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    return VerifyResponse(
+        verification_id=fixture["run_id"],
+        verdict=Verdict(fixture["verdict"]),
+        claim=fixture["claim"],
+        evidence=fixture["evidence"],
+        confidence=float(fixture["completion_confidence"]["score"]),
+        call_id=fixture["call_id"],
+        summary=fixture["summary"],
+        raw_status=fixture["status"].lower(),
+        authority_status=fixture.get("authority_status", "unknown"),
+        evidence_quality=fixture.get("evidence_quality", "insufficient"),
+        qualifier=fixture.get("qualifier") or None,
+        provenance=fixture.get("source", "CALL-E live run fixture"),
+    )

--- a/apps/python/callproof/fixtures/live_hotline_unresolved.json
+++ b/apps/python/callproof/fixtures/live_hotline_unresolved.json
@@ -1,0 +1,34 @@
+{
+  "fixture_version": 2,
+  "captured_at": "2026-09-10T21:36:11Z",
+  "source": "Live CALL-E MCP run against the official hackathon test hotline",
+  "run_id": "rHM-HeX8luVltZHgoWmsaA",
+  "call_id": "4bbd2c4d5b284577b2d10fdb5f382b7d",
+  "status": "COMPLETED",
+  "claim": "The verification call successfully reached the test endpoint",
+  "verdict": "UNRESOLVED",
+  "task_completed": true,
+  "completion_confidence": {
+    "score": 0.9,
+    "label": "high"
+  },
+  "authority_status": "non_authoritative",
+  "evidence_quality": "insufficient",
+  "qualifier": "The hotline could identify itself as the general inbound test hotline, but could not attest that this call reached a specific test endpoint.",
+  "summary": "The hotline did not confirm that the verification call successfully reached a specific test endpoint. It confirmed that the accurate report is that the hotline cannot confirm whether the statement is true.",
+  "evidence": [
+    "A live hotline agent answered and identified the line as a general inbound CALL-E/Collie test hotline.",
+    "The hotline said it could not confirm whether the verification call reached a specific test endpoint.",
+    "The hotline agreed that reporting it cannot confirm the statement is the right phrasing."
+  ],
+  "transcript": [
+    {"offset_seconds": 0, "speaker": "BOT", "text": "Hi, is this the official CALL-E test hotline?"},
+    {"offset_seconds": 11, "speaker": "USER", "text": "Thanks for calling. How can I help you today? I'm Collie, the AI based agent answering this hotline. If you wanna learn more, it's hey collie.com."},
+    {"offset_seconds": 12, "speaker": "BOT", "text": "I'm calling for CallProof to ask: is the statement, 'the verification call successfully reached the test endpoint,' true?"},
+    {"offset_seconds": 25, "speaker": "USER", "text": "I'm not sure I can confirm that from here. What exact proof or log details are you looking for?"},
+    {"offset_seconds": 26, "speaker": "BOT", "text": "Could you please state the relevant information?"},
+    {"offset_seconds": 40, "speaker": "USER", "text": "I can say that I'm Collie, an AI voice agent on a general inbound test hotline. But I can't confirm whether a verification call successfully reached a specific test endpoint."},
+    {"offset_seconds": 42, "speaker": "BOT", "text": "So I should report that the hotline can't confirm whether the statement is true."},
+    {"offset_seconds": 51, "speaker": "USER", "text": "Yes. That's the right way to phrase it."}
+  ]
+}

--- a/apps/python/callproof/requirements.txt
+++ b/apps/python/callproof/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+httpx==0.28.1
+pydantic==2.11.7

--- a/apps/python/callproof/run.ps1
+++ b/apps/python/callproof/run.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location $PSScriptRoot
+
+if (-not (Test-Path ".venv")) {
+    python -m venv .venv
+}
+
+& .\.venv\Scripts\python.exe -m pip install -r requirements.txt
+
+Write-Host ""
+Write-Host "CallProof starting at http://127.0.0.1:8000" -ForegroundColor Green
+Write-Host "Recorded live proof and deterministic scenario work without credentials."
+if (-not $env:CALLE_API_KEY) {
+    Write-Host "CALLE_API_KEY is not set; Developer API live mode will remain unavailable." -ForegroundColor Yellow
+}
+Write-Host ""
+
+& .\.venv\Scripts\python.exe -m uvicorn app:app --host 127.0.0.1 --port 8000 --reload

--- a/apps/python/callproof/test_safety.py
+++ b/apps/python/callproof/test_safety.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+from fastapi import HTTPException
+
+import app as service
+
+
+class LiveSafetyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_authorization_is_required_before_network(self):
+        with patch.dict("os.environ", {}, clear=True), patch.object(service.httpx, "AsyncClient") as client:
+            with self.assertRaises(HTTPException) as error:
+                await service.create_call(service.VerifyRequest(claim="Fictional delivery is ready", phone="+12025550100"))
+            self.assertEqual(error.exception.status_code, 403)
+            client.assert_not_called()
+
+    async def test_invalid_destinations_are_rejected_before_network(self):
+        for phone in ("+02025550100", "+１２０２５５５０１００", "2025550100"):
+            with self.subTest(phone=phone), patch.object(service.httpx, "AsyncClient") as client:
+                with self.assertRaises(HTTPException) as error:
+                    await service.create_call(service.VerifyRequest(claim="Fictional delivery is ready", phone=phone, authorized=True))
+                self.assertEqual(error.exception.status_code, 422)
+                self.assertNotIn(phone, error.exception.detail)
+                client.assert_not_called()
+
+    async def test_remote_live_requests_are_rejected(self):
+        for peer, origin in (("192.0.2.1", "http://127.0.0.1"), ("127.0.0.1", "http://example.invalid")):
+            with self.subTest(peer=peer, origin=origin), patch.object(service, "create_call", new_callable=AsyncMock) as create:
+                transport = httpx.ASGITransport(app=service.app, client=(peer, 12345))
+                async with httpx.AsyncClient(transport=transport, base_url=origin) as client:
+                    response = await client.post("/verify", json={})
+                self.assertEqual(response.status_code, 403)
+                create.assert_not_called()
+
+    async def test_live_response_masks_nested_and_claim_phone_numbers(self):
+        phone = "+12025550100"
+        call = {"id": "offline-call", "status": "completed", "summary": f"Call {phone}", "evidence": ["Contact +1 (202) 555-0100"]}
+        with patch.object(service, "create_call", new_callable=AsyncMock, return_value={"id": "offline-call"}), patch.object(service, "wait_for_terminal", new_callable=AsyncMock, return_value=call):
+            result = await service.verify(service.VerifyRequest(claim=f"Fictional delivery contact {phone}", phone=phone, authorized=True))
+        serialized = result.model_dump_json()
+        self.assertNotIn(phone, serialized)
+        self.assertNotIn("+1 (202) 555-0100", serialized)
+        self.assertIn("+***0100", serialized)
+
+    async def test_provider_error_body_is_not_exposed(self):
+        response = httpx.Response(400, text="private-provider-error-body")
+        fake_client = AsyncMock()
+        fake_client.__aenter__.return_value = fake_client
+        fake_client.post.return_value = response
+        with patch.dict("os.environ", {"CALLE_API_KEY": "offline-test-placeholder"}, clear=True), patch.object(service.httpx, "AsyncClient", return_value=fake_client):
+            with self.assertRaises(HTTPException) as error:
+                await service.create_call(service.VerifyRequest(claim="Fictional delivery is ready", phone="+12025550100", authorized=True))
+        self.assertNotIn("private-provider-error-body", error.exception.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python/callproof/test_verdicts.py
+++ b/apps/python/callproof/test_verdicts.py
@@ -1,0 +1,97 @@
+import unittest
+
+from app import Verdict, confidence_for, map_verdict
+
+
+class VerdictSemanticsTests(unittest.TestCase):
+    def test_direct_authoritative_confirmation_verifies(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "confirmed",
+                    "evidence_quality": "direct",
+                    "authority_status": "authoritative",
+                }
+            ),
+            Verdict.VERIFIED,
+        )
+
+    def test_direct_authoritative_contradiction_contradicts(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "contradicted",
+                    "evidence_quality": "direct",
+                    "authority_status": "authoritative",
+                }
+            ),
+            Verdict.CONTRADICTED,
+        )
+
+    def test_non_authoritative_confirmation_stays_unresolved(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "confirmed",
+                    "evidence_quality": "direct",
+                    "authority_status": "non_authoritative",
+                }
+            ),
+            Verdict.UNRESOLVED,
+        )
+
+    def test_unknown_authority_stays_unresolved(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "confirmed",
+                    "evidence_quality": "direct",
+                    "authority_status": "unknown",
+                }
+            ),
+            Verdict.UNRESOLVED,
+        )
+
+    def test_unknown_claim_is_unresolved(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "unknown",
+                    "evidence_quality": "insufficient",
+                    "authority_status": "authoritative",
+                }
+            ),
+            Verdict.UNRESOLVED,
+        )
+
+    def test_qualified_confirmation_does_not_verify(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "confirmed",
+                    "evidence_quality": "qualified",
+                    "authority_status": "authoritative",
+                }
+            ),
+            Verdict.UNRESOLVED,
+        )
+
+    def test_qualified_authoritative_contradiction_can_contradict(self):
+        self.assertEqual(
+            map_verdict(
+                {
+                    "claim_status": "contradicted",
+                    "evidence_quality": "qualified",
+                    "authority_status": "authoritative",
+                }
+            ),
+            Verdict.CONTRADICTED,
+        )
+
+    def test_unresolved_can_still_be_high_confidence(self):
+        call = {"completion_confidence": {"score": 0.9, "label": "high"}}
+        self.assertEqual(confidence_for(call), 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this adds

CallProof verifies one operational claim by phone without treating call completion as proof.

It uses CALL-E to capture claim status, the factual answer, recipient authority, evidence quality, and material qualifiers. A deterministic warrant policy then returns VERIFIED, CONTRADICTED, or UNRESOLVED.

## Safety / no-call path

The app includes a deterministic production scenario and a sanitized replay of a real completed CALL-E MCP run. Both place no calls.

Live calls require explicit operator action, an authorized E.164 recipient, and a server-side CALL-E credential. Non-authoritative or insufficient evidence resolves to UNRESOLVED.

## Validation

python -m unittest test_verdicts.py

A real CALL-E MCP run against the official hackathon test hotline is included as a sanitized fixture and demonstrates a high-confidence UNRESOLVED result.