### PR TITLE
docs: add Aftercall  to Apps list

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
+| [`python/aftercall`](python/aftercall) | Python / React | AI post-discharge care coordinator that uses CALL-E to conduct consent-aware follow-up calls, collect structured patient-reported recovery information, identify risk signals, and escalate concerning responses to a human care team. |
 | [`typescript/kol`](typescript/kol/) | TypeScript / Node | Evidence-gated healthcare claim-status calls that require transcript-grounded fields, the intended payer department, the actual question, and an independent IVR route receipt; includes a 640-case no-call evaluation and explicit live CALL-E path. |
 | [`typescript/speakeasy`](typescript/speakeasy/) | TypeScript / iOS | Multilingual "AI makes the call for you": speak a task in your language, confirm the read-back, then CALL-E places the English call with a live transcript and narrates the outcome back in your language; front-loaded preferences and a speculative two-call flow avoid holds; fake-transport no-call mode by default. |
 | [`python/holdfor-board`](python/holdfor-board/) | Python | Post-visit follow-up board for a GP practice: a check-in call's answers reach a human queue as a Review Item, the patient's own verbatim words travel with it, and no rebooking call exists without a prior human Release carrying a bounded date-and-mode envelope. Runs offline on a stored transcript fixture with no credentials. |

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,7 +10,7 @@ Current apps:
 
 | App | Language | Purpose |
 | --- | --- | --- |
-| [`python/aftercall`](python/aftercall) | Python / React | AI post-discharge care coordinator that uses CALL-E to conduct consent-aware follow-up calls, collect structured patient-reported recovery information, identify risk signals, and escalate concerning responses to a human care team. |
+| [`python/aftercall`](python/aftercall) | Python / React | AI post-discharge care coordinator that uses CALL-E to conduct consent-aware follow-up calls, collect structured patient-reported recovery information, identify risk signals, and to escalate concerning responses to a human care team. |
 | [`typescript/kol`](typescript/kol/) | TypeScript / Node | Evidence-gated healthcare claim-status calls that require transcript-grounded fields, the intended payer department, the actual question, and an independent IVR route receipt; includes a 640-case no-call evaluation and explicit live CALL-E path. |
 | [`typescript/speakeasy`](typescript/speakeasy/) | TypeScript / iOS | Multilingual "AI makes the call for you": speak a task in your language, confirm the read-back, then CALL-E places the English call with a live transcript and narrates the outcome back in your language; front-loaded preferences and a speculative two-call flow avoid holds; fake-transport no-call mode by default. |
 | [`python/holdfor-board`](python/holdfor-board/) | Python | Post-visit follow-up board for a GP practice: a check-in call's answers reach a human queue as a Review Item, the patient's own verbatim words travel with it, and no rebooking call exists without a prior human Release carrying a bounded date-and-mode envelope. Runs offline on a stored transcript fixture with no credentials. |

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -12,7 +12,7 @@ guide for [AfterCare app](https://github.com/frasfras/after-call).
 - [Source repository](https://github.com/frasfras/after-call)
 
 ## Structured checkin
-   The patient is asked about their medical procedure as well as how they feel and whether
+   The patient is asked about their medical procedure as well as how they feel and flags whether
    they need to be reseen.
    The call response is information for clinicians. 
 
@@ -22,4 +22,4 @@ guide for [AfterCare app](https://github.com/frasfras/after-call).
 
 ## Default call demonstration
 
-- The [demo](https://aftercare.ai.studio/#/demo) enter who to call and about what
+- For The [demo](https://aftercare.ai.studio/#/demo) enter who to call and about what

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -24,11 +24,11 @@ guide for [AfterCare app](https://github.com/frasfras/after-call).
 - The CALL-E token is stored in secrets management in Cloud run and refered to as CALLE_TOKEN
 
 ## Side effects, retries, and cancellation
-  Starting in live demo mode sends the authorized number, call instructions
+  Starting in live demo mode sends the authorized number, call instructions.
   Planning and scheduling does not initiate call.
-  no retries
-  Demo may cost credits and contact a real phone. Only test with personal number or agreeing recipient 
-  Patient can decline call
+  no retries.
+  Demo may cost credits and contact a real phone. Only test with personal number or agreeing recipient .
+  Patient can decline call.
   
 ## Default call demonstration
 

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -1,4 +1,4 @@
-# AfterCare
+# AfterCare Call
 
 AfterCare is a post-discharge care coordinator that uses CALL-E to conduct
  consent-aware follow-up calls, collect structured patient-reported recovery information,

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -32,4 +32,4 @@ guide for [AfterCare app](https://github.com/frasfras/after-call).
   
 ## Default call demonstration
 
-- For The [demo](https://aftercare.ai.studio/#/demo) enter who to call and about what
+- For The [demo](https://aftercare.ai.studio/demo) enter who to call and about what

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -11,15 +11,25 @@ guide for [AfterCare app](https://github.com/frasfras/after-call).
 - [Public demo](https://aftercare.ai.studio/)
 - [Source repository](https://github.com/frasfras/after-call)
 
+**Provider:** CALL-E MCP
+
 ## Structured checkin
    The patient is asked about their medical procedure as well as how they feel and flags whether
    they need to be reseen.
    The call response is information for clinicians. 
+   Patient can decline call
 
 ## Credentials
 
-- The CALL-E token is stored in secrets management in Cloud run and refered as CALLE_TOKEN
+- The CALL-E token is stored in secrets management in Cloud run and refered to as CALLE_TOKEN
 
+## Side effects, retries, and cancellation
+  Starting in live demo mode sends the authorized number, call instructions
+  Planning and scheduling does not initiate call.
+  no retries
+  Demo may cost credits and contact a real phone. Only test with personal number or agreeing recipient 
+  Patient can decline call
+  
 ## Default call demonstration
 
 - For The [demo](https://aftercare.ai.studio/#/demo) enter who to call and about what

--- a/apps/python/aftercall/README.md
+++ b/apps/python/aftercall/README.md
@@ -1,0 +1,25 @@
+# AfterCare
+
+AfterCare is a post-discharge care coordinator that uses CALL-E to conduct
+ consent-aware follow-up calls, collect structured patient-reported recovery information,
+ identify risk signals and instantly flags anyone who needs to be escalated.
+
+This directory is a 
+guide for [AfterCare app](https://github.com/frasfras/after-call).
+
+
+- [Public demo](https://aftercare.ai.studio/)
+- [Source repository](https://github.com/frasfras/after-call)
+
+## Structured checkin
+   The patient is asked about their medical procedure as well as how they feel and whether
+   they need to be reseen.
+   The call response is information for clinicians. 
+
+## Credentials
+
+- The CALL-E token is stored in secrets management in Cloud run and refered as CALLE_TOKEN
+
+## Default call demonstration
+
+- The [demo](https://aftercare.ai.studio/#/demo) enter who to call and about what


### PR DESCRIPTION
## Summary
AfterCall:  a post-discharge care coordinator that uses CALL-E to conduct consent-aware follow-up calls, collect structured patient-reported recovery information, identify risk signals and instantly flags anyone who needs to be escalated

## Type
- [✔] New runnable app


## Checklist

- [✔] Repository-facing content is written in English.
- [✔] Branch name, commit messages, and PR title follow `docs/git-naming-conventions.md`.
- [✔] No secrets, tokens, private phone numbers, call recordings, or private transcripts are included.
- [✔] Real-world side effects are clearly described.
- [✔] Phone numbers are masked in documentation and test fixtures unless they are clearly fictional.
- [✔] Recurring workflows include cancellation behavior.
- [✔] Runnable code has a dry-run, fake-server, or no-call path by default.
- [✔] `python3 scripts/validate_repository.py` passes.
