### PR TITLE
docs(cod-confirm): fix the live-call quickstart and the stale env example

### DIFF
--- a/apps/python/cod-confirm/.env.example
+++ b/apps/python/cod-confirm/.env.example
@@ -14,7 +14,9 @@ CALL_TIMEOUT_SECONDS=300
 # nothing, because whoever answered is not the customer the order belongs to.
 DEMO_PHONE=
 
-# Comma separated E.164 numbers this run may dial. Empty means no
-# restriction, which is what a real shop wants. Set it while testing so a
-# stray row in the order book cannot put a call through to a stranger.
+# Comma separated E.164 numbers this run may dial. Required for --live, and
+# empty means nothing may be dialled. There is deliberately no setting that
+# means "call whatever the order book says": an order book is data, and data
+# can be wrong, stale, or somebody else's. A deployment builds this list for
+# the sweep it is about to run.
 CALL_ALLOWLIST=

--- a/apps/python/cod-confirm/README.md
+++ b/apps/python/cod-confirm/README.md
@@ -148,28 +148,59 @@ pip install -r requirements.txt
 cp .env.example .env      # add your CALL-E API key
 
 python -m codconfirm.run              # dry run: full sweep, no calls, no credit
-python -m codconfirm.run --live --limit 1   # place one real call
 python -m codconfirm.run --reset      # restore the demo order book
 ```
+
+The dry run needs no API key and places no call:
 
 ```
 Dry run. No calls are placed. Pass --live to use call credit.
 
 4 of 5 pending order(s) justify a call.
-Order 1044  Shahriar Kabir  9800 BDT  risk 95%  net +165
+Order 1044  Shahriar Example  9800 BDT  risk 95%  net +165
   -> pending-confirmation: No answer, attempt 1.
-Order 1042  Tanvir Alam  6200 BDT  risk 25%  net +59
-  -> confirmed: Confirmed, address corrected. Said "yes I still want it".
+Order 1042  Tanvir Example  6200 BDT  risk 25%  net +59
+  -> confirmed: Confirmed, address corrected. Said "yes I still want it". Prefers delivery after 6pm.
+Order 1045  Farhana Example  4750 BDT  risk 28%  net +57
+  -> pending-confirmation: No answer, attempt 1.
+Order 1041  Rumana Example  3450 BDT  risk 8%  net +1
+  -> confirmed: Confirmed, address corrected. Said "yes I still want it". Prefers delivery after 6pm.
 
 Order book
   confirmed                2
   pending-confirmation     3
 
   1 order(s) left uncalled on purpose:
-    1043  Nusrat Jahan       net -0.5 per call
+    1043  Nusrat Example     net -0.5 per call
 ```
 
-Tests: `python -m pytest tests -q`
+### Placing a real call
+
+A live run only dials numbers named on `CALL_ALLOWLIST`, and the demo order
+book uses `+999` numbers, which cannot be dialled at all. So to hear the call
+yourself, point the run at a handset you control and put that handset on the
+allowlist:
+
+```bash
+export YOUR_NUMBER="+..."   # your own phone, in E.164 form
+CALL_ALLOWLIST="$YOUR_NUMBER" DEMO_PHONE="$YOUR_NUMBER" \
+  python -m codconfirm.run --live --limit 1
+```
+
+The call goes out through CALL-E and the transcript is kept on the order.
+Because it was redirected away from the order's own number, the answer is
+advisory: the order goes to `needs-human` instead of being confirmed, which
+is the redirect rule doing its job. Without `CALL_ALLOWLIST` a live run stops
+before the first ring and says why.
+
+### Tests
+
+```bash
+pip install pytest
+python -m pytest tests -q
+```
+
+71 tests, none of which need an API key or place a call.
 
 ## How it fits a real shop
 
@@ -187,14 +218,18 @@ codconfirm/
   orders.py      the order model and the store it reads and writes
   economics.py   which orders justify a call, and in what order
   schema.py      the call brief and the structured answer we ask for
+  phones.py      which numbers may be dialled, and cleaning what comes back
   agent.py       places the call through CALL-E
   decide.py      one call result -> one order status
   run.py         the sweep and the command line
 data/
   orders.seed.json   the demo order book
 tests/
-  test_decide.py     the decision table
-  test_economics.py  the call-budget model
+  test_decide.py       the decision table
+  test_economics.py    the call-budget model
+  test_phones.py       destination validation, masking and the allowlist
+  test_sweep.py        the sweep loop end to end, with the phone line replaced
+  test_call_safety.py  what a call may and may not be taken to mean
 ```
 
 ## Licence


### PR DESCRIPTION
## Summary

Follow-up to #313. The allowlist rule that went in during that review made two pieces of the `cod-confirm` documentation wrong, and neither was caught because both still read plausibly.

**The quickstart's live example no longer worked.** It was a bare `python -m codconfirm.run --live --limit 1`. Under the allowlist rule that stops before the first ring. And because the demo order book uses undialable `+999` numbers, setting an allowlist on its own still dials nothing. The example now sets both `CALL_ALLOWLIST` and `DEMO_PHONE` to a handset the reader controls, and explains what the redirect means for the result: advisory, so the order goes to `needs-human` rather than being confirmed.

I checked the new command end to end with a deliberately invalid key: it passes the allowlist, redirects to the demo handset, reaches `POST /v1/calls`, and CALL-E's 401 is recorded as refused before dialling. No call was placed.

**`.env.example` contradicted the code.** It still described an empty `CALL_ALLOWLIST` as "no restriction, which is what a real shop wants". It now says the allowlist is required for `--live` and that empty means nothing may be dialled.

Also brought in line with the code:

- The sample output is pasted from a real dry run and checked line for line against it. It had been showing the customer names from before the fixtures became fictional, and left out two of the orders.
- The test instruction now installs `pytest`, which `requirements.txt` does not include.
- The layout lists `phones.py` and the three test files it was missing.

Documentation only. No code or behaviour changes. 71 tests still pass.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [ ] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [x] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
