### PR TITLE
feat(skills): add no-show-shield day-batch confirmation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [`pharmacy-cash-price`](skills/pharmacy-cash-price/) - Asks one retail pharmacy for a cash price with no insurance and returns a structured quote, a refusal, or an explicit unknown, with the disclosure and the medical boundary written into the call.
 - [`logistics-exception`](skills/logistics-exception/) - Resolves a missed dock window by calling the driver and receiving dock concurrently with one strict CALL-E result schema, reconciling terminal results by event id and re-fetch, combining only reached-contact facts into a recovery card, and gating any dock-changing follow-up call behind explicit human approval.
 - [`otherend-task-test`](skills/otherend-task-test/) - Rehearses a CALL-E task text and result schema against a programmable receptionist line the operator owns, reads the deterministic grade (manifest, self-report, fabrication, disclosure, confidence calibration), and turns each failing check into a task-text edit before the task reaches real people.
+- [`no-show-shield`](skills/no-show-shield/) - Calls every booking on a given day to confirm it, writes yes/reschedule/cancel outcomes back to the operator's calendar, and returns a short list of only the slots that still need a human.
 
 ### Apps
 

--- a/skills/no-show-shield/SKILL.md
+++ b/skills/no-show-shield/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: no-show-shield
+description: Call every booking on a given day to confirm it, capture reschedule and cancellation outcomes as structured JSON, write the results back to a calendar file, and hand the operator a short list of slots that still need a human. Mock provider and preview mode by default; a hard call budget meters every real call.
+license: MIT
+---
+
+# No-Show Shield
+
+Use this skill when a solo operator — a trades business, a mobile clinic, a
+single-chair salon — has explicit authority to place disclosed confirmation
+calls to **the customers already booked into a given day**, and wants the
+answers back as data rather than as voicemail they still have to action.
+
+It differs from [`appointment-confirm`](../appointment-confirm/) in scope
+rather than intent: that skill confirms one appointment and deliberately
+leaves the diary alone. This one walks a whole day's book, applies each
+outcome to a calendar file, and reports only the exceptions. Use
+`appointment-confirm` when a human is reviewing every result; use this when
+the operator wants an unattended evening run and a short morning list.
+
+## What it does
+
+1. **Sync** — loads a day's bookings from a JSON calendar file.
+2. **Preview** — prints who would be called, with no calls placed. Always
+   available, and the default way to check a run before it happens.
+3. **Run** — places one CALL-E call per pending booking, with a
+   `result_schema` of `confirmed` / `reschedule_requested` / `cancelled` /
+   `no_answer` / `unknown`, plus a free-text reschedule preference.
+4. **Write-back** — applies each structured outcome to the calendar file,
+   preserving the customer's stated preference verbatim.
+5. **Summary** — prints totals and a `Needs you:` line naming only the
+   bookings a human must now handle.
+
+## When not to use it
+
+- Cold outreach, sales, or any call the recipient has not already transacted
+  into. This skill confirms existing bookings only.
+- Medical, legal, or financial advice of any kind. The agent states the
+  service name and time and nothing more; it does not discuss treatment,
+  diagnosis, obligations, or money.
+- Emergencies or time-critical safety matters. It has no escalation path and
+  must not be relied on where a missed call has consequences.
+- Debt collection, or any context where a recipient may feel pressured.
+
+## Call behaviour
+
+The agent announces that it is an AI in its first turn, on every call. It
+asks one question at a time, never argues, never tries to talk a customer out
+of a change, and will not promise a new slot — a reschedule request is
+recorded and handed to a human with a "we'll text to confirm" close. Wrong
+number or a request not to call ends the call immediately and records the
+outcome as `unknown` with a note.
+
+See [`references/safety.md`](references/safety.md) for the full rule set and
+[`references/examples.md`](references/examples.md) for runnable examples.
+
+## Source
+
+Reference implementation, tests, and an honest limitations section:
+https://github.com/landbuild/no-show-shield

--- a/skills/no-show-shield/references/examples.md
+++ b/skills/no-show-shield/references/examples.md
@@ -1,0 +1,74 @@
+# Examples
+
+All examples use the fictional demo calendar shipped with the reference
+implementation. No example places a call to a real person.
+
+## 1. Preview a day (no calls placed)
+
+```bash
+python3 -m noshow_shield sync data/demo-schedule.json
+python3 -m noshow_shield preview --date 2026-09-12
+```
+
+```text
+Would call for 2026-09-12:
+  08:00  Priya Raman        Hot water inspection   +61491570156
+  09:30  Dean Whitford      Blocked drain          +61491570157
+```
+
+## 2. Offline run against the mock provider
+
+The mock provider returns deterministic outcomes per booking, so the whole
+pipeline — including calendar write-back and the summary — can be exercised
+with no credentials and no spend.
+
+```bash
+python3 -m noshow_shield run --date 2026-09-12
+```
+
+## 3. Live run, every call routed to your own handset
+
+```bash
+export CALLE_API_KEY="..."
+python3 -m noshow_shield run --date 2026-09-12 --live --override-phone +61400000000
+```
+
+`--live` refuses to start without `--override-phone`, so a demonstration
+cannot dial a booking's stored number.
+
+## 4. What comes back
+
+A reschedule captured from a real call, as written to the calendar:
+
+```json
+{
+  "confirmation_status": "reschedule_requested",
+  "reschedule_preference": "Thursday afternoon at 3:00 PM",
+  "notes": "Customer asked to move the blocked drain appointment and was told the business will follow up by text to lock it in."
+}
+```
+
+## 5. The operator summary
+
+```text
+Shorewood Plumbing (demo) — confirmation run for 2026-09-12
+----------------------------------------------
+08:00  Priya Raman        Hot water inspection   -> confirmed
+09:30  Dean Whitford      Blocked drain          -> reschedule_requested
+                          (wants: Thursday afternoon at 3:00 PM)
+----------------------------------------------
+Totals: confirmed=1, reschedule_requested=1
+Needs you: Dean Whitford
+```
+
+The `Needs you:` line is the point of the skill: one glance, and the operator
+knows the only booking that still costs them time.
+
+## Notes from live use
+
+- The first call of a session has been observed to take several minutes
+  between `create` and the phone ringing; subsequent calls connect faster.
+  Budget wall-clock time accordingly when demonstrating.
+- Times are rendered into natural speech ("tomorrow at 9:30 in the morning")
+  before they reach the model. Passing ISO dates through causes the agent to
+  read them out digit by digit.

--- a/skills/no-show-shield/references/safety.md
+++ b/skills/no-show-shield/references/safety.md
@@ -1,0 +1,70 @@
+# Safety rules
+
+These are the rules the reference implementation enforces in code, not
+aspirations. Where a rule is enforced by a specific mechanism, the mechanism
+is named.
+
+## Explicit user intent
+
+- Calls are placed only to customers who already hold a booking in the
+  operator's own calendar file. There is no discovery, enrichment, or list
+  building of any kind.
+- A run is always operator-initiated for one named date. There is no
+  scheduler, daemon, or cron path in the skill.
+- `preview` places no calls and is the documented first step of every run.
+
+## Phone numbers
+
+- Every destination is validated as E.164 before a call is attempted;
+  malformed numbers are skipped and reported, never "fixed" by guessing a
+  country code.
+- Demo and test data use only ACMA-reserved fictional Australian numbers
+  (the `+61 491 570 xxx` range), which are allocated for exactly this purpose
+  and reach no one.
+- A live demonstration must pass `--override-phone`, which routes **every**
+  call in the run to one number the operator supplies at the command line.
+  This exists so a demo can never dial a third party by accident.
+
+## Masking in summaries
+
+- The operator summary prints names, times, services, and outcomes. It does
+  not print customer phone numbers.
+- When recording or sharing a terminal session, the `--override-phone`
+  argument echoes the operator's own number into the scrollback and window
+  title; redact it before publishing. (This was learned the hard way.)
+
+## Credentials
+
+- `CALLE_API_KEY` is read from the environment only. It is never written to
+  the calendar file, the call ledger, the summary, or any log line.
+- The repository ships a `.gitignore` covering `.env` and all run artefacts.
+
+## No hidden recurrence, no duplicate jobs
+
+- One invocation calls each pending booking at most once. Completed outcomes
+  are written back immediately, so a re-run of the same date calls only what
+  is still pending or previously unanswered.
+- There is no retry loop, no background queue, and no state that survives
+  outside the visible calendar and ledger files.
+- A file-backed **call budget** caps the number of real calls that can ever
+  be placed, and has no override flag: exceeding it raises and stops the run.
+  Raising the cap is a deliberate edit to the configuration, recorded in
+  version control.
+
+## Cancellation
+
+- A run is a foreground process; interrupting it stops further calls.
+  Outcomes already returned are already written, so state is never
+  half-applied in a way that hides what happened.
+- Any booking the agent could not resolve is surfaced in `Needs you:` rather
+  than retried silently.
+
+## Content boundaries
+
+- The agent states the service name and the appointment time. It does not
+  discuss medical, legal, or financial matters, and is not to be used for
+  appointments where the subject of the call is itself sensitive.
+- It never asks for payment details, identity documents, or any personal
+  information. It only asks whether an existing time still suits.
+- It does not argue, persuade, or attempt retention. A cancellation is
+  accepted on the first statement of it.


### PR DESCRIPTION
## What this adds

`skills/no-show-shield/` — a skill that calls **every booking on a given day**, captures each outcome as structured JSON, writes the results back to a calendar file, and returns a short list of only the slots that still need a human.

## Why it isn't a duplicate of `appointment-confirm`

They differ in scope, and the SKILL.md says so explicitly so a reader can pick correctly:

| | `appointment-confirm` | `no-show-shield` |
|---|---|---|
| Unit of work | one appointment | one day's book |
| Calendar | deliberately untouched | outcomes written back |
| Intended use | human reviews each result | unattended evening run, short morning list |

The use case is the solo operator — trades, mobile clinic, single-chair salon — who loses a whole slot to a no-show and has no hour in the evening to ring ten people.

## Safety

`references/safety.md` covers every item in CONTRIBUTING's safety list, and describes mechanisms rather than intentions:

- **Intent** — calls go only to customers already booked in the operator's own calendar file; no discovery or list building; runs are operator-initiated for one named date; `preview` places no calls and is the documented first step.
- **E.164** — validated before dialling; malformed numbers are skipped and reported, never guessed at.
- **Masking** — summaries print names, times and outcomes, never customer numbers.
- **Credentials** — `CALLE_API_KEY` from the environment only; never written to calendar, ledger, or summary.
- **No hidden recurrence** — no scheduler, daemon, or retry loop exists in the skill; a re-run only picks up what is still pending.
- **No duplicate jobs** — outcomes are written back immediately, so a booking is called at most once per run.
- **Call budget** — a file-backed cap with no override flag; exceeding it raises and stops the run. Raising it is a tracked edit.
- **Content boundaries** — service name and time only; no medical, legal, or financial discussion; cancellations accepted on first statement, never contested.

Demo data uses only ACMA-reserved fictional Australian numbers (`+61 491 570 xxx`). A live demonstration must pass `--override-phone`, which routes every call in the run to one number the operator types at the command line, so a demo cannot dial a third party by accident.

## Validation

```
python3 scripts/check_branch_name.py --branch feat/no-show-shield   # passes
python3 scripts/validate_repository.py                              # Repository validation passed.
```

## Notes from live use

Two things learned running this against real calls, both written into `references/examples.md` for the next person:

- The first call of a session can take several minutes between `create` and the phone ringing; later calls connect faster. Worth budgeting wall-clock time when demonstrating.
- Times need rendering into natural speech ("tomorrow at 9:30 in the morning") before they reach the model — passing ISO dates through makes the agent read them out digit by digit.

Reference implementation with tests and an honest limitations section: https://github.com/landbuild/no-show-shield

Submitted for the CALL-E "Your Code Is Calling" hackathon.
