### PR TITLE
Add VendorPulse project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This project is an awesome list for AI-agent phone-call workflows. Add resources
 - [ShohojSheba Voice](https://shohojsheba-call-e-preview.redwan-rahman.workers.dev/judge) - Consent-gated healthcare staffing dispatch that uses structured CALL-E results to advance after a verified decline, pauses on acceptance, and keeps final assignment human-controlled.
 
 - [WristCall AI](https://github.com/Baklolman69/WristCallAI) - Wear OS smartwatch assistant that searches Google via SerpApi, synthesizes call intent with Groq AI 120B, and dispatches autonomous phone calls via CALL-E with 3-bullet voice summaries.
-
+-  [VendorPulse](https://github.com/Eman2123/VendorPlus) - Autonomous CALL-E-powered vendor check-in tool that calls suppliers about order status, scores delivery risk, and escalates high-risk vendors for human review.
 Runnable demo apps live under [`apps/`](apps/). They are not a CALL-E SDK and do not define a supported application API.
 
 | App | Language | Purpose |


### PR DESCRIPTION
## Summary

Adds VendorPulse to the Apps list. VendorPulse is a FastAPI + Next.js app that uses CALL-E to call vendors/suppliers, ask about order status, extract delivery risk signals from the call transcript, and flag high-risk vendors for human review via a dashboard.

## Type

- [x] README awesome-list entry

## Checklist

- [x] Repository-facing content is written in English.
- [ ] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [x] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [x] Real-world side effects are clearly described.
- [x] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [ ] Recurring workflows include cancellation behavior.
- [ ] Runnable code has a dry-run, fake-server, or no-call path by default.
- [ ] `python3 scripts/validate_repository.py` passes.