### PR TITLE
feat(apps): complete async live Reality Resolver execution

### DIFF
--- a/apps/python/reality-resolver/api/custom_case.py
+++ b/apps/python/reality-resolver/api/custom_case.py
@@ -1,0 +1,171 @@
+"""Validation and normalization for one client-supplied Case.
+
+Custom cases stay in memory for one resolution. They are never written to
+``cases/`` and therefore cannot widen the shipped-case allowlist or expose the
+operator's untracked live fixture. The returned ``Case`` is the same model the
+deterministic engine already consumes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from datetime import timedelta
+from typing import Any
+
+from client import PHONE_PATTERN, parse_utc_timestamp
+from evidence.model import Ambiguity, Case, Evidence, EvidenceMatrix, EvidenceType
+
+CUSTOM_CASE_FIELDS = frozenset(
+    {
+        "name",
+        "use_case",
+        "deadline",
+        "decision_deadline_threshold_hours",
+        "decision_options",
+        "call_phone",
+        "call_task_hint",
+        "evidence",
+        "industry",
+    }
+)
+CUSTOM_USE_CASES = frozenset(
+    {
+        "appointment_confirmation",
+        "critical_service_escalation",
+        "factual_state_confirmation",
+    }
+)
+DEFAULT_CUSTOM_PHONE = "+10000000003"
+MAX_EVIDENCE_ITEMS = 20
+MAX_TEXT_CHARS = 2000
+MAX_NAME_CHARS = 160
+MAX_USE_CASE_CHARS = 80
+MAX_INDUSTRY_CHARS = 80
+MAX_THRESHOLD_HOURS = 24 * 30
+MAX_FRESHNESS_HOURS = 24 * 365
+
+
+class CustomCaseValidationError(ValueError):
+    """A safe, client-facing validation failure with no input echo."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _fail(code: str, message: str) -> None:
+    raise CustomCaseValidationError(code, message)
+
+
+def _text(value: Any, field: str, maximum: int, *, required: bool = True) -> str:
+    if not isinstance(value, str):
+        _fail("invalid_custom_case", f"{field} must be a string")
+    if any(ord(char) < 32 for char in value):
+        _fail("invalid_custom_case", f"{field} contains control characters")
+    normalized = value.strip()
+    if required and not normalized:
+        _fail("invalid_custom_case", f"{field} is required")
+    if len(normalized) > maximum:
+        _fail("custom_case_too_large", f"{field} is too long")
+    return normalized
+
+
+def _number(value: Any, field: str, maximum: float, *, minimum: float = 0.0) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        _fail("invalid_custom_case", f"{field} must be a finite number")
+    if value < minimum or value > maximum:
+        _fail("invalid_custom_case", f"{field} is outside the supported range")
+    return float(value)
+
+
+def parse_custom_case(raw: Any) -> Case:
+    """Validate a public custom-case object and return the engine's Case."""
+    if not isinstance(raw, dict):
+        _fail("invalid_custom_case", "custom_case must be a JSON object")
+
+    unknown = set(raw) - CUSTOM_CASE_FIELDS
+    if unknown:
+        _fail("unknown_custom_case_field", "custom_case contains an unsupported field")
+
+    name = _text(raw.get("name"), "name", MAX_NAME_CHARS)
+    use_case = _text(raw.get("use_case"), "use_case", MAX_USE_CASE_CHARS)
+    if use_case not in CUSTOM_USE_CASES:
+        _fail("unsupported_custom_use_case", "use_case is not supported for custom cases")
+
+    deadline_text = _text(raw.get("deadline"), "deadline", 64)
+    try:
+        deadline = parse_utc_timestamp(deadline_text)
+    except (TypeError, ValueError, OverflowError, argparse.ArgumentTypeError):
+        _fail("invalid_custom_deadline", "deadline must be an ISO 8601 UTC timestamp")
+
+    threshold = _number(
+        raw.get("decision_deadline_threshold_hours"),
+        "decision_deadline_threshold_hours",
+        MAX_THRESHOLD_HOURS,
+        minimum=0.01,
+    )
+
+    options = raw.get("decision_options")
+    if not isinstance(options, dict) or set(options) != {"if_confirmed", "if_cancelled"}:
+        _fail("invalid_custom_case", "decision_options must define if_confirmed and if_cancelled")
+    decision_options = {
+        key: _text(options[key], f"decision_options.{key}", 160)
+        for key in ("if_confirmed", "if_cancelled")
+    }
+
+    call_task_hint = _text(raw.get("call_task_hint"), "call_task_hint", MAX_TEXT_CHARS)
+    call_phone = raw.get("call_phone", DEFAULT_CUSTOM_PHONE)
+    call_phone = _text(call_phone, "call_phone", 32)
+    if not PHONE_PATTERN.fullmatch(call_phone):
+        _fail("invalid_custom_phone", "call_phone must be strict ASCII E.164")
+
+    if "industry" in raw:
+        _text(raw["industry"], "industry", MAX_INDUSTRY_CHARS)
+
+    evidence_raw = raw.get("evidence")
+    if not isinstance(evidence_raw, list) or not evidence_raw:
+        _fail("invalid_custom_evidence", "evidence must be a non-empty array")
+    if len(evidence_raw) > MAX_EVIDENCE_ITEMS:
+        _fail("custom_case_too_large", "evidence has too many items")
+
+    evidence_items: list[Evidence] = []
+    evidence_fields = {"source", "type", "freshness_hours", "claim", "ambiguity"}
+    for item in evidence_raw:
+        if not isinstance(item, dict) or set(item) != evidence_fields:
+            _fail("invalid_custom_evidence", "each evidence item has an invalid shape")
+        source = _text(item.get("source"), "evidence.source", 160)
+        claim = _text(item.get("claim"), "evidence.claim", MAX_TEXT_CHARS)
+        evidence_type = _text(item.get("type"), "evidence.type", 32)
+        ambiguity = _text(item.get("ambiguity"), "evidence.ambiguity", 32)
+        try:
+            evidence_enum = EvidenceType(evidence_type)
+            ambiguity_enum = Ambiguity(ambiguity)
+        except ValueError:
+            _fail("invalid_custom_evidence", "evidence type or ambiguity is unsupported")
+        freshness = _number(
+            item.get("freshness_hours"),
+            "evidence.freshness_hours",
+            MAX_FRESHNESS_HOURS,
+        )
+        evidence_items.append(
+            Evidence(
+                source=source,
+                type=evidence_enum,
+                freshness=timedelta(hours=freshness),
+                claim=claim,
+                ambiguity=ambiguity_enum,
+            )
+        )
+
+    return Case(
+        name=name,
+        evidence=EvidenceMatrix(tuple(evidence_items)),
+        deadline=deadline,
+        decision_deadline_threshold=timedelta(hours=threshold),
+        decision_options=decision_options,
+        call_phone=call_phone,
+        call_task_hint=call_task_hint,
+        use_case=use_case,
+    )

--- a/apps/python/reality-resolver/api/progress.py
+++ b/apps/python/reality-resolver/api/progress.py
@@ -36,7 +36,7 @@ from api.serialize import (
     reasoning_payload,
     verdict_payload,
 )
-from api.store import ResolutionStore
+from api.store import ResolutionNotFoundError, ResolutionStore
 from compliance.models import PreCallDecision
 from evidence.engine import ReasoningResult
 from evidence.model import Case
@@ -68,7 +68,24 @@ class StoreObserver(Observer):
         self._next_legal_window: str | None = None
 
     def _publish(self, patch: dict[str, Any]) -> None:
-        self._store.update(self._id, patch)
+        """Best-effort. The store is a volatile projection; the pipeline
+        is the source of truth.
+
+        An entry can be evicted while its resolution is still running -
+        the store is bounded and FIFO, and updating does not refresh an
+        entry's position. Losing the projection is a publication problem,
+        not a reason to abort the work, and letting it propagate would do
+        exactly that: pipeline.resolve() wraps no observer call, so an
+        exception raised here kills the resolution mid-flight.
+
+        Only that one exception is swallowed. Anything else raised in
+        here is a real fault in this class, and hiding it would turn a
+        bug into silence.
+        """
+        try:
+            self._store.update(self._id, patch)
+        except ResolutionNotFoundError:
+            return
 
     def _publish_compliance(self) -> None:
         self._publish(

--- a/apps/python/reality-resolver/api/progress.py
+++ b/apps/python/reality-resolver/api/progress.py
@@ -102,7 +102,8 @@ class StoreObserver(Observer):
         self._publish(
             {
                 "state": "running",
-                "mode": mode,
+                # The seed owns HTTP execution mode (fake/live). The
+                # pipeline's EXECUTE/DRY-RUN label belongs to the CLI.
                 "case": case_summary(case),
                 "evidence": [evidence_item(item) for item in case.evidence.items],
             }

--- a/apps/python/reality-resolver/api/progress.py
+++ b/apps/python/reality-resolver/api/progress.py
@@ -1,0 +1,141 @@
+"""Publishes a running resolution's progress into a ResolutionStore.
+
+pipeline.resolve() already notifies an Observer at each stage - that is
+how resolver.py streams to a terminal. This is the same contract with a
+different destination: instead of printing, each hook writes the piece of
+the public payload that has just become true.
+
+Nothing here decides anything. Every value published is either handed in
+by the hook or projected by api/serialize.py; no rule is scored, no
+compliance is evaluated, no verdict is derived. The observer is a
+translator between an event and a field, and if it ever needed to compute
+something to fill a field, that would mean the field does not exist yet.
+
+The states it writes are `running` and `completed`, and only those.
+`queued` belongs to whoever creates the entry, before any of this runs;
+`failed` belongs to whoever catches the exception, after it stops. Those
+are transport facts about a job, and this class does not own the job.
+
+Not defined here, on purpose: on_api_key. The base class's no-op is
+inherited, so the credential pipeline.resolve() passes to that hook
+reaches no code in this module and cannot reach the store. The safety
+comes from the absence of a method, not from a method that is careful -
+see tests/test_progress.py, which asserts the absence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.serialize import (
+    call_decision_label,
+    call_projection,
+    case_summary,
+    compliance_payload,
+    evidence_item,
+    reasoning_payload,
+    verdict_payload,
+)
+from api.store import ResolutionStore
+from compliance.models import PreCallDecision
+from evidence.engine import ReasoningResult
+from evidence.model import Case
+from pipeline import Observer
+from verdict import Verdict
+
+
+class StoreObserver(Observer):
+    """One per resolution, used by the one thread running it.
+
+    That confinement is why nothing here is locked: the accumulator
+    below is only ever touched by the thread inside resolve(). The store
+    it writes to is shared, and does its own locking.
+
+    The accumulator exists because two fields arrive in pieces. A
+    compliance payload needs the unfiltered decision, the applicable
+    subset and the exempted names together, and those come from two
+    different hooks - with a third, on_blocked, adding the next legal
+    window afterwards. Holding them is not deciding anything; it is
+    waiting until there is enough to project.
+    """
+
+    def __init__(self, store: ResolutionStore, resolution_id: str) -> None:
+        self._store = store
+        self._id = resolution_id
+        self._decision: PreCallDecision | None = None
+        self._applicable: PreCallDecision | None = None
+        self._exempted: tuple[str, ...] = ()
+        self._next_legal_window: str | None = None
+
+    def _publish(self, patch: dict[str, Any]) -> None:
+        self._store.update(self._id, patch)
+
+    def _publish_compliance(self) -> None:
+        self._publish(
+            {
+                "compliance": compliance_payload(
+                    self._decision, self._applicable, self._exempted, self._next_legal_window
+                )
+            }
+        )
+
+    # --- hooks --------------------------------------------------------
+
+    def on_start(self, case: Case, mode: str) -> None:
+        self._publish(
+            {
+                "state": "running",
+                "mode": mode,
+                "case": case_summary(case),
+                "evidence": [evidence_item(item) for item in case.evidence.items],
+            }
+        )
+
+    def on_reasoning(self, reasoning: ReasoningResult) -> None:
+        self._publish(
+            {
+                "reasoning": reasoning_payload(reasoning),
+                "call_decision": call_decision_label(reasoning),
+            }
+        )
+
+    def on_compliance_checks(self, decision: PreCallDecision) -> None:
+        # Held, not published: compliance_payload needs the applicable
+        # subset too, and that arrives from the next hook.
+        self._decision = decision
+
+    def on_use_case_filter(
+        self, applicable: PreCallDecision, exempted_checks: tuple[str, ...], use_case: str
+    ) -> None:
+        self._applicable = applicable
+        self._exempted = exempted_checks
+        self._publish_compliance()
+
+    def on_blocked(self, window: str) -> None:
+        self._next_legal_window = window
+        self._publish_compliance()
+
+    def on_call_created(self, call_id: str, status: Any) -> None:
+        # call_id is the provider's own identifier and is deliberately
+        # unused: it is not a fact about the decision, and it is on the
+        # list of things a client never sees. What matters here is that
+        # a call now exists, which is what makes "calling" true.
+        self._publish({"call": call_projection({"status": status}, placed=True)})
+
+    def on_poll(self, call: dict[str, Any]) -> None:
+        self._publish({"call": call_projection(call, placed=True)})
+
+    def on_call_completed(self, call: dict[str, Any]) -> None:
+        self._publish({"call": call_projection(call, placed=True)})
+
+    def on_verdict(self, verdict: Verdict) -> None:
+        self._publish({"verdict": verdict_payload(verdict), "state": "completed"})
+
+    # on_call_preview is not implemented: the preview is the real request
+    # body, carrying the recipient in the clear and the hardened task that
+    # embeds the case's call_task_hint. There is nothing in it a client
+    # may see, so nothing is taken from it.
+    #
+    # on_dry_run and on_poll_warning are not implemented either: neither
+    # corresponds to a field of the public payload, and inventing one to
+    # have somewhere to put them is exactly what this module must not do.

--- a/apps/python/reality-resolver/api/progress.py
+++ b/apps/python/reality-resolver/api/progress.py
@@ -37,11 +37,14 @@ from api.serialize import (
     verdict_payload,
 )
 from api.store import ResolutionNotFoundError, ResolutionStore
+from client import sanitize_provider_error_message
 from compliance.models import PreCallDecision
 from evidence.engine import ReasoningResult
 from evidence.model import Case
 from pipeline import Observer
 from verdict import Verdict
+
+_SAFE_PROVIDER_STATUSES = frozenset({"queued", "in_progress", "completed", "failed", "canceled"})
 
 
 class StoreObserver(Observer):
@@ -66,6 +69,30 @@ class StoreObserver(Observer):
         self._applicable: PreCallDecision | None = None
         self._exempted: tuple[str, ...] = ()
         self._next_legal_window: str | None = None
+        # Provider diagnostics stay in this worker-local accumulator. They
+        # are never part of the public resolution projection.
+        self._phase = "preflight"
+        self._call_id_present = False
+        self._last_provider_status: str | None = None
+
+    @staticmethod
+    def _safe_provider_status(value: Any) -> str | None:
+        if value is None:
+            return None
+        text = sanitize_provider_error_message(value)
+        if text in _SAFE_PROVIDER_STATUSES:
+            return text
+        return "unknown"
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return provider-safe worker diagnostics for local logging only."""
+        result: dict[str, Any] = {
+            "phase": self._phase,
+            "call_id_present": self._call_id_present,
+        }
+        if self._last_provider_status is not None:
+            result["last_provider_status"] = self._last_provider_status
+        return result
 
     def _publish(self, patch: dict[str, Any]) -> None:
         """Best-effort. The store is a volatile projection; the pipeline
@@ -97,6 +124,11 @@ class StoreObserver(Observer):
         )
 
     # --- hooks --------------------------------------------------------
+
+    def on_call_preview(self, preview: dict[str, Any]) -> None:
+        # The preview is emitted immediately before the provider client is
+        # constructed and POST /v1/calls begins. Do not retain its contents.
+        self._phase = "create"
 
     def on_start(self, case: Case, mode: str) -> None:
         self._publish(
@@ -138,9 +170,14 @@ class StoreObserver(Observer):
         # unused: it is not a fact about the decision, and it is on the
         # list of things a client never sees. What matters here is that
         # a call now exists, which is what makes "calling" true.
+        self._phase = "poll"
+        self._call_id_present = True
+        self._last_provider_status = self._safe_provider_status(status)
         self._publish({"call": call_projection({"status": status}, placed=True)})
 
     def on_poll(self, call: dict[str, Any]) -> None:
+        self._phase = "poll"
+        self._last_provider_status = self._safe_provider_status(call.get("status"))
         self._publish({"call": call_projection(call, placed=True)})
 
     def on_call_completed(self, call: dict[str, Any]) -> None:

--- a/apps/python/reality-resolver/api/serialize.py
+++ b/apps/python/reality-resolver/api/serialize.py
@@ -18,10 +18,9 @@ resolution payloads on the same rule.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
-from client import mask_phone
+from client import _OBVIOUS_SECRET, _PHONE_IN_TEXT, mask_phone
 from compliance.models import PreCallDecision
 from evidence.engine import ReasoningResult
 from evidence.model import Case, Evidence
@@ -113,11 +112,10 @@ def cases_payload(cases: tuple[Case, ...]) -> dict[str, Any]:
 # silently the next time a rule is written the same way - every reason
 # this module emits is scrubbed by the same function.
 #
-# Same shape as client.PHONE_PATTERN and [0-9] for the same reason: for a
+# Shared with client.PHONE_PATTERN and [0-9] for the same reason: for a
 # str pattern \d matches every Unicode decimal digit, so a number written
 # in Arabic-Indic or fullwidth digits would slip past a \d version of
 # this and reach the client intact.
-_PHONE_IN_TEXT = re.compile(r"\+[1-9][0-9]{6,14}")
 
 
 def sanitize_reason(text: str, max_chars: int = MAX_TEXT_CHARS) -> str:
@@ -193,6 +191,16 @@ ALLOWED_RESULT_KEYS = (
     "manipulation_attempt_note",
 )
 
+_RESULT_ENUMS = {
+    "subject_intent": {"confirmed", "cancelled", "uncertain", "unknown"},
+    "answered_by": {"human", "voicemail", "ivr", "unknown"},
+}
+_PROVIDER_STATUSES = {"queued", "in_progress", "completed", "failed", "canceled"}
+
+
+def _provider_text(value: str) -> str:
+    return sanitize_reason(_OBVIOUS_SECRET.sub("[redacted]", value))
+
 
 def call_projection(call: dict[str, Any] | None, placed: bool) -> dict[str, Any]:
     """Three facts and the structured result. Nothing else from the
@@ -213,19 +221,25 @@ def call_projection(call: dict[str, Any] | None, placed: bool) -> dict[str, Any]
     if call is None:
         return {"placed": placed, "provider_status": None, "result": None}
 
-    raw_result = call.get("structured_result") or {}
-    result = {
-        key: (_text(value) if isinstance(value, str) else value)
-        for key, value in raw_result.items()
-        if key in ALLOWED_RESULT_KEYS
-    } or None
+    raw_result = call.get("structured_result")
+    result: dict[str, Any] = {}
+    if isinstance(raw_result, dict):
+        for key in ALLOWED_RESULT_KEYS:
+            value = raw_result.get(key)
+            if key in _RESULT_ENUMS:
+                if isinstance(value, str) and value in _RESULT_ENUMS[key]:
+                    result[key] = value
+            elif key == "manipulation_attempt_detected":
+                if type(value) is bool:
+                    result[key] = value
+            elif isinstance(value, str):
+                result[key] = _provider_text(value)
+    status = call.get("status")
 
     return {
         "placed": placed,
-        "provider_status": _text(str(call.get("status")), MAX_IDENTIFIER_CHARS)
-        if call.get("status") is not None
-        else None,
-        "result": result,
+        "provider_status": status if isinstance(status, str) and status in _PROVIDER_STATUSES else None,
+        "result": result or None,
     }
 
 

--- a/apps/python/reality-resolver/api/serialize.py
+++ b/apps/python/reality-resolver/api/serialize.py
@@ -194,20 +194,24 @@ ALLOWED_RESULT_KEYS = (
 )
 
 
-def call_payload(resolution: Resolution) -> dict[str, Any]:
+def call_projection(call: dict[str, Any] | None, placed: bool) -> dict[str, Any]:
     """Three facts and the structured result. Nothing else from the
     provider response crosses this line.
 
-    Resolution.call is the raw object: it carries the recipient's number
+    `call` is the raw provider object: it carries the recipient's number
     in the clear, every transcript turn, the 3.6k-character hardened
     task (which embeds the case's call_task_hint), per-attempt provider
     ids, and free-text summaries. None of that is projected here, and
     the omission is enforced by naming what is included rather than by
     listing what is not - a field added upstream is excluded by default.
+
+    Takes the raw object rather than a Resolution so that a caller
+    holding only a partial view - a call in progress, say - projects it
+    through this same allowlist instead of a second copy of it. Two
+    copies of a security boundary can drift; one cannot.
     """
-    call = resolution.call
     if call is None:
-        return {"placed": resolution.call_placed, "provider_status": None, "result": None}
+        return {"placed": placed, "provider_status": None, "result": None}
 
     raw_result = call.get("structured_result") or {}
     result = {
@@ -217,12 +221,35 @@ def call_payload(resolution: Resolution) -> dict[str, Any]:
     } or None
 
     return {
-        "placed": resolution.call_placed,
+        "placed": placed,
         "provider_status": _text(str(call.get("status")), MAX_IDENTIFIER_CHARS)
         if call.get("status") is not None
         else None,
         "result": result,
     }
+
+
+def call_payload(resolution: Resolution) -> dict[str, Any]:
+    return call_projection(resolution.call, resolution.call_placed)
+
+
+def case_summary(case: Case) -> dict[str, Any]:
+    """The three case fields a resolution carries, as opposed to the
+    fuller catalog entry case_metadata() builds. No phone number here at
+    all, masked or otherwise: a resolution never needs one.
+    """
+    return {
+        "name": _text(case.name),
+        "use_case": _text(case.use_case),
+        "decision_options": {str(k): _text(str(v)) for k, v in case.decision_options.items()},
+    }
+
+
+def call_decision_label(reasoning: ReasoningResult) -> str:
+    """A label for the engine's own boolean, and only that. It restates
+    decision_critical; it never recomputes it.
+    """
+    return "CALL_JUSTIFIED" if reasoning.decision_critical else "NO_CALL_NEEDED"
 
 
 def verdict_payload(verdict: Verdict | None) -> dict[str, Any] | None:
@@ -260,16 +287,10 @@ def resolution_payload(
         "id": _text(resolution_id, MAX_IDENTIFIER_CHARS),
         "state": _text(state, MAX_IDENTIFIER_CHARS),
         "mode": _text(mode, MAX_IDENTIFIER_CHARS),
-        "case": {
-            "name": _text(resolution.case.name),
-            "use_case": _text(resolution.case.use_case),
-            "decision_options": {
-                str(k): _text(str(v)) for k, v in resolution.case.decision_options.items()
-            },
-        },
+        "case": case_summary(resolution.case),
         "evidence": [evidence_item(item) for item in resolution.case.evidence.items],
         "reasoning": reasoning_payload(resolution.reasoning),
-        "call_decision": "CALL_JUSTIFIED" if resolution.reasoning.decision_critical else "NO_CALL_NEEDED",
+        "call_decision": call_decision_label(resolution.reasoning),
         "compliance": compliance_payload(
             resolution.compliance,
             resolution.applicable_compliance,

--- a/apps/python/reality-resolver/api/server.py
+++ b/apps/python/reality-resolver/api/server.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -65,6 +66,9 @@ MAX_DRAIN_BYTES = 1 << 20  # 1 MiB
 DRAIN_CHUNK_BYTES = 64 * 1024
 
 RESOLUTIONS_PATH = "/api/resolutions"
+CORS_ORIGIN_ENV = "REALITY_RESOLVER_CORS_ORIGIN"
+CORS_ALLOW_METHODS = "GET, POST, OPTIONS"
+CORS_ALLOW_HEADERS = "Content-Type"
 
 # Upper bound on the polling loop of one HTTP-driven resolution.
 #
@@ -268,8 +272,18 @@ class Handler(BaseHTTPRequestHandler):
         """
         return
 
+    def _cors_headers(self) -> dict[str, str]:
+        configured_origin = os.environ.get(CORS_ORIGIN_ENV)
+        request_origin = self.headers.get("Origin")
+        if configured_origin and configured_origin != "*" and request_origin == configured_origin:
+            return {
+                "Access-Control-Allow-Origin": configured_origin,
+                "Vary": "Origin",
+            }
+        return {}
+
     def _send(self, status: int, body: dict[str, Any], extra_headers: dict[str, str] | None = None) -> None:
-        raw = json.dumps(body).encode("utf-8")
+        raw = b"" if status == 204 else json.dumps(body).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(raw)))
@@ -279,10 +293,13 @@ class Handler(BaseHTTPRequestHandler):
             # closing without the header leaves the client believing it
             # may send another request down a socket that is going away.
             self.send_header("Connection", "close")
-        for name, value in (extra_headers or {}).items():
+        headers = self._cors_headers()
+        headers.update(extra_headers or {})
+        for name, value in headers.items():
             self.send_header(name, value)
         self.end_headers()
-        self.wfile.write(raw)
+        if raw:
+            self.wfile.write(raw)
 
     def _path(self) -> str:
         return urlparse(self.path).path.rstrip("/") or "/"
@@ -395,6 +412,25 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:
         self._dispatch("POST")
+
+    def do_OPTIONS(self) -> None:
+        self.body = self._read_request_body()
+        path = self._path()
+        if path not in ROUTES and not path.startswith(f"{RESOLUTIONS_PATH}/"):
+            self._not_found()
+            return
+
+        if self._cors_headers():
+            self._send(
+                204,
+                {},
+                {
+                    "Access-Control-Allow-Methods": CORS_ALLOW_METHODS,
+                    "Access-Control-Allow-Headers": CORS_ALLOW_HEADERS,
+                },
+            )
+            return
+        self._send(204, {})
 
     # --- route handlers ------------------------------------------------
 

--- a/apps/python/reality-resolver/api/server.py
+++ b/apps/python/reality-resolver/api/server.py
@@ -31,6 +31,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from api.backend import FakeCallBackend
+from api.custom_case import CustomCaseValidationError, parse_custom_case
 from api.progress import StoreObserver
 from api.serialize import case_summary, cases_payload, error_payload, health_payload
 from api.store import CaseNotFoundError, CaseStore, ResolutionNotFoundError, ResolutionStore
@@ -68,7 +69,7 @@ DRAIN_CHUNK_BYTES = 64 * 1024
 RESOLUTIONS_PATH = "/api/resolutions"
 CORS_ORIGIN_ENV = "REALITY_RESOLVER_CORS_ORIGIN"
 CORS_ALLOW_METHODS = "GET, POST, OPTIONS"
-CORS_ALLOW_HEADERS = "Content-Type"
+CORS_ALLOW_HEADERS = "Content-Type, X-Calle-Api-Key"
 
 # Upper bound on the polling loop of one HTTP-driven resolution.
 #
@@ -107,9 +108,16 @@ DEFAULT_SCENARIO = "confirmed"
 
 # The HTTP contract is split by execution mode. Values from the other
 # mode are rejected explicitly instead of being silently ignored.
-FAKE_REQUEST_FIELDS = frozenset({"case", "execution_mode", "scenario", "now_utc"})
+FAKE_REQUEST_FIELDS = frozenset({"case", "execution_mode", "scenario", "now_utc", "custom_case"})
 LIVE_REQUEST_FIELDS = frozenset(
-    {"case", "execution_mode", "destination", "authorize_destination", "gdpr_basis_documented"}
+    {
+        "case",
+        "execution_mode",
+        "destination",
+        "authorize_destination",
+        "gdpr_basis_documented",
+        "custom_case",
+    }
 )
 RESOLUTION_REQUEST_FIELDS = FAKE_REQUEST_FIELDS | LIVE_REQUEST_FIELDS
 
@@ -477,6 +485,17 @@ class Handler(BaseHTTPRequestHandler):
         if not isinstance(case_name, str) or not case_name:
             return 422, error_payload("invalid_case", "case must be a non-empty string")
 
+        custom_case = None
+        if "custom_case" in payload:
+            if case_name != "custom":
+                return 422, error_payload("invalid_case", "custom_case requires case=custom")
+            try:
+                custom_case = parse_custom_case(payload["custom_case"])
+            except CustomCaseValidationError as exc:
+                return 422, error_payload(exc.code, exc.message)
+        elif case_name == "custom":
+            return 422, error_payload("missing_custom_case", "custom_case is required for case=custom")
+
         now_utc = None
         if execution_mode == "fake":
             forbidden = sorted(set(payload) - FAKE_REQUEST_FIELDS)
@@ -544,11 +563,15 @@ class Handler(BaseHTTPRequestHandler):
             except (ValueError, argparse.ArgumentTypeError):
                 return 422, error_payload("invalid_now_utc", "now_utc must be an ISO 8601 UTC string")
 
-        try:
-            case_path = self.store.path_for(case_name)
-            case = self.store.get(case_name)
-        except CaseNotFoundError:
-            return 404, error_payload("case_not_found", "no such case")
+        if custom_case is not None:
+            case_path = None
+            case = custom_case
+        else:
+            try:
+                case_path = self.store.path_for(case_name)
+                case = self.store.get(case_name)
+            except CaseNotFoundError:
+                return 404, error_payload("case_not_found", "no such case")
 
         # Fake demonstration time is relative to the fixture, not today's
         # clock. Explicit test times remain supported; no-call always
@@ -560,8 +583,9 @@ class Handler(BaseHTTPRequestHandler):
 
         live = execution_mode == "live"
         request = ResolutionRequest(
-            case_path=str(case_path),
+            case_path=str(case_path or ""),
             base_url=REAL_API_BASE_URL if live else self.backend.base_url,
+            case=custom_case,
             execute=True,
             allow_live=live,
             authorize_destination=authorize_destination if live else None,

--- a/apps/python/reality-resolver/api/server.py
+++ b/apps/python/reality-resolver/api/server.py
@@ -4,28 +4,36 @@ No framework: this app already serves HTTP with http.server in
 fake_server.py, four endpoints do not justify a dependency tree, and
 CONTRIBUTING asks contributions to install without one.
 
-Scope of this file today, stated so the boundary is checkable rather
-than assumed: it imports the case store and the serializers, and nothing
-else from the app. It does not import pipeline, client, or any CALL-E
-code path; it cannot place a call, cannot start a resolution, and needs
-no credential to run. Importing this module starts nothing - the server
-is created by create_server() and run by main().
+Scope of this file, stated so the boundary is checkable rather than
+assumed: it validates input, seeds an entry, hands the run to
+pipeline.resolve() on a worker, and serves what the store holds. It
+scores no rule, builds no compliance context, reconciles nothing and
+constructs no provider client - resolve() is the only caller of any of
+those, here as in the CLI, and a test scans this file to keep it that
+way. It needs no credential to run and can place no real call.
+
+Importing this module starts nothing: the server is created by
+create_server(), the fake backend and the worker pool are started and
+stopped by whoever creates them, and main() does all three in order.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import urlparse
 
 from api.backend import FakeCallBackend
-from api.serialize import cases_payload, error_payload, health_payload, resolution_payload
+from api.progress import StoreObserver
+from api.serialize import case_summary, cases_payload, error_payload, health_payload
 from api.store import CaseNotFoundError, CaseStore, ResolutionNotFoundError, ResolutionStore
-from client import CallEAPIError, parse_utc_timestamp
+from client import parse_utc_timestamp
+from evidence.model import Case
 from fake_server import SUBJECT_CANCELLED_PHONE, SUBJECT_VOICEMAIL_PHONE
-from pipeline import ResolutionRefused, ResolutionRequest, resolve
+from pipeline import ResolutionRequest, resolve
 
 # Loopback by default and on purpose. This server has no authentication,
 # so binding it to every interface would be a decision an operator makes
@@ -90,7 +98,117 @@ DEFAULT_SCENARIO = "confirmed"
 # client trying to reach a knob this API does not expose - base_url,
 # execute, allow_live, authorize_destination, phone - and is refused
 # rather than ignored, so a mistaken client hears about it.
-RESOLUTION_REQUEST_FIELDS = frozenset({"case", "scenario", "now_utc"})
+RESOLUTION_REQUEST_FIELDS = frozenset({"case", "execution_mode", "scenario", "now_utc"})
+
+# Execution backends this build can actually drive. "live" is a value the
+# architecture recognises and this build does not implement, which is why
+# it answers 501 rather than 422: the request is well formed, the server
+# just cannot do it. Answering 422 would tell a client the value is wrong,
+# and silently accepting it would claim a capability that does not exist.
+IMPLEMENTED_EXECUTION_MODES = frozenset({"fake"})
+KNOWN_EXECUTION_MODES = IMPLEMENTED_EXECUTION_MODES | {"live"}
+
+# Resolutions run on a small pool rather than on the request thread.
+# Four is not about throughput - a fake resolution takes about 25 ms -
+# it is a bound. ThreadingHTTPServer already spawns one thread per
+# connection without a ceiling; adding unbounded workers on top would
+# double that problem. A saturated pool queues, which is honest here:
+# `queued` is a real state the client can see.
+MAX_WORKERS = 4
+
+# How many connections the OS may hold waiting to be accepted.
+#
+# socketserver's default is 5, which ThreadingHTTPServer inherits. That
+# was survivable while a POST did all its work inline and clients
+# arrived spread out; now that accepting is nearly instant, a client
+# can burst - and a burst of 40 simultaneous connections had five of
+# them refused by the kernel before this server ever saw them. Measured,
+# not theorised: it made a concurrency test fail roughly one run in
+# three. This is the accept queue, not a concurrency limit; work is
+# still bounded by MAX_WORKERS.
+REQUEST_QUEUE_SIZE = 64
+
+
+class ResolverHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer with a backlog that survives a burst."""
+
+    request_queue_size = REQUEST_QUEUE_SIZE
+
+
+def queued_entry(resolution_id: str, case: Case, mode: str) -> dict[str, Any]:
+    """The entry a resolution starts life as: every key of the public
+    contract present, and everything not yet known set to null.
+
+    The nulls are the job's own seed, not something StoreObserver
+    invented - it still publishes a field only once the pipeline has made
+    it true. What this buys is a stable shape from the very first
+    response, so a client is never reading a payload whose keys appear
+    one at a time.
+
+    The key set is asserted against resolution_payload's in the tests:
+    two places build this contract, and they must not drift.
+    """
+    return {
+        "id": resolution_id,
+        "state": "queued",
+        "mode": mode,
+        "case": case_summary(case),
+        "evidence": None,
+        "reasoning": None,
+        "call_decision": None,
+        "compliance": None,
+        # An object rather than null, unlike the fields above, because
+        # this one is already known: nothing has been placed yet, and
+        # `placed: false` says so. It also keeps the shape identical to
+        # what resolution_payload produces on the branches that never
+        # call - a client reading call.placed must not have to check
+        # whether `call` is an object first.
+        "call": {"placed": False, "provider_status": None, "result": None},
+        "verdict": None,
+        "error": None,
+    }
+
+
+def _run_resolution(
+    resolutions: ResolutionStore, resolution_id: str, request: ResolutionRequest
+) -> None:
+    """Run one resolution to completion, off the request thread.
+
+    Module-level rather than a Handler method on purpose: by the time
+    this runs, the request that started it has been answered and its
+    handler is gone.
+
+    It decides nothing. resolve() is called exactly as the CLI calls it,
+    with a StoreObserver attached; the only thing added here is turning
+    an exception into a transport state. Every exception becomes
+    `failed` with a null verdict - a technical failure is never an engine
+    outcome, so a timeout, a provider error or a bug cannot surface as a
+    cancellation. BaseException is deliberately not caught: a
+    KeyboardInterrupt or a SystemExit is the interpreter going down, not
+    a resolution failing.
+
+    The reply carries this module's own text, never str(exc): provider
+    error bodies and pipeline messages can quote back a number, a task,
+    or an input, and none of that belongs in a stored payload.
+    """
+    try:
+        resolve(request, StoreObserver(resolutions, resolution_id))
+    except Exception:
+        try:
+            resolutions.update(
+                resolution_id,
+                {
+                    "state": "failed",
+                    "verdict": None,
+                    "error": {
+                        "code": "resolution_failed",
+                        "message": "the resolution could not be completed",
+                    },
+                },
+            )
+        except ResolutionNotFoundError:
+            # Evicted while running; there is nothing left to mark.
+            return
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -107,6 +225,10 @@ class Handler(BaseHTTPRequestHandler):
     @property
     def backend(self) -> FakeCallBackend:
         return self.server.backend  # type: ignore[attr-defined]
+
+    @property
+    def executor(self) -> ThreadPoolExecutor:
+        return self.server.executor  # type: ignore[attr-defined]
 
     def log_message(self, *args: Any) -> None:
         """Silent, same as fake_server.py. The default writes the request
@@ -252,14 +374,13 @@ class Handler(BaseHTTPRequestHandler):
         return 200, cases_payload(self.store.all())
 
     def handle_create_resolution(self) -> tuple[int, dict[str, Any]]:
-        """Validate, hand the whole run to pipeline.resolve(), serialize
-        what came back.
+        """Validate, seed an entry, hand the run to a worker, answer 202.
 
         This method makes no decision about the case. It does not score
         R1-R4, build a PreCallContext, run or filter compliance checks,
         or reconcile anything - resolve() is the only caller of any of
         those, here as in the CLI. Everything below is either input
-        validation or translation.
+        validation, transport, or handing work to _run_resolution.
         """
         try:
             payload = json.loads(self.body or b"")
@@ -275,6 +396,20 @@ class Handler(BaseHTTPRequestHandler):
             # steer, and silently ignoring it would hide that.
             return 422, error_payload(
                 "unknown_field", f"this endpoint accepts only {sorted(RESOLUTION_REQUEST_FIELDS)}"
+            )
+
+        # Checked before anything else about the case, because a mode
+        # this build cannot drive makes the rest moot.
+        execution_mode = payload.get("execution_mode")
+        if execution_mode not in KNOWN_EXECUTION_MODES:
+            return 422, error_payload(
+                "invalid_execution_mode",
+                f"execution_mode is required and must be one of {sorted(KNOWN_EXECUTION_MODES)}",
+            )
+        if execution_mode not in IMPLEMENTED_EXECUTION_MODES:
+            return 501, error_payload(
+                "live_not_available",
+                "live execution is not available in this build; no real call can be placed",
             )
 
         case_name = payload.get("case")
@@ -303,6 +438,7 @@ class Handler(BaseHTTPRequestHandler):
 
         try:
             case_path = self.store.path_for(case_name)
+            case = self.store.get(case_name)
         except CaseNotFoundError:
             return 404, error_payload("case_not_found", "no such case")
 
@@ -325,17 +461,20 @@ class Handler(BaseHTTPRequestHandler):
         )
 
         resolution_id = self.resolutions.new_id()
-        try:
-            resolution = resolve(request)
-        except (CallEAPIError, TimeoutError, RuntimeError, ResolutionRefused):
-            # A technical failure, and it stays one: no Resolution means
-            # no verdict, and the client is told the run failed rather
-            # than handed an outcome nobody computed.
-            return 502, error_payload("resolution_failed", "the resolution could not be completed")
+        seed = queued_entry(resolution_id, case, MODE)
 
-        body = resolution_payload(resolution, resolution_id, "completed", MODE)
-        self.resolutions.put(resolution_id, body)
-        return 201, body
+        # Seeded before the work is submitted, never after. The observer
+        # publishes through store.update(), which requires the entry to
+        # exist; a worker that started first could reach on_start before
+        # this line ran and lose the whole run's progress.
+        #
+        # The store gets a copy, and this reply keeps its own. Handing
+        # over the same object would leave the response being serialized
+        # while a worker mutates it - a 202 that sometimes says "running",
+        # or worse, a torn mixture of two states.
+        self.resolutions.put(resolution_id, dict(seed))
+        self.executor.submit(_run_resolution, self.resolutions, resolution_id, request)
+        return 202, seed
 
     def handle_get_resolution(self, resolution_id: str) -> tuple[int, dict[str, Any]]:
         try:
@@ -357,19 +496,32 @@ def create_server(
     store: CaseStore | None = None,
     backend: FakeCallBackend | None = None,
     resolutions: ResolutionStore | None = None,
-) -> ThreadingHTTPServer:
+    executor: ThreadPoolExecutor | None = None,
+) -> ResolverHTTPServer:
     """Build a server without starting it, and without starting the
     backend either.
 
-    The two lifecycles stay separate deliberately: whoever starts the
-    fake backend stops it. Wiring its start into this function would
-    make a forgotten stop invisible, and would tie a listener nobody
-    named to the lifetime of an HTTP server that may outlive it.
+    The lifecycles stay separate deliberately: whoever starts the fake
+    backend stops it, and whoever submits work to the executor shuts it
+    down. Wiring either into this function would make a forgotten
+    teardown invisible, and would tie threads nobody named to the
+    lifetime of an HTTP server that may outlive them. A default executor
+    is built for convenience; a caller that actually submits resolutions
+    should own one and shut it down.
     """
-    server = ThreadingHTTPServer((host, port), Handler)
-    server.store = store or CaseStore()  # type: ignore[attr-defined]
-    server.backend = backend or FakeCallBackend()  # type: ignore[attr-defined]
-    server.resolutions = resolutions or ResolutionStore()  # type: ignore[attr-defined]
+    server = ResolverHTTPServer((host, port), Handler)
+    # `is None` rather than `or`, and not as a style preference:
+    # ResolutionStore defines __len__, so an empty one is falsy and
+    # `resolutions or ResolutionStore()` silently threw away the store a
+    # caller had passed in. Anything given here is used, empty or not.
+    server.store = store if store is not None else CaseStore()  # type: ignore[attr-defined]
+    server.backend = backend if backend is not None else FakeCallBackend()  # type: ignore[attr-defined]
+    server.resolutions = (  # type: ignore[attr-defined]
+        resolutions if resolutions is not None else ResolutionStore()
+    )
+    server.executor = (  # type: ignore[attr-defined]
+        executor if executor is not None else ThreadPoolExecutor(max_workers=MAX_WORKERS)
+    )
     return server
 
 
@@ -384,7 +536,8 @@ def main(argv: list[str] | None = None) -> int:
 
     backend = FakeCallBackend()
     backend.start()
-    server = create_server(args.host, args.port, backend=backend)
+    executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+    server = create_server(args.host, args.port, backend=backend, executor=executor)
     host, port = server.server_address[:2]
     print(f"Reality Resolver API on http://{host}:{port} (mode={MODE}, no real call can be placed)", flush=True)
     try:
@@ -392,7 +545,13 @@ def main(argv: list[str] | None = None) -> int:
     except KeyboardInterrupt:
         print("\nStopped.", flush=True)
     finally:
+        # Order matters. Stop accepting, let in-flight resolutions finish,
+        # and only then take the backend away - a worker still polling
+        # would otherwise find its provider gone mid-run. MAX_POLL_SECONDS
+        # is what makes wait=True safe: it bounds how long a resolution
+        # can hold the shutdown, and these are not daemon threads.
         server.server_close()
+        executor.shutdown(wait=True)
         backend.stop()
     return 0
 

--- a/apps/python/reality-resolver/api/server.py
+++ b/apps/python/reality-resolver/api/server.py
@@ -90,6 +90,12 @@ CORS_ALLOW_HEADERS = "Content-Type, X-Calle-Api-Key"
 # does not justify. The ceiling is lowered here, not removed.
 MAX_POLL_SECONDS = 10.0
 
+# Real calls include ringing, conversation, and provider-side result
+# finalization. Keep the deterministic fake bound above, but give the live
+# provider a finite window that remains below the frontend's four-minute
+# polling ceiling.
+MAX_LIVE_POLL_SECONDS = 180.0
+
 # The fake scenarios, including the no-call clock preset, and the only way
 # a fake request influences which number is dialled. It picks an outcome
 # by name; the number is chosen here, from fake_server.py's own reserved
@@ -217,8 +223,9 @@ def _run_resolution(
     or an input, and none of that belongs in a stored payload.
     """
     try:
+        observer = StoreObserver(resolutions, resolution_id)
         try:
-            resolve(request, StoreObserver(resolutions, resolution_id))
+            resolve(request, observer)
         except Exception as exc:
             if isinstance(exc, ProviderCallFailedError):
                 code = "provider_failed"
@@ -230,6 +237,17 @@ def _run_resolution(
                 code = "calle_network_error"
             else:
                 code = "resolution_failed"
+            diagnostics = observer.diagnostics()
+            status_suffix = ""
+            if "last_provider_status" in diagnostics:
+                status_suffix = f" last_provider_status={diagnostics['last_provider_status']}"
+            print(
+                "CALL-E resolution_error "
+                f"code={code} phase={diagnostics['phase']} "
+                f"call_id_present={'true' if diagnostics['call_id_present'] else 'false'}"
+                f"{status_suffix}",
+                flush=True,
+            )
             try:
                 resolutions.update(
                     resolution_id,
@@ -594,7 +612,7 @@ class Handler(BaseHTTPRequestHandler):
             now_utc=now_utc,
             gdpr_basis_documented=(payload.get("gdpr_basis_documented", False) if live else False),
             poll_interval_seconds=0.01,
-            poll_timeout_seconds=MAX_POLL_SECONDS,
+            poll_timeout_seconds=MAX_LIVE_POLL_SECONDS if live else MAX_POLL_SECONDS,
         )
 
         live_capacity = None

--- a/apps/python/reality-resolver/api/server.py
+++ b/apps/python/reality-resolver/api/server.py
@@ -1,4 +1,4 @@
-"""Read-only HTTP surface over the case catalog, on the standard library.
+"""HTTP surface over the case catalog and resolutions, on the standard library.
 
 No framework: this app already serves HTTP with http.server in
 fake_server.py, four endpoints do not justify a dependency tree, and
@@ -10,7 +10,8 @@ pipeline.resolve() on a worker, and serves what the store holds. It
 scores no rule, builds no compliance context, reconciles nothing and
 constructs no provider client - resolve() is the only caller of any of
 those, here as in the CLI, and a test scans this file to keep it that
-way. It needs no credential to run and can place no real call.
+way. Live execution requires an explicit per-request credential and
+destination authorization.
 
 Importing this module starts nothing: the server is created by
 create_server(), the fake backend and the worker pool are started and
@@ -21,7 +22,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import urlparse
@@ -30,10 +33,15 @@ from api.backend import FakeCallBackend
 from api.progress import StoreObserver
 from api.serialize import case_summary, cases_payload, error_payload, health_payload
 from api.store import CaseNotFoundError, CaseStore, ResolutionNotFoundError, ResolutionStore
-from client import parse_utc_timestamp
+from client import (
+    CallEAPIError,
+    REAL_API_BASE_URL,
+    build_recipient,
+    parse_utc_timestamp,
+)
 from evidence.model import Case
 from fake_server import SUBJECT_CANCELLED_PHONE, SUBJECT_VOICEMAIL_PHONE
-from pipeline import ResolutionRequest, resolve
+from pipeline import ProviderCallFailedError, ResolutionRequest, resolve
 
 # Loopback by default and on purpose. This server has no authentication,
 # so binding it to every interface would be a decision an operator makes
@@ -45,11 +53,10 @@ DEFAULT_PORT = 8000
 # engine answered; it is not a build identifier and carries no path.
 ENGINE_VERSION = "0.0.0"
 
-# There is no live mode to report yet: nothing in this server can reach a
-# provider, so anything other than "fake" would be a claim the code does
-# not back. The configuration seam belongs with the phase that can
-# actually place a call.
-MODE = "fake"
+# The server can run either the local fake backend or the explicitly
+# authorized live CALL-E path. Resolution entries carry their selected
+# mode; health reports the capability set.
+MODE = "mixed"
 
 # Largest declared request body this server will read and discard before
 # giving up on reusing the connection. No route reads input, so this only
@@ -78,15 +85,15 @@ RESOLUTIONS_PATH = "/api/resolutions"
 # does not justify. The ceiling is lowered here, not removed.
 MAX_POLL_SECONDS = 10.0
 
-# The four outcomes the fake backend can be steered to, and the only way
-# a client influences which number is dialled. It picks an outcome by
-# name; the number is chosen here, from fake_server.py's own reserved
-# sentinels and Ofcom's reserved drama range. A client never sends a
-# phone number, so there is no request shape that reaches an arbitrary
-# one - and "blocked" is not a bypass in the other direction either: it
-# routes to a number with no jurisdiction mapping, and the hard gate
-# refuses it for real.
+# The fake scenarios, including the no-call clock preset, and the only way
+# a fake request influences which number is dialled. It picks an outcome
+# by name; the number is chosen here, from fake_server.py's own reserved
+# sentinels and Ofcom's reserved drama range. Live requests use their
+# separately validated destination, and "blocked" is not a bypass in the
+# fake path either: it routes to a number with no jurisdiction mapping,
+# and the hard gate refuses it for real.
 SCENARIO_PHONES: dict[str, str | None] = {
+    "no-call": None,  # the fake clock places the deadline outside R4's threshold
     "confirmed": None,  # the case file's own number: fake server's happy path
     "cancelled": SUBJECT_CANCELLED_PHONE,
     "voicemail": SUBJECT_VOICEMAIL_PHONE,
@@ -94,19 +101,19 @@ SCENARIO_PHONES: dict[str, str | None] = {
 }
 DEFAULT_SCENARIO = "confirmed"
 
-# Exactly the keys a resolution request may carry. Anything else is a
-# client trying to reach a knob this API does not expose - base_url,
-# execute, allow_live, authorize_destination, phone - and is refused
-# rather than ignored, so a mistaken client hears about it.
-RESOLUTION_REQUEST_FIELDS = frozenset({"case", "execution_mode", "scenario", "now_utc"})
+# The HTTP contract is split by execution mode. Values from the other
+# mode are rejected explicitly instead of being silently ignored.
+FAKE_REQUEST_FIELDS = frozenset({"case", "execution_mode", "scenario", "now_utc"})
+LIVE_REQUEST_FIELDS = frozenset(
+    {"case", "execution_mode", "destination", "authorize_destination", "gdpr_basis_documented"}
+)
+RESOLUTION_REQUEST_FIELDS = FAKE_REQUEST_FIELDS | LIVE_REQUEST_FIELDS
 
-# Execution backends this build can actually drive. "live" is a value the
-# architecture recognises and this build does not implement, which is why
-# it answers 501 rather than 422: the request is well formed, the server
-# just cannot do it. Answering 422 would tell a client the value is wrong,
-# and silently accepting it would claim a capability that does not exist.
-IMPLEMENTED_EXECUTION_MODES = frozenset({"fake"})
-KNOWN_EXECUTION_MODES = IMPLEMENTED_EXECUTION_MODES | {"live"}
+# Execution backends this build can actually drive. Both modes share the
+# same pipeline; the live branch is guarded by explicit authorization and
+# a process-local concurrency limit.
+IMPLEMENTED_EXECUTION_MODES = frozenset({"fake", "live"})
+KNOWN_EXECUTION_MODES = IMPLEMENTED_EXECUTION_MODES
 
 # Resolutions run on a small pool rather than on the request thread.
 # Four is not about throughput - a fake resolution takes about 25 ms -
@@ -115,6 +122,9 @@ KNOWN_EXECUTION_MODES = IMPLEMENTED_EXECUTION_MODES | {"live"}
 # double that problem. A saturated pool queues, which is honest here:
 # `queued` is a real state the client can see.
 MAX_WORKERS = 4
+
+# Process-local safety limit for real calls. Fake runs do not use it.
+MAX_LIVE_CONCURRENT = 1
 
 # How many connections the OS may hold waiting to be accepted.
 #
@@ -170,7 +180,10 @@ def queued_entry(resolution_id: str, case: Case, mode: str) -> dict[str, Any]:
 
 
 def _run_resolution(
-    resolutions: ResolutionStore, resolution_id: str, request: ResolutionRequest
+    resolutions: ResolutionStore,
+    resolution_id: str,
+    request: ResolutionRequest,
+    live_capacity: threading.BoundedSemaphore | None = None,
 ) -> None:
     """Run one resolution to completion, off the request thread.
 
@@ -192,23 +205,37 @@ def _run_resolution(
     or an input, and none of that belongs in a stored payload.
     """
     try:
-        resolve(request, StoreObserver(resolutions, resolution_id))
-    except Exception:
         try:
-            resolutions.update(
-                resolution_id,
-                {
-                    "state": "failed",
-                    "verdict": None,
-                    "error": {
-                        "code": "resolution_failed",
-                        "message": "the resolution could not be completed",
+            resolve(request, StoreObserver(resolutions, resolution_id))
+        except Exception as exc:
+            if isinstance(exc, ProviderCallFailedError):
+                code = "provider_failed"
+            elif isinstance(exc, TimeoutError):
+                code = "calle_timeout"
+            elif isinstance(exc, CallEAPIError):
+                code = "calle_auth_error" if exc.status_code in {401, 403} else "calle_api_error"
+            elif request.allow_live:
+                code = "calle_network_error"
+            else:
+                code = "resolution_failed"
+            try:
+                resolutions.update(
+                    resolution_id,
+                    {
+                        "state": "failed",
+                        "verdict": None,
+                        "error": {
+                            "code": code,
+                            "message": "the resolution could not be completed",
+                        },
                     },
-                },
-            )
-        except ResolutionNotFoundError:
-            # Evicted while running; there is nothing left to mark.
-            return
+                )
+            except ResolutionNotFoundError:
+                # Evicted while running; there is nothing left to mark.
+                return
+    finally:
+        if live_capacity is not None:
+            live_capacity.release()
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -229,6 +256,10 @@ class Handler(BaseHTTPRequestHandler):
     @property
     def executor(self) -> ThreadPoolExecutor:
         return self.server.executor  # type: ignore[attr-defined]
+
+    @property
+    def live_capacity(self) -> threading.BoundedSemaphore:
+        return self.server.live_capacity  # type: ignore[attr-defined]
 
     def log_message(self, *args: Any) -> None:
         """Silent, same as fake_server.py. The default writes the request
@@ -280,7 +311,7 @@ class Handler(BaseHTTPRequestHandler):
         them gone. Doing both in one place means no route can forget the
         half it does not care about.
 
-        Neither route reads input, and skipping this was a real defect
+        Other routes do not read input, and skipping this was a real defect
         rather than a theoretical one: under protocol_version HTTP/1.1
         the bytes stayed in the socket, and the following request on the
         same connection was parsed starting from them - answering with
@@ -398,32 +429,73 @@ class Handler(BaseHTTPRequestHandler):
                 "unknown_field", f"this endpoint accepts only {sorted(RESOLUTION_REQUEST_FIELDS)}"
             )
 
-        # Checked before anything else about the case, because a mode
-        # this build cannot drive makes the rest moot.
+        # Check the mode before loading a case so the request contract is
+        # deterministic and unsupported values cannot steer execution.
         execution_mode = payload.get("execution_mode")
-        if execution_mode not in KNOWN_EXECUTION_MODES:
+        if not isinstance(execution_mode, str) or execution_mode not in KNOWN_EXECUTION_MODES:
             return 422, error_payload(
                 "invalid_execution_mode",
                 f"execution_mode is required and must be one of {sorted(KNOWN_EXECUTION_MODES)}",
             )
-        if execution_mode not in IMPLEMENTED_EXECUTION_MODES:
-            return 501, error_payload(
-                "live_not_available",
-                "live execution is not available in this build; no real call can be placed",
-            )
-
         case_name = payload.get("case")
         if not isinstance(case_name, str) or not case_name:
             return 422, error_payload("invalid_case", "case must be a non-empty string")
 
-        scenario = payload.get("scenario", DEFAULT_SCENARIO)
-        if scenario not in SCENARIO_PHONES:
-            return 422, error_payload(
-                "invalid_scenario", f"scenario must be one of {sorted(SCENARIO_PHONES)}"
-            )
-
         now_utc = None
-        if "now_utc" in payload:
+        if execution_mode == "fake":
+            forbidden = sorted(set(payload) - FAKE_REQUEST_FIELDS)
+            if forbidden:
+                return 422, error_payload(
+                    "field_not_allowed", f"fields are not allowed in fake mode: {forbidden}"
+                )
+            scenario = payload.get("scenario", DEFAULT_SCENARIO)
+            if not isinstance(scenario, str) or scenario not in SCENARIO_PHONES:
+                return 422, error_payload(
+                    "invalid_scenario", f"scenario must be one of {sorted(SCENARIO_PHONES)}"
+                )
+        else:
+            forbidden = sorted(set(payload) - LIVE_REQUEST_FIELDS)
+            if forbidden:
+                return 422, error_payload(
+                    "field_not_allowed", f"fields are not allowed in live mode: {forbidden}"
+                )
+            scenario = None
+            api_key_header = self.headers.get("X-Calle-Api-Key")
+            api_key = api_key_header if api_key_header is not None else ""
+            if not api_key.strip():
+                return 401, error_payload("missing_api_key", "X-Calle-Api-Key is required for live execution")
+            if "gdpr_basis_documented" in payload and type(payload["gdpr_basis_documented"]) is not bool:
+                return 422, error_payload(
+                    "invalid_gdpr_basis_documented", "gdpr_basis_documented must be a boolean"
+                )
+            destination = payload.get("destination")
+            authorize_destination = payload.get("authorize_destination")
+            if not isinstance(destination, str) or not destination:
+                return 422, error_payload("missing_destination", "destination is required in live mode")
+            if not isinstance(authorize_destination, str) or not authorize_destination:
+                return 422, error_payload(
+                    "missing_authorize_destination", "authorize_destination is required in live mode"
+                )
+            try:
+                build_recipient(destination, None, None)
+            except (TypeError, ValueError):
+                return 422, error_payload("invalid_destination", "destination must be strict ASCII E.164")
+            try:
+                build_recipient(authorize_destination, None, None)
+            except (TypeError, ValueError):
+                return 422, error_payload(
+                    "invalid_authorize_destination", "authorize_destination must be strict ASCII E.164"
+                )
+            if destination != authorize_destination:
+                return 422, error_payload(
+                    "destination_authorization_mismatch",
+                    "destination and authorize_destination must match exactly",
+                )
+
+        if execution_mode == "fake" and self.headers.get("X-Calle-Api-Key") is not None:
+            return 422, error_payload("api_key_not_allowed", "X-Calle-Api-Key is only accepted in live mode")
+
+        if execution_mode == "fake" and "now_utc" in payload:
             if not isinstance(payload["now_utc"], str):
                 return 422, error_payload("invalid_now_utc", "now_utc must be an ISO 8601 UTC string")
             try:
@@ -442,26 +514,36 @@ class Handler(BaseHTTPRequestHandler):
         except CaseNotFoundError:
             return 404, error_payload("case_not_found", "no such case")
 
-        # Everything a client cannot influence is fixed here. base_url
-        # comes from the backend this process started, allow_live is
-        # False and there is no code path that sets it otherwise, and
-        # execute targets that same fake backend - the alternative,
-        # dry-run, stops before a verdict exists and would leave the
-        # cockpit with nothing to show.
+        # Fake demonstration time is relative to the fixture, not today's
+        # clock. Explicit test times remain supported; no-call always
+        # prepares R4=false, even when a frontend also sends now_utc.
+        if execution_mode == "fake" and scenario == "no-call":
+            now_utc = case.deadline - case.decision_deadline_threshold - timedelta(seconds=1)
+        elif execution_mode == "fake" and now_utc is None:
+            now_utc = case.deadline - case.decision_deadline_threshold / 2
+
+        live = execution_mode == "live"
         request = ResolutionRequest(
             case_path=str(case_path),
-            base_url=self.backend.base_url,
+            base_url=REAL_API_BASE_URL if live else self.backend.base_url,
             execute=True,
-            allow_live=False,
-            authorize_destination=None,
-            phone_override=SCENARIO_PHONES[scenario],
+            allow_live=live,
+            authorize_destination=authorize_destination if live else None,
+            api_key=api_key if live else None,
+            phone_override=destination if live else SCENARIO_PHONES[scenario],
             now_utc=now_utc,
+            gdpr_basis_documented=(payload.get("gdpr_basis_documented", False) if live else False),
             poll_interval_seconds=0.01,
             poll_timeout_seconds=MAX_POLL_SECONDS,
         )
 
-        resolution_id = self.resolutions.new_id()
-        seed = queued_entry(resolution_id, case, MODE)
+        live_capacity = None
+        if live:
+            if not self.live_capacity.acquire(blocking=False):
+                return 429, error_payload(
+                    "live_capacity_reached", "one live resolution is already in progress"
+                )
+            live_capacity = self.live_capacity
 
         # Seeded before the work is submitted, never after. The observer
         # publishes through store.update(), which requires the entry to
@@ -472,8 +554,17 @@ class Handler(BaseHTTPRequestHandler):
         # over the same object would leave the response being serialized
         # while a worker mutates it - a 202 that sometimes says "running",
         # or worse, a torn mixture of two states.
-        self.resolutions.put(resolution_id, dict(seed))
-        self.executor.submit(_run_resolution, self.resolutions, resolution_id, request)
+        try:
+            resolution_id = self.resolutions.new_id()
+            seed = queued_entry(resolution_id, case, execution_mode)
+            self.resolutions.put(resolution_id, dict(seed))
+            self.executor.submit(_run_resolution, self.resolutions, resolution_id, request, live_capacity)
+        except Exception:
+            if live_capacity is not None:
+                live_capacity.release()
+            return 503, error_payload(
+                "resolution_submit_failed", "the resolution could not be accepted"
+            )
         return 202, seed
 
     def handle_get_resolution(self, resolution_id: str) -> tuple[int, dict[str, Any]]:
@@ -522,13 +613,13 @@ def create_server(
     server.executor = (  # type: ignore[attr-defined]
         executor if executor is not None else ThreadPoolExecutor(max_workers=MAX_WORKERS)
     )
+    server.live_capacity = threading.BoundedSemaphore(MAX_LIVE_CONCURRENT)  # type: ignore[attr-defined]
     return server
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="HTTP surface for Reality Resolver, against an in-process fake CALL-E "
-        "backend. Places no real calls: there is no live mode to select."
+        description="HTTP surface for Reality Resolver, with fake and explicitly authorized live CALL-E modes."
     )
     parser.add_argument("--host", default=DEFAULT_HOST)
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
@@ -539,7 +630,7 @@ def main(argv: list[str] | None = None) -> int:
     executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
     server = create_server(args.host, args.port, backend=backend, executor=executor)
     host, port = server.server_address[:2]
-    print(f"Reality Resolver API on http://{host}:{port} (mode={MODE}, no real call can be placed)", flush=True)
+    print(f"Reality Resolver API on http://{host}:{port} (mode={MODE})", flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/apps/python/reality-resolver/api/store.py
+++ b/apps/python/reality-resolver/api/store.py
@@ -158,9 +158,19 @@ class ResolutionStore:
             entry.update(patch)
 
     def get(self, resolution_id: str) -> dict[str, Any]:
+        """A consistent snapshot, not the live entry.
+
+        The copy is the point. A resolution running on a worker keeps
+        calling update() on its entry, so handing out the stored dict
+        would let a reader serialize it while it changes underneath -
+        producing a payload that is half one state and half the next.
+        Taken under the lock, a shallow copy is enough: update() replaces
+        whole top-level values and never edits a nested object in place,
+        so the references captured here cannot shift afterwards.
+        """
         with self._lock:
             try:
-                return self._entries[resolution_id]
+                return dict(self._entries[resolution_id])
             except KeyError:
                 raise ResolutionNotFoundError(resolution_id) from None
 

--- a/apps/python/reality-resolver/api/store.py
+++ b/apps/python/reality-resolver/api/store.py
@@ -129,6 +129,34 @@ class ResolutionStore:
             while len(self._entries) > self._max:
                 self._entries.popitem(last=False)
 
+    def update(self, resolution_id: str, patch: dict[str, Any]) -> None:
+        """Merge `patch` into an existing entry's top-level keys.
+
+        Shallow on purpose: every key a progress event touches - state,
+        reasoning, compliance, call, verdict - is replaced whole, because
+        that is how the publisher builds them. A deep merge would let a
+        half-built nested object survive underneath a newer one.
+
+        Deliberately does not move the entry to the end. put() does,
+        because inserting is what defines FIFO position; updating is not
+        a reinsertion, and treating it as one would let a resolution that
+        keeps reporting progress outlive older entries indefinitely. The
+        consequence is real and accepted here rather than hidden: a long
+        run can be evicted while it is still going. Protecting in-flight
+        work belongs with a model of in-flight work, which does not exist
+        yet.
+
+        Raises for an unknown id, like get() - an update has nothing to
+        merge into, and silently creating an entry would invent a
+        resolution nobody started.
+        """
+        with self._lock:
+            try:
+                entry = self._entries[resolution_id]
+            except KeyError:
+                raise ResolutionNotFoundError(resolution_id) from None
+            entry.update(patch)
+
     def get(self, resolution_id: str) -> dict[str, Any]:
         with self._lock:
             try:

--- a/apps/python/reality-resolver/client.py
+++ b/apps/python/reality-resolver/client.py
@@ -55,7 +55,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NoReturn, Protocol
@@ -108,6 +108,10 @@ TERMINAL_STATUSES = frozenset({"completed", "failed", "canceled"})
 # compliance/dispatcher.py), so a non-ASCII digit here would also silently
 # degrade routing rather than fail closed.
 PHONE_PATTERN = re.compile(r"^\+[1-9][0-9]{6,14}$")
+
+# Provider messages are untrusted text. Keep these recognizers shared with
+# the HTTP projection layer so phone and obvious-secret masking cannot drift.
+_PHONE_IN_TEXT = re.compile(r"\+[1-9][0-9]{6,14}")
 
 # Fields accepted at the top level of CreateCallRequest. The real API rejects
 # unknown fields (additionalProperties: false), so the client only ever
@@ -163,6 +167,17 @@ ERROR_HINTS = {
     "unauthorized": "CALLE_API_KEY is missing, malformed, expired, or invalid.",
     "forbidden": "The API key is valid but lacks access to this project, region, or operation.",
 }
+
+MAX_PROVIDER_ERROR_MESSAGE_CHARS = 1000
+MAX_PROVIDER_ERROR_CODE_CHARS = 64
+_OBVIOUS_SECRET = re.compile(
+    r"\b(?:Bearer\s+[A-Za-z0-9._~+/=-]+|"
+    r"(?:iams_|sk-|sk_)[A-Za-z0-9_-]+|"
+    r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|"
+    r"(?:api[_-]?key|access[_-]?token|token|secret|password)\s*[:=]\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s,;]+))",
+    re.IGNORECASE,
+)
 
 # Status codes worth a bounded retry: rate limiting and transient provider
 # or server trouble. Everything else is treated as a final answer.
@@ -309,6 +324,24 @@ def mask_phone(phone: str | None) -> str:
     return f"{prefix}...{phone[-4:]}"
 
 
+def sanitize_provider_error_code(value: Any) -> str:
+    """Return a bounded, log-safe provider error code."""
+    text = value if isinstance(value, str) else repr(value)
+    if text in KNOWN_ERROR_CODES:
+        return text
+    if re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,63}", text):
+        return text[:MAX_PROVIDER_ERROR_CODE_CHARS]
+    return "unknown_error"
+
+
+def sanitize_provider_error_message(value: Any) -> str:
+    """Mask phones/secrets and escape controls before provider-error logging."""
+    text = value if isinstance(value, str) else repr(value)
+    text = _OBVIOUS_SECRET.sub("[redacted]", text)
+    text = _PHONE_IN_TEXT.sub(lambda match: mask_phone(match.group(0)), text)
+    return sanitize_for_display(text, MAX_PROVIDER_ERROR_MESSAGE_CHARS)
+
+
 def require_api_key() -> str:
     api_key = os.environ.get(API_KEY_ENV_VAR)
     if not api_key:
@@ -355,7 +388,7 @@ def resolve_api_key(request: ApiKeyContext) -> str:
 
 
 def build_recipient(phone: str, locale: str | None, region: str | None) -> dict[str, Any]:
-    if not PHONE_PATTERN.match(phone):
+    if not PHONE_PATTERN.fullmatch(phone):
         raise ValueError(
             f"phone {mask_phone(phone)!r} is not valid E.164 (expected pattern {PHONE_PATTERN.pattern})"
         )
@@ -614,7 +647,7 @@ def build_hardened_task(operator_task: str, disclosure_script: str | None = None
 @dataclass
 class CallEClient:
     base_url: str
-    api_key: str
+    api_key: str = field(repr=False)
     allow_live: bool = False
     timeout_seconds: float = 30.0
 
@@ -680,11 +713,23 @@ class CallEClient:
                 try:
                     payload = json.loads(exc.read().decode("utf-8") or "{}")
                 except json.JSONDecodeError as decode_exc:
+                    print(
+                        f"CALL-E provider_error status={exc.code} code=invalid_error_body "
+                        "message=provider error body was not valid JSON",
+                        flush=True,
+                    )
                     raise RuntimeError(
                         f"{method} {url} returned HTTP {exc.code} with a body that is not valid JSON: {decode_exc}"
                     ) from decode_exc
                 error = payload.get("error", {})
                 code = error.get("code", "unknown_error")
+                provider_message = error.get("message", str(exc))
+                print(
+                    f"CALL-E provider_error status={exc.code} "
+                    f"code={sanitize_provider_error_code(code)} "
+                    f"message={sanitize_provider_error_message(provider_message)}",
+                    flush=True,
+                )
                 if retryable and exc.code in RETRYABLE_STATUS_CODES and attempt < MAX_ATTEMPTS:
                     retry_after = exc.headers.get("Retry-After") if exc.headers else None
                     delay = float(retry_after) if retry_after else BASE_BACKOFF_SECONDS * (2 ** (attempt - 1))
@@ -699,7 +744,7 @@ class CallEClient:
                     time.sleep(delay)
                     last_error = None
                     continue
-                raise CallEAPIError(exc.code, code, error.get("message", str(exc)), error.get("details", {})) from exc
+                raise CallEAPIError(exc.code, code, provider_message, error.get("details", {})) from exc
             except urllib.error.URLError as exc:
                 # exc.reason is produced by urllib/the socket layer, but a
                 # TLS failure can embed server-supplied text (certificate

--- a/apps/python/reality-resolver/client.py
+++ b/apps/python/reality-resolver/client.py
@@ -58,7 +58,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Protocol
 
 from compliance.models import PreCallDecision
 
@@ -316,18 +316,41 @@ def require_api_key() -> str:
     return api_key
 
 
-def resolve_api_key(args: argparse.Namespace) -> str:
-    """Only read/require the real CALLE_API_KEY when all three are true:
-    --execute, --allow-live, and base_url is the real API. Every other
-    path (dry-run, or --execute against a non-real base_url) uses a
-    hardcoded, obviously-fake key and never touches the environment
-    variable at all - so the fake server can never receive a real
-    credential, even if CALLE_API_KEY happens to be set in the caller's
-    shell.
+class ApiKeyContext(Protocol):
+    """The four attributes resolve_api_key() reads.
+
+    Spelled out as a Protocol rather than typed as the concrete request
+    object, because pipeline.ResolutionRequest imports this module and
+    the reverse would be circular. It replaces an argparse.Namespace
+    annotation that stopped being accurate once the pipeline was
+    extracted and became this function's only caller.
     """
-    live_target = args.base_url.rstrip("/") == REAL_API_BASE_URL.rstrip("/")
-    if args.execute and live_target and args.allow_live:
-        return require_api_key()
+
+    base_url: str
+    execute: bool
+    allow_live: bool
+    api_key: str | None
+
+
+def resolve_api_key(request: ApiKeyContext) -> str:
+    """Only use a real credential when all three are true: execute,
+    allow_live, and base_url is the real API. Every other path (dry-run,
+    or execute against a non-real base_url) uses a hardcoded,
+    obviously-fake key and never touches the environment variable at all
+    - so the fake server can never receive a real credential, even if
+    CALLE_API_KEY happens to be set in the caller's shell, and even if
+    the caller supplied a per-request key.
+
+    On the live path, a per-request request.api_key wins over the
+    environment. That is what lets one process serve several resolutions
+    with different credentials without writing to os.environ - shared
+    mutable state through which two concurrent runs could swap keys. An
+    unset or empty value falls back to CALLE_API_KEY, which is exactly
+    the CLI's behaviour and the only behaviour before this existed.
+    """
+    live_target = request.base_url.rstrip("/") == REAL_API_BASE_URL.rstrip("/")
+    if request.execute and live_target and request.allow_live:
+        return request.api_key or require_api_key()
     return FAKE_DEV_API_KEY
 
 

--- a/apps/python/reality-resolver/compliance/use_cases.py
+++ b/apps/python/reality-resolver/compliance/use_cases.py
@@ -71,6 +71,10 @@ _COMMERCIAL_SOLICITATION_SUFFIXES = (
 _EXEMPT_SUFFIXES_BY_USE_CASE: dict[str, tuple[str, ...]] = {
     "appointment_confirmation": _COMMERCIAL_SOLICITATION_SUFFIXES,
     "critical_service_escalation": _COMMERCIAL_SOLICITATION_SUFFIXES,
+    # Custom cases are limited to factual state confirmation. They use the
+    # same non-solicitation applicability set as the shipped cases while the
+    # case's own evidence and actions remain fully data-driven.
+    "factual_state_confirmation": _COMMERCIAL_SOLICITATION_SUFFIXES,
 }
 
 

--- a/apps/python/reality-resolver/pipeline.py
+++ b/apps/python/reality-resolver/pipeline.py
@@ -80,6 +80,9 @@ class ResolutionRequest:
 
     case_path: str
     base_url: str
+    # Custom HTTP cases are normalized into the same engine model and kept
+    # in memory. The path remains the CLI/shipped-case contract.
+    case: Case | None = field(default=None, repr=False)
     execute: bool = False
     allow_live: bool = False
     authorize_destination: str | None = None
@@ -246,7 +249,7 @@ def resolve(request: ResolutionRequest, observer: Observer | None = None) -> Res
 
     _check_preconditions(request)
 
-    case = load_case(request.case_path)
+    case = request.case if request.case is not None else load_case(request.case_path)
     if request.phone_override:
         case = replace(case, call_phone=request.phone_override)
 

--- a/apps/python/reality-resolver/pipeline.py
+++ b/apps/python/reality-resolver/pipeline.py
@@ -61,6 +61,14 @@ class ResolutionRefused(Exception):
     """
 
 
+class ProviderCallFailedError(RuntimeError):
+    """CALL-E accepted the request but ended the call technically."""
+
+    def __init__(self, status: str) -> None:
+        self.status = status
+        super().__init__(f"CALL-E call ended with provider status {status!r}")
+
+
 @dataclass(frozen=True)
 class ResolutionRequest:
     """Everything the pipeline needs, with no argparse dependency.
@@ -358,6 +366,13 @@ def resolve(request: ResolutionRequest, observer: Observer | None = None) -> Res
         on_warn=observer.on_poll_warning,
     )
     observer.on_call_completed(final_call)
+
+    provider_status = final_call.get("status")
+    if provider_status in {"failed", "canceled"}:
+        # A provider failure is transport state, never a subject intent.
+        # Do not let reconciliation turn it into a business cancellation
+        # or an ambiguous answer.
+        raise ProviderCallFailedError(provider_status)
 
     structured_result = final_call.get("structured_result")
     verdict = reconcile(structured_result, case.decision_options, case.evidence)

--- a/apps/python/reality-resolver/pipeline.py
+++ b/apps/python/reality-resolver/pipeline.py
@@ -26,7 +26,7 @@ whatever the underlying layer already raised.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any
 
@@ -65,10 +65,9 @@ class ResolutionRefused(Exception):
 class ResolutionRequest:
     """Everything the pipeline needs, with no argparse dependency.
 
-    base_url/execute/allow_live are named exactly as client.py's
+    base_url/execute/allow_live/api_key are named exactly as client.py's
     resolve_api_key() reads them, so this object can be handed to it
-    directly - that function is duck-typed on those three attributes and
-    stays unmodified.
+    directly.
     """
 
     case_path: str
@@ -76,6 +75,19 @@ class ResolutionRequest:
     execute: bool = False
     allow_live: bool = False
     authorize_destination: str | None = None
+    # A CALL-E credential for this one resolution, or None to fall back to
+    # the CALLE_API_KEY environment variable - which is what the CLI does,
+    # unchanged. It exists so a caller handling several resolutions at
+    # once never has to write to os.environ: that is shared mutable state,
+    # and two concurrent runs would be able to swap each other's
+    # credentials through it.
+    #
+    # repr=False because a frozen dataclass renders every field by
+    # default, and this one is a secret - any log line, exception message
+    # or debugger frame that rendered the request would carry it. It is
+    # also never copied into Resolution (see that class: eleven fields,
+    # none of them this one), so it cannot reach a serializer or a store.
+    api_key: str | None = field(default=None, repr=False)
     phone_override: str | None = None
     now_utc: datetime | None = None
     poll_interval_seconds: float = 2.0

--- a/apps/python/reality-resolver/test_client.py
+++ b/apps/python/reality-resolver/test_client.py
@@ -38,6 +38,7 @@ from client import (
 )
 from compliance.jurisdictions import fr, us_federal
 from fake_server import INSUFFICIENT_BALANCE_PHONE, RATE_LIMITED_ONCE_PHONE, FakeCalleServer
+from pipeline import ResolutionRequest
 from verdict import subject_intent_result_schema
 
 TEST_API_KEY = "iams_live_fake_test_key_do_not_use"
@@ -830,3 +831,99 @@ def test_verdict_evidence_line_is_bounded_at_display_time() -> None:
     assert ESC not in printed
     for line in printed.splitlines():
         assert len(line) <= MAX_DISPLAY_CHARS + 10  # + the "    - " prefix
+
+
+# --- per-request CALL-E credential -----------------------------------
+#
+# resolve_api_key() has exactly one caller, pipeline.resolve(), which
+# hands it a ResolutionRequest - so these use the real object rather than
+# a stand-in, and test the integration as it actually runs.
+#
+# SENTINEL_KEY is deliberately shaped like a credential so that a leak
+# would be visible in any output; it is not one.
+
+SENTINEL_KEY = "iams_live_per_request_sentinel_not_a_real_credential"
+
+
+def _live_request(**overrides: Any) -> ResolutionRequest:
+    fields: dict[str, Any] = {
+        "case_path": "not-read-by-this-function",
+        "base_url": REAL_API_BASE_URL,
+        "execute": True,
+        "allow_live": True,
+    }
+    fields.update(overrides)
+    return ResolutionRequest(**fields)
+
+
+def test_a_per_request_key_is_used_on_the_live_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """And it wins over the environment, so one process can serve several
+    resolutions with different credentials without touching os.environ.
+    """
+    monkeypatch.setenv("CALLE_API_KEY", "environment-key-should-not-win")
+
+    assert client_module.resolve_api_key(_live_request(api_key=SENTINEL_KEY)) == SENTINEL_KEY
+
+
+def test_no_per_request_key_falls_back_to_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI's behaviour, unchanged: it has no such flag, so api_key is
+    always None there.
+    """
+    monkeypatch.setenv("CALLE_API_KEY", "environment-key")
+
+    assert client_module.resolve_api_key(_live_request()) == "environment-key"
+    assert client_module.resolve_api_key(_live_request(api_key=None)) == "environment-key"
+
+
+def test_an_empty_per_request_key_falls_back_to_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty string is not a credential."""
+    monkeypatch.setenv("CALLE_API_KEY", "environment-key")
+
+    assert client_module.resolve_api_key(_live_request(api_key="")) == "environment-key"
+
+
+def test_neither_a_per_request_key_nor_an_environment_key_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CALLE_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="CALLE_API_KEY is not set"):
+        client_module.resolve_api_key(_live_request())
+
+
+def test_a_per_request_key_never_reaches_a_non_live_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guarantee that predates this field and must survive it: the
+    fake server can never receive a real credential - not from the
+    environment, and now not from a request either.
+    """
+    monkeypatch.setenv("CALLE_API_KEY", "environment-key")
+
+    for request in (
+        _live_request(api_key=SENTINEL_KEY, base_url="http://127.0.0.1:9999"),
+        _live_request(api_key=SENTINEL_KEY, execute=False),
+        _live_request(api_key=SENTINEL_KEY, allow_live=False),
+    ):
+        resolved = client_module.resolve_api_key(request)
+        assert resolved == client_module.FAKE_DEV_API_KEY
+        assert resolved != SENTINEL_KEY
+
+
+def test_a_request_never_renders_its_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """repr() on a frozen dataclass prints every field by default. This
+    one is declared repr=False, so a log line or an exception that
+    rendered the request cannot carry the credential.
+    """
+    request = _live_request(api_key=SENTINEL_KEY)
+
+    for rendered in (repr(request), str(request), f"{request}"):
+        assert SENTINEL_KEY not in rendered
+        # The field itself is absent, not merely its value: no "api_key="
+        # pair is rendered at all.
+        assert "api_key=" not in rendered
+        assert "authorize_destination=None, phone_override=None" in rendered
+    # The attribute is still there for resolve_api_key to read.
+    assert request.api_key == SENTINEL_KEY

--- a/apps/python/reality-resolver/tests/test_api.py
+++ b/apps/python/reality-resolver/tests/test_api.py
@@ -453,7 +453,8 @@ def test_the_http_layer_makes_no_decision_of_its_own() -> None:
     ):
         assert forbidden not in source, f"{forbidden} in the HTTP layer duplicates the pipeline"
 
-    assert "resolve(request, StoreObserver(" in source, (
+    assert "observer = StoreObserver(resolutions, resolution_id)" in source
+    assert "resolve(request, observer)" in source, (
         "the run must be delegated to the pipeline, with progress published rather than derived"
     )
 
@@ -1397,11 +1398,12 @@ def test_the_poll_bound_is_armed_on_the_http_path() -> None:
     """The constant exists and is actually handed to the pipeline. A
     bound nobody passes is not a bound.
     """
-    from api.server import MAX_POLL_SECONDS
+    from api.server import MAX_LIVE_POLL_SECONDS, MAX_POLL_SECONDS
 
     assert MAX_POLL_SECONDS == 10.0
+    assert MAX_LIVE_POLL_SECONDS == 180.0
     source = Path(__import__("api.server", fromlist=["x"]).__file__).read_text(encoding="utf-8")
-    assert "poll_timeout_seconds=MAX_POLL_SECONDS" in source
+    assert "poll_timeout_seconds=MAX_LIVE_POLL_SECONDS if live else MAX_POLL_SECONDS" in source
 
 
 def test_the_normal_branches_are_unaffected_by_the_bound() -> None:

--- a/apps/python/reality-resolver/tests/test_api.py
+++ b/apps/python/reality-resolver/tests/test_api.py
@@ -265,11 +265,127 @@ def test_post_to_cases_is_405() -> None:
         assert headers["Allow"] == "GET"
 
 
-def test_no_cors_header_is_sent_by_default() -> None:
+def test_no_cors_header_is_sent_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REALITY_RESOLVER_CORS_ORIGIN", raising=False)
     with api_server() as base_url:
-        _, _, headers = request(base_url, "/api/health")
+        req = urllib.request.Request(
+            f"{base_url}/api/health",
+            method="GET",
+            headers={"Origin": "https://reality-resolver-frontend.example"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            headers = response.headers
 
         assert "Access-Control-Allow-Origin" not in headers
+
+
+def test_configured_cors_origin_is_echoed_only_for_an_exact_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    allowed_origin = "https://reality-resolver-frontend.example"
+    monkeypatch.setenv("REALITY_RESOLVER_CORS_ORIGIN", allowed_origin)
+
+    with api_server() as base_url:
+        _, _, allowed_headers = request(
+            base_url,
+            "/api/health",
+            method="GET",
+        )
+        assert "Access-Control-Allow-Origin" not in allowed_headers
+
+        req = urllib.request.Request(
+            f"{base_url}/api/health",
+            method="GET",
+            headers={"Origin": allowed_origin},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            assert response.status == 200
+            assert response.headers["Access-Control-Allow-Origin"] == allowed_origin
+            assert response.headers["Vary"] == "Origin"
+
+        req = urllib.request.Request(
+            f"{base_url}/api/health",
+            method="GET",
+            headers={"Origin": "https://another-origin.example"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_wildcard_cors_configuration_is_never_echoed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REALITY_RESOLVER_CORS_ORIGIN", "*")
+
+    with api_server() as base_url:
+        req = urllib.request.Request(
+            f"{base_url}/api/health",
+            method="GET",
+            headers={"Origin": "*"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_authorized_options_returns_minimal_preflight_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    allowed_origin = "https://reality-resolver-frontend.example"
+    monkeypatch.setenv("REALITY_RESOLVER_CORS_ORIGIN", allowed_origin)
+
+    with api_server() as base_url:
+        req = urllib.request.Request(
+            f"{base_url}/api/resolutions",
+            method="OPTIONS",
+            headers={"Origin": allowed_origin, "Access-Control-Request-Method": "POST"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            assert response.status == 204
+            assert response.headers["Access-Control-Allow-Origin"] == allowed_origin
+            assert "GET" in response.headers["Access-Control-Allow-Methods"]
+            assert "POST" in response.headers["Access-Control-Allow-Methods"]
+            assert "OPTIONS" in response.headers["Access-Control-Allow-Methods"]
+            assert "Content-Type" in response.headers["Access-Control-Allow-Headers"]
+            assert response.headers["Vary"] == "Origin"
+            assert response.read() == b""
+
+
+def test_wrong_origin_options_receives_no_cors_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REALITY_RESOLVER_CORS_ORIGIN", "https://reality-resolver-frontend.example")
+
+    with api_server() as base_url:
+        req = urllib.request.Request(
+            f"{base_url}/api/resolutions",
+            method="OPTIONS",
+            headers={"Origin": "https://another-origin.example", "Access-Control-Request-Method": "POST"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            assert response.status == 204
+            assert "Access-Control-Allow-Origin" not in response.headers
+            assert "Access-Control-Allow-Methods" not in response.headers
+            assert "Access-Control-Allow-Headers" not in response.headers
+            assert "Vary" not in response.headers
+
+
+def test_configured_cors_does_not_change_existing_get_and_post_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allowed_origin = "https://reality-resolver-frontend.example"
+    monkeypatch.setenv("REALITY_RESOLVER_CORS_ORIGIN", allowed_origin)
+
+    with api_server() as base_url:
+        for path in ("/api/health", "/api/cases"):
+            req = urllib.request.Request(
+                f"{base_url}{path}",
+                method="GET",
+                headers={"Origin": allowed_origin},
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                assert response.status == 200
+
+        status, body, headers = post(
+            base_url,
+            "/api/resolutions",
+            {"case": "critical-service-escalation", "execution_mode": "fake", "scenario": "confirmed"},
+            headers={"Origin": allowed_origin},
+        )
+        assert status == 202
+        assert body["state"] == "queued"
+        assert headers["Access-Control-Allow-Origin"] == allowed_origin
 
 
 # --- G. no credential required ---------------------------------------

--- a/apps/python/reality-resolver/tests/test_api.py
+++ b/apps/python/reality-resolver/tests/test_api.py
@@ -15,6 +15,7 @@ import re
 import sys
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 import urllib.error
 import urllib.request
 from collections.abc import Iterator
@@ -39,20 +40,26 @@ def api_server_and_backend() -> Iterator[tuple[str, Any]]:
     code, so a test cannot accidentally depend on one starting the other.
     """
     from api.backend import FakeCallBackend
-    from api.server import create_server
+    from api.server import MAX_WORKERS, create_server
 
     backend = FakeCallBackend()
     backend.start()
-    server = create_server("127.0.0.1", 0, backend=backend)
+    executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+    server = create_server("127.0.0.1", 0, backend=backend, executor=executor)
     thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.0005}, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
     try:
         yield f"http://{host}:{port}", backend
     finally:
+        # Same order main() uses, and for the same reason: a worker still
+        # polling would otherwise find its backend gone. Without this a
+        # test leaks workers that outlive it, keep hitting a dead port,
+        # and interfere with whatever runs next.
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+        executor.shutdown(wait=True)
         backend.stop()
 
 
@@ -72,6 +79,43 @@ def post(base_url: str, path: str, payload: Any) -> tuple[int, Any, dict[str, st
             return response.status, json.loads(response.read()), dict(response.headers)
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read()), dict(exc.headers)
+
+
+def create_resolution(base_url: str, **fields: Any) -> tuple[int, Any]:
+    """POST a fake-mode resolution. execution_mode is filled in here so
+    every caller does not have to repeat it; pass it explicitly to test
+    the field itself.
+    """
+    payload: dict[str, Any] = {"execution_mode": "fake"}
+    payload.update(fields)
+    status, body, _ = post(base_url, "/api/resolutions", payload)
+    return status, body
+
+
+def await_resolution(base_url: str, resolution_id: str, timeout: float = 15.0) -> Any:
+    """Poll GET until the resolution reaches a terminal state.
+
+    This is what a client does now, and the states it walks through are
+    the backend's real ones - nothing here waits a fixed time and calls
+    it progress.
+    """
+    deadline = time.monotonic() + timeout
+    body: Any = None
+    while time.monotonic() < deadline:
+        status, body, _ = request(base_url, f"/api/resolutions/{resolution_id}")
+        assert status == 200, f"GET returned {status}"
+        if body["state"] in ("completed", "failed"):
+            return body
+        time.sleep(0.005)
+    raise AssertionError(f"resolution stayed in state {body and body['state']!r} for {timeout}s")
+
+
+def resolve_via_api(base_url: str, **fields: Any) -> Any:
+    """The whole client flow: create, then read the outcome back."""
+    status, created = create_resolution(base_url, **fields)
+    assert status == 202, f"POST returned {status}: {created}"
+    assert created["state"] == "queued"
+    return await_resolution(base_url, created["id"])
 
 
 def request(base_url: str, path: str, method: str = "GET") -> tuple[int, Any, dict[str, str]]:
@@ -292,7 +336,9 @@ def test_the_http_layer_makes_no_decision_of_its_own() -> None:
     ):
         assert forbidden not in source, f"{forbidden} in the HTTP layer duplicates the pipeline"
 
-    assert "resolve(request)" in source, "the handler must delegate the whole run to the pipeline"
+    assert "resolve(request, StoreObserver(" in source, (
+        "the run must be delegated to the pipeline, with progress published rather than derived"
+    )
 
 
 def test_importing_the_server_starts_nothing() -> None:
@@ -615,9 +661,8 @@ HERO = "critical-service-escalation"
 
 def test_no_call_needed_never_reaches_the_gate_or_the_backend() -> None:
     with api_server_and_backend() as (base_url, backend):
-        status, body, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": FAR})
+        body = resolve_via_api(base_url, case=HERO, now_utc=FAR)
 
-        assert status == 201
         assert body["state"] == "completed"
         assert body["call_decision"] == "NO_CALL_NEEDED"
         assert body["reasoning"]["decision_critical"] is False
@@ -629,11 +674,9 @@ def test_no_call_needed_never_reaches_the_gate_or_the_backend() -> None:
 
 def test_blocked_scenario_is_refused_by_the_real_hard_gate() -> None:
     with api_server_and_backend() as (base_url, backend):
-        status, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "blocked", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="blocked", now_utc=NEAR)
 
-        assert status == 201
+        assert body["state"] == "completed", "a compliance block is a verdict, not a failure"
         assert body["reasoning"]["decision_critical"] is True
         assert body["call_decision"] == "CALL_JUSTIFIED"
         assert body["compliance"]["allowed"] is False
@@ -645,11 +688,8 @@ def test_blocked_scenario_is_refused_by_the_real_hard_gate() -> None:
 
 def test_confirmed_scenario_resolves_to_the_cases_own_action() -> None:
     with api_server_and_backend() as (base_url, backend):
-        status, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "confirmed", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
 
-        assert status == 201
         assert body["verdict"] == {"status": "RESOLVED", "action": "CONTINUE_DISPATCH"}
         assert body["call"]["placed"] is True
         assert body["call"]["provider_status"] == "completed"
@@ -659,9 +699,7 @@ def test_confirmed_scenario_resolves_to_the_cases_own_action() -> None:
 
 def test_cancelled_scenario_resolves_to_the_cases_own_alternate_action() -> None:
     with api_server() as base_url:
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "cancelled", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="cancelled", now_utc=NEAR)
 
         assert body["verdict"] == {"status": "RESOLVED_ALT", "action": "REASSIGN_TECHNICIAN"}
 
@@ -671,9 +709,7 @@ def test_voicemail_is_human_review_and_never_the_cancelled_action() -> None:
     cancellation, and no field of the response may say otherwise.
     """
     with api_server() as base_url:
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "voicemail", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="voicemail", now_utc=NEAR)
 
         assert body["verdict"] == {"status": "UNRESOLVED_AMBIGUOUS", "action": "HUMAN_REVIEW"}
         raw = json.dumps(body)
@@ -683,9 +719,7 @@ def test_voicemail_is_human_review_and_never_the_cancelled_action() -> None:
 
 def test_the_other_shipped_use_case_runs_through_the_same_endpoint() -> None:
     with api_server() as base_url:
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": "ghost-appointment", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case="ghost-appointment", now_utc=NEAR)
 
         assert body["verdict"] == {"status": "RESOLVED", "action": "KEEP_SLOT"}
         assert body["case"]["use_case"] == "appointment_confirmation"
@@ -696,11 +730,17 @@ def test_the_other_shipped_use_case_runs_through_the_same_endpoint() -> None:
 
 def test_a_created_resolution_can_be_read_back_unchanged() -> None:
     with api_server() as base_url:
-        _, created, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": NEAR})
-        status, fetched, _ = request(base_url, f"/api/resolutions/{created['id']}")
+        status, created = create_resolution(base_url, case=HERO, now_utc=NEAR)
+        assert status == 202
+        resolved = await_resolution(base_url, created["id"])
 
+        # The id survives the run, and a second read returns exactly what
+        # the first one did - GET is a projection of stored state, not a
+        # fresh computation.
+        assert resolved["id"] == created["id"]
+        status, again, _ = request(base_url, f"/api/resolutions/{created['id']}")
         assert status == 200
-        assert fetched == created
+        assert again == resolved
 
 
 def test_an_unknown_resolution_is_a_uniform_404() -> None:
@@ -753,7 +793,7 @@ def test_malformed_json_is_400() -> None:
 def test_an_unknown_case_is_404_and_reveals_nothing_about_the_filesystem() -> None:
     with api_server() as base_url:
         for name in ("nope", LIVE_FIXTURE, "../client", "ghost-appointment.json"):
-            status, body, _ = post(base_url, "/api/resolutions", {"case": name})
+            status, body = create_resolution(base_url, case=name)
             assert status == 404
             assert body["error"]["code"] == "case_not_found"
             assert name not in json.dumps(body), "the response must not echo the requested name"
@@ -762,9 +802,7 @@ def test_an_unknown_case_is_404_and_reveals_nothing_about_the_filesystem() -> No
 def test_an_invalid_scenario_is_422() -> None:
     with api_server() as base_url:
         for scenario in ("live", "REAL", "", None, 1, "resolved"):
-            status, body, _ = post(
-                base_url, "/api/resolutions", {"case": HERO, "scenario": scenario}
-            )
+            status, body = create_resolution(base_url, case=HERO, scenario=scenario)
             assert status == 422
             assert body["error"]["code"] == "invalid_scenario"
 
@@ -772,7 +810,7 @@ def test_an_invalid_scenario_is_422() -> None:
 def test_an_invalid_case_field_is_422() -> None:
     with api_server() as base_url:
         for case in (None, 1, "", [], {}):
-            status, body, _ = post(base_url, "/api/resolutions", {"case": case})
+            status, body = create_resolution(base_url, case=case)
             assert status == 422
             assert body["error"]["code"] == "invalid_case"
 
@@ -780,7 +818,7 @@ def test_an_invalid_case_field_is_422() -> None:
 def test_an_invalid_now_utc_is_422() -> None:
     with api_server() as base_url:
         for value in ("yesterday", "2026-13-45", 1757000000, None):
-            status, body, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": value})
+            status, body = create_resolution(base_url, case=HERO, now_utc=value)
             assert status == 422
             assert body["error"]["code"] == "invalid_now_utc"
 
@@ -798,7 +836,9 @@ def test_no_request_field_can_steer_the_engine(field: str) -> None:
     """
     with api_server_and_backend() as (base_url, backend):
         status, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "now_utc": NEAR, field: "anything"}
+            base_url,
+            "/api/resolutions",
+            {"case": HERO, "execution_mode": "fake", "now_utc": NEAR, field: "anything"},
         )
 
         assert status == 422, f"{field} must be refused, not ignored"
@@ -825,8 +865,7 @@ def test_the_api_never_talks_to_the_real_provider() -> None:
 def test_resolutions_work_without_any_calle_credential(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CALLE_API_KEY", raising=False)
     with api_server() as base_url:
-        status, body, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": NEAR})
-        assert status == 201
+        body = resolve_via_api(base_url, case=HERO, now_utc=NEAR)
         assert body["verdict"]["status"] == "RESOLVED"
 
 
@@ -836,12 +875,8 @@ def test_resolutions_work_without_any_calle_credential(monkeypatch: pytest.Monke
 def _every_resolution_response(base_url: str) -> list[dict[str, Any]]:
     bodies = []
     for scenario in ("confirmed", "cancelled", "voicemail", "blocked"):
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": scenario, "now_utc": NEAR}
-        )
-        bodies.append(body)
-    _, body, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": FAR})
-    bodies.append(body)
+        bodies.append(resolve_via_api(base_url, case=HERO, scenario=scenario, now_utc=NEAR))
+    bodies.append(resolve_via_api(base_url, case=HERO, now_utc=FAR))
     return bodies
 
 
@@ -867,9 +902,7 @@ def test_no_provider_internal_reaches_a_resolution_response() -> None:
 
 def test_the_call_projection_names_exactly_what_it_exposes() -> None:
     with api_server() as base_url:
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "confirmed", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
 
         assert set(body["call"]) == {"placed", "provider_status", "result"}
         assert set(body["call"]["result"]) <= {
@@ -888,9 +921,7 @@ def test_a_compliance_reason_carrying_a_phone_number_is_masked() -> None:
     dialled. It must still explain itself, without the digits.
     """
     with api_server() as base_url:
-        _, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "blocked", "now_utc": NEAR}
-        )
+        body = resolve_via_api(base_url, case=HERO, scenario="blocked", now_utc=NEAR)
 
         reasons = [check["reason"] for check in body["compliance"]["checks"]]
         joined = " ".join(reasons)
@@ -1069,16 +1100,24 @@ def test_forty_concurrent_posts_stay_consistent_over_http() -> None:
         results: list[tuple[int, str]] = []
         lock = threading.Lock()
 
+        failures: list[BaseException] = []
+
         def worker(index: int) -> None:
-            scenario = ("confirmed", "cancelled", "voicemail")[index % 3]
-            barrier.wait(timeout=20)
-            status, body, _ = post(
-                base_url,
-                "/api/resolutions",
-                {"case": HERO, "scenario": scenario, "now_utc": NEAR},
-            )
-            with lock:
-                results.append((status, body["id"]))
+            # Records its own failure rather than letting threading
+            # swallow it: a silently missing result reads as "the server
+            # dropped it", which is a different bug from "the client
+            # raised".
+            try:
+                scenario = ("confirmed", "cancelled", "voicemail")[index % 3]
+                barrier.wait(timeout=20)
+                status, body = create_resolution(
+                    base_url, case=HERO, scenario=scenario, now_utc=NEAR
+                )
+                with lock:
+                    results.append((status, body["id"]))
+            except BaseException as exc:  # noqa: BLE001 - re-raised below
+                with lock:
+                    failures.append(exc)
 
         workers = [threading.Thread(target=worker, args=(i,)) for i in range(40)]
         for worker_thread in workers:
@@ -1086,17 +1125,23 @@ def test_forty_concurrent_posts_stay_consistent_over_http() -> None:
         for worker_thread in workers:
             worker_thread.join(timeout=60)
 
+        assert not failures, f"a client thread raised: {failures[0]!r}"
         assert len(results) == 40, "every concurrent POST must have answered"
-        assert all(status == 201 for status, _ in results), "the 201 contract holds under load"
+        assert all(status == 202 for status, _ in results), "the 202 contract holds under load"
         ids = [rid for _, rid in results]
         assert len(set(ids)) == 40, "ids collided under concurrency"
-        assert backend.creates == 40
 
-        # Every one of them is still readable through its own id.
-        for rid in ids[-10:]:
-            status, fetched, _ = request(base_url, f"/api/resolutions/{rid}")
-            assert status == 200
-            assert fetched["id"] == rid
+        # Every one of them runs to a verdict and stays readable by id.
+        for rid in ids:
+            resolved = await_resolution(base_url, rid, timeout=30.0)
+            assert resolved["id"] == rid
+            assert resolved["state"] == "completed"
+            assert resolved["verdict"] is not None
+
+        # backend.creates counts fake-server calls, and fake_server.py
+        # increments it outside its own lock, so this is a sanity check
+        # rather than a guarantee - it is not this repository's to fix.
+        assert backend.creates == 40
 
 
 # --- 3.6-a: the polling loop is bounded ------------------------------
@@ -1133,37 +1178,44 @@ def wedged_provider(poll_seconds: float = 0.05) -> Iterator[None]:
 
 
 def test_a_call_that_never_terminates_fails_technically_without_a_verdict() -> None:
+    """The failure is now a stored transport state rather than a 502:
+    the run was accepted, started, and could not finish. What must not
+    change is that it stays a technical failure - no verdict is invented
+    from it, and in particular nothing reads as a cancellation.
+    """
     with api_server_and_backend() as (base_url, backend):
         with wedged_provider():
             started = time.monotonic()
-            status, body, _ = post(
-                base_url,
-                "/api/resolutions",
-                {"case": HERO, "scenario": "confirmed", "now_utc": NEAR},
+            status, created = create_resolution(
+                base_url, case=HERO, scenario="confirmed", now_utc=NEAR
             )
+            assert status == 202
+            body = await_resolution(base_url, created["id"])
             elapsed = time.monotonic() - started
 
-        assert status == 502
+        assert body["state"] == "failed"
+        assert body["verdict"] is None, "a technical failure has no verdict"
         assert body["error"]["code"] == "resolution_failed"
 
-        # A technical failure is a technical failure. No verdict is
-        # invented, and nothing in the reply can be read as one.
-        raw = json.dumps(body)
-        assert "verdict" not in body
+        raw = json.dumps(body["verdict"]) + json.dumps(body["error"])
         for forbidden in (
-            "RESOLVED", "RESOLVED_ALT", "CANCELLED", "UNRESOLVED_AMBIGUOUS",
+            "RESOLVED", "CANCELLED", "UNRESOLVED",
             "REASSIGN_TECHNICIAN", "CONTINUE_DISPATCH", "HUMAN_REVIEW",
         ):
             assert forbidden not in raw, f"{forbidden} appeared in a technical failure"
-        assert "Traceback" not in raw
-        assert set(body) == {"error"}
+        assert "Traceback" not in json.dumps(body)
 
-        # The request returned instead of pinning a worker thread forever.
-        assert elapsed < 5.0, f"the request took {elapsed:.1f}s; the poll bound did not fire"
+        # The poll bound fired instead of pinning a worker forever.
+        assert elapsed < 5.0, f"the run took {elapsed:.1f}s; the poll bound did not fire"
         assert backend.creates == 1, "the call was created; only its completion never came"
 
 
-def test_a_timed_out_resolution_is_not_stored() -> None:
+def test_a_timed_out_resolution_is_stored_as_failed() -> None:
+    """The opposite of what the synchronous contract did, and
+    deliberately: a run that was accepted has an id the client is holding,
+    so it must be readable afterwards. What it must never hold is a
+    verdict.
+    """
     from api.backend import FakeCallBackend
     from api.server import create_server
     from api.store import ResolutionStore
@@ -1171,7 +1223,10 @@ def test_a_timed_out_resolution_is_not_stored() -> None:
     backend = FakeCallBackend()
     backend.start()
     resolutions = ResolutionStore()
-    server = create_server("127.0.0.1", 0, backend=backend, resolutions=resolutions)
+    executor = ThreadPoolExecutor(max_workers=2)
+    server = create_server(
+        "127.0.0.1", 0, backend=backend, resolutions=resolutions, executor=executor
+    )
     thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.0005}, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
@@ -1179,15 +1234,20 @@ def test_a_timed_out_resolution_is_not_stored() -> None:
     try:
         assert len(resolutions) == 0
         with wedged_provider():
-            status, _, _ = post(
-                base_url, "/api/resolutions", {"case": HERO, "scenario": "confirmed", "now_utc": NEAR}
+            status, created = create_resolution(
+                base_url, case=HERO, scenario="confirmed", now_utc=NEAR
             )
-        assert status == 502
-        assert len(resolutions) == 0, "a failed run must leave nothing behind"
+            assert status == 202
+            body = await_resolution(base_url, created["id"])
+
+        assert body["state"] == "failed"
+        assert body["verdict"] is None
+        assert len(resolutions) == 1, "the client holds this id and must be able to read it"
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+        executor.shutdown(wait=True)
         backend.stop()
 
 
@@ -1199,14 +1259,13 @@ def test_the_server_still_works_after_a_timeout() -> None:
 
     with api_server_and_backend() as (base_url, _):
         with wedged_provider():
-            assert post(base_url, "/api/resolutions", {"case": HERO, "now_utc": NEAR})[0] == 502
+            status, created = create_resolution(base_url, case=HERO, now_utc=NEAR)
+            assert status == 202
+            assert await_resolution(base_url, created["id"])["state"] == "failed"
 
         # The context restored both the provider and the real bound, so
         # this second run is the ordinary path again.
-        status, body, _ = post(
-            base_url, "/api/resolutions", {"case": HERO, "scenario": "confirmed", "now_utc": NEAR}
-        )
-        assert status == 201
+        body = resolve_via_api(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
         assert body["verdict"] == {"status": "RESOLVED", "action": "CONTINUE_DISPATCH"}
         assert request(base_url, "/api/health")[0] == 200
 
@@ -1239,10 +1298,680 @@ def test_the_normal_branches_are_unaffected_by_the_bound() -> None:
             ("blocked", "UNRESOLVED_CALL_BLOCKED"),
         ):
             started = time.monotonic()
-            status, body, _ = post(
-                base_url, "/api/resolutions", {"case": HERO, "scenario": scenario, "now_utc": NEAR}
-            )
+            body = resolve_via_api(base_url, case=HERO, scenario=scenario, now_utc=NEAR)
             elapsed = time.monotonic() - started
-            assert status == 201
             assert body["verdict"]["status"] == expected
             assert elapsed < 5.0, f"{scenario} took {elapsed:.1f}s, uncomfortably close to the bound"
+
+
+# --- L3: asynchronous execution --------------------------------------
+#
+# POST accepts and returns; the work happens on a pool and is read back
+# with GET. The states a client sees are the backend's own, not a timer.
+
+
+def test_post_returns_immediately_with_a_queued_entry() -> None:
+    with api_server() as base_url:
+        started = time.monotonic()
+        status, body = create_resolution(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+        elapsed = time.monotonic() - started
+
+        assert status == 202
+        assert body["state"] == "queued"
+        assert body["id"].startswith("res_")
+        assert body["mode"] == "fake"
+        assert body["case"]["name"] == HERO
+        # Accepting must not wait for the work.
+        assert elapsed < 2.0, f"POST took {elapsed:.2f}s; it should not run the resolution"
+
+
+def test_the_queued_entry_already_has_the_full_contract_shape() -> None:
+    """A client should never read a payload whose keys arrive one at a
+    time. The seeded nulls are the job's, not the observer's.
+    """
+    with api_server() as base_url:
+        _, queued = create_resolution(base_url, case=HERO, now_utc=NEAR)
+        resolved = await_resolution(base_url, queued["id"])
+
+        assert set(queued) == set(resolved), "the shape must not change as the run progresses"
+        for key in ("evidence", "reasoning", "call_decision", "compliance", "verdict"):
+            assert queued[key] is None, f"{key} cannot be known at queue time"
+        # call is the exception, and knowingly: nothing has been placed.
+        assert queued["call"] == {"placed": False, "provider_status": None, "result": None}
+        assert queued["error"] is None
+
+
+def test_the_queued_shape_matches_what_a_finished_run_produces() -> None:
+    """queued_entry and resolution_payload both build the public
+    contract. Two builders, one contract - so their key sets are pinned
+    against each other rather than trusted to stay in step.
+    """
+    import io
+    from contextlib import redirect_stdout
+
+    from api.serialize import resolution_payload
+    from api.server import queued_entry
+    from api.store import CaseStore
+    from client import parse_utc_timestamp
+    from fake_server import FakeCalleServer
+    from pipeline import ResolutionRequest, resolve
+
+    case = CaseStore().get(HERE.name and "critical-service-escalation")
+    seeded = queued_entry("res_x", case, "fake")
+
+    with FakeCalleServer() as server, redirect_stdout(io.StringIO()):
+        resolution = resolve(
+            ResolutionRequest(
+                case_path=str(CaseStore().path_for("critical-service-escalation")),
+                base_url=server.base_url,
+                execute=True,
+                poll_interval_seconds=0.01,
+                now_utc=parse_utc_timestamp(NEAR),
+            )
+        )
+    finished = resolution_payload(resolution, "res_x", "completed", "fake")
+
+    assert set(seeded) == set(finished)
+    assert set(seeded["case"]) == set(finished["case"])
+    assert set(seeded["call"]) == set(finished["call"])
+
+
+def test_a_resolution_really_passes_through_running() -> None:
+    """Observed, not assumed: the wedged provider holds the run open
+    long enough for a GET to catch it mid-flight, with compliance already
+    decided and no verdict yet.
+    """
+    with api_server() as base_url:
+        with wedged_provider(poll_seconds=2.0):
+            _, created = create_resolution(
+                base_url, case=HERO, scenario="confirmed", now_utc=NEAR
+            )
+            # Wait for the moment the frontend calls "Calling": still
+            # running, and a call now exists. Breaking on the first sight
+            # of `running` would be a race - that can be the instant
+            # after on_start, before compliance has even been consulted.
+            seen_running = None
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                _, body, _ = request(base_url, f"/api/resolutions/{created['id']}")
+                if body["state"] == "running" and body["call"]["placed"]:
+                    seen_running = body
+                    break
+                time.sleep(0.005)
+
+            assert seen_running is not None, "the run never reported itself as running with a call"
+            assert seen_running["verdict"] is None, "no verdict exists while still running"
+            assert seen_running["reasoning"]["decision_critical"] is True
+            assert seen_running["compliance"]["allowed"] is True
+            assert seen_running["call"]["placed"] is True, "a call was created; that is real"
+
+            await_resolution(base_url, created["id"])
+
+
+def test_the_observer_receives_the_pipelines_real_events() -> None:
+    """Every stage of the finished payload is present, which can only
+    happen if each hook actually fired.
+    """
+    with api_server() as base_url:
+        body = resolve_via_api(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+
+        assert [rule["rule_name"] for rule in body["reasoning"]["rules"]] == [
+            "R1_structured_state",
+            "R2_human_qualification",
+            "R3_unresolved_evidence",
+            "R4_decision_deadline",
+        ]
+        assert len(body["evidence"]) == 3
+        assert body["compliance"]["jurisdiction_chain"] == ["us_federal"]
+        assert body["compliance"]["exempted_for_use_case"]
+        assert body["call"]["provider_status"] == "completed"
+        assert body["verdict"]["status"] == "RESOLVED"
+
+
+def test_several_resolutions_run_concurrently_without_mixing_up() -> None:
+    """Different scenarios submitted together must each come back with
+    their own verdict, not somebody else's.
+    """
+    with api_server() as base_url:
+        wanted = {
+            "confirmed": "RESOLVED",
+            "cancelled": "RESOLVED_ALT",
+            "voicemail": "UNRESOLVED_AMBIGUOUS",
+            "blocked": "UNRESOLVED_CALL_BLOCKED",
+        }
+        created = {}
+        for scenario in wanted:
+            status, body = create_resolution(
+                base_url, case=HERO, scenario=scenario, now_utc=NEAR
+            )
+            assert status == 202
+            created[scenario] = body["id"]
+
+        assert len(set(created.values())) == 4
+        for scenario, expected in wanted.items():
+            resolved = await_resolution(base_url, created[scenario])
+            assert resolved["verdict"]["status"] == expected, f"{scenario} came back wrong"
+
+
+def test_the_server_stays_healthy_after_a_worker_fails() -> None:
+    with api_server() as base_url:
+        with wedged_provider():
+            _, created = create_resolution(base_url, case=HERO, now_utc=NEAR)
+            assert await_resolution(base_url, created["id"])["state"] == "failed"
+
+        assert request(base_url, "/api/health")[0] == 200
+        assert request(base_url, "/api/cases")[0] == 200
+        assert resolve_via_api(base_url, case=HERO, now_utc=NEAR)["state"] == "completed"
+
+
+def test_an_evicted_entry_does_not_kill_the_resolution() -> None:
+    """The store is a volatile projection. Losing it must not abort the
+    engine - StoreObserver swallows the eviction, and the run still
+    finishes, silently.
+    """
+    import io
+    from contextlib import redirect_stdout
+
+    from api.progress import StoreObserver
+    from api.store import ResolutionNotFoundError, ResolutionStore
+    from client import parse_utc_timestamp
+    from fake_server import FakeCalleServer
+    from pipeline import ResolutionRequest, resolve
+
+    store = ResolutionStore(max_entries=1)
+    rid = ResolutionStore.new_id()
+    store.put(rid, {"id": rid, "state": "queued"})
+    store.put(ResolutionStore.new_id(), {"state": "queued"})  # evicts rid
+
+    with pytest.raises(ResolutionNotFoundError):
+        store.get(rid)
+
+    with FakeCalleServer() as server, redirect_stdout(io.StringIO()):
+        resolution = resolve(
+            ResolutionRequest(
+                case_path=str(HERE / "cases" / f"{HERO}.json"),
+                base_url=server.base_url,
+                execute=True,
+                poll_interval_seconds=0.01,
+                now_utc=__import__("client").parse_utc_timestamp(NEAR),
+            ),
+            StoreObserver(store, rid),
+        )
+
+    assert resolution.verdict is not None, "the engine must finish even with nowhere to publish"
+    assert resolution.verdict.status == "RESOLVED"
+    assert parse_utc_timestamp is not None  # import used above
+
+
+# --- L3: execution_mode -----------------------------------------------
+
+
+def test_execution_mode_is_required() -> None:
+    with api_server() as base_url:
+        status, body, _ = post(base_url, "/api/resolutions", {"case": HERO, "now_utc": NEAR})
+
+        assert status == 422
+        assert body["error"]["code"] == "invalid_execution_mode"
+
+
+@pytest.mark.parametrize("mode", ["FAKE", "Fake", "", None, 1, "simulation", "real"])
+def test_an_unknown_execution_mode_is_422(mode: Any) -> None:
+    with api_server() as base_url:
+        status, body, _ = post(
+            base_url, "/api/resolutions", {"case": HERO, "execution_mode": mode}
+        )
+
+        assert status == 422
+        assert body["error"]["code"] == "invalid_execution_mode"
+
+
+def test_live_is_501_not_422_and_places_nothing() -> None:
+    """live is a value the architecture recognises and this build does
+    not implement. 422 would say the client got it wrong; 501 says the
+    server cannot do it. Accepting it would claim a capability that does
+    not exist.
+    """
+    with api_server_and_backend() as (base_url, backend):
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            {"case": HERO, "execution_mode": "live", "now_utc": NEAR},
+        )
+
+        assert status == 501
+        assert body["error"]["code"] == "live_not_available"
+        assert "real call" in body["error"]["message"]
+        assert backend.creates == 0, "a refused live request must run nothing"
+
+
+def test_live_is_refused_before_the_case_is_even_looked_up() -> None:
+    """A capability this build lacks makes the rest of the request moot,
+    so the mode is checked first.
+    """
+    with api_server() as base_url:
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            {"case": "definitely-not-a-case", "execution_mode": "live"},
+        )
+
+        assert status == 501
+        assert body["error"]["code"] == "live_not_available"
+
+
+def test_no_live_credential_or_destination_field_is_accepted() -> None:
+    """The live contract does not exist yet, so none of its fields do
+    either - they are unknown fields, refused like any other.
+    """
+    with api_server() as base_url:
+        for field in ("api_key", "call_e_api_key", "destination", "authorize_destination"):
+            status, body, _ = post(
+                base_url,
+                "/api/resolutions",
+                {"case": HERO, "execution_mode": "fake", field: "x"},
+            )
+            assert status == 422
+            assert body["error"]["code"] == "unknown_field"
+
+
+def test_health_still_reports_fake_only() -> None:
+    with api_server() as base_url:
+        _, body, _ = request(base_url, "/api/health")
+
+        assert body["mode"] == "fake"
+
+
+# --- L3: nothing sensitive survives the async path --------------------
+
+
+def test_no_secret_reaches_a_stored_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = "iams_live_async_sentinel_must_never_appear"
+    monkeypatch.setenv("CALLE_API_KEY", sentinel)
+    case = load_case(HERE / "cases" / f"{HERO}.json")
+
+    with api_server() as base_url:
+        bodies = [
+            resolve_via_api(base_url, case=HERO, scenario=scenario, now_utc=NEAR)
+            for scenario in ("confirmed", "cancelled", "voicemail", "blocked")
+        ]
+        raw = json.dumps(bodies)
+
+        assert sentinel not in raw
+        assert "CALLE_API_KEY" not in raw
+        assert "api_key" not in raw
+        assert case.call_phone not in raw
+        assert not re.search(r"\+[1-9][0-9]{6,14}", raw)
+        assert case.call_task_hint[:40] not in raw
+        assert "Required disclosure" not in raw
+        assert "transcript" not in raw
+        assert "provider_call_id" not in raw
+        assert "call_fake" not in raw
+        assert "evidence_cited" not in raw
+
+
+# --- L3.4: the shutdown sequence, proved rather than asserted --------
+#
+# main() tears down in a documented order: stop accepting, let in-flight
+# resolutions finish, then take the backend away. These tests exercise
+# that order for real, and one of them deliberately gets it wrong so the
+# right one is not passing vacuously.
+
+
+@contextmanager
+def slow_provider(delay: float = 0.25) -> Iterator[None]:
+    """Delay every poll, without changing what it returns.
+
+    Wraps CallEClient.get_call around the real one, so the fake backend
+    stays in the loop: if it goes away mid-run, the call genuinely fails
+    the way it would in production. fake_server.py is untouched and
+    nothing is faked - only slowed, so a resolution can be caught while
+    it is still in flight.
+    """
+    from client import CallEClient
+
+    original = CallEClient.get_call
+
+    def delayed(self: Any, call_id: str) -> Any:
+        time.sleep(delay)
+        return original(self, call_id)
+
+    CallEClient.get_call = delayed  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        CallEClient.get_call = original  # type: ignore[method-assign]
+
+
+@contextmanager
+def manual_server() -> Iterator[tuple[str, Any, Any, Any]]:
+    """A server whose teardown the test performs itself, step by step."""
+    from api.backend import FakeCallBackend
+    from api.server import MAX_WORKERS, create_server
+    from api.store import ResolutionStore
+
+    backend = FakeCallBackend()
+    backend.start()
+    executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+    resolutions = ResolutionStore()
+    server = create_server(
+        "127.0.0.1", 0, backend=backend, executor=executor, resolutions=resolutions
+    )
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.0005}, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        yield f"http://{host}:{port}", server, executor, backend
+    finally:
+        try:
+            server.shutdown()
+            server.server_close()
+        except Exception:  # noqa: BLE001 - the test may have closed it already
+            pass
+        thread.join(timeout=5)
+        executor.shutdown(wait=True)
+        backend.stop()
+
+
+def test_shutdown_lets_an_in_flight_resolution_finish_before_the_backend_goes() -> None:
+    """The whole point of the order. A resolution is deliberately still
+    running when teardown starts; if the backend were stopped first it
+    would die on a refused connection and land in `failed`. Reaching
+    `completed` is the evidence the order held.
+    """
+    from api.store import ResolutionStore  # noqa: F401 - typing only
+
+    with slow_provider(delay=0.25), manual_server() as (base_url, server, executor, backend):
+        status, created = create_resolution(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+        assert status == 202
+
+        resolutions = server.resolutions
+        # Wait until the run is genuinely under way, so this is not a
+        # test of a job that had already finished.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if resolutions.get(created["id"])["state"] == "running":
+                break
+            time.sleep(0.005)
+        assert resolutions.get(created["id"])["state"] == "running", "nothing was in flight"
+
+        server.shutdown()
+        server.server_close()
+        executor.shutdown(wait=True)
+
+        entry = resolutions.get(created["id"])
+        assert entry["state"] == "completed", "shutdown did not wait for the resolution"
+        assert entry["verdict"] == {"status": "RESOLVED", "action": "CONTINUE_DISPATCH"}
+
+        backend.stop()
+        assert backend.running is False
+
+
+def test_stopping_the_backend_first_breaks_the_run_which_is_why_the_order_exists() -> None:
+    """The counter-proof. Deliberately wrong order: the backend is taken
+    away while a resolution is polling it. The run must fail as a
+    technical failure - never with an invented verdict - and this is what
+    makes the previous test meaningful rather than vacuous.
+
+    Slow because CallEClient retries a GET four times with 1+2+4 s of
+    backoff before giving up; that retry policy is client.py's and is not
+    this phase's to change.
+    """
+    with slow_provider(delay=0.25), manual_server() as (base_url, server, executor, backend):
+        status, created = create_resolution(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+        assert status == 202
+        resolutions = server.resolutions
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if resolutions.get(created["id"])["state"] == "running":
+                break
+            time.sleep(0.005)
+
+        backend.stop()  # wrong order, on purpose
+        executor.shutdown(wait=True)
+
+        entry = resolutions.get(created["id"])
+        assert entry["state"] == "failed"
+        assert entry["verdict"] is None, "a lost backend must never produce a verdict"
+        assert entry["error"]["code"] == "resolution_failed"
+
+
+def test_nothing_can_reach_the_backend_once_it_is_stopped() -> None:
+    """Proved at the socket, not inferred: after stop() the port accepts
+    nothing and can be bound again, so no worker could still be talking
+    to it.
+    """
+    import socket
+
+    from api.backend import FakeCallBackend
+
+    backend = FakeCallBackend()
+    backend.start()
+    host, port = backend.base_url.removeprefix("http://").split(":")
+    backend.stop()
+
+    probe = socket.socket()
+    probe.settimeout(1.0)
+    try:
+        with pytest.raises(OSError):
+            probe.connect((host, int(port)))
+    finally:
+        probe.close()
+
+    rebind = socket.socket()
+    rebind.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        rebind.bind((host, int(port)))
+    finally:
+        rebind.close()
+
+
+def test_main_tears_down_in_the_order_these_tests_exercise() -> None:
+    """The sequence above is performed by hand; main() performs it for
+    real. Pinned against main()'s own source so the tested order and the
+    shipped order cannot drift apart.
+    """
+    import ast
+
+    import api.server as server_module
+
+    source = Path(server_module.__file__).read_text(encoding="utf-8")
+    main_fn = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+    finally_body = next(
+        handler.finalbody for handler in ast.walk(main_fn) if isinstance(handler, ast.Try)
+    )
+    calls = [ast.unparse(stmt.value) for stmt in finally_body if isinstance(stmt, ast.Expr)]
+
+    assert calls == [
+        "server.server_close()",
+        "executor.shutdown(wait=True)",
+        "backend.stop()",
+    ], f"main() tears down in the wrong order: {calls}"
+
+
+# --- L3.4: concurrency on the fake backend ---------------------------
+
+
+def test_more_resolutions_than_workers_all_complete() -> None:
+    """The pool queues rather than rejecting, and `queued` is a real
+    state a client can observe while it waits.
+    """
+    from api.server import MAX_WORKERS
+
+    with api_server() as base_url:
+        ids = []
+        for index in range(MAX_WORKERS * 3):
+            status, body = create_resolution(
+                base_url,
+                case=HERO,
+                scenario=("confirmed", "cancelled", "voicemail")[index % 3],
+                now_utc=NEAR,
+            )
+            assert status == 202
+            assert body["state"] == "queued"
+            ids.append(body["id"])
+
+        assert len(set(ids)) == MAX_WORKERS * 3
+        for resolution_id in ids:
+            assert await_resolution(base_url, resolution_id, timeout=30.0)["state"] == "completed"
+
+
+def test_a_burst_of_failing_workers_does_not_take_the_server_with_them() -> None:
+    with api_server() as base_url:
+        with wedged_provider():
+            ids = [create_resolution(base_url, case=HERO, now_utc=NEAR)[1]["id"] for _ in range(8)]
+            for resolution_id in ids:
+                assert await_resolution(base_url, resolution_id, timeout=30.0)["state"] == "failed"
+
+        assert request(base_url, "/api/health")[0] == 200
+        assert request(base_url, "/api/cases")[0] == 200
+        healthy = resolve_via_api(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+        assert healthy["verdict"]["status"] == "RESOLVED"
+
+
+def test_concurrent_runs_of_both_cases_keep_their_own_verdicts() -> None:
+    with api_server() as base_url:
+        wanted = [
+            (HERO, "confirmed", "CONTINUE_DISPATCH"),
+            (HERO, "cancelled", "REASSIGN_TECHNICIAN"),
+            ("ghost-appointment", "confirmed", "KEEP_SLOT"),
+            ("ghost-appointment", "cancelled", "RELEASE_SLOT"),
+        ]
+        barrier = threading.Barrier(len(wanted))
+        outcomes: dict[int, Any] = {}
+        lock = threading.Lock()
+        failures: list[BaseException] = []
+
+        def worker(index: int) -> None:
+            try:
+                case, scenario, _ = wanted[index]
+                barrier.wait(timeout=20)
+                with lock:
+                    outcomes[index] = resolve_via_api(
+                        base_url, case=case, scenario=scenario, now_utc=NEAR
+                    )
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    failures.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(wanted))]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+
+        assert not failures, f"a client thread raised: {failures[0]!r}"
+        for index, (case, _, expected_action) in enumerate(wanted):
+            assert outcomes[index]["case"]["name"] == case
+            assert outcomes[index]["verdict"]["action"] == expected_action
+
+
+# --- L3.4: no real CALL-E is reachable -------------------------------
+
+
+def test_every_client_the_server_builds_targets_the_local_fake_backend() -> None:
+    """A runtime proof rather than a source scan: every CallEClient
+    constructed while serving is recorded, and each one must be pointed
+    at this process's loopback backend with allow_live off.
+    """
+    from client import CallEClient, REAL_API_BASE_URL
+
+    constructed: list[tuple[str, bool]] = []
+    original_init = CallEClient.__post_init__
+
+    def recording_post_init(self: Any) -> None:
+        constructed.append((self.base_url, self.allow_live))
+        original_init(self)
+
+    CallEClient.__post_init__ = recording_post_init  # type: ignore[method-assign]
+    try:
+        with api_server_and_backend() as (base_url, backend):
+            for scenario in ("confirmed", "cancelled", "voicemail"):
+                resolve_via_api(base_url, case=HERO, scenario=scenario, now_utc=NEAR)
+            expected_backend = backend.base_url
+    finally:
+        CallEClient.__post_init__ = original_init  # type: ignore[method-assign]
+
+    assert constructed, "no client was built; the test proved nothing"
+    for target, allow_live in constructed:
+        assert target == expected_backend, f"a client was pointed at {target!r}"
+        assert target.startswith("http://127.0.0.1:")
+        assert allow_live is False
+        assert REAL_API_BASE_URL not in target
+
+
+def test_the_real_provider_host_appears_nowhere_in_the_http_layer() -> None:
+    import api.server as server_module
+
+    source = Path(server_module.__file__).read_text(encoding="utf-8")
+
+    assert "heycall-e.com" not in source
+    assert "allow_live=False" in source
+    assert "base_url=self.backend.base_url" in source
+    assert "allow_live=True" not in source
+
+
+def test_a_blocked_run_places_no_call_at_all() -> None:
+    with api_server_and_backend() as (base_url, backend):
+        body = resolve_via_api(base_url, case=HERO, scenario="blocked", now_utc=NEAR)
+
+        assert body["verdict"]["status"] == "UNRESOLVED_CALL_BLOCKED"
+        assert body["call"] == {"placed": False, "provider_status": None, "result": None}
+        assert backend.creates == 0
+
+
+# --- L3.4: nothing leaks, including while running and when failed ----
+
+
+def test_a_running_resolution_leaks_nothing_either() -> None:
+    """The anti-leak sweep covered finished payloads. A partially filled
+    one goes through the same projections, and this checks it does.
+    """
+    case = load_case(HERE / "cases" / f"{HERO}.json")
+
+    with api_server() as base_url:
+        with wedged_provider(poll_seconds=2.0):
+            _, created = create_resolution(base_url, case=HERO, scenario="confirmed", now_utc=NEAR)
+            snapshots = []
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                _, body, _ = request(base_url, f"/api/resolutions/{created['id']}")
+                snapshots.append(body)
+                if body["state"] in ("completed", "failed"):
+                    break
+                time.sleep(0.005)
+            await_resolution(base_url, created["id"])
+
+        raw = json.dumps(snapshots)
+        assert case.call_phone not in raw
+        assert not re.search(r"\+[1-9][0-9]{6,14}", raw)
+        assert case.call_task_hint[:40] not in raw
+        assert "Required disclosure" not in raw
+        assert "transcript" not in raw
+        assert "provider_call_id" not in raw
+        assert "call_fake" not in raw
+        assert "evidence_cited" not in raw
+        assert any(s["state"] == "running" for s in snapshots), "no running snapshot was captured"
+
+
+def test_a_failed_resolution_leaks_nothing_and_says_nothing_internal() -> None:
+    with api_server() as base_url:
+        with wedged_provider():
+            _, created = create_resolution(base_url, case=HERO, now_utc=NEAR)
+            body = await_resolution(base_url, created["id"])
+
+        assert body["state"] == "failed"
+        raw = json.dumps(body)
+        assert "Traceback" not in raw
+        assert "TimeoutError" not in raw
+        assert "call_fake" not in raw
+        assert "127.0.0.1" not in raw, "the internal backend URL reached the client"
+        assert "C:\\" not in raw and "/Users/" not in raw
+        assert body["error"] == {
+            "code": "resolution_failed",
+            "message": "the resolution could not be completed",
+        }

--- a/apps/python/reality-resolver/tests/test_api.py
+++ b/apps/python/reality-resolver/tests/test_api.py
@@ -340,6 +340,7 @@ def test_authorized_options_returns_minimal_preflight_headers(monkeypatch: pytes
             assert "POST" in response.headers["Access-Control-Allow-Methods"]
             assert "OPTIONS" in response.headers["Access-Control-Allow-Methods"]
             assert "Content-Type" in response.headers["Access-Control-Allow-Headers"]
+            assert "X-Calle-Api-Key" in response.headers["Access-Control-Allow-Headers"]
             assert response.headers["Vary"] == "Origin"
             assert response.read() == b""
 

--- a/apps/python/reality-resolver/tests/test_api.py
+++ b/apps/python/reality-resolver/tests/test_api.py
@@ -2,9 +2,8 @@
 
 Everything here runs against a server on a random loopback port, driven
 with urllib from the standard library - the same shape as the rest of
-this suite. No test reaches a provider, and in this phase the server has
-no code path that could: it cannot start a resolution and imports no
-CALL-E client.
+this suite. Fake tests use the local backend; live tests replace the
+provider client with an in-process stub and never reach the real API.
 """
 
 from __future__ import annotations
@@ -69,11 +68,12 @@ def api_server() -> Iterator[str]:
         yield base_url
 
 
-def post(base_url: str, path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+def post(
+    base_url: str, path: str, payload: Any, headers: dict[str, str] | None = None
+) -> tuple[int, Any, dict[str, str]]:
     data = payload if isinstance(payload, (bytes, bytearray)) else json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        f"{base_url}{path}", data=data, method="POST", headers={"Content-Type": "application/json"}
-    )
+    request_headers = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(f"{base_url}{path}", data=data, method="POST", headers=request_headers)
     try:
         with urllib.request.urlopen(req, timeout=15) as response:
             return response.status, json.loads(response.read()), dict(response.headers)
@@ -150,7 +150,7 @@ def test_health_returns_ok_and_nothing_else() -> None:
         assert headers["Content-Type"] == "application/json"
         assert int(headers["Content-Length"]) > 0
         assert body["status"] == "ok"
-        assert body["mode"] == "fake"
+        assert body["mode"] == "mixed"
         assert body["engine_version"]
         # A health endpoint is where configuration classically leaks.
         assert set(body) == {"status", "mode", "engine_version"}
@@ -426,7 +426,7 @@ def test_post_body_then_get_on_the_same_connection_stays_clean() -> None:
         assert content_type == "application/json"
         payload = json.loads(body)
         assert payload["status"] == "ok"
-        assert payload["mode"] == "fake"
+        assert payload["mode"] == "mixed"
         assert "MUST_NOT_BE_REFLECTED" not in body, "the previous body contaminated this response"
         assert "<html" not in body.lower()
 
@@ -842,24 +842,25 @@ def test_no_request_field_can_steer_the_engine(field: str) -> None:
         )
 
         assert status == 422, f"{field} must be refused, not ignored"
-        assert body["error"]["code"] == "unknown_field"
+        expected_code = "field_not_allowed" if field == "authorize_destination" else "unknown_field"
+        assert body["error"]["code"] == expected_code
         assert backend.creates == 0, "a refused request must not have run anything"
 
 
-def test_the_api_never_talks_to_the_real_provider() -> None:
-    """base_url comes from the backend this process started. There is no
-    request shape that changes it, and no live mode to select.
+def test_the_api_selects_the_server_side_provider_target() -> None:
+    """The client cannot choose the provider URL or live flags. Fake uses
+    the loopback backend; live construction is covered separately.
     """
     import api.server as server_module
 
     source = Path(server_module.__file__).read_text(encoding="utf-8")
-    assert "api.heycall-e.com" not in source
-    assert "allow_live=False" in source
-    assert "base_url=self.backend.base_url" in source
+    assert "REAL_API_BASE_URL" in source
+    assert "allow_live=live" in source
+    assert "base_url=REAL_API_BASE_URL if live else self.backend.base_url" in source
 
     with api_server() as base_url:
         _, body, _ = request(base_url, "/api/health")
-        assert body["mode"] == "fake"
+        assert body["mode"] == "mixed"
 
 
 def test_resolutions_work_without_any_calle_credential(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1195,7 +1196,7 @@ def test_a_call_that_never_terminates_fails_technically_without_a_verdict() -> N
 
         assert body["state"] == "failed"
         assert body["verdict"] is None, "a technical failure has no verdict"
-        assert body["error"]["code"] == "resolution_failed"
+        assert body["error"]["code"] == "calle_timeout"
 
         raw = json.dumps(body["verdict"]) + json.dumps(body["error"])
         for forbidden in (
@@ -1525,11 +1526,9 @@ def test_an_unknown_execution_mode_is_422(mode: Any) -> None:
         assert body["error"]["code"] == "invalid_execution_mode"
 
 
-def test_live_is_501_not_422_and_places_nothing() -> None:
-    """live is a value the architecture recognises and this build does
-    not implement. 422 would say the client got it wrong; 501 says the
-    server cannot do it. Accepting it would claim a capability that does
-    not exist.
+def test_live_requires_api_key_and_live_fields() -> None:
+    """A live request using fake-only fields is rejected before work is
+    accepted; valid live construction is covered by dedicated tests.
     """
     with api_server_and_backend() as (base_url, backend):
         status, body, _ = post(
@@ -1538,47 +1537,47 @@ def test_live_is_501_not_422_and_places_nothing() -> None:
             {"case": HERO, "execution_mode": "live", "now_utc": NEAR},
         )
 
-        assert status == 501
-        assert body["error"]["code"] == "live_not_available"
-        assert "real call" in body["error"]["message"]
+        assert status == 422
+        assert body["error"]["code"] == "field_not_allowed"
         assert backend.creates == 0, "a refused live request must run nothing"
 
 
-def test_live_is_refused_before_the_case_is_even_looked_up() -> None:
-    """A capability this build lacks makes the rest of the request moot,
-    so the mode is checked first.
-    """
+def test_live_unknown_case_is_not_leaked_without_provider_access() -> None:
     with api_server() as base_url:
         status, body, _ = post(
             base_url,
             "/api/resolutions",
-            {"case": "definitely-not-a-case", "execution_mode": "live"},
+            {
+                "case": "definitely-not-a-case",
+                "execution_mode": "live",
+                "destination": "+12025550187",
+                "authorize_destination": "+12025550187",
+            },
+            headers={"X-Calle-Api-Key": "live-test-key"},
         )
 
-        assert status == 501
-        assert body["error"]["code"] == "live_not_available"
+        assert status == 404
+        assert body["error"]["code"] == "case_not_found"
 
 
-def test_no_live_credential_or_destination_field_is_accepted() -> None:
-    """The live contract does not exist yet, so none of its fields do
-    either - they are unknown fields, refused like any other.
-    """
+def test_live_only_fields_are_refused_in_fake_mode() -> None:
     with api_server() as base_url:
-        for field in ("api_key", "call_e_api_key", "destination", "authorize_destination"):
+        for field in ("api_key", "call_e_api_key", "destination", "authorize_destination", "gdpr_basis_documented"):
             status, body, _ = post(
                 base_url,
                 "/api/resolutions",
                 {"case": HERO, "execution_mode": "fake", field: "x"},
             )
             assert status == 422
-            assert body["error"]["code"] == "unknown_field"
+            expected_code = "field_not_allowed" if field in {"destination", "authorize_destination", "gdpr_basis_documented"} else "unknown_field"
+            assert body["error"]["code"] == expected_code
 
 
-def test_health_still_reports_fake_only() -> None:
+def test_health_reports_mixed_capabilities() -> None:
     with api_server() as base_url:
         _, body, _ = request(base_url, "/api/health")
 
-        assert body["mode"] == "fake"
+        assert body["mode"] == "mixed"
 
 
 # --- L3: nothing sensitive survives the async path --------------------
@@ -1904,15 +1903,19 @@ def test_every_client_the_server_builds_targets_the_local_fake_backend() -> None
         assert REAL_API_BASE_URL not in target
 
 
-def test_the_real_provider_host_appears_nowhere_in_the_http_layer() -> None:
+def test_the_live_http_layer_uses_only_server_side_provider_configuration() -> None:
     import api.server as server_module
 
     source = Path(server_module.__file__).read_text(encoding="utf-8")
 
-    assert "heycall-e.com" not in source
-    assert "allow_live=False" in source
-    assert "base_url=self.backend.base_url" in source
-    assert "allow_live=True" not in source
+    assert "REAL_API_BASE_URL" in source
+    assert "base_url=REAL_API_BASE_URL if live else self.backend.base_url" in source
+    assert "allow_live=live" in source
+    assert "phone_override=destination if live" in source
+    assert "X-Calle-Api-Key" in source
+    # The endpoint is imported from client.py rather than repeated in the
+    # HTTP layer, so the provider host is never a client-controlled field.
+    assert "base_url" in source
 
 
 def test_a_blocked_run_places_no_call_at_all() -> None:
@@ -1972,6 +1975,6 @@ def test_a_failed_resolution_leaks_nothing_and_says_nothing_internal() -> None:
         assert "127.0.0.1" not in raw, "the internal backend URL reached the client"
         assert "C:\\" not in raw and "/Users/" not in raw
         assert body["error"] == {
-            "code": "resolution_failed",
+            "code": "calle_timeout",
             "message": "the resolution could not be completed",
         }

--- a/apps/python/reality-resolver/tests/test_custom_case.py
+++ b/apps/python/reality-resolver/tests/test_custom_case.py
@@ -1,0 +1,206 @@
+"""Offline and fake-provider coverage for normalized custom cases."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from api.custom_case import CustomCaseValidationError, parse_custom_case
+
+
+def custom_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": "Synthetic logistics confirmation",
+        "use_case": "factual_state_confirmation",
+        "deadline": "2026-09-11T08:00:00Z",
+        "decision_deadline_threshold_hours": 24,
+        "decision_options": {
+            "if_confirmed": "KEEP_DELIVERY_PLAN",
+            "if_cancelled": "ASSIGN_BACKUP_DRIVER",
+        },
+        "call_task_hint": "Ask the assigned driver to confirm whether the delivery plan remains feasible.",
+        "evidence": [
+            {
+                "source": "dispatch-system",
+                "type": "structured",
+                "freshness_hours": 2,
+                "claim": "driver assigned and delivery confirmed for 08:00",
+                "ambiguity": "low",
+            },
+            {
+                "source": "driver-message",
+                "type": "human",
+                "freshness_hours": 1,
+                "claim": "vehicle issue, I might not be able to complete the delivery",
+                "ambiguity": "high",
+            },
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_custom_case_parser_returns_the_existing_engine_model() -> None:
+    case = parse_custom_case(custom_payload())
+
+    assert case.name == "Synthetic logistics confirmation"
+    assert case.use_case == "factual_state_confirmation"
+    assert case.decision_options["if_confirmed"] == "KEEP_DELIVERY_PLAN"
+    assert len(case.evidence.items) == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("deadline", "tomorrow", "invalid_custom_deadline"),
+        ("use_case", "medical_decision", "unsupported_custom_use_case"),
+        ("call_phone", "+١٢٠٢٥٥٥٠١٨٧", "invalid_custom_phone"),
+        ("evidence", [], "invalid_custom_evidence"),
+    ],
+)
+def test_custom_case_parser_rejects_invalid_inputs(field: str, value: Any, code: str) -> None:
+    with pytest.raises(CustomCaseValidationError) as error:
+        parse_custom_case(custom_payload(**{field: value}))
+    assert error.value.code == code
+
+
+def test_custom_case_parser_rejects_oversized_evidence() -> None:
+    evidence = custom_payload()["evidence"] * 11
+    with pytest.raises(CustomCaseValidationError) as error:
+        parse_custom_case(custom_payload(evidence=evidence))
+    assert error.value.code == "custom_case_too_large"
+
+
+@contextmanager
+def api_server_and_backend() -> Iterator[tuple[str, Any]]:
+    from api.backend import FakeCallBackend
+    from api.server import MAX_WORKERS, create_server
+
+    backend = FakeCallBackend()
+    backend.start()
+    executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+    server = create_server("127.0.0.1", 0, backend=backend, executor=executor)
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.0005}, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        yield f"http://{host}:{port}", backend
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        executor.shutdown(wait=True)
+        backend.stop()
+
+
+def post(base_url: str, payload: dict[str, Any]) -> tuple[int, Any]:
+    request = urllib.request.Request(
+        f"{base_url}/api/resolutions",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read())
+
+
+def get(base_url: str, resolution_id: str) -> tuple[int, Any]:
+    try:
+        with urllib.request.urlopen(f"{base_url}/api/resolutions/{resolution_id}", timeout=15) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read())
+
+
+def await_terminal(base_url: str, resolution_id: str) -> dict[str, Any]:
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        status, body = get(base_url, resolution_id)
+        assert status == 200
+        if body["state"] in {"completed", "failed"}:
+            return body
+        time.sleep(0.005)
+    raise AssertionError("custom resolution did not reach a terminal state")
+
+
+def resolve_custom(base_url: str, **fields: Any) -> dict[str, Any]:
+    payload = {"case": "custom", "execution_mode": "fake", "custom_case": custom_payload()}
+    payload.update(fields)
+    status, created = post(base_url, payload)
+    assert status == 202, created
+    assert created["state"] == "queued"
+    return await_terminal(base_url, created["id"])
+
+
+def test_custom_confirmed_uses_real_engine_and_dynamic_action() -> None:
+    with api_server_and_backend() as (base_url, backend):
+        result = resolve_custom(base_url, scenario="confirmed")
+
+        assert result["state"] == "completed"
+        assert result["reasoning"]["decision_critical"] is True
+        assert result["call_decision"] == "CALL_JUSTIFIED"
+        assert result["verdict"] == {"status": "RESOLVED", "action": "KEEP_DELIVERY_PLAN"}
+        assert backend.creates == 1
+        assert "+10000000003" not in json.dumps(result)
+
+
+def test_custom_cancelled_and_voicemail_use_provider_scenarios() -> None:
+    with api_server_and_backend() as (base_url, _):
+        cancelled = resolve_custom(base_url, scenario="cancelled")
+        voicemail = resolve_custom(base_url, scenario="voicemail")
+
+        assert cancelled["verdict"] == {"status": "RESOLVED_ALT", "action": "ASSIGN_BACKUP_DRIVER"}
+        assert voicemail["verdict"] == {"status": "UNRESOLVED_AMBIGUOUS", "action": "HUMAN_REVIEW"}
+
+
+def test_custom_no_call_and_blocked_never_reach_provider() -> None:
+    with api_server_and_backend() as (base_url, backend):
+        no_call = resolve_custom(base_url, scenario="no-call")
+        blocked = resolve_custom(base_url, scenario="blocked")
+
+        assert no_call["verdict"] == {"status": "NO_CALL_NEEDED", "action": "NO_ACTION_REQUIRED"}
+        assert blocked["verdict"] == {"status": "UNRESOLVED_CALL_BLOCKED", "action": "RETRY_WHEN_PERMITTED"}
+        assert backend.creates == 0
+
+
+def test_custom_case_requires_strict_top_level_contract() -> None:
+    with api_server_and_backend() as (base_url, _):
+        status, body = post(
+            base_url,
+            {
+                "case": "custom",
+                "execution_mode": "fake",
+                "custom_case": custom_payload(unexpected="nope"),
+            },
+        )
+        assert status == 422
+        assert body["error"]["code"] == "unknown_custom_case_field"
+
+
+def test_custom_live_still_requires_per_request_api_key() -> None:
+    with api_server_and_backend() as (base_url, _):
+        status, body = post(
+            base_url,
+            {
+                "case": "custom",
+                "execution_mode": "live",
+                "custom_case": custom_payload(),
+                "destination": "+12025550187",
+                "authorize_destination": "+12025550187",
+                "gdpr_basis_documented": True,
+            },
+        )
+        assert status == 401
+        assert body["error"]["code"] == "missing_api_key"

--- a/apps/python/reality-resolver/tests/test_live_api.py
+++ b/apps/python/reality-resolver/tests/test_live_api.py
@@ -1,0 +1,437 @@
+"""Live HTTP contract tests with an in-process CALL-E double.
+
+The live branch is exercised through the same ``pipeline.resolve`` used by
+the fake branch. The provider client is replaced in every test that can
+reach it, so this module never contacts the real CALL-E host.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from api.server import REAL_API_BASE_URL
+from client import CallEAPIError, CallEClient
+from evidence.model import load_case
+from pipeline import ResolutionRequest
+from verdict import Verdict
+
+from tests.test_api import HERE, api_server, api_server_and_backend, await_resolution, post
+
+
+CASE = "critical-service-escalation"
+DESTINATION = "+12025550187"
+API_KEY = "live_test_key_not_a_real_credential"
+
+
+def live_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "case": CASE,
+        "execution_mode": "live",
+        "destination": DESTINATION,
+        "authorize_destination": DESTINATION,
+        "gdpr_basis_documented": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def live_headers(key: str = API_KEY) -> dict[str, str]:
+    return {"X-Calle-Api-Key": key}
+
+
+class StubCallEClient:
+    """A provider-shaped double that records construction safely."""
+
+    instances: list["StubCallEClient"] = []
+    final_status = "completed"
+    final_result: dict[str, Any] | None = {
+        "subject_intent": "confirmed",
+        "answered_by": "human",
+    }
+    create_error: Exception | None = None
+    poll_error: Exception | None = None
+
+    def __init__(self, base_url: str, api_key: str, allow_live: bool) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+        self.allow_live = allow_live
+        self.__class__.instances.append(self)
+
+    def create_call(self, **_: Any) -> dict[str, Any]:
+        if self.create_error is not None:
+            raise self.create_error
+        return {"id": "stub_call_id", "status": "queued"}
+
+    def poll_until_terminal(self, call_id: str, **_: Any) -> dict[str, Any]:
+        if self.poll_error is not None:
+            raise self.poll_error
+        result: dict[str, Any] = {"id": call_id, "status": self.final_status}
+        if self.final_result is not None:
+            result["structured_result"] = dict(self.final_result)
+        return result
+
+
+@pytest.fixture
+def stub_client(monkeypatch: pytest.MonkeyPatch):
+    import pipeline
+
+    StubCallEClient.instances = []
+    StubCallEClient.final_status = "completed"
+    StubCallEClient.final_result = {"subject_intent": "confirmed", "answered_by": "human"}
+    StubCallEClient.create_error = None
+    StubCallEClient.poll_error = None
+    monkeypatch.setattr(pipeline, "CallEClient", StubCallEClient)
+    return StubCallEClient
+
+
+@pytest.mark.parametrize("header", [None, "", "   "])
+def test_live_requires_a_nonempty_header_and_never_falls_back_to_environment(
+    monkeypatch: pytest.MonkeyPatch, header: str | None
+) -> None:
+    monkeypatch.setenv("CALLE_API_KEY", "environment_key_must_not_be_used")
+    headers = {} if header is None else {"X-Calle-Api-Key": header}
+    with api_server_and_backend() as (base_url, backend):
+        status, body, _ = post(base_url, "/api/resolutions", live_payload(), headers=headers)
+        assert status == 401
+        assert body["error"]["code"] == "missing_api_key"
+        assert backend.creates == 0
+        assert "environment_key" not in json.dumps(body)
+
+
+def test_live_header_is_rejected_in_fake_mode() -> None:
+    with api_server_and_backend() as (base_url, backend):
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            {"case": CASE, "execution_mode": "fake"},
+            headers=live_headers(),
+        )
+        assert status == 422
+        assert body["error"]["code"] == "api_key_not_allowed"
+        assert backend.creates == 0
+
+
+@pytest.mark.parametrize(
+    "payload, code",
+    [
+        (live_payload(destination=None), "missing_destination"),
+        (live_payload(authorize_destination=None), "missing_authorize_destination"),
+    ],
+)
+def test_live_requires_both_destination_fields(payload: dict[str, Any], code: str) -> None:
+    with api_server() as base_url:
+        status, body, _ = post(base_url, "/api/resolutions", payload, headers=live_headers())
+        assert status == 422
+        assert body["error"]["code"] == code
+
+
+@pytest.mark.parametrize(
+    "field, value, code",
+    [
+        ("destination", "+12025550187\n", "invalid_destination"),
+        ("destination", "+12025550187 ", "invalid_destination"),
+        ("destination", "+1202 5550187", "invalid_destination"),
+        ("destination", "+١٢٠٢٥٥٥٠١٨٧", "invalid_destination"),
+        ("destination", "+１２０２５５５０１８７", "invalid_destination"),
+        ("destination", "+12025550187x", "invalid_destination"),
+        ("authorize_destination", "+12025550187\r\n", "invalid_authorize_destination"),
+        ("authorize_destination", "+١٢٠٢٥٥٥٠١٨٧", "invalid_authorize_destination"),
+    ],
+)
+def test_live_requires_strict_ascii_e164(field: str, value: str, code: str) -> None:
+    with api_server() as base_url:
+        status, body, _ = post(
+            base_url, "/api/resolutions", live_payload(**{field: value}), headers=live_headers()
+        )
+        assert status == 422
+        assert body["error"]["code"] == code
+
+
+def test_live_requires_exact_destination_authorization_match() -> None:
+    with api_server() as base_url:
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            live_payload(authorize_destination="+12025550188"),
+            headers=live_headers(),
+        )
+        assert status == 422
+        assert body["error"]["code"] == "destination_authorization_mismatch"
+
+
+@pytest.mark.parametrize("field", ["scenario", "now_utc"])
+def test_fake_only_fields_are_rejected_in_live(field: str) -> None:
+    with api_server() as base_url:
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            live_payload(**{field: "confirmed"}),
+            headers=live_headers(),
+        )
+        assert status == 422
+        assert body["error"]["code"] == "field_not_allowed"
+
+
+@pytest.mark.parametrize("field", ["destination", "authorize_destination", "gdpr_basis_documented"])
+def test_live_only_fields_are_rejected_in_fake(field: str) -> None:
+    with api_server() as base_url:
+        value: Any = True if field == "gdpr_basis_documented" else DESTINATION
+        status, body, _ = post(
+            base_url,
+            "/api/resolutions",
+            {"case": CASE, "execution_mode": "fake", field: value},
+        )
+        assert status == 422
+        assert body["error"]["code"] == "field_not_allowed"
+
+
+def test_live_construction_uses_server_values_and_keeps_key_out_of_public_state(
+    stub_client: type[StubCallEClient], capsys: pytest.CaptureFixture[str]
+) -> None:
+    with api_server_and_backend() as (base_url, backend):
+        status, queued, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert status == 202
+        assert queued["state"] == "queued"
+        assert queued["mode"] == "live"
+        assert "api_key" not in json.dumps(queued)
+
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "completed"
+        assert result["mode"] == "live"
+        assert result["verdict"] == {"status": "RESOLVED", "action": "CONTINUE_DISPATCH"}
+        assert API_KEY not in json.dumps(result)
+        assert backend.creates == 0
+
+    assert len(stub_client.instances) == 1
+    client = stub_client.instances[0]
+    assert client.base_url == REAL_API_BASE_URL
+    assert client.allow_live is True
+    assert client.api_key == API_KEY
+    assert API_KEY not in capsys.readouterr().out
+
+
+def test_live_compliance_block_is_completed_without_provider_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pipeline
+
+    class MustNotConstruct:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("a blocked live run must not construct CallEClient")
+
+    monkeypatch.setattr(pipeline, "CallEClient", MustNotConstruct)
+    unmapped_number = "+442079460123"
+    with api_server_and_backend() as (base_url, backend):
+        status, queued, _ = post(
+            base_url,
+            "/api/resolutions",
+            live_payload(destination=unmapped_number, authorize_destination=unmapped_number),
+            headers=live_headers(),
+        )
+        assert status == 202
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "completed"
+        assert result["verdict"] == {
+            "status": "UNRESOLVED_CALL_BLOCKED",
+            "action": "RETRY_WHEN_PERMITTED",
+        }
+        assert result["call"] == {"placed": False, "provider_status": None, "result": None}
+        assert backend.creates == 0
+
+
+@pytest.mark.parametrize("status", ["failed", "canceled"])
+def test_provider_failed_or_canceled_is_a_technical_failure(
+    stub_client: type[StubCallEClient], status: str
+) -> None:
+    stub_client.final_status = status
+    with api_server() as base_url:
+        http_status, queued, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert http_status == 202
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "failed"
+        assert result["verdict"] is None
+        assert result["error"]["code"] == "provider_failed"
+        assert result["call"]["provider_status"] == status
+
+
+@pytest.mark.parametrize(
+    "error, code",
+    [
+        (TimeoutError("provider timed out"), "calle_timeout"),
+        (CallEAPIError(401, "unauthorized", "secret provider text", {"token": API_KEY}), "calle_auth_error"),
+        (CallEAPIError(500, "internal_error", "secret provider text", {}), "calle_api_error"),
+        (RuntimeError("network details must stay private"), "calle_network_error"),
+    ],
+)
+def test_live_provider_errors_are_safe_technical_failures(
+    stub_client: type[StubCallEClient], error: Exception, code: str
+) -> None:
+    if isinstance(error, TimeoutError) or isinstance(error, CallEAPIError):
+        stub_client.poll_error = error
+    else:
+        stub_client.create_error = error
+
+    with api_server() as base_url:
+        status, queued, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert status == 202
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "failed"
+        assert result["verdict"] is None
+        assert result["error"] == {
+            "code": code,
+            "message": "the resolution could not be completed",
+        }
+        rendered = json.dumps(result)
+        assert API_KEY not in rendered
+        assert "secret provider text" not in rendered
+        assert "network details" not in rendered
+
+
+def test_completed_ambiguous_result_remains_unresolved_ambiguous(
+    stub_client: type[StubCallEClient],
+) -> None:
+    stub_client.final_result = {"subject_intent": "unknown", "answered_by": "voicemail"}
+    with api_server() as base_url:
+        status, queued, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert status == 202
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "completed"
+        assert result["verdict"]["status"] == "UNRESOLVED_AMBIGUOUS"
+
+
+def test_completed_cancelled_result_keeps_the_business_verdict(
+    stub_client: type[StubCallEClient],
+) -> None:
+    stub_client.final_result = {"subject_intent": "cancelled", "answered_by": "human"}
+    with api_server() as base_url:
+        status, queued, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert status == 202
+        result = await_resolution(base_url, queued["id"])
+        assert result["state"] == "completed"
+        assert result["verdict"] == {
+            "status": "RESOLVED_ALT",
+            "action": "REASSIGN_TECHNICIAN",
+        }
+
+
+def test_request_and_client_repr_hide_the_live_key() -> None:
+    request = ResolutionRequest(
+        case_path="case.json",
+        base_url=REAL_API_BASE_URL,
+        execute=True,
+        allow_live=True,
+        api_key=API_KEY,
+    )
+    client = CallEClient(REAL_API_BASE_URL, API_KEY, allow_live=True)
+    assert API_KEY not in repr(request)
+    assert API_KEY not in repr(client)
+
+
+def _no_call_resolve(request: ResolutionRequest, observer: Any) -> None:
+    observer.on_start(load_case(request.case_path), "EXECUTE")
+    observer.on_verdict(Verdict("NO_CALL_NEEDED", "NO_ACTION_REQUIRED", ()))
+
+
+def test_live_capacity_is_immediate_fake_is_independent_and_releases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import api.server as server_module
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_resolve(request: ResolutionRequest, observer: Any) -> None:
+        if not request.allow_live:
+            _no_call_resolve(request, observer)
+            return
+        entered.set()
+        observer.on_start(load_case(request.case_path), "EXECUTE")
+        release.wait(5)
+        observer.on_verdict(Verdict("NO_CALL_NEEDED", "NO_ACTION_REQUIRED", ()))
+
+    monkeypatch.setattr(server_module, "resolve", blocking_resolve)
+    with api_server_and_backend() as (base_url, backend):
+        status, first, _ = post(base_url, "/api/resolutions", live_payload(), headers=live_headers())
+        assert status == 202
+        assert entered.wait(2)
+
+        fake_status, fake_body, _ = post(
+            base_url,
+            "/api/resolutions",
+            {"case": CASE, "execution_mode": "fake", "scenario": "no-call"},
+        )
+        assert fake_status == 202
+        assert fake_body["mode"] == "fake"
+        assert await_resolution(base_url, fake_body["id"])["state"] == "completed"
+
+        second_status, second_body, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert second_status == 429
+        assert second_body["error"]["code"] == "live_capacity_reached"
+
+        release.set()
+        assert await_resolution(base_url, first["id"])["state"] == "completed"
+        third_status, third, _ = post(
+            base_url, "/api/resolutions", live_payload(), headers=live_headers()
+        )
+        assert third_status == 202
+        assert await_resolution(base_url, third["id"])["state"] == "completed"
+        assert backend.creates == 0
+
+
+def test_live_capacity_releases_after_worker_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    import api.server as server_module
+
+    def failing_resolve(*_: Any, **__: Any) -> None:
+        raise RuntimeError("private worker detail")
+
+    monkeypatch.setattr(server_module, "resolve", failing_resolve)
+    with api_server_and_backend() as (base_url, _):
+        status, first, _ = post(base_url, "/api/resolutions", live_payload(), headers=live_headers())
+        assert status == 202
+        assert await_resolution(base_url, first["id"])["error"]["code"] == "calle_network_error"
+
+        monkeypatch.setattr(server_module, "resolve", _no_call_resolve)
+        status, second, _ = post(base_url, "/api/resolutions", live_payload(), headers=live_headers())
+        assert status == 202
+        assert await_resolution(base_url, second["id"])["state"] == "completed"
+
+
+def test_live_capacity_releases_when_submit_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    import api.server as server_module
+
+    original_submit = ThreadPoolExecutor.submit
+    calls = 0
+
+    def fail_first_submit(self: ThreadPoolExecutor, *args: Any, **kwargs: Any):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            raise RuntimeError("submit failed")
+        return original_submit(self, *args, **kwargs)
+
+    monkeypatch.setattr(ThreadPoolExecutor, "submit", fail_first_submit)
+    monkeypatch.setattr(server_module, "resolve", _no_call_resolve)
+    with api_server_and_backend() as (base_url, _):
+        status, body, _ = post(base_url, "/api/resolutions", live_payload(), headers=live_headers())
+        assert status == 503
+        assert body["error"]["code"] == "resolution_submit_failed"
+
+        monkeypatch.setattr(ThreadPoolExecutor, "submit", original_submit)
+        status, queued, _ = post(base_url, "/api/resolutions", live_payload(), headers=live_headers())
+        assert status == 202
+        assert await_resolution(base_url, queued["id"])["state"] == "completed"

--- a/apps/python/reality-resolver/tests/test_live_diagnostics.py
+++ b/apps/python/reality-resolver/tests/test_live_diagnostics.py
@@ -1,0 +1,177 @@
+"""Offline coverage for live provider payloads, phases, and timeouts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import api.server as server_module
+import client as client_module
+from api.progress import StoreObserver
+from api.store import ResolutionStore
+from client import CallEAPIError, CallEClient, build_recipient
+from compliance.dispatcher import resolve_jurisdiction_chain, resolve_locale_and_region
+from pipeline import ResolutionRequest
+from verdict import subject_intent_result_schema
+
+
+def _seeded_store() -> tuple[ResolutionStore, str]:
+    store = ResolutionStore()
+    resolution_id = "res_offline_diagnostics"
+    store.put(resolution_id, {"state": "queued", "call": {"placed": False}})
+    return store, resolution_id
+
+
+def test_us_payload_uses_en_us_and_only_supported_create_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    chain = resolve_jurisdiction_chain("+12760000000")
+    locale, region, _ = resolve_locale_and_region(chain)
+    assert chain == ("us_federal",)
+    assert (locale, region) == ("en-US", "US")
+
+    captured: dict[str, Any] = {}
+
+    def fake_request(
+        _client: CallEClient,
+        method: str,
+        path: str,
+        headers: dict[str, str],
+        body: bytes | None,
+    ) -> dict[str, Any]:
+        captured.update(
+            {
+                "method": method,
+                "path": path,
+                "headers": headers,
+                "body": json.loads((body or b"{}").decode("utf-8")),
+            }
+        )
+        return {"id": "call_offline", "status": "queued"}
+
+    monkeypatch.setattr(CallEClient, "_request", fake_request)
+    client = CallEClient("http://127.0.0.1:9", "local-dev-placeholder")
+    client.create_call(
+        task="offline task",
+        recipients=[build_recipient("+12760000000", locale, region)],
+        result_schema=subject_intent_result_schema(),
+        idempotency_key="offline-idempotency",
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/v1/calls"
+    body = captured["body"]
+    assert set(body) == {"task", "recipients", "result_schema"}
+    assert body["recipients"] == [{"phones": ["+12760000000"], "locale": "en-US", "region": "US"}]
+    assert "fr-FR" not in json.dumps(body)
+    assert '"region": "FR"' not in json.dumps(body)
+
+
+def test_french_routing_remains_french() -> None:
+    chain = resolve_jurisdiction_chain("+33155550123")
+    assert resolve_locale_and_region(chain)[:2] == ("fr-FR", "FR")
+
+
+def test_poll_timeout_diagnostic_is_phase_aware_and_provider_safe(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store, resolution_id = _seeded_store()
+
+    def fake_resolve(request: ResolutionRequest, observer: Any) -> None:
+        observer.on_call_preview({})
+        observer.on_call_created("call_offline", "queued")
+        observer.on_poll({"status": "in_progress"})
+        raise TimeoutError("provider poll deadline")
+
+    monkeypatch.setattr(server_module, "resolve", fake_resolve)
+    server_module._run_resolution(
+        store,
+        resolution_id,
+        ResolutionRequest(case_path="", base_url="https://api.heycall-e.com", allow_live=True),
+    )
+
+    result = store.get(resolution_id)
+    assert result["state"] == "failed"
+    assert result["error"]["code"] == "calle_timeout"
+    assert result["verdict"] is None
+    assert result["call"]["placed"] is True
+
+    rendered = capsys.readouterr().out
+    assert "CALL-E resolution_error code=calle_timeout phase=poll call_id_present=true last_provider_status=in_progress" in rendered
+    assert "provider poll deadline" not in rendered
+
+
+def test_post_http_422_is_api_error_in_create_phase_and_does_not_poll(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    store, resolution_id = _seeded_store()
+    events: list[str] = []
+
+    def fake_resolve(request: ResolutionRequest, observer: Any) -> None:
+        events.append("create")
+        observer.on_call_preview({})
+        raise CallEAPIError(422, "call_not_ready", "provider rejected request", {})
+
+    monkeypatch.setattr(server_module, "resolve", fake_resolve)
+    server_module._run_resolution(
+        store,
+        resolution_id,
+        ResolutionRequest(case_path="", base_url="https://api.heycall-e.com", allow_live=True),
+    )
+
+    result = store.get(resolution_id)
+    assert events == ["create"]
+    assert result["error"]["code"] == "calle_api_error"
+    assert result["error"]["code"] != "calle_timeout"
+    rendered = capsys.readouterr().out
+    assert "phase=create call_id_present=false" in rendered
+    assert "last_provider_status" not in rendered
+
+
+def test_post_socket_timeout_is_one_attempt_and_never_starts_polling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def fake_urlopen(request: Any, timeout: float | None = None) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("offline socket timeout")
+
+    monkeypatch.setattr(client_module.urllib.request, "urlopen", fake_urlopen)
+    client = CallEClient("http://127.0.0.1:9", "local-dev-placeholder")
+    with pytest.raises(RuntimeError):
+        client.create_call(task="offline task", idempotency_key="offline-idempotency")
+    assert attempts == 1
+
+
+def test_success_without_provider_id_is_safe_create_failure(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    store, resolution_id = _seeded_store()
+    polled = False
+
+    def fake_resolve(request: ResolutionRequest, observer: Any) -> None:
+        nonlocal polled
+        observer.on_call_preview({})
+        created: dict[str, Any] = {"status": "queued"}
+        _ = created["id"]
+        polled = True
+
+    monkeypatch.setattr(server_module, "resolve", fake_resolve)
+    server_module._run_resolution(
+        store,
+        resolution_id,
+        ResolutionRequest(case_path="", base_url="https://api.heycall-e.com", allow_live=True),
+    )
+    result = store.get(resolution_id)
+    assert result["state"] == "failed"
+    assert result["error"]["code"] == "calle_network_error"
+    assert result["call"]["placed"] is False
+    assert polled is False
+    assert "phase=create call_id_present=false" in capsys.readouterr().out
+
+
+def test_fake_and_live_poll_budgets_are_separate() -> None:
+    assert server_module.MAX_POLL_SECONDS == 10.0
+    assert server_module.MAX_LIVE_POLL_SECONDS == 180.0
+    source = open(server_module.__file__, encoding="utf-8").read()
+    assert "poll_timeout_seconds=MAX_LIVE_POLL_SECONDS if live else MAX_POLL_SECONDS" in source

--- a/apps/python/reality-resolver/tests/test_p0.py
+++ b/apps/python/reality-resolver/tests/test_p0.py
@@ -1,0 +1,153 @@
+"""P0 regressions: deterministic fake inputs and safe public output."""
+import copy
+import json
+
+import pytest
+
+from api.progress import StoreObserver
+from api.serialize import call_projection
+from api.server import queued_entry
+from api.store import ResolutionStore
+from client import build_recipient
+from evidence.model import load_case
+from verdict import Verdict, reconcile
+from tests.test_api import HERE, api_server_and_backend, create_resolution, await_resolution, post
+
+
+@pytest.mark.parametrize("phone", ["+12025550187", "+33123456789"])
+def test_complete_ascii_phone_is_accepted(phone):
+    assert build_recipient(phone, None, None)["phones"] == [phone]
+
+
+@pytest.mark.parametrize("phone", [
+    "+12025550187\n", "+12025550187 ", " +12025550187",
+    "+1202 5550187", "+\u0661\u0662\u0660\u0662\u0665\u0665\u0665\u0660\u0661\u0668\u0667", "+\uff11\uff12\uff10\uff12\uff15\uff15\uff15\uff10\uff11\uff18\uff17",
+    "x+12025550187", "+12025550187x", "+12025550187\r\n",
+])
+def test_incomplete_or_non_ascii_phone_is_rejected(phone):
+    with pytest.raises(ValueError):
+        build_recipient(phone, None, None)
+
+
+@pytest.mark.parametrize("case_name", ["critical-service-escalation", "ghost-appointment"])
+@pytest.mark.parametrize("scenario, verdict", [
+    ("no-call", "NO_CALL_NEEDED"), ("confirmed", "RESOLVED"),
+    ("cancelled", "RESOLVED_ALT"), ("voicemail", "UNRESOLVED_AMBIGUOUS"),
+    ("blocked", "UNRESOLVED_CALL_BLOCKED"),
+])
+def test_fake_scenarios_need_no_magic_date(case_name, scenario, verdict):
+    with api_server_and_backend() as (url, backend):
+        status, seed = create_resolution(url, case=case_name, scenario=scenario)
+        assert status == 202
+        assert seed["mode"] == "fake"
+        result = await_resolution(url, seed["id"])
+        assert result["state"] == "completed"
+        assert result["mode"] == "fake"
+        assert result["verdict"]["status"] == verdict
+        assert backend.creates == (0 if scenario in ("no-call", "blocked") else 1)
+        r4 = result["reasoning"]["rules"][3]
+        assert r4["triggered"] is (scenario != "no-call")
+
+
+def test_no_call_prepares_conditions_even_with_explicit_near_time():
+    with api_server_and_backend() as (url, backend):
+        status, seed = create_resolution(url, case="critical-service-escalation",
+            scenario="no-call", now_utc="2099-01-01T00:00:00Z")
+        assert status == 202
+        result = await_resolution(url, seed["id"])
+        assert result["verdict"]["status"] == "NO_CALL_NEEDED"
+        assert result["compliance"] is None
+        assert backend.creates == 0
+        status, body, _ = post(
+            url,
+            "/api/resolutions",
+            {"case": "critical-service-escalation", "execution_mode": "live", "scenario": "no-call"},
+            headers={"X-Calle-Api-Key": "not-a-real-key"},
+        )
+        assert status == 422
+        assert body["error"]["code"] == "field_not_allowed"
+        assert backend.creates == 0
+
+
+@pytest.mark.parametrize("mode", ["fake", "live"])
+def test_observer_preserves_seed_mode_at_every_state(mode):
+    case = load_case(HERE / "cases" / "critical-service-escalation.json")
+    store = ResolutionStore()
+    store.put("test", queued_entry("test", case, mode))
+    observer = StoreObserver(store, "test")
+    assert (store.get("test")["state"], store.get("test")["mode"]) == ("queued", mode)
+    observer.on_start(case, "EXECUTE")
+    assert (store.get("test")["state"], store.get("test")["mode"]) == ("running", mode)
+    observer.on_verdict(Verdict("NO_CALL_NEEDED", "NO_ACTION_REQUIRED", ()))
+    assert (store.get("test")["state"], store.get("test")["mode"]) == ("completed", mode)
+
+
+@pytest.mark.parametrize("secret", [
+    "iams_live_not_a_real_credential", "sk-test_not_a_real_key",
+    "Bearer abc123.fake-token", "api_key=obvious-private-value",
+    'token="private value"', "eyJabc.def.ghi",
+])
+def test_provider_notes_hide_phones_and_obvious_secrets_without_mutation(secret):
+    raw = {"status": "completed", "structured_result": {
+        "subject_intent": "confirmed", "answered_by": "human",
+        "manipulation_attempt_detected": False,
+        "confidence_note": "Call +12025550187 with " + secret,
+        "manipulation_attempt_note": secret,
+    }}
+    original = copy.deepcopy(raw)
+    public = call_projection(raw, True)
+    rendered = json.dumps(public)
+    assert "+12025550187" not in rendered
+    assert secret not in rendered
+    assert "[redacted]" in rendered
+    assert public["result"]["subject_intent"] == "confirmed"
+    assert raw == original
+    case = load_case(HERE / "cases" / "critical-service-escalation.json")
+    assert reconcile(raw["structured_result"], case.decision_options, case.evidence).status == "RESOLVED"
+
+
+@pytest.mark.parametrize("value", [{"token": "private"}, ["private"], 1, None])
+def test_unexpected_provider_shapes_are_not_projected(value):
+    assert call_projection({"status": value, "structured_result": value}, True) == {
+        "placed": True, "provider_status": None, "result": None}
+    fields = {key: value for key in ("subject_intent", "answered_by",
+        "confidence_note", "manipulation_attempt_note", "manipulation_attempt_detected")}
+    assert call_projection({"structured_result": fields}, True)["result"] is None
+
+
+def test_invalid_enum_strings_are_not_reflected_and_notes_are_bounded():
+    public = call_projection({"status": "secret status", "structured_result": {
+        "subject_intent": "secret intent", "answered_by": "secret answer",
+        "confidence_note": "iams_" + "x" * 3000,
+        "manipulation_attempt_note": "a" * 3000,
+    }}, True)
+    assert public["provider_status"] is None
+    assert "subject_intent" not in public["result"]
+    assert "answered_by" not in public["result"]
+    assert public["result"]["confidence_note"] == "[redacted]"
+    assert len(public["result"]["manipulation_attempt_note"]) == 2000
+
+
+def test_fake_decision_clock_is_fixture_relative(monkeypatch):
+    import pipeline
+    from datetime import timedelta
+
+    evaluated_times = []
+    original = pipeline.evaluate
+
+    def record(matrix, deadline, now, threshold):
+        evaluated_times.append((deadline, now, threshold))
+        return original(matrix, deadline, now, threshold)
+
+    monkeypatch.setattr(pipeline, "evaluate", record)
+    with api_server_and_backend() as (url, backend):
+        for scenario in ("confirmed", "no-call"):
+            status, seed = create_resolution(url, case="critical-service-escalation", scenario=scenario)
+            assert status == 202
+            result = await_resolution(url, seed["id"])
+            assert result["state"] == "completed"
+        assert backend.creates == 1
+    deadline, now, threshold = evaluated_times[0]
+    assert now == deadline - threshold / 2
+    deadline, now, threshold = evaluated_times[1]
+    assert now == deadline - threshold - timedelta(seconds=1)

--- a/apps/python/reality-resolver/tests/test_pipeline.py
+++ b/apps/python/reality-resolver/tests/test_pipeline.py
@@ -11,6 +11,7 @@ here reaches a real provider or places a real call.
 from __future__ import annotations
 
 import json
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -276,3 +277,48 @@ def test_resolve_works_without_an_observer_at_all() -> None:
 
         assert result.verdict is not None
         assert result.verdict.status == "RESOLVED"
+
+
+# --- per-request credential: it must not reach the Resolution --------
+#
+# ResolutionRequest can now carry a CALL-E key. Resolution must not: it
+# is what gets serialized and stored, so a key that reached it would
+# reach a client. Checked here rather than trusted, because the two
+# classes live in the same file and nothing but a test stops someone
+# copying the field across.
+
+SENTINEL_KEY = "iams_live_pipeline_sentinel_not_a_real_credential"
+
+
+def test_a_per_request_key_never_appears_in_the_resolution() -> None:
+    with FakeCalleServer() as server:
+        result = resolve(_request(ESCALATION, server.base_url, execute=True, api_key=SENTINEL_KEY))
+
+        rendered = json.dumps(asdict(result), default=str)
+        assert SENTINEL_KEY not in rendered
+        assert "api_key" not in rendered
+        assert result.verdict is not None
+        assert result.verdict.status == "RESOLVED"
+
+
+def test_a_per_request_key_changes_nothing_against_the_fake_backend() -> None:
+    """The fake path is unaffected: resolve_api_key only honours a
+    per-request key on the live path, so supplying one here must produce
+    exactly the same run as not supplying one.
+    """
+    with FakeCalleServer() as server:
+        without = resolve(_request(ESCALATION, server.base_url, execute=True))
+        with_key = resolve(_request(ESCALATION, server.base_url, execute=True, api_key=SENTINEL_KEY))
+
+        assert without.verdict == with_key.verdict
+        assert without.call_placed == with_key.call_placed is True
+        assert without.call is not None and with_key.call is not None
+        assert (
+            without.call["structured_result"] == with_key.call["structured_result"]
+        ), "the fake backend must behave identically with or without a key"
+
+
+def test_the_default_is_none_so_the_cli_path_is_untouched() -> None:
+    request = ResolutionRequest(case_path="x", base_url="http://127.0.0.1:1")
+
+    assert request.api_key is None

--- a/apps/python/reality-resolver/tests/test_progress.py
+++ b/apps/python/reality-resolver/tests/test_progress.py
@@ -92,6 +92,38 @@ def test_update_replaces_a_key_whole_rather_than_merging_into_it() -> None:
     }
 
 
+def test_a_snapshot_already_returned_never_changes_under_its_reader() -> None:
+    """get() hands out a copy, and this is the invariant that requires it.
+
+    A reader holds its result while it serializes it; a worker keeps
+    calling update() on the same resolution. If get() returned the live
+    entry, the reader would be looking at a payload that shifts under it -
+    half one state, half the next. So the object it already has must stay
+    exactly as it was, no matter what happens to the entry afterwards.
+    """
+    store, rid = _seeded_store()
+    store.update(rid, {"state": "running", "verdict": None})
+
+    snapshot = store.get(rid)
+    assert snapshot["state"] == "running"
+
+    # Everything a running resolution goes on to publish.
+    store.update(rid, {"reasoning": {"decision_critical": True}})
+    store.update(rid, {"call": {"placed": True, "provider_status": "completed", "result": None}})
+    store.update(rid, {"state": "completed", "verdict": {"status": "RESOLVED", "action": "GO"}})
+
+    assert snapshot["state"] == "running", "the snapshot followed the entry"
+    assert snapshot["verdict"] is None
+    assert "reasoning" not in snapshot
+    assert "call" not in snapshot
+    assert snapshot is not store.get(rid), "each read must be its own snapshot"
+    assert store.get(rid)["state"] == "completed", "the entry itself did move on"
+
+    # And writing into a snapshot cannot write back into the store.
+    snapshot["state"] = "tampered"
+    assert store.get(rid)["state"] == "completed"
+
+
 def test_update_on_an_unknown_id_raises_like_get() -> None:
     store, _ = _seeded_store()
 

--- a/apps/python/reality-resolver/tests/test_progress.py
+++ b/apps/python/reality-resolver/tests/test_progress.py
@@ -1,0 +1,362 @@
+"""Tests for api/progress.py and ResolutionStore.update().
+
+Everything here runs below HTTP: the observer is driven by
+pipeline.resolve() directly, or by calling its hooks by hand. No route
+consumes it yet, which is exactly why it is worth pinning now - the
+guarantees it has to keep are easier to state, and to break, before
+anything depends on them.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import threading
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from api.progress import StoreObserver
+from api.serialize import resolution_payload
+from api.store import ResolutionNotFoundError, ResolutionStore
+from client import parse_utc_timestamp
+from fake_server import SUBJECT_CANCELLED_PHONE, SUBJECT_VOICEMAIL_PHONE, FakeCalleServer
+from pipeline import ResolutionRequest, resolve
+
+HERE = Path(__file__).resolve().parent.parent
+ESCALATION = str(HERE / "cases" / "critical-service-escalation.json")
+NEAR = "2026-09-10T20:00:00Z"
+FAR = "2026-09-01T10:00:00Z"
+
+# Shaped like a credential so a leak would be unmistakable. It is not one.
+SENTINEL_KEY = "iams_live_progress_sentinel_not_a_real_credential"
+
+
+def _request(base_url: str, **overrides: Any) -> ResolutionRequest:
+    fields: dict[str, Any] = {
+        "case_path": ESCALATION,
+        "base_url": base_url,
+        "poll_interval_seconds": 0.01,
+        "now_utc": parse_utc_timestamp(NEAR),
+    }
+    fields.update(overrides)
+    return ResolutionRequest(**fields)
+
+
+def _seeded_store() -> tuple[ResolutionStore, str]:
+    """A store holding the entry a job creator would have made before
+    starting work: queued, and nothing decided yet.
+    """
+    store = ResolutionStore()
+    resolution_id = ResolutionStore.new_id()
+    store.put(resolution_id, {"id": resolution_id, "state": "queued", "error": None})
+    return store, resolution_id
+
+
+def _run(store: ResolutionStore, resolution_id: str, **overrides: Any) -> Any:
+    """resolve() with a StoreObserver, with the client's request logging
+    swallowed so it does not drown the test output.
+    """
+    with FakeCalleServer() as server, redirect_stdout(io.StringIO()):
+        return resolve(_request(server.base_url, **overrides), StoreObserver(store, resolution_id))
+
+
+# --- ResolutionStore.update() ----------------------------------------
+
+
+def test_update_merges_top_level_keys_and_leaves_the_rest_alone() -> None:
+    store, rid = _seeded_store()
+
+    store.update(rid, {"state": "running", "reasoning": {"decision_critical": True}})
+
+    entry = store.get(rid)
+    assert entry["state"] == "running"
+    assert entry["reasoning"] == {"decision_critical": True}
+    assert entry["id"] == rid, "untouched keys must survive"
+    assert entry["error"] is None
+
+
+def test_update_replaces_a_key_whole_rather_than_merging_into_it() -> None:
+    store, rid = _seeded_store()
+    store.update(rid, {"call": {"placed": True, "provider_status": "in_progress", "result": None}})
+
+    store.update(rid, {"call": {"placed": True, "provider_status": "completed", "result": {"x": 1}}})
+
+    assert store.get(rid)["call"] == {
+        "placed": True,
+        "provider_status": "completed",
+        "result": {"x": 1},
+    }
+
+
+def test_update_on_an_unknown_id_raises_like_get() -> None:
+    store, _ = _seeded_store()
+
+    with pytest.raises(ResolutionNotFoundError):
+        store.update("res_never_issued", {"state": "running"})
+
+
+def test_update_does_not_change_fifo_position() -> None:
+    """An update is not a reinsertion. Updating the oldest entry must not
+    save it from being evicted first.
+    """
+    store = ResolutionStore(max_entries=3)
+    ids = [ResolutionStore.new_id() for _ in range(3)]
+    for index, rid in enumerate(ids):
+        store.put(rid, {"n": index})
+
+    store.update(ids[0], {"n": 99})  # touch the oldest
+    store.put(ResolutionStore.new_id(), {"n": 3})  # push one in
+
+    with pytest.raises(ResolutionNotFoundError):
+        store.get(ids[0])
+    assert len(store) == 3
+
+
+def test_the_cap_and_opaque_ids_are_unchanged_by_update() -> None:
+    store = ResolutionStore()
+    ids = [ResolutionStore.new_id() for _ in range(250)]
+    for rid in ids:
+        store.put(rid, {"state": "queued"})
+        store.update(rid, {"state": "running"})
+
+    assert len(store) == 200
+    assert all(rid.startswith("res_") and len(rid) > 12 for rid in ids)
+    assert len(set(ids)) == 250, "ids must stay unique and opaque"
+    for leak in ("critical", "escalation", "ghost", "2026", "confirmed"):
+        assert not any(leak in rid for rid in ids)
+
+
+def test_concurrent_updates_and_puts_keep_the_store_consistent() -> None:
+    """Barrier rather than sleeps, so the threads collide at a known
+    instant. As with put(), the GIL already makes the unlocked version
+    survive this - the lock is what makes it a guarantee.
+    """
+    store = ResolutionStore(max_entries=200)
+    pinned = [ResolutionStore.new_id() for _ in range(20)]
+    for rid in pinned:
+        store.put(rid, {"n": 0})
+
+    barrier = threading.Barrier(30)
+    failures: list[BaseException] = []
+
+    def updater(rid: str) -> None:
+        try:
+            barrier.wait(timeout=15)
+            for n in range(50):
+                store.update(rid, {"n": n})
+        except ResolutionNotFoundError:
+            return  # evicted by the writers below; not a broken store
+        except BaseException as exc:  # noqa: BLE001
+            failures.append(exc)
+
+    def writer() -> None:
+        try:
+            barrier.wait(timeout=15)
+            for _ in range(50):
+                store.put(ResolutionStore.new_id(), {"payload": True})
+        except BaseException as exc:  # noqa: BLE001
+            failures.append(exc)
+
+    workers = [threading.Thread(target=updater, args=(rid,)) for rid in pinned]
+    workers += [threading.Thread(target=writer) for _ in range(10)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=60)
+
+    assert not failures, f"a worker raised: {failures[0]!r}"
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(store) == 200
+
+
+# --- StoreObserver: the credential must not reach it ------------------
+
+
+def test_the_observer_does_not_define_on_api_key() -> None:
+    """The guarantee is the absence of a method, not a careful one.
+    pipeline.resolve() calls observer.on_api_key(api_key) with the real
+    credential; inheriting the base class's no-op means it reaches no
+    code here at all.
+    """
+    assert "on_api_key" not in vars(StoreObserver)
+
+
+def test_calling_on_api_key_directly_stores_nothing() -> None:
+    store, rid = _seeded_store()
+    before = dict(store.get(rid))
+
+    StoreObserver(store, rid).on_api_key(SENTINEL_KEY)
+
+    assert store.get(rid) == before
+    assert SENTINEL_KEY not in json.dumps(store.get(rid))
+
+
+def test_a_full_run_with_a_key_never_writes_it_to_the_store() -> None:
+    store, rid = _seeded_store()
+
+    _run(store, rid, execute=True, api_key=SENTINEL_KEY)
+
+    rendered = json.dumps(store.get(rid))
+    assert SENTINEL_KEY not in rendered
+    assert "api_key" not in rendered
+
+
+# --- StoreObserver: progression ---------------------------------------
+
+
+def test_progress_moves_from_queued_to_running_to_completed() -> None:
+    store, rid = _seeded_store()
+    assert store.get(rid)["state"] == "queued"
+
+    _run(store, rid, execute=True)
+
+    entry = store.get(rid)
+    assert entry["state"] == "completed"
+    assert entry["verdict"] == {"status": "RESOLVED", "action": "CONTINUE_DISPATCH"}
+    assert entry["call"]["placed"] is True
+    assert entry["call"]["provider_status"] == "completed"
+
+
+def test_each_stage_publishes_only_what_has_become_true() -> None:
+    """Hooks driven by hand, so the intermediate states can be observed
+    one at a time rather than inferred from the end result.
+    """
+    store, rid = _seeded_store()
+    with FakeCalleServer() as server, redirect_stdout(io.StringIO()):
+        observer = StoreObserver(store, rid)
+        request = _request(server.base_url, execute=True)
+
+        from evidence.engine import evaluate
+        from evidence.model import load_case
+
+        case = load_case(request.case_path)
+        observer.on_start(case, "EXECUTE")
+        after_start = dict(store.get(rid))
+        assert after_start["state"] == "running"
+        assert after_start["case"]["name"] == "critical-service-escalation"
+        assert len(after_start["evidence"]) == 3
+        assert "reasoning" not in after_start, "reasoning is not known yet"
+        assert "verdict" not in after_start
+
+        observer.on_reasoning(
+            evaluate(case.evidence, case.deadline, request.now_utc, case.decision_deadline_threshold)
+        )
+        after_reasoning = dict(store.get(rid))
+        assert after_reasoning["reasoning"]["decision_critical"] is True
+        assert after_reasoning["call_decision"] == "CALL_JUSTIFIED"
+        assert "compliance" not in after_reasoning
+        assert "call" not in after_reasoning
+
+        observer.on_call_created("call_provider_secret_id", "queued")
+        after_created = dict(store.get(rid))
+        assert after_created["call"] == {
+            "placed": True,
+            "provider_status": "queued",
+            "result": None,
+        }
+        assert "call_provider_secret_id" not in json.dumps(after_created), "a provider id leaked"
+        assert "verdict" not in after_created, "no verdict exists until on_verdict fires"
+
+
+def test_the_blocked_branch_publishes_a_next_legal_window() -> None:
+    store, rid = _seeded_store()
+
+    _run(store, rid, phone_override="+442079460123")
+
+    entry = store.get(rid)
+    assert entry["compliance"]["allowed"] is False
+    assert entry["compliance"]["next_legal_window"]
+    assert entry["verdict"]["status"] == "UNRESOLVED_CALL_BLOCKED"
+    # No call hook ever fires on this branch, so the key is simply
+    # absent - which is the honest representation of "none was placed".
+    assert "call" not in entry, "no call was placed, so nothing may report one"
+
+
+def test_the_no_call_branch_completes_without_compliance() -> None:
+    store, rid = _seeded_store()
+
+    _run(store, rid, now_utc=parse_utc_timestamp(FAR))
+
+    entry = store.get(rid)
+    assert entry["state"] == "completed"
+    assert entry["call_decision"] == "NO_CALL_NEEDED"
+    assert entry["verdict"] == {"status": "NO_CALL_NEEDED", "action": "NO_ACTION_REQUIRED"}
+    assert "compliance" not in entry, "the gate was never consulted, so nothing may report it"
+
+
+@pytest.mark.parametrize(
+    ("phone", "expected_status", "expected_action"),
+    [
+        (None, "RESOLVED", "CONTINUE_DISPATCH"),
+        (SUBJECT_CANCELLED_PHONE, "RESOLVED_ALT", "REASSIGN_TECHNICIAN"),
+        (SUBJECT_VOICEMAIL_PHONE, "UNRESOLVED_AMBIGUOUS", "HUMAN_REVIEW"),
+    ],
+)
+def test_every_verdict_branch_reaches_the_store(
+    phone: str | None, expected_status: str, expected_action: str
+) -> None:
+    store, rid = _seeded_store()
+
+    _run(store, rid, execute=True, phone_override=phone)
+
+    assert store.get(rid)["verdict"] == {"status": expected_status, "action": expected_action}
+
+
+# --- equivalence with the synchronous payload -------------------------
+
+
+def test_the_published_state_matches_the_payload_the_pipeline_would_produce() -> None:
+    """The point of the whole module: a resolution watched stage by stage
+    ends up saying the same thing as one serialized in a single shot.
+
+    Compared field by field on the public contract rather than with a
+    blind equality, because the observer only writes fields as they
+    become true - `error` is never one of them, since a failure is caught
+    by whoever owns the job, not by a hook.
+    """
+    store, rid = _seeded_store()
+    resolution = _run(store, rid, execute=True)
+
+    published = store.get(rid)
+    expected = resolution_payload(resolution, rid, "completed", "fake")
+
+    for key in ("id", "state", "case", "evidence", "reasoning", "call_decision", "verdict"):
+        assert published[key] == expected[key], f"{key} diverged"
+
+    # call: same projection, and identical here because the projection
+    # keeps nothing that varies between two runs (no ids, no timestamps).
+    assert published["call"] == expected["call"]
+    assert published["compliance"] == expected["compliance"]
+
+    # `error` is present because the seeded entry carried it, not
+    # because a hook wrote one: the observer never touches it.
+    assert published["error"] is None
+    assert set(published) == set(expected), "the published keys must be the public contract"
+
+
+def test_nothing_sensitive_ever_reaches_the_store() -> None:
+    from evidence.model import load_case
+
+    case = load_case(ESCALATION)
+    store, rid = _seeded_store()
+
+    _run(store, rid, execute=True, api_key=SENTINEL_KEY)
+
+    rendered = json.dumps(store.get(rid))
+    assert case.call_phone not in rendered
+    assert not re.search(r"\+[1-9][0-9]{6,14}", rendered), "an unmasked E.164 number reached the store"
+    assert case.call_task_hint[:40] not in rendered
+    assert "Required disclosure" not in rendered, "the hardened task reached the store"
+    assert "transcript" not in rendered
+    assert "Hello from the fake server" not in rendered
+    assert "provider_call_id" not in rendered
+    assert "call_fake" not in rendered, "a provider id reached the store"
+    assert "metadata" not in rendered
+    assert "evidence_cited" not in rendered
+    assert "recipients" not in rendered
+    assert "attempts" not in rendered
+    assert SENTINEL_KEY not in rendered

--- a/apps/python/reality-resolver/tests/test_progress.py
+++ b/apps/python/reality-resolver/tests/test_progress.py
@@ -52,7 +52,7 @@ def _seeded_store() -> tuple[ResolutionStore, str]:
     """
     store = ResolutionStore()
     resolution_id = ResolutionStore.new_id()
-    store.put(resolution_id, {"id": resolution_id, "state": "queued", "error": None})
+    store.put(resolution_id, {"id": resolution_id, "state": "queued", "mode": "fake", "error": None})
     return store, resolution_id
 
 
@@ -356,7 +356,7 @@ def test_the_published_state_matches_the_payload_the_pipeline_would_produce() ->
     published = store.get(rid)
     expected = resolution_payload(resolution, rid, "completed", "fake")
 
-    for key in ("id", "state", "case", "evidence", "reasoning", "call_decision", "verdict"):
+    for key in ("id", "state", "mode", "case", "evidence", "reasoning", "call_decision", "verdict"):
         assert published[key] == expected[key], f"{key} diverged"
 
     # call: same projection, and identical here because the projection

--- a/apps/python/reality-resolver/tests/test_provider_error_logging.py
+++ b/apps/python/reality-resolver/tests/test_provider_error_logging.py
@@ -1,0 +1,125 @@
+"""Offline coverage for provider-safe CALL-E HTTP error logging."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+import client as client_module
+from client import CallEAPIError, CallEClient
+
+
+def _http_error(
+    message: str,
+    *,
+    code: str = "invalid_request",
+    details: object | None = None,
+    status: int = 422,
+) -> urllib.error.HTTPError:
+    error: dict[str, object] = {"code": code, "message": message}
+    if details is not None:
+        error["details"] = details
+    body = json.dumps({"error": error}).encode("utf-8")
+    return urllib.error.HTTPError(
+        "https://api.invalid/v1/calls",
+        status,
+        "unprocessable",
+        {},
+        io.BytesIO(body),
+    )
+
+
+def _run_failed_post(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], error: urllib.error.HTTPError) -> str:
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(client_module.urllib.request, "urlopen", fail)
+    with pytest.raises(CallEAPIError):
+        CallEClient("https://api.invalid", "offline-test-key").create_call(task="offline test")
+    return capsys.readouterr().out
+
+
+def test_provider_error_log_keeps_normal_code_and_omits_details(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    output = _run_failed_post(
+        monkeypatch,
+        capsys,
+        _http_error("payload was rejected", details={"field": "task", "secret": "do-not-log"}),
+    )
+
+    assert "CALL-E provider_error status=422 code=invalid_request message=payload was rejected" in output
+    assert "do-not-log" not in output
+    assert "details" not in output
+    assert "offline-test-key" not in output
+    assert "Authorization" not in output
+
+
+@pytest.mark.parametrize(
+    ("message", "forbidden_fragment", "expected_fragment"),
+    [
+        ("recipient +12025550187 is unsupported", "+12025550187", "+...0187"),
+        ("request used Bearer super_secret_token_value", "super_secret_token_value", "[redacted]"),
+        ("api_key=iams_live_fake_key_value", "iams_live_fake_key_value", "[redacted]"),
+        ("token=plausible-secret-token-value", "plausible-secret-token-value", "[redacted]"),
+    ],
+)
+def test_provider_error_log_masks_sensitive_message_content(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    message: str,
+    forbidden_fragment: str,
+    expected_fragment: str,
+) -> None:
+    output = _run_failed_post(monkeypatch, capsys, _http_error(message))
+
+    assert forbidden_fragment not in output
+    assert expected_fragment in output
+
+
+def test_provider_error_log_escapes_controls_and_bounds_message(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    message = "first\r\nsecond\x00" + ("x" * 2000)
+    output = _run_failed_post(monkeypatch, capsys, _http_error(message))
+
+    log_line = next(line for line in output.splitlines() if line.startswith("CALL-E provider_error"))
+    assert "\r" not in log_line
+    assert "\x00" not in log_line
+    assert "\\r" in log_line
+    assert "\\n" in log_line
+    assert "\\x00" in log_line
+    assert "truncated" in log_line
+    assert len(log_line.split("message=", 1)[1]) <= 1000
+
+
+def test_provider_error_log_never_includes_details_even_when_they_contain_secrets(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    details = {"phone": "+12025550187", "token": "iams_live_details_secret"}
+    output = _run_failed_post(monkeypatch, capsys, _http_error("invalid recipient", details=details))
+
+    assert "12025550187" not in output
+    assert "iams_live_details_secret" not in output
+    assert "details" not in output
+
+
+def test_invalid_json_error_body_logs_only_fixed_safe_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    invalid_body = io.BytesIO(b"not-json-with-a-fake-token")
+    error = urllib.error.HTTPError("https://api.invalid/v1/calls", 502, "bad gateway", {}, invalid_body)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(client_module.urllib.request, "urlopen", fail)
+    with pytest.raises(RuntimeError, match="body that is not valid JSON"):
+        CallEClient("https://api.invalid", "offline-test-key").create_call(task="offline test")
+
+    output = capsys.readouterr().out
+    assert "CALL-E provider_error status=502 code=invalid_error_body message=provider error body was not valid JSON" in output
+    assert "fake-token" not in output


### PR DESCRIPTION
## Summary

- add asynchronous queued/running/completed/failed Reality Resolver execution after #389
- preserve the fake backend demo while enabling the guarded live CALL-E path
- enforce strict destination authorization and live capacity limits
- handle provider failures as technical failures with provider-safe diagnostics
- add offline and mocked-live coverage

## Validation

- Reality Resolver test suite — **409 passed**
- `python scripts/validate_repository.py` — **passed**
- `git diff --check` — **passed**

The repository-wide pytest command cannot currently complete collection because the external `calle-ai` dependency is unavailable in the local environment. The complete Reality Resolver suite passes independently.

No real CALL-E calls are made by the test suite.

## Notes

This PR contains only the incremental Reality Resolver work completed after merged PR #389.

The live HTTP path uses the real CALL-E pipeline, while the deterministic fake provider remains available for safe and reproducible demos.