### PR TITLE
feat(cod-confirm): run the sweep against a live WooCommerce store

### DIFF
--- a/apps/python/cod-confirm/.env.example
+++ b/apps/python/cod-confirm/.env.example
@@ -14,7 +14,9 @@ CALL_TIMEOUT_SECONDS=300
 # nothing, because whoever answered is not the customer the order belongs to.
 DEMO_PHONE=
 
-# Comma separated E.164 numbers this run may dial. Empty means no
-# restriction, which is what a real shop wants. Set it while testing so a
-# stray row in the order book cannot put a call through to a stranger.
+# Comma separated E.164 numbers this run may dial. Required for --live, and
+# empty means nothing may be dialled. There is deliberately no setting that
+# means "call whatever the order book says": an order book is data, and data
+# can be wrong, stale, or somebody else's. A deployment builds this list for
+# the sweep it is about to run.
 CALL_ALLOWLIST=

--- a/apps/python/cod-confirm/.env.example
+++ b/apps/python/cod-confirm/.env.example
@@ -20,3 +20,24 @@ DEMO_PHONE=
 # can be wrong, stale, or somebody else's. A deployment builds this list for
 # the sweep it is about to run.
 CALL_ALLOWLIST=
+
+# Where the orders come from: the demo book in this folder, or a live store.
+# `json` (the default) or `woocommerce`.
+STORE_SOURCE=json
+
+# Only needed when STORE_SOURCE=woocommerce. Create the key pair under
+# WooCommerce > Settings > Advanced > REST API with read/write access. The
+# base URL must be https, because the key pair travels as basic auth.
+WOO_BASE_URL=
+WOO_KEY=
+WOO_SECRET=
+
+# The shop's own city. Parcels going anywhere else count as out of city.
+STORE_CITY=
+
+# Optional WooCommerce settings, with their defaults:
+# WOO_ORDER_STATUSES=processing,on-hold      placed, not yet dispatched
+# WOO_LOOKBACK_DAYS=7                        ignore older orders
+# WOO_REFUSED_STATUSES=failed,refused,returned
+# WOO_DEFAULT_FREIGHT=70                     freight to assume on free shipping
+# WOO_DEFAULT_CALLING_CODE=                  e.g. 880; empty means never guess

--- a/apps/python/cod-confirm/README.md
+++ b/apps/python/cod-confirm/README.md
@@ -148,28 +148,59 @@ pip install -r requirements.txt
 cp .env.example .env      # add your CALL-E API key
 
 python -m codconfirm.run              # dry run: full sweep, no calls, no credit
-python -m codconfirm.run --live --limit 1   # place one real call
 python -m codconfirm.run --reset      # restore the demo order book
 ```
+
+The dry run needs no API key and places no call:
 
 ```
 Dry run. No calls are placed. Pass --live to use call credit.
 
 4 of 5 pending order(s) justify a call.
-Order 1044  Shahriar Kabir  9800 BDT  risk 95%  net +165
+Order 1044  Shahriar Example  9800 BDT  risk 95%  net +165
   -> pending-confirmation: No answer, attempt 1.
-Order 1042  Tanvir Alam  6200 BDT  risk 25%  net +59
-  -> confirmed: Confirmed, address corrected. Said "yes I still want it".
+Order 1042  Tanvir Example  6200 BDT  risk 25%  net +59
+  -> confirmed: Confirmed, address corrected. Said "yes I still want it". Prefers delivery after 6pm.
+Order 1045  Farhana Example  4750 BDT  risk 28%  net +57
+  -> pending-confirmation: No answer, attempt 1.
+Order 1041  Rumana Example  3450 BDT  risk 8%  net +1
+  -> confirmed: Confirmed, address corrected. Said "yes I still want it". Prefers delivery after 6pm.
 
 Order book
   confirmed                2
   pending-confirmation     3
 
   1 order(s) left uncalled on purpose:
-    1043  Nusrat Jahan       net -0.5 per call
+    1043  Nusrat Example     net -0.5 per call
 ```
 
-Tests: `python -m pytest tests -q`
+### Placing a real call
+
+A live run only dials numbers named on `CALL_ALLOWLIST`, and the demo order
+book uses `+999` numbers, which cannot be dialled at all. So to hear the call
+yourself, point the run at a handset you control and put that handset on the
+allowlist:
+
+```bash
+export YOUR_NUMBER="+..."   # your own phone, in E.164 form
+CALL_ALLOWLIST="$YOUR_NUMBER" DEMO_PHONE="$YOUR_NUMBER" \
+  python -m codconfirm.run --live --limit 1
+```
+
+The call goes out through CALL-E and the transcript is kept on the order.
+Because it was redirected away from the order's own number, the answer is
+advisory: the order goes to `needs-human` instead of being confirmed, which
+is the redirect rule doing its job. Without `CALL_ALLOWLIST` a live run stops
+before the first ring and says why.
+
+### Tests
+
+```bash
+pip install pytest
+python -m pytest tests -q
+```
+
+71 tests, none of which need an API key or place a call.
 
 ## How it fits a real shop
 
@@ -187,14 +218,18 @@ codconfirm/
   orders.py      the order model and the store it reads and writes
   economics.py   which orders justify a call, and in what order
   schema.py      the call brief and the structured answer we ask for
+  phones.py      which numbers may be dialled, and cleaning what comes back
   agent.py       places the call through CALL-E
   decide.py      one call result -> one order status
   run.py         the sweep and the command line
 data/
   orders.seed.json   the demo order book
 tests/
-  test_decide.py     the decision table
-  test_economics.py  the call-budget model
+  test_decide.py       the decision table
+  test_economics.py    the call-budget model
+  test_phones.py       destination validation, masking and the allowlist
+  test_sweep.py        the sweep loop end to end, with the phone line replaced
+  test_call_safety.py  what a call may and may not be taken to mean
 ```
 
 ## Licence

--- a/apps/python/cod-confirm/README.md
+++ b/apps/python/cod-confirm/README.md
@@ -92,8 +92,9 @@ call rarely produces a clearer one, so it goes to a human instead.
 
 The decision table in [`decide.py`](codconfirm/decide.py) is total: every
 combination of answers maps to exactly one status, so no order is left in
-limbo by a reply nobody anticipated. Seventy one tests cover it, the pricing model
-and the call-safety rules, and none of them need an API key or place a call.
+limbo by a reply nobody anticipated. Ninety five tests cover it, the pricing model,
+the call-safety rules and the WooCommerce connector, and none of them need an
+API key, a store or a phone line.
 
 ## Side effects and safety
 
@@ -138,6 +139,10 @@ and the call-safety rules, and none of them need an API key or place a call.
 - Ninety seconds, maximum.
 - `MAX_CALL_ATTEMPTS` bounds retries per order. Nothing recurs on its own:
   each sweep is one command, and stopping is not running it again.
+- **Against a live WooCommerce store**, a `--live` run writes to it: a
+  private order note and two meta fields per order it acted on. It never
+  changes an order's status or address. A dry run reads the store and writes
+  nothing. See [Run it against a real WooCommerce store](#run-it-against-a-real-woocommerce-store).
 - The demo order book carries fictional numbers. `DEMO_PHONE` redirects a
   live run to one handset you control, so a demo never dials a stranger.
 
@@ -200,22 +205,67 @@ pip install pytest
 python -m pytest tests -q
 ```
 
-71 tests, none of which need an API key or place a call.
+95 tests, none of which need an API key, a store or a phone line.
 
-## How it fits a real shop
+## Run it against a real WooCommerce store
 
-[`orders.py`](codconfirm/orders.py) is the only file that knows where orders
-live. It reads and writes JSON shaped like a WooCommerce order payload, so
-pointing it at a live store means replacing `load` and `save` with two REST
-calls. The pricing constants in `Economics` are the shop's own numbers and
-are meant to be edited.
+The demo book is a JSON file, but the sweep runs against a live WooCommerce
+store with no code changes. Create a REST API key under *WooCommerce >
+Settings > Advanced > REST API* with read/write access, then:
+
+```bash
+STORE_SOURCE=woocommerce
+WOO_BASE_URL=https://your-shop.example      # must be https
+WOO_KEY=ck_...
+WOO_SECRET=cs_...
+STORE_CITY=Dhaka                            # optional: marks out-of-city parcels
+```
+
+**What it reads.** Cash-on-delivery orders still waiting for dispatch
+(`processing` and `on-hold` by default) that were placed in the last seven
+days. Ringing somebody about an order from last month is not a confirmation,
+so older ones are left alone. Prepaid orders are skipped: nothing is waiting
+at the door.
+
+**Where the risk comes from.** Each customer's history in the same store,
+matched exactly on their phone number: completed orders count as deliveries
+taken, and `failed`, `refused` or `returned` orders as refusals. WooCommerce
+has no built-in "refused at the door" status, so set
+`WOO_REFUSED_STATUSES` to whatever your shop calls it. A free-shipping order
+is priced at `WOO_DEFAULT_FREIGHT` rather than zero, because free shipping to
+the customer is not free to the shop.
+
+**What it writes, and only on `--live`.** A private order note with the
+decision, and the transcript when a person has to finish the order, plus two
+meta fields, `cod_confirm_status` and `cod_confirm_attempts`. Each order is
+written the moment its call ends, not at the end of the sweep, so a store that
+stops answering halfway cannot leave called customers looking uncalled. If a
+write fails, the sweep stops and names the order that needs recording by hand.
+
+**What it never does.** It never changes an order's WooCommerce status and
+never edits the order's address. Whether a confirmed order moves to packing
+or a refused one is cancelled stays the shop's decision. A corrected address
+from the call arrives as a note for a person to apply, because a misheard
+street is a parcel sent somewhere else.
+
+**The safety rules still hold across runs.** An order the sweep marked
+`needs-human` is not picked up again until somebody clears its
+`cod_confirm_status`, so an ambiguous call is never redialled by a later
+sweep. A phone number stored without a country code is not guessed at: the
+order goes to a person, unless you set `WOO_DEFAULT_CALLING_CODE` (for example
+`880`) to say every local number is in one country.
+
+A dry run against a live store reads it and writes nothing, so it is safe to
+point at a real shop first. The pricing constants in `Economics` are the
+shop's own numbers and are meant to be edited.
 
 ## Layout
 
 ```
 codconfirm/
   config.py      settings from the environment
-  orders.py      the order model and the store it reads and writes
+  orders.py      the order model and the demo order book
+  woo.py         reading a live WooCommerce store, and writing results back
   economics.py   which orders justify a call, and in what order
   schema.py      the call brief and the structured answer we ask for
   phones.py      which numbers may be dialled, and cleaning what comes back
@@ -230,6 +280,7 @@ tests/
   test_phones.py       destination validation, masking and the allowlist
   test_sweep.py        the sweep loop end to end, with the phone line replaced
   test_call_safety.py  what a call may and may not be taken to mean
+  test_woo.py          a live store, played by a fake one, with every write recorded
 ```
 
 ## Licence

--- a/apps/python/cod-confirm/codconfirm/orders.py
+++ b/apps/python/cod-confirm/codconfirm/orders.py
@@ -6,6 +6,7 @@ JSON file for a live store is a matter of replacing `load` and `save`.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Iterable
@@ -73,6 +74,15 @@ def save(orders: Iterable[Order], path: Path | None = None) -> None:
     rows = [asdict(order) for order in orders]
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+
+
+def source() -> str:
+    """Where the orders come from: the demo book here, or a live store.
+
+    `json` reads and writes the demo order book in this folder.
+    `woocommerce` reads a live store through `woo.py`.
+    """
+    return os.environ.get("STORE_SOURCE", "json").strip().lower() or "json"
 
 
 def pending(orders: Iterable[Order]) -> list[Order]:

--- a/apps/python/cod-confirm/codconfirm/run.py
+++ b/apps/python/cod-confirm/codconfirm/run.py
@@ -7,6 +7,7 @@ import logging
 from codconfirm import economics as econ_mod
 from codconfirm import phones
 from codconfirm import orders as store
+from codconfirm import woo
 from codconfirm.agent import new_run_id, place_call, simulate_call
 from codconfirm.config import Settings
 from codconfirm.decide import decide
@@ -31,7 +32,17 @@ def sweep(*, live: bool, limit: int | None = None,
         except phones.UnsafeNumber as exc:
             raise SystemExit(str(exc)) from exc
 
-    all_orders = store.load()
+    shop = None
+    if store.source() == "woocommerce":
+        try:
+            shop = woo.store()
+            all_orders = shop.load()
+        except woo.WooError as exc:
+            raise SystemExit(str(exc)) from exc
+        log.info("Read %d cash-on-delivery order(s) from %s.",
+                 len(all_orders), shop.config.base_url)
+    else:
+        all_orders = store.load()
     waiting = store.pending(all_orders)
 
     queue = econ_mod.rank([o for o in waiting if econ_mod.worth_calling(o, econ)], econ)
@@ -45,7 +56,7 @@ def sweep(*, live: bool, limit: int | None = None,
 
     if not queue:
         log.info("Nothing worth calling right now.")
-        store.save(all_orders)
+        persist(all_orders, shop, live)
         return all_orders, skipped
 
     phone = phone or settings.demo_phone or None
@@ -82,12 +93,50 @@ def sweep(*, live: bool, limit: int | None = None,
             if attempt.summary:
                 order.log(f"summary: {phones.scrub(attempt.summary)}")
 
+        if shop is not None and live:
+            # Recorded straight after the call, not at the end of the sweep.
+            # If the store stops answering halfway, a batch at the end would
+            # leave every called order looking uncalled, and the next sweep
+            # would ring them all again.
+            try:
+                shop.write_back([order])
+            except woo.WooError as exc:
+                raise SystemExit(
+                    f"Order {order.id} was called but its result could not be "
+                    f"written back to the store ({exc}). Record it by hand before "
+                    "the next sweep, or it may be called again."
+                ) from exc
+
         if outcome.halt:
             log.warning("  stopping the sweep here rather than risk a second call.")
             break
 
-    store.save(all_orders)
+    persist(all_orders, shop, live)
     return all_orders, skipped
+
+
+def persist(all_orders: list[store.Order], shop, live: bool) -> None:
+    """Keep what this sweep decided.
+
+    The demo book is a local file and is always saved. A live store is only
+    written to on a live run: a dry run reads the shop and changes nothing in
+    it, which is what makes it safe to point at a real one first.
+    """
+    if shop is None:
+        store.save(all_orders)
+        return
+    if not live:
+        log.info("\nDry run: nothing was written back to the store.")
+        return
+    # Called orders were recorded one by one as the sweep went. What is left
+    # here is anything decided without a call, such as an order sent to a
+    # person because its phone number could not be used.
+    try:
+        changed = shop.write_back(all_orders)
+    except woo.WooError as exc:
+        raise SystemExit(f"Writing the remaining results back failed: {exc}") from exc
+    if changed:
+        log.info("\nWrote %d further result(s) back to the store.", changed)
 
 
 def summarise(all_orders: list[store.Order], skipped: list[store.Order]) -> None:
@@ -131,6 +180,9 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     if args.reset:
+        if store.source() != "json":
+            raise SystemExit("--reset only restores the demo order book. "
+                             "It does nothing to a live store.")
         store.reset()
         print("Demo order book restored.")
         return

--- a/apps/python/cod-confirm/codconfirm/woo.py
+++ b/apps/python/cod-confirm/codconfirm/woo.py
@@ -1,0 +1,398 @@
+"""Reading a live WooCommerce store, and writing decisions back into it.
+
+Everything else in this package speaks in `Order`. This is the only file
+that knows WooCommerce exists, so a shop swaps its demo book for its real
+one by setting `STORE_SOURCE=woocommerce` and three credentials, not by
+changing the sweep.
+
+What it reads:
+
+* cash-on-delivery orders still waiting for dispatch, placed recently
+* each customer's history in the same store, matched on their phone number,
+  so the refusal risk comes from the shop's own records rather than from a
+  national average
+
+What it writes, and only on a `--live` run:
+
+* a private order note carrying the decision, and the transcript when a
+  person has to finish the order
+* two meta fields, `cod_confirm_status` and `cod_confirm_attempts`, so the
+  next sweep knows what has already happened
+
+It never changes an order's WooCommerce status. Whether a confirmed order
+moves to packing, or a refused one is cancelled, stays the shop's decision,
+made in the shop's own workflow. That also keeps the rules that matter most
+here true across runs: an order sent to a person is not picked up again until
+somebody clears its `cod_confirm_status`, so an ambiguous call is never
+redialled by a later sweep.
+
+The mapping is where the care is. A REST payload is written for a page, and
+a page can afford to be vague: HTML in a product name, a phone number with no
+country code, a free-shipping order whose freight the shop still pays. Each
+of those is resolved here rather than passed on.
+"""
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import html
+import http.client
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+from codconfirm import phones
+from codconfirm.orders import CANCELLED, CONFIRMED, NEEDS_HUMAN, PENDING, Order
+
+API = "/wp-json/wc/v3"
+
+# Statuses this sweep sets, and so treats as already decided on the next run.
+DECIDED = {CONFIRMED, CANCELLED, NEEDS_HUMAN}
+
+META_STATUS = "cod_confirm_status"
+META_ATTEMPTS = "cod_confirm_attempts"
+NOTE_PREFIX = "COD Confirm: "
+
+# A store that keeps answering with full pages would otherwise be read
+# forever. Five thousand orders is far past any small shop's pending book.
+MAX_PAGES = 50
+
+TAGS = re.compile(r"<[^>]+>")
+SPACE = re.compile(r"\s+")
+
+
+class WooError(RuntimeError):
+    """The store could not be reached, or answered with something unusable."""
+
+
+def _csv(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+@dataclass(frozen=True)
+class WooConfig:
+    base_url: str
+    key: str
+    secret: str
+    statuses: tuple[str, ...] = ("processing", "on-hold")
+    """WooCommerce statuses that mean "placed, not yet dispatched"."""
+
+    lookback_days: int = 7
+    """Only orders placed this recently are confirmed.
+
+    Ringing somebody about an order from last month is not a confirmation, it
+    is an ambush, and the parcel has usually been dealt with some other way.
+    """
+
+    refused_statuses: tuple[str, ...] = ("failed", "refused", "returned")
+    """Statuses that mean the customer did not take delivery.
+
+    WooCommerce has no built-in "refused at the door", so shops use their
+    own. Set WOO_REFUSED_STATUSES to whatever yours are called.
+    """
+
+    home_city: str = ""
+    """The shop's own city. Parcels outside it travel further and refuse more."""
+
+    calling_code: str = ""
+    """Country calling code for numbers stored without one, e.g. 880.
+
+    Empty means no guessing: a number without a country code is sent to a
+    person instead of being rewritten. Adding digits to a destination is
+    changing it, and that should be a decision somebody made.
+    """
+
+    default_freight: float = 70.0
+    """One-way courier cost to assume when an order shows free shipping.
+
+    Free shipping to the customer is not free to the shop, and pricing a
+    call as though the freight were nothing would talk the sweep out of
+    every free-delivery order.
+    """
+
+    timeout: float = 20.0
+
+    @classmethod
+    def from_env(cls) -> "WooConfig":
+        base = os.environ.get("WOO_BASE_URL", "").strip().rstrip("/")
+        key = os.environ.get("WOO_KEY", "").strip()
+        secret = os.environ.get("WOO_SECRET", "").strip()
+        if not (base and key and secret):
+            raise WooError(
+                "STORE_SOURCE=woocommerce needs WOO_BASE_URL, WOO_KEY and WOO_SECRET."
+            )
+        parsed = urllib.parse.urlparse(base)
+        local = parsed.hostname in {"127.0.0.1", "localhost"}
+        if parsed.scheme != "https" and not local:
+            # The key pair travels as basic auth. Over plain HTTP that is the
+            # shop's write access to every order, in the clear.
+            raise WooError("WOO_BASE_URL must be https:// so the API key is not sent in the clear.")
+
+        return cls(
+            base_url=base,
+            key=key,
+            secret=secret,
+            statuses=_csv(os.environ.get("WOO_ORDER_STATUSES", "processing,on-hold")),
+            lookback_days=int(os.environ.get("WOO_LOOKBACK_DAYS", "7")),
+            refused_statuses=_csv(os.environ.get("WOO_REFUSED_STATUSES", "failed,refused,returned")),
+            home_city=os.environ.get("STORE_CITY", "").strip(),
+            calling_code=os.environ.get("WOO_DEFAULT_CALLING_CODE", "").strip().lstrip("+"),
+            default_freight=float(os.environ.get("WOO_DEFAULT_FREIGHT", "70")),
+        )
+
+
+@dataclass
+class _Seen:
+    """What the store last held for an order, to know what has changed since."""
+
+    status: str
+    attempts: int
+    notes: int
+    address: str
+
+
+@dataclass
+class WooStore:
+    config: WooConfig
+    _seen: dict[str, _Seen] = field(default_factory=dict)
+
+    # --- transport ------------------------------------------------------
+
+    def _request(self, method: str, path: str, params: dict | None = None,
+                 body: dict | None = None):
+        url = f"{self.config.base_url}{API}{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        token = base64.b64encode(f"{self.config.key}:{self.config.secret}".encode()).decode()
+        headers = {"Authorization": f"Basic {token}", "Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.config.timeout) as response:
+                return json.loads(response.read().decode() or "null")
+        except urllib.error.HTTPError as exc:
+            exc.close()
+            # Never echo the URL back with credentials, and never the body a
+            # store sends on error, which can carry customer data.
+            raise WooError(f"The store answered {exc.code} to {method} {path}.") from None
+        except (OSError, http.client.HTTPException, json.JSONDecodeError) as exc:
+            # A connection dropped halfway through a write is exactly the case
+            # the sweep has to report cleanly: the call may already have been
+            # made. Anything the network can throw becomes one error the sweep
+            # knows how to stop on, not a traceback after the phone has rung.
+            raise WooError(f"The store could not be reached: {type(exc).__name__}.") from None
+
+    def _paged(self, path: str, params: dict) -> list[dict]:
+        rows: list[dict] = []
+        for page in range(1, MAX_PAGES + 1):
+            batch = self._request("GET", path, {**params, "per_page": 100, "page": page})
+            if not isinstance(batch, list):
+                raise WooError(f"Expected a list of orders from {path}.")
+            rows.extend(batch)
+            if len(batch) < 100:
+                return rows
+        raise WooError(f"The store returned more than {MAX_PAGES * 100} orders; "
+                       "narrow WOO_ORDER_STATUSES or WOO_LOOKBACK_DAYS.")
+
+    # --- reading --------------------------------------------------------
+
+    def load(self, now: dt.datetime | None = None) -> list[Order]:
+        """The cash-on-delivery orders this sweep should consider."""
+        now = now or dt.datetime.now(dt.timezone.utc)
+        after = (now - dt.timedelta(days=self.config.lookback_days)).strftime("%Y-%m-%dT%H:%M:%S")
+        raw = self._paged("/orders", {
+            "status": ",".join(self.config.statuses),
+            "after": after,
+            # The cut-off is worked out in UTC, so tell the store that, or it
+            # reads it in the shop's own time zone and moves it by hours.
+            "dates_are_gmt": "true",
+        })
+
+        history: dict[str, list[dict]] = {}
+        orders: list[Order] = []
+        self._seen.clear()
+        for row in raw:
+            if row.get("payment_method") != "cod":
+                continue  # paid up front: nothing is waiting at the door
+            orders.append(self._to_order(row, history))
+        return orders
+
+    def _to_order(self, row: dict, history: dict[str, list[dict]]) -> Order:
+        billing = row.get("billing") or {}
+        shipping = row.get("shipping") or {}
+        meta = {m.get("key"): m.get("value") for m in row.get("meta_data") or []}
+
+        raw_phone = str(billing.get("phone") or "")
+        phone = international(raw_phone, self.config.calling_code)
+
+        place = shipping if shipping.get("address_1") else billing
+        address = ", ".join(
+            plain(place.get(part)) for part in ("address_1", "address_2", "city", "postcode")
+            if plain(place.get(part))
+        )
+
+        items = []
+        for line in row.get("line_items") or []:
+            name = plain(line.get("name"))
+            quantity = int(line.get("quantity") or 1)
+            if name:
+                items.append(f"{name} x{quantity}" if quantity > 1 else name)
+
+        freight = money(row.get("shipping_total"))
+        city = plain(place.get("city"))
+
+        try:
+            attempts = int(meta.get(META_ATTEMPTS) or 0)
+            corrupt = False
+        except (TypeError, ValueError):
+            # Reading garbage as zero would hand this customer a fresh set of
+            # attempts. Reading it as anything else would be a guess.
+            attempts, corrupt = 0, True
+
+        order = Order(
+            id=str(row["id"]),
+            customer_name=plain(f"{billing.get('first_name', '')} {billing.get('last_name', '')}"),
+            phone=phone,
+            address=address,
+            items=items or ["(no items listed)"],
+            total=money(row.get("total")),
+            shipping_cost=freight if freight > 0 else self.config.default_freight,
+            outside_home_city=bool(self.config.home_city and city
+                                   and city.casefold() != self.config.home_city.casefold()),
+            status=str(meta.get(META_STATUS) or PENDING),
+            attempts=attempts,
+        )
+        # Recorded before anything below changes the order, so that a
+        # decision made while reading it still counts as a change to write.
+        self._seen[order.id] = _Seen(order.status, order.attempts, 0, order.address)
+
+        if corrupt and order.status == PENDING:
+            order.status = NEEDS_HUMAN
+            order.log(f"{META_ATTEMPTS} on this order is not a number, so how many "
+                      "times it has been called is unknown. It was not called again.")
+            return order
+
+        if order.status == PENDING:
+            try:
+                phones.normalise(phone)
+            except phones.UnsafeNumber:
+                # Unusable as it stands, and rewriting it would be guessing at
+                # somebody's phone number. A person fixes the order instead.
+                order.status = NEEDS_HUMAN
+                order.log(
+                    "The phone number on this order is not in international form, "
+                    "so it was not called. Add the country code, or set "
+                    "WOO_DEFAULT_CALLING_CODE if every order is local."
+                )
+                return order
+
+        past = self._history(phone, history)
+        earlier = [o for o in past if str(o.get("id")) != order.id]
+        order.previous_orders = sum(1 for o in earlier if o.get("status") == "completed")
+        order.previous_refusals = sum(
+            1 for o in earlier if o.get("status") in self.config.refused_statuses
+        )
+        return order
+
+    def _history(self, phone: str, cache: dict[str, list[dict]]) -> list[dict]:
+        """Every order this store holds for the same phone number."""
+        if phone in cache:
+            return cache[phone]
+        found = self._paged("/orders", {"search": phone, "status": "any"})
+        # A search matches substrings in any field. Only an exact phone match
+        # is this customer; a partial one is somebody else.
+        same = [
+            o for o in found
+            if international(str((o.get("billing") or {}).get("phone") or ""),
+                             self.config.calling_code) == phone
+        ]
+        cache[phone] = same
+        return same
+
+    # --- writing --------------------------------------------------------
+
+    def write_back(self, orders: list[Order]) -> int:
+        """Record what this sweep decided. Returns how many orders changed."""
+        changed = 0
+        for order in orders:
+            seen = self._seen.get(order.id)
+            if seen is None:
+                continue
+            # An order the sweep only looked at, such as one it decided was
+            # not worth a call, is left alone. Writing "not called" onto it on
+            # every run would bury the notes that matter under ones that do not.
+            if (order.status, order.attempts) == (seen.status, seen.attempts):
+                continue
+
+            notes = list(order.notes[seen.notes:])
+            if order.address != seen.address:
+                # The customer gave a different address on the call. It is
+                # passed on for a person to apply, not written over the order's
+                # own: a misheard street is a parcel sent somewhere else.
+                notes.append(
+                    f"The customer gave a corrected delivery address on the call: "
+                    f"{order.address}. The order's own address has not been changed."
+                )
+
+            for note in notes:
+                self._request("POST", f"/orders/{order.id}/notes", body={
+                    "note": NOTE_PREFIX + phones.scrub(note, limit=2000),
+                    "customer_note": False,
+                })
+            self._request("PUT", f"/orders/{order.id}", body={"meta_data": [
+                {"key": META_STATUS, "value": order.status},
+                {"key": META_ATTEMPTS, "value": str(order.attempts)},
+            ]})
+            self._seen[order.id] = _Seen(order.status, order.attempts,
+                                         len(order.notes), order.address)
+            changed += 1
+        return changed
+
+
+def international(raw: str, calling_code: str) -> str:
+    """A stored phone number in E.164 form, if it can be had without guessing.
+
+    Formatting is removed. A local number starting with 0 gains the country
+    code only when the shop has said which country that is. Anything else is
+    returned as it was, to be refused by `phones.normalise` downstream.
+    """
+    stripped = re.sub(r"[ ()\-.]", "", raw.strip())
+    if stripped.startswith("+"):
+        return stripped
+    # 00 is the international prefix, but only when a real country code
+    # follows it. Country codes never start with 0, so 000... is a local
+    # number and is left to the rule below.
+    if stripped[:2] == "00" and stripped[2:3] not in ("", "0") and stripped[2:].isdigit():
+        return "+" + stripped[2:]
+    if calling_code and stripped.isdigit():
+        if stripped.startswith(calling_code):
+            return "+" + stripped
+        if stripped.startswith("0"):
+            return "+" + calling_code + stripped[1:]
+    return raw.strip()
+
+
+def plain(value) -> str:
+    """Text a person can read on a call: no tags, no entities, one line."""
+    if not value:
+        return ""
+    return SPACE.sub(" ", html.unescape(TAGS.sub(" ", str(value)))).strip()
+
+
+def money(value) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def store() -> WooStore:
+    return WooStore(WooConfig.from_env())

--- a/apps/python/cod-confirm/tests/test_woo.py
+++ b/apps/python/cod-confirm/tests/test_woo.py
@@ -1,0 +1,369 @@
+"""A live WooCommerce store, played by a fake one.
+
+The fake speaks the parts of the WooCommerce REST API the connector uses and
+records every write, so what is tested is the real HTTP path: auth, paging,
+the order and history queries, and exactly what lands back in the store.
+Every order in it is fictional, on country code 999. Nothing here touches a
+network or a real shop.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import socket
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from codconfirm import agent, orders, run as sweeper, woo
+
+KEY, SECRET = "ck_test", "cs_test"
+NOW = dt.datetime(2026, 9, 11, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def row(order_id, first, phone, *, status="processing", method="cod", total="3450.00",
+        shipping="80.00", city="Dhaka", items=("Hand-block cotton bedsheet",), meta=None):
+    address = {"first_name": first, "last_name": "Example", "address_1": f"{order_id} Example Road",
+               "address_2": "", "city": city, "postcode": "1205", "phone": phone}
+    return {
+        "id": order_id, "status": status, "payment_method": method, "total": total,
+        "shipping_total": shipping, "billing": address, "shipping": dict(address),
+        "line_items": [{"name": name, "quantity": 1} for name in items],
+        "meta_data": [{"key": k, "value": v} for k, v in (meta or {}).items()],
+    }
+
+
+class FakeStore:
+    """The orders a shop holds, and a log of everything written to it."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.notes: list[tuple[int, str]] = []
+        self.meta: dict[int, dict] = {}
+        self.puts: list[dict] = []
+        self.queries: list[dict] = []
+        self.fail_writes = False
+        self.drop_writes = False
+
+    def handler(self):
+        store = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _authorised(self):
+                import base64
+                expected = "Basic " + base64.b64encode(f"{KEY}:{SECRET}".encode()).decode()
+                if self.headers.get("Authorization") != expected:
+                    self._send(401, {"code": "woocommerce_rest_cannot_view"})
+                    return False
+                return True
+
+            def _send(self, code, body):
+                data = json.dumps(body).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def _body(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                return json.loads(self.rfile.read(length) or b"{}")
+
+            def do_GET(self):
+                if not self._authorised():
+                    return
+                url = urllib.parse.urlparse(self.path)
+                query = dict(urllib.parse.parse_qsl(url.query))
+                store.queries.append(query)
+                if query.get("page", "1") != "1":
+                    return self._send(200, [])
+                if "search" in query:
+                    hits = [r for r in store.rows if query["search"] in r["billing"]["phone"]]
+                    return self._send(200, hits)
+                wanted = query.get("status", "").split(",")
+                return self._send(200, [r for r in store.rows if r["status"] in wanted])
+
+            def _refuse_write(self):
+                """Answer a write the way a failing store would, if asked to."""
+                if store.drop_writes:
+                    # The connection simply goes away, with no HTTP answer at all.
+                    self.close_connection = True
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                    return True
+                if store.fail_writes:
+                    self._send(500, {"code": "internal"})
+                    return True
+                return False
+
+            def do_POST(self):
+                if not self._authorised():
+                    return
+                body = self._body()
+                if self._refuse_write():
+                    return
+                order_id = int(self.path.split("/orders/")[1].split("/")[0])
+                store.notes.append((order_id, body["note"]))
+                self._send(201, {"id": len(store.notes)})
+
+            def do_PUT(self):
+                if not self._authorised():
+                    return
+                body = self._body()
+                if self._refuse_write():
+                    return
+                order_id = int(self.path.rsplit("/", 1)[1])
+                store.puts.append(body)
+                for item in body["meta_data"]:
+                    store.meta.setdefault(order_id, {})[item["key"]] = item["value"]
+                self._send(200, {"id": order_id})
+
+        return Handler
+
+
+@pytest.fixture
+def shop(monkeypatch):
+    """A running fake store, and the environment that points the sweep at it."""
+    fake = FakeStore([
+        # Refused twice before, and out of the shop's own city.
+        row(282, "Shahriar", "+99900000044", total="9800.00", shipping="150.00",
+            city="Chattogram", items=("Brass table lamp",)),
+        row(274, "Shahriar", "+99900000044", status="failed"),
+        row(273, "Shahriar", "+99900000044", status="failed"),
+        # A loyal customer.
+        row(285, "Rumana", "+99900000041"),
+        row(271, "Rumana", "+99900000041", status="completed"),
+        row(270, "Rumana", "+99900000041", status="completed"),
+        # Paid up front: nothing to confirm.
+        row(287, "Tanvir", "+99900000042", method="bacs"),
+    ])
+    server = ThreadingHTTPServer(("127.0.0.1", 0), fake.handler())
+    threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05},
+                     daemon=True).start()
+
+    monkeypatch.setenv("STORE_SOURCE", "woocommerce")
+    monkeypatch.setenv("WOO_BASE_URL", f"http://127.0.0.1:{server.server_address[1]}")
+    monkeypatch.setenv("WOO_KEY", KEY)
+    monkeypatch.setenv("WOO_SECRET", SECRET)
+    monkeypatch.setenv("STORE_CITY", "Dhaka")
+    for name in ("WOO_DEFAULT_CALLING_CODE", "CALL_ALLOWLIST", "DEMO_PHONE", "CALLE_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    yield fake
+    server.shutdown()
+    server.server_close()
+
+
+def load(**overrides):
+    store = woo.store()
+    return store, {o.id: o for o in store.load(now=NOW)}
+
+
+# --- reading ---------------------------------------------------------------
+
+def test_only_cash_on_delivery_orders_are_read(shop):
+    _, found = load()
+    assert set(found) == {"282", "285"}, "the prepaid order has nothing waiting at the door"
+
+
+def test_risk_comes_from_the_shops_own_history(shop):
+    _, found = load()
+    assert found["282"].previous_refusals == 2
+    assert found["282"].previous_orders == 0
+    assert found["285"].previous_orders == 2
+    assert found["285"].previous_refusals == 0
+
+
+def test_an_order_outside_the_shops_city_is_marked(shop):
+    _, found = load()
+    assert found["282"].outside_home_city is True
+    assert found["285"].outside_home_city is False
+
+
+def test_only_recent_orders_are_asked_for(shop, monkeypatch):
+    monkeypatch.setenv("WOO_LOOKBACK_DAYS", "3")
+    load()
+    first = shop.queries[0]
+    assert first["after"] == "2026-09-08T12:00:00"
+    assert first["status"] == "processing,on-hold"
+
+
+def test_a_decided_order_is_never_picked_up_again(shop):
+    """Ambiguous means a person reconciles it, across runs as well as within one."""
+    shop.rows.append(row(290, "Farhana", "+99900000045",
+                         meta={woo.META_STATUS: orders.NEEDS_HUMAN, woo.META_ATTEMPTS: "1"}))
+    _, found = load()
+    assert found["290"].status == orders.NEEDS_HUMAN
+    assert found["290"] not in orders.pending(found.values())
+
+
+def test_a_local_number_is_not_guessed_at(shop):
+    shop.rows.append(row(291, "Nusrat", "0999 000 0043"))
+    _, found = load()
+    assert found["291"].status == orders.NEEDS_HUMAN
+    assert "international form" in found["291"].notes[0]
+
+
+def test_a_local_number_gains_the_country_code_the_shop_names(shop, monkeypatch):
+    monkeypatch.setenv("WOO_DEFAULT_CALLING_CODE", "999")
+    shop.rows.append(row(291, "Nusrat", "0000 000 043"))
+    _, found = load()
+    assert found["291"].phone == "+999000000043"
+    assert found["291"].status == orders.PENDING
+
+
+def test_free_shipping_is_not_free_to_the_shop(shop):
+    shop.rows.append(row(292, "Nadia", "+99900000046", shipping="0.00"))
+    _, found = load()
+    assert found["292"].shipping_cost == 70.0
+
+
+def test_markup_in_a_store_payload_is_not_read_out(shop):
+    shop.rows.append(row(293, "Nadia", "+99900000047",
+                         items=("<strong>Jute</strong> rug &amp; mat",)))
+    _, found = load()
+    assert found["293"].items == ["Jute rug & mat"]
+
+
+def test_a_partial_phone_match_is_somebody_else(shop):
+    """A search for one number matches others that contain it. Only exact counts."""
+    shop.rows.append(row(275, "Other", "+999000000441", status="failed"))
+    _, found = load()
+    assert found["282"].previous_refusals == 2
+
+
+def test_the_cut_off_is_sent_as_utc(shop):
+    load()
+    assert shop.queries[0]["dates_are_gmt"] == "true"
+
+
+def test_a_garbled_attempt_count_is_not_read_as_zero(shop):
+    """Zero would hand the customer a fresh set of calls."""
+    shop.rows.append(row(294, "Nadia", "+99900000048", meta={woo.META_ATTEMPTS: "two"}))
+    _, found = load()
+    assert found["294"].status == orders.NEEDS_HUMAN
+
+
+def test_a_store_that_never_stops_paging_is_cut_off(shop, monkeypatch):
+    monkeypatch.setattr(woo, "MAX_PAGES", 2)
+    store = woo.store()
+    monkeypatch.setattr(store, "_request", lambda *a, **k: [{"id": 1}] * 100)
+    with pytest.raises(woo.WooError, match="more than 200 orders"):
+        store.load(now=NOW)
+
+
+def test_the_key_is_never_sent_in_the_clear(monkeypatch):
+    monkeypatch.setenv("WOO_BASE_URL", "http://shop.example")
+    monkeypatch.setenv("WOO_KEY", KEY)
+    monkeypatch.setenv("WOO_SECRET", SECRET)
+    with pytest.raises(woo.WooError, match="https"):
+        woo.WooConfig.from_env()
+
+
+def test_a_wrong_key_is_a_clear_error_not_a_crash(shop, monkeypatch):
+    monkeypatch.setenv("WOO_SECRET", "cs_wrong")
+    with pytest.raises(woo.WooError, match="401"):
+        load()
+
+
+# --- writing -----------------------------------------------------------------
+
+def answer(monkeypatch, outcome):
+    monkeypatch.setattr(sweeper, "simulate_call", lambda order, seed=None: outcome)
+
+
+def confirmed():
+    return agent.CallOutcome(result={
+        "reached_customer": "yes", "confirmed": "yes", "address_correct": "yes",
+        "confirmation_quote": "yes send it"})
+
+
+def test_a_dry_run_writes_nothing_to_the_store(shop, monkeypatch):
+    answer(monkeypatch, confirmed())
+    sweeper.sweep(live=False)
+    assert shop.notes == [] and shop.meta == {}
+
+
+def test_a_called_order_gets_a_note_and_its_status(shop, monkeypatch):
+    store = woo.store()
+    found = {o.id: o for o in store.load(now=NOW)}
+    order = found["282"]
+    order.attempts += 1
+    order.status = orders.CONFIRMED
+    order.log('Confirmed, address unchanged. Said "yes send it".')
+
+    assert store.write_back([order]) == 1
+    assert shop.meta[282] == {woo.META_STATUS: orders.CONFIRMED, woo.META_ATTEMPTS: "1"}
+    assert shop.notes == [(282, 'COD Confirm: Confirmed, address unchanged. Said "yes send it".')]
+
+
+def test_an_order_only_looked_at_is_left_alone(shop):
+    """A "not worth calling" note on every run would bury the ones that matter."""
+    store = woo.store()
+    found = {o.id: o for o in store.load(now=NOW)}
+    found["285"].log("Not called: the call costs more than the refusal risk it removes.")
+    assert store.write_back(list(found.values())) == 0
+    assert shop.notes == []
+
+
+def test_a_result_is_written_once_not_on_every_save(shop):
+    store = woo.store()
+    order = {o.id: o for o in store.load(now=NOW)}["282"]
+    order.attempts, order.status = 1, orders.CONFIRMED
+    order.log("Confirmed.")
+    store.write_back([order])
+    store.write_back([order])
+    assert len(shop.notes) == 1
+
+
+def test_a_corrected_address_is_passed_on_not_applied(shop):
+    store = woo.store()
+    order = {o.id: o for o in store.load(now=NOW)}["282"]
+    order.attempts, order.status = 1, orders.CONFIRMED
+    order.address = "Flat 3B, 282 Example Road, Chattogram"
+    store.write_back([order])
+    assert any("corrected delivery address" in note for _, note in shop.notes)
+    assert all(set(body) == {"meta_data"} for body in shop.puts), (
+        "the order's own address is for a person to change, not the sweep"
+    )
+
+
+def test_a_bad_phone_is_recorded_on_a_live_run(shop, monkeypatch):
+    """Sent to a person while reading, so it has to reach the store too."""
+    shop.rows.append(row(291, "Nusrat", "0999 000 0043"))
+    monkeypatch.setenv("CALLE_API_KEY", "test-key")
+    monkeypatch.setenv("CALL_ALLOWLIST", "+99900000044,+99900000041")
+    monkeypatch.setattr(sweeper, "place_call", lambda *a, **k: confirmed())
+    sweeper.sweep(live=True)
+    assert shop.meta[291][woo.META_STATUS] == orders.NEEDS_HUMAN
+
+
+def test_a_failed_write_stops_the_sweep_and_names_the_order(shop, monkeypatch):
+    """Otherwise the next sweep would ring a called customer again."""
+    monkeypatch.setenv("CALLE_API_KEY", "test-key")
+    monkeypatch.setenv("CALL_ALLOWLIST", "+99900000044,+99900000041")
+    monkeypatch.setattr(sweeper, "place_call", lambda *a, **k: confirmed())
+    shop.fail_writes = True
+    with pytest.raises(SystemExit) as stopped:
+        sweeper.sweep(live=True, limit=1)
+    assert "was called but its result could not be written back" in str(stopped.value)
+
+
+def test_a_dropped_connection_on_a_write_stops_the_sweep_too(shop, monkeypatch):
+    """A store that simply goes away mid-write is the same danger as a 500."""
+    monkeypatch.setenv("CALLE_API_KEY", "test-key")
+    monkeypatch.setenv("CALL_ALLOWLIST", "+99900000044,+99900000041")
+    monkeypatch.setattr(sweeper, "place_call", lambda *a, **k: confirmed())
+    shop.drop_writes = True
+    with pytest.raises(SystemExit) as stopped:
+        sweeper.sweep(live=True, limit=1)
+    assert "was called but its result could not be written back" in str(stopped.value)
+
+
+def test_reset_refuses_to_touch_a_live_store(shop, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["run", "--reset"])
+    with pytest.raises(SystemExit, match="live store"):
+        sweeper.main()


### PR DESCRIPTION
## Summary

Builds on #464, which fixes the `cod-confirm` quickstart; this branch sits on top of it, so the first commit here is that one and will drop out once #464 is merged. The new work is the second commit.

`cod-confirm` ran against a JSON order book, and its README said a live WooCommerce store was "two REST calls away". This makes that true: `STORE_SOURCE=woocommerce` and a REST key pair, with no change to the sweep.

**What it reads.** Cash-on-delivery orders still waiting for dispatch (`processing`, `on-hold`), placed in the last seven days, and each customer's history in the same store, matched exactly on phone number. The refusal risk the sweep prices calls with now comes from the shop's own records, deliveries taken and deliveries refused, instead of fields a demo book fills in by hand. Prepaid orders are skipped. Free shipping is priced at a default freight, because it is not free to the shop.

**What it writes, and only on `--live`.** A private order note with the decision, and the transcript when a person has to finish the order, plus two meta fields, `cod_confirm_status` and `cod_confirm_attempts`, that carry state to the next sweep. A dry run reads the store and writes nothing.

## Safety

The existing rules hold across runs, and the connector adds its own:

- **Each order is written back the moment its call ends**, not at the end of the sweep. If the store stopped answering halfway, a batch at the end would leave every called order looking uncalled, and the next sweep would ring them all again. A failed write stops the sweep and names the order that needs recording by hand.
- **Any network failure becomes one clean stop**, including a connection dropped mid-write. The first version only caught HTTP errors, and a test of a store that drops the connection caught a raw `ConnectionAbortedError` escaping after the call had been made. That test now fails on the old code and passes on the fix.
- An order marked `needs-human` is **never picked up again** until a person clears its `cod_confirm_status`.
- A number stored without a country code is **not guessed at**: the order goes to a person, unless the shop names its country with `WOO_DEFAULT_CALLING_CODE`.
- A garbled attempt count is not read as zero, which would hand the customer a fresh set of calls.
- It **never changes an order's WooCommerce status or address.** A corrected address from the call arrives as a note for a person to apply.
- The key pair is refused over plain HTTP. Errors never echo the URL or the store's response body.
- Paging is capped, so a store that keeps returning full pages cannot be read forever.

## Verification

- Standard library only: `requirements.txt` is unchanged.
- 24 new tests against a fake WooCommerce REST server that records every write, including a store that answers 500 or drops the connection mid-write. 95 in all, none needing a network, a store or a phone line. Stable across 45 consecutive runs with `-W error::ResourceWarning`.
- End to end against a real WooCommerce 11.1 store holding fictional `+999` orders. The dry run read five cash-on-delivery orders and their history, skipped the prepaid one and anything older than the look-back window, and wrote nothing. A live run with a deliberately invalid CALL-E key was refused before dialling and recorded exactly one private note and the two meta fields on the order, leaving its WooCommerce status as `processing`.

## Type

- [ ] New skill
- [ ] New runnable app
- [ ] New workflow plugin
- [x] New provider adapter
- [ ] New scheduler recipe
- [ ] README awesome-list entry
- [ ] Safety or documentation update
- [ ] Validation or tooling update

## Checklist

- [x] Repository-facing content is written in English.
- [x] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [x] Recurring workflows include cancellation behavior.
- [x] Runnable code has a dry-run, fake-server, or no-call path by default.
- [x] `python3 scripts/validate_repository.py` passes.
